### PR TITLE
Close PR-first governance rollout

### DIFF
--- a/.codex/memory/active-work.md
+++ b/.codex/memory/active-work.md
@@ -2,12 +2,27 @@
 
 Last updated: 2026-07-11
 Owner: Codex
-Status: v0.6.0 production rollout and GitHub release complete
+Status: PR-first contributor governance and dynamic OKF wiki rollout complete
 
 This is the required project-scoped handoff for new Codex chats. Verify all
 drift-prone values live before acting. Do not copy secrets or OAuth codes here.
 
 ## Current repository state
+
+- Protected `origin/main` and visible local `main` were verified at
+  `a4ebcb369ec527da9ce0dee6d2a708437599dc94` after PR #4 merged through the
+  rebase path. The local landing receipt and contributor runtime marker name
+  the same commit.
+- PR #4 preserves Gemini as the originating agent, Codex as repair/integration
+  authority, and Grok 4.5 CLI-plane review evidence. All six required CI jobs
+  passed on the reviewed head.
+- Branch protection now requires all six CI jobs, strict up-to-date checks,
+  stale-review dismissal, CODEOWNER review, linear history, and conversation
+  resolution. Admin enforcement remains temporarily off until the independent
+  project-admin bot can approve owner-authored PRs.
+- Automatic Grok PR review is disabled. Approved collaborators request the
+  advisory review explicitly with `@grok review`, preventing surprise model
+  usage and permanently queued self-hosted jobs.
 
 - The deployment implementation base was verified and pushed as
   `3ed02c21b8b0d4b84f2dbbdbbe89edba64c4255f`. Always resolve the current full
@@ -27,6 +42,14 @@ drift-prone values live before acting. Do not copy secrets or OAuth codes here.
   Docker, offline evals, Project Site, and `Control Cloud Run Image`.
 
 ## Cloud control deployment
+
+- Cloud Run revision `unigrok-control-center-a4ebcb3` serves 100% of traffic
+  from immutable image digest
+  `sha256:299b95b453884ad729d2756dc69a97e8e241e9af6333913cf4bfdce0cf00cc7e`.
+- Sites version 4 is deployed from site-only commit
+  `bde70c90d6cac26bb4d0b92c91454092734e195f`.
+- `grokmcp.org` and `control.grokmcp.org` both return the canonical OKF manifest
+  and generated API reference. The raw Cloud Run URL remains disabled.
 
 - GCP project: `agentixai-inc`; region: `us-east1`.
 - Cloud Run service: `unigrok-control-center`.

--- a/.github/workflows/grok-review.yml
+++ b/.github/workflows/grok-review.yml
@@ -1,8 +1,6 @@
 name: UniGrok PR Review
 
 on:
-  pull_request_target:
-    types: [opened, reopened, synchronize, ready_for_review]
   issue_comment:
     types: [created]
   workflow_dispatch:
@@ -24,8 +22,6 @@ jobs:
   review:
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request_target' &&
-       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)) ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
@@ -37,8 +33,8 @@ jobs:
     runs-on: ${{ fromJSON(vars.UNIGROK_REVIEW_RUNNER_JSON || '["self-hosted","unigrok-review"]') }}
     timeout-minutes: 10
     steps:
-      # pull_request_target is intentional: run only trusted default-branch code.
-      # Never check out, execute, install, or import code from the reviewed PR.
+      # Run only trusted default-branch code. Never check out, execute, install,
+      # or import code from the reviewed PR.
       - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.repository.default_branch }}
@@ -53,8 +49,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
-          EXPECTED_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           UNIGROK_MCP_URL: ${{ vars.UNIGROK_REVIEW_MCP_URL || 'http://127.0.0.1:4765/mcp' }}
           UNIGROK_REVIEW_PLANE: ${{ vars.UNIGROK_REVIEW_PLANE || 'cli' }}
           UNIGROK_CLIENT_TOKEN: ${{ secrets.UNIGROK_CLIENT_TOKEN }}

--- a/docs/adr/0001-cloud-control-plane-governance.md
+++ b/docs/adr/0001-cloud-control-plane-governance.md
@@ -159,16 +159,17 @@ This ADR intentionally does not pretend the migration already happened.
 |---|---|---|
 | GitHub Grok review | Trusted default-branch script on a restricted self-hosted runner; advisory comment | Configurable authenticated API-plane endpoint on a hosted runner, with cost/rate controls |
 | Landing receipt | Local JSON receipt written by `scripts/land`; not cryptographically signed | Broker-issued signed receipt verifiable against a published key |
