### PR TITLE
Require exact-head Codex approval

### DIFF
--- a/.codex/memory/active-work.md
+++ b/.codex/memory/active-work.md
@@ -16,10 +16,11 @@ drift-prone values live before acting. Do not copy secrets or OAuth codes here.
 - PR #4 preserves Gemini as the originating agent, Codex as repair/integration
   authority, and Grok 4.5 CLI-plane review evidence. All six required CI jobs
   passed on the reviewed head.
-- Branch protection now requires all six CI jobs, strict up-to-date checks,
-  stale-review dismissal, CODEOWNER review, linear history, and conversation
-  resolution. Admin enforcement remains temporarily off until the independent
-  project-admin bot can approve owner-authored PRs.
+- Branch protection now requires all six CI jobs plus the exact-head
+  `Codex Approval` status, strict up-to-date checks, linear history, and
+  conversation resolution, with administrator enforcement enabled. The
+  owner-only approval dispatch validates the live PR head and uses no model
+  credits; a dedicated project-admin App identity remains a future refinement.
 - Automatic Grok PR review is disabled. Approved collaborators request the
   advisory review explicitly with `@grok review`, preventing surprise model
   usage and permanently queued self-hosted jobs.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -48,4 +48,5 @@ each claim you make against the actual source:
 
 - [ ] Required CI and CODEOWNER review pass on the current head
 - [ ] Codex disposition applies to the current head
+- [ ] Required `Codex Approval` status is present on the current head
 - [ ] Landing/merge receipt is captured by the currently operative integration path

--- a/.github/workflows/codex-approval.yml
+++ b/.github/workflows/codex-approval.yml
@@ -1,0 +1,50 @@
+name: Codex Approval
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number
+        required: true
+        type: string
+      head_sha:
+        description: Exact 40-character PR head approved by Codex
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: write
+
+jobs:
+  approve:
+    if: ${{ github.actor == github.repository_owner }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify current PR head and publish approval
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          REVIEWED_HEAD: ${{ inputs.head_sha }}
+          REPOSITORY: ${{ github.repository }}
+          SERVER_URL: ${{ github.server_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "${PR_NUMBER}" =~ ^[1-9][0-9]*$ ]]
+          [[ "${REVIEWED_HEAD}" =~ ^[0-9a-f]{40}$ ]]
+
+          actual_head="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha')"
+          base_branch="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.base.ref')"
+          state="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.state')"
+
+          test "${state}" = "open"
+          test "${base_branch}" = "main"
+          test "${actual_head}" = "${REVIEWED_HEAD}"
+
+          gh api --method POST "repos/${REPOSITORY}/statuses/${REVIEWED_HEAD}" \
+            -f state=success \
+            -f context='Codex Approval' \
+            -f description='Codex approved this exact PR head' \
+            -f target_url="${SERVER_URL}/${REPOSITORY}/pull/${PR_NUMBER}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,12 @@ merge, tag, and release decisions. See
 [ADR 0001](docs/adr/0001-cloud-control-plane-governance.md) for the current
 local landing contract and the explicitly not-yet-live remote broker design.
 
+Codex approval is enforced as a required commit status bound to the exact PR
+head. Only the repository owner may dispatch `.github/workflows/codex-approval.yml`;
+the workflow re-reads the open PR and refuses a stale SHA or non-`main` target.
+This deterministic check uses no model credits. Any new commit requires a new
+Codex review and approval dispatch.
+
 Security vulnerabilities should be reported privately as described in
 [SECURITY.md](SECURITY.md), not opened as public issues.
 

--- a/docs/adr/0001-cloud-control-plane-governance.md
+++ b/docs/adr/0001-cloud-control-plane-governance.md
@@ -161,7 +161,8 @@ This ADR intentionally does not pretend the migration already happened.
 | Landing receipt | Local JSON receipt written by `scripts/land`; not cryptographically signed | Broker-issued signed receipt verifiable against a published key |
 | Canonical integration branch | Protected `origin/main` through PRs; Codex synchronizes local `main` and records the local landing receipt | Broker-verified merge with a signed receipt; local `main` remains a synchronized replica |
 | GitHub authorization | GitHub workflow association gates | GitHub App user identity plus fresh repository-role checks for the protected control surface |
-| GitHub mutation broker | Not implemented | Deployed GitHub App controller with short-lived tokens, allowlisted mutations, and audit log |
+| Codex approval | Owner-dispatched required status validates the exact open PR head without model usage | Dedicated project-admin App identity with signed dispositions |
+| GitHub mutation broker | Not implemented; GitHub protected merge remains the mutation boundary | Deployed GitHub App controller with short-lived tokens, allowlisted mutations, and audit log |
 
 Until the target broker and signed receipt verifier are deployed and exercised
 end to end, the repository's transitional `AGENTS.md` contract remains

--- a/tests/test_github_review_integration.py
+++ b/tests/test_github_review_integration.py
@@ -359,6 +359,22 @@ def test_chatgpt_github_operator_guide_keeps_credentials_separate():
     assert "not live GitHub OAuth" in guide
 
 
+def test_codex_approval_workflow_is_owner_only_and_exact_head_bound():
+    workflow = (ROOT / ".github" / "workflows" / "codex-approval.yml").read_text(encoding="utf-8")
+
+    assert "workflow_dispatch:" in workflow
+    assert "github.actor == github.repository_owner" in workflow
+    assert "statuses: write" in workflow
+    assert "pull-requests: read" in workflow
+    assert "test \"${actual_head}\" = \"${REVIEWED_HEAD}\"" in workflow
+    assert "test \"${base_branch}\" = \"main\"" in workflow
+    assert "context='Codex Approval'" in workflow
+    assert "state=success" in workflow
+    assert "actions/checkout" not in workflow
+    assert "XAI_API_KEY" not in workflow
+    assert "UNIGROK_MCP_URL" not in workflow
+
+
 def test_cloud_governance_contract_marks_target_features_not_live():
     adr = (
         ROOT / "docs" / "adr" / "0001-cloud-control-plane-governance.md"


### PR DESCRIPTION
## Summary\n- add an owner-only, exact-head Codex Approval workflow\n- make approval deterministic and zero-credit\n- document the enforced contributor gate and future App-identity refinement\n\n## Verification\n- 18 focused governance tests passed\n- git diff --check passed\n\nAgent-Assisted-By: Codex <codex@openai.com>