### PR TITLE
docs: add Troubleshooting/FAQ section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ endpoint:
 <summary><strong>Requests hang or timeout</strong></summary>
 
 Large prompts or long tool-use chains may exceed default timeouts. Check:
-
+- Server logs: `docker compose logs -f grok-mcp`
 - Network connectivity to `api.x.ai`
 - Docker resource limits (increase memory if containers are OOM-killed)
 - Server logs: `docker compose logs -f unigrok`

--- a/README.md
+++ b/README.md
@@ -321,7 +321,12 @@ guidance.
 <summary><strong>Port 8080 is already in use</strong></summary>
 
 Another service is bound to port 8080. Either stop it or change the UniGrok
-port by setting `UNIGROK_PORT` in your `.env` file:
+Another service is bound to port 8080. Either stop it, or change the host
+port mapping in `docker-compose.yml` (e.g. `"127.0.0.1:9090:8080"`):
+
+```yaml
+    ports:
+      - "127.0.0.1:9090:8080"
 
 ```bash
 UNIGROK_PORT=9090

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ If using the Grok CLI plane, ensure `grok auth status` shows authenticated.
 <details>
 <summary><strong><code>mcp-remote</code> bridge not connecting</strong></summary>
 
-If your IDE uses `mcp-remote` to connect to UniGrok's Streamable HTTP
+1. Confirm the server is running: `curl http://localhost:8080/healthz`
 endpoint:
 
 1. Confirm the server is running: `curl http://localhost:8080/health`

--- a/README.md
+++ b/README.md
@@ -358,7 +358,8 @@ Verify your `XAI_API_KEY` in `.env` is valid and has not expired. You can
 test it directly:
 
 ```bash
-curl -H "Authorization: Bearer $XAI_API_KEY" https://api.x.ai/v1/models
+If using the Grok CLI plane, ensure `grok --check` succeeds (this is the
+same probe UniGrok's router uses for plane readiness).
 ```
 
 If using the Grok CLI plane, ensure `grok auth status` shows authenticated.

--- a/README.md
+++ b/README.md
@@ -315,6 +315,75 @@ or extension that exposes `document.modelContext`, and keep the target tab at
 See [SECURITY.md](SECURITY.md) for vulnerability reporting and deployment
 guidance.
 
+## Troubleshooting / FAQ
+
+<details>
+<summary><strong>Port 8080 is already in use</strong></summary>
+
+Another service is bound to port 8080. Either stop it or change the UniGrok
+port by setting `UNIGROK_PORT` in your `.env` file:
+
+```bash
+UNIGROK_PORT=9090
+```
+
+Then access the Control Center at `http://localhost:9090/ui/`.
+
+</details>
+
+<details>
+<summary><strong>Docker containers won't start</strong></summary>
+
+Make sure Docker Desktop (or the Docker daemon on Linux) is running. Then:
+
+```bash
+docker compose down -v   # clean up any stale state
+docker compose up --build -d
+```
+
+On Windows with WSL2, ensure WSL integration is enabled in Docker Desktop
+settings.
+
+</details>
+
+<details>
+<summary><strong>API key rejected / 401 Unauthorized</strong></summary>
+
+Verify your `XAI_API_KEY` in `.env` is valid and has not expired. You can
+test it directly:
+
+```bash
+curl -H "Authorization: Bearer $XAI_API_KEY" https://api.x.ai/v1/models
+```
+
+If using the Grok CLI plane, ensure `grok auth status` shows authenticated.
+
+</details>
+
+<details>
+<summary><strong><code>mcp-remote</code> bridge not connecting</strong></summary>
+
+If your IDE uses `mcp-remote` to connect to UniGrok's Streamable HTTP
+endpoint:
+
+1. Confirm the server is running: `curl http://localhost:8080/health`
+2. Check that your IDE config points to `http://localhost:8080/mcp` (not
+   `/sse` — UniGrok uses Streamable HTTP, not SSE)
+3. Restart the IDE's MCP client after configuration changes
+
+</details>
+
+<details>
+<summary><strong>Requests hang or timeout</strong></summary>
+
+Large prompts or long tool-use chains may exceed default timeouts. Check:
+
+- Network connectivity to `api.x.ai`
+- Docker resource limits (increase memory if containers are OOM-killed)
+- Server logs: `docker compose logs -f unigrok`
+
+</details>
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -318,21 +318,24 @@ guidance.
 ## Troubleshooting / FAQ
 
 <details>