-| Canonical integration branch | Shared local `main`, then Codex-managed remote publication | Protected `origin/main` after broker-verified merge; local `main` becomes a synchronized replica |
+| Canonical integration branch | Protected `origin/main` through PRs; Codex synchronizes local `main` and records the local landing receipt | Broker-verified merge with a signed receipt; local `main` remains a synchronized replica |
 | GitHub authorization | GitHub workflow association gates | GitHub App user identity plus fresh repository-role checks for the protected control surface |
 | GitHub mutation broker | Not implemented | Deployed GitHub App controller with short-lived tokens, allowlisted mutations, and audit log |
 
 Until the target broker and signed receipt verifier are deployed and exercised
-end to end, the repository's existing `AGENTS.md` contract remains operative:
-Codex runs `scripts/land`, a local successful receipt is required, and local
-`main` is integrated before remote publication. Documentation or UI mockups
-must not label the future controller, remote landing, or GitHub authorization
-as live.
+end to end, the repository's transitional `AGENTS.md` contract remains
+operative: every change reaches `origin/main` through a PR, Codex records an
+exact-head disposition, only a `codex/*` integration branch may run
+`scripts/land`, and local `main` is synchronized to the protected merge. The
+connected maintainer identity remains a documented temporary bypass for
+owner-authored agent PRs; it is not the future independent bot approval.
 
 ## Required GitHub repository policy
 

--- a/tests/test_github_review_integration.py
+++ b/tests/test_github_review_integration.py
@@ -322,10 +322,12 @@ def test_github_review_rejects_base_change_before_comment(tmp_path, monkeypatch)
         asyncio.run(module.main())
 
 
-def test_github_review_workflow_never_checks_out_pr_code():
+def test_github_review_workflow_is_on_demand_and_never_checks_out_pr_code():
     workflow = (ROOT / ".github" / "workflows" / "grok-review.yml").read_text(encoding="utf-8")
 
-    assert "pull_request_target:" in workflow
+    assert "pull_request_target:" not in workflow
+    assert "issue_comment:" in workflow
+    assert "workflow_dispatch:" in workflow
     assert "contents: read" in workflow
     assert "pull-requests: write" in workflow
     assert "issues: write" not in workflow
@@ -334,12 +336,12 @@ def test_github_review_workflow_never_checks_out_pr_code():
     assert '["self-hosted","unigrok-review"]' in workflow
     assert "persist-credentials: false" in workflow
     assert "ref: ${{ github.event.pull_request.head" not in workflow
-    assert "EXPECTED_BASE_SHA: ${{ github.event.pull_request.base.sha }}" in workflow
-    assert "EXPECTED_HEAD_SHA: ${{ github.event.pull_request.head.sha }}" in workflow
+    assert "EXPECTED_BASE_SHA:" not in workflow
+    assert "EXPECTED_HEAD_SHA:" not in workflow
     assert "vars.UNIGROK_REVIEW_MCP_URL" in workflow
     assert "vars.UNIGROK_REVIEW_PLANE || 'cli'" in workflow
     assert "UNIGROK_REVIEW_EXTERNALS" not in workflow
-    assert "github.event.pull_request.author_association" in workflow
+    assert "github.event.pull_request.author_association" not in workflow
     assert "github.event.comment.author_association" in workflow
     assert '[\"OWNER\",\"MEMBER\",\"COLLABORATOR\"]' in workflow
 


### PR DESCRIPTION
## Summary

Closes the PR-first contributor-governance rollout after PR #4 and the production wiki deployments.

## Changes

- records the exact merged GitHub, local runtime, Sites, and Cloud Run state
- updates the governance ADR to reflect protected `origin/main` as canonical
- changes advisory Grok PR review from automatic to explicit `@grok review` or manual dispatch
- updates the workflow contract test

## Why

Automatic review queued indefinitely when the trusted self-hosted runner was unavailable and could create uncertainty about credits. On-demand review keeps model usage intentional while preserving the trusted default-branch review path.

## Verification

- `17 passed` focused workflow and release-hygiene tests
- `git diff --check` clean
- PR #4 merged at `a4ebcb3`; six required checks passed
- both local services, `grokmcp.org`, and `control.grokmcp.org` verified live

Agent-Assisted-By: Codex via Codex Desktop