-<summary><strong>Port 8080 is already in use</strong></summary>
+<summary><strong>Port 4765 is already in use</strong></summary>
 
-Another service is bound to port 8080. Either stop it or change the UniGrok
-Another service is bound to port 8080. Either stop it, or change the host
-port mapping in `docker-compose.yml` (e.g. `"127.0.0.1:9090:8080"`):
+UniGrok publishes its local service on host port `4765`. Either stop the
+conflicting process or choose another host port in `.env`:
 
-```yaml
-    ports:
-      - "127.0.0.1:9090:8080"
-
-```bash
+```dotenv
 UNIGROK_PORT=9090
 ```
 
-Then access the Control Center at `http://localhost:9090/ui/`.
+Recreate the service and use the selected port for the Control Center and MCP:
+
+```bash
+docker compose up --build -d
+curl http://localhost:9090/healthz
+```
+
+The corresponding MCP endpoint is `http://localhost:9090/mcp`. Port `8080`
+remains container-internal and should not be placed in IDE configuration.
 
 </details>
 
@@ -342,12 +345,13 @@ Then access the Control Center at `http://localhost:9090/ui/`.
 Make sure Docker Desktop (or the Docker daemon on Linux) is running. Then:
 
 ```bash
-docker compose down -v   # clean up any stale state
+docker compose down
 docker compose up --build -d
+docker compose ps
 ```
 
 On Windows with WSL2, ensure WSL integration is enabled in Docker Desktop
-settings.
+settings. If startup still fails, inspect `docker compose logs grok-mcp`.
 
 </details>
 
@@ -358,24 +362,25 @@ Verify your `XAI_API_KEY` in `.env` is valid and has not expired. You can
 test it directly:
 
 ```bash
-If using the Grok CLI plane, ensure `grok --check` succeeds (this is the
-same probe UniGrok's router uses for plane readiness).
+curl --fail --silent --show-error \
+  -H "Authorization: Bearer ${XAI_API_KEY}" \
+  https://api.x.ai/v1/models
 ```
 
-If using the Grok CLI plane, ensure `grok auth status` shows authenticated.
+For the subscription-backed CLI plane, open **Setup & Status** in the Control
+Center. If authentication is missing, run `docker compose run --rm
+grok-cli-auth` and complete the device-code login. UniGrok uses `grok --check`
+inside the service as its readiness probe.
 
 </details>
 
 <details>
 <summary><strong><code>mcp-remote</code> bridge not connecting</strong></summary>
 
-1. Confirm the server is running: `curl http://localhost:8080/healthz`
-endpoint:
-
-1. Confirm the server is running: `curl http://localhost:8080/health`
-2. Check that your IDE config points to `http://localhost:8080/mcp` (not
+1. Confirm the server is running: `curl http://localhost:4765/healthz`.
+2. Check that your IDE config points to `http://localhost:4765/mcp` (not
    `/sse` — UniGrok uses Streamable HTTP, not SSE)
-3. Restart the IDE's MCP client after configuration changes
+3. Restart the IDE's MCP client after configuration changes.
 
 </details>
 
@@ -383,10 +388,11 @@ endpoint:
 <summary><strong>Requests hang or timeout</strong></summary>
 
 Large prompts or long tool-use chains may exceed default timeouts. Check:
+
 - Server logs: `docker compose logs -f grok-mcp`
 - Network connectivity to `api.x.ai`
 - Docker resource limits (increase memory if containers are OOM-killed)
-- Server logs: `docker compose logs -f unigrok`
+- The request's route and degradation metadata in the Control Center
 
 </details>
 


### PR DESCRIPTION
## Summary

Adds a Troubleshooting/FAQ section to README.md covering the most common issues new users encounter.

## Changes

Added 5 collapsible FAQ entries before the Development section:
- Port 8080 already in use (with UNIGROK_PORT env var solution)
- Docker containers won't start (WSL2 note for Windows)
- API key rejected / 401 Unauthorized (with curl test command)
- mcp-remote bridge not connecting (Streamable HTTP vs SSE clarification)
- Requests hang or timeout (resource limits, logs command)

## Motivation

Addresses item #1 in issue #1 (Help wanted: first community contributors). The issue specifically requests a Troubleshooting/FAQ section covering port conflicts, Docker issues, key rejection, and mcp-remote quirks.

## Testing

Documentation-only change. Uses collapsible HTML details/summary elements for clean formatting.