### PR TITLE
feat(swarm): add hardened $0 static fast-gate

### DIFF
--- a/.codex/memory/active-work.md
+++ b/.codex/memory/active-work.md
@@ -9,6 +9,16 @@ drift-prone values live before acting. Do not copy secrets or OAuth codes here.
 
 ## Current repository state
 
+- The Claude-originated swarm static fast-gate is integrated through the
+  protected Codex path; resolve its PR and rebased merge commit live. Codex
+  review hardened Ruff execution with isolated configuration and ignored
+  suppression comments, and changed baseline comparison from a total count to
+  a diagnostic multiset so mutants cannot trade one existing undefined name
+  for a different new one. The reviewed head passed 1,018 tests, 12/12 offline
+  evals, and deterministic OKF verification. The gate remains correctness-only,
+  fail-open when Ruff is unavailable, configurable with
+  `UNIGROK_SWARM_RUFF_FILTER=0`, and additive to the existing test oracle.
+
 - PR #10 merged the Claude-originated swarm optimizer through the protected
   Codex path after landing review repaired strict CLI billing, candidate
   identity, Pareto/apply selection, callable-signature preservation, path and
@@ -126,7 +136,8 @@ drift-prone values live before acting. Do not copy secrets or OAuth codes here.
 
 ## Remaining gates
 
-The v0.6.0 release, Claude intelligence, and swarm optimizer gates are complete:
+The v0.6.0 release, Claude intelligence, swarm optimizer, and static fast-gate
+gates are complete:
 
 1. Sites production environment revision `5` includes the non-secret
    `CONTROL_CENTER_ORIGIN=https://control.grokmcp.org`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to UniGrok MCP will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Swarm optimizer $0 static fast-gate**: mutants now pass a
+  baseline-relative ruff `F821`/`F823` check (undefined names — the
+  hallucination class `compile()` cannot catch) between compile and the
+  sandbox stages, killing doomed candidates in milliseconds instead of
+  seconds of sandbox time; correctness-only rules, so style never culls
+  mutant diversity, and the gate no-ops when ruff is unavailable
+  (`UNIGROK_SWARM_RUFF_FILTER=0` disables). Formatting/comment-only no-op
+  mutants (identical AST) are additionally discarded for free like duplicate
+  hashes — evaluating them would just re-measure the baseline.
 - **Swarm optimizer storage skeleton** (`UNIGROK_SWARM`, off by default):
   migration v12 adds `swarm_tasks` and `swarm_candidates` for the upcoming
   contributor-only swarm code optimizer (bounded Pareto search over rewrites

--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -836,6 +836,22 @@ def apply_byte_replacement(source: bytes, start: int, end: int, replacement: byt
 
 Exact byte splice: everything outside [start:end) is byte-identical.
 
+### Function: `is_ast_identical` {#swarm-ast_utils-is_ast_identical}
+
+```python
+def is_ast_identical(original_span: bytes, replacement: bytes) -> bool
+```
+
+**Keywords:** is, ast, identical
+
+True when the replacement parses to the SAME AST as the original span
+(a formatting/comment-only no-op mutant) — evaluating it would just
+re-measure the baseline, so the funnel discards it for free like a
+duplicate hash. Indented method spans are dedented before parsing; any
+parse failure returns False so the funnel proceeds and judges the
+candidate properly (this check may only ever discard true no-ops, never
+hide a real mutant).
+
 ## swarm/config.py {#swarm-config}
 
 ### Function: `swarm_mode` {#swarm-config-swarm_mode}
@@ -914,6 +930,19 @@ Heartbeat staleness horizon: a running task whose row has not been
 touched for this long is reported failed_stale (the runner touches
 updated_at after every candidate). Deliberately derived from the eval
 timeout — a healthy swarm can far exceed JobManager's global default.
+
+### Function: `swarm_ruff_filter` {#swarm-config-swarm_ruff_filter}
+
+```python
+def swarm_ruff_filter() -> bool
+```
+
+**Keywords:** swarm, ruff, filter
+
+UNIGROK_SWARM_RUFF_FILTER=0/false/no/off disables the $0 ruff static
+fast-gate between compile() and the sandbox stages. The gate only saves
+sandbox seconds — the tests stage still catches everything it would
+have — so disabling it is always safe.
 
 ### Function: `reset_swarm_state` {#swarm-config-reset_swarm_state}
 
@@ -1195,6 +1224,30 @@ contract command; medians + raw samples (for noise-floor math).
 Raises SandboxError when the command fails or breaks the contract —
 for the BASELINE that fails the task; for a mutant the engine treats
 it as an infeasible candidate at the bench stage.
+
+## swarm/static_gate.py {#swarm-static_gate}
+
+### Function: `ruff_bin` {#swarm-static_gate-ruff_bin}
+
+```python
+def ruff_bin() -> Optional[str]
+```
+
+**Keywords:** ruff, bin
+
+The venv's ruff first (a pinned project dependency), PATH second.
+
+### Function: `count_violations` {#swarm-static_gate-count_violations}
+
+```python
+async def count_violations(source: bytes, timeout: float=10.0) -> Optional[int]
+```
+
+**Keywords:** count, violations
+
+F821/F823 violation count for `source`, or None when the gate cannot
+run (ruff missing, timeout, or internal error) — callers must treat None
+as gate-disabled, never as clean.
 
 ## tools/chats.py {#tools-chats}
 

--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -1237,6 +1237,18 @@ def ruff_bin() -> Optional[str]
 
 The venv's ruff first (a pinned project dependency), PATH second.
 
+### Function: `violation_counts` {#swarm-static_gate-violation_counts}
+
+```python
+async def violation_counts(source: bytes, timeout: float=10.0) -> Optional[ViolationCounts]
+```
+
+**Keywords:** violation, counts
+
+F821/F823 diagnostics keyed by rule and message, or None when the gate cannot
+run (ruff missing, timeout, or internal error) — callers must treat None
+as gate-disabled, never as clean.
+
 ### Function: `count_violations` {#swarm-static_gate-count_violations}
 
 ```python
@@ -1245,9 +1257,7 @@ async def count_violations(source: bytes, timeout: float=10.0) -> Optional[int]
 
 **Keywords:** count, violations
 
-F821/F823 violation count for `source`, or None when the gate cannot
-run (ruff missing, timeout, or internal error) — callers must treat None
-as gate-disabled, never as clean.
+Compatibility helper returning the total F821/F823 diagnostic count.
 
 ## tools/chats.py {#tools-chats}
 

--- a/example.env
+++ b/example.env
@@ -176,3 +176,6 @@ UNIGROK_SWARM_DEFAULT_BUDGET_USD=2.00
 UNIGROK_SWARM_MAX_BUDGET_USD=10.00
 UNIGROK_SWARM_MAX_COPY_MB=500
 UNIGROK_SWARM_CHILD_MEM_MB=2048
+# $0 ruff F821/F823 static gate between compile() and the sandbox stages
+# (baseline-relative, correctness-only rules, no-ops if ruff is unavailable).
+UNIGROK_SWARM_RUFF_FILTER=1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "tree-sitter-python>=0.25,<0.26",
     "coverage>=7.6",
     "pytest>=9.1.1",
+    "ruff>=0.9",
 ]
 
 [project.scripts]

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -836,6 +836,22 @@ def apply_byte_replacement(source: bytes, start: int, end: int, replacement: byt
 
 Exact byte splice: everything outside [start:end) is byte-identical.
 
+### Function: `is_ast_identical` {#swarm-ast_utils-is_ast_identical}
+
+```python
+def is_ast_identical(original_span: bytes, replacement: bytes) -> bool
+```
+
+**Keywords:** is, ast, identical
+
+True when the replacement parses to the SAME AST as the original span
+(a formatting/comment-only no-op mutant) — evaluating it would just
+re-measure the baseline, so the funnel discards it for free like a
+duplicate hash. Indented method spans are dedented before parsing; any
+parse failure returns False so the funnel proceeds and judges the
+candidate properly (this check may only ever discard true no-ops, never
+hide a real mutant).
+
 ## swarm/config.py {#swarm-config}
 
 ### Function: `swarm_mode` {#swarm-config-swarm_mode}
@@ -914,6 +930,19 @@ Heartbeat staleness horizon: a running task whose row has not been
 touched for this long is reported failed_stale (the runner touches
 updated_at after every candidate). Deliberately derived from the eval
 timeout — a healthy swarm can far exceed JobManager's global default.
+
+### Function: `swarm_ruff_filter` {#swarm-config-swarm_ruff_filter}
+
+```python
+def swarm_ruff_filter() -> bool
+```
+
+**Keywords:** swarm, ruff, filter
+
+UNIGROK_SWARM_RUFF_FILTER=0/false/no/off disables the $0 ruff static
+fast-gate between compile() and the sandbox stages. The gate only saves
+sandbox seconds — the tests stage still catches everything it would
+have — so disabling it is always safe.
 
 ### Function: `reset_swarm_state` {#swarm-config-reset_swarm_state}
 
@@ -1195,6 +1224,30 @@ contract command; medians + raw samples (for noise-floor math).
 Raises SandboxError when the command fails or breaks the contract —
 for the BASELINE that fails the task; for a mutant the engine treats
 it as an infeasible candidate at the bench stage.
+
+## swarm/static_gate.py {#swarm-static_gate}
+
+### Function: `ruff_bin` {#swarm-static_gate-ruff_bin}
+
+```python
+def ruff_bin() -> Optional[str]
+```
+
+**Keywords:** ruff, bin
+
+The venv's ruff first (a pinned project dependency), PATH second.
+
+### Function: `count_violations` {#swarm-static_gate-count_violations}
+
+```python
+async def count_violations(source: bytes, timeout: float=10.0) -> Optional[int]
+```
+
+**Keywords:** count, violations
+
+F821/F823 violation count for `source`, or None when the gate cannot
+run (ruff missing, timeout, or internal error) — callers must treat None
+as gate-disabled, never as clean.
 
 ## tools/chats.py {#tools-chats}
 

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -1237,6 +1237,18 @@ def ruff_bin() -> Optional[str]
 
 The venv's ruff first (a pinned project dependency), PATH second.
 
+### Function: `violation_counts` {#swarm-static_gate-violation_counts}
+
+```python
+async def violation_counts(source: bytes, timeout: float=10.0) -> Optional[ViolationCounts]
+```
+
+**Keywords:** violation, counts
+
+F821/F823 diagnostics keyed by rule and message, or None when the gate cannot
+run (ruff missing, timeout, or internal error) — callers must treat None
+as gate-disabled, never as clean.
+
 ### Function: `count_violations` {#swarm-static_gate-count_violations}
 
 ```python
@@ -1245,9 +1257,7 @@ async def count_violations(source: bytes, timeout: float=10.0) -> Optional[int]
 
 **Keywords:** count, violations
 
-F821/F823 violation count for `source`, or None when the gate cannot
-run (ruff missing, timeout, or internal error) — callers must treat None
-as gate-disabled, never as clean.
+Compatibility helper returning the total F821/F823 diagnostic count.
 
 ## tools/chats.py {#tools-chats}
 

--- a/src/swarm/ast_utils.py
+++ b/src/swarm/ast_utils.py
@@ -9,6 +9,7 @@ rejected at task start rather than discovered as corrupted files at apply.
 from __future__ import annotations
 
 import ast
+import textwrap
 from typing import List, Optional, Tuple
 
 import tree_sitter_python
@@ -171,3 +172,19 @@ def apply_byte_replacement(source: bytes, start: int, end: int, replacement: byt
     if not (0 <= start <= end <= len(source)):
         raise ValueError("replacement span out of bounds")
     return source[:start] + replacement + source[end:]
+
+
+def is_ast_identical(original_span: bytes, replacement: bytes) -> bool:
+    """True when the replacement parses to the SAME AST as the original span
+    (a formatting/comment-only no-op mutant) — evaluating it would just
+    re-measure the baseline, so the funnel discards it for free like a
+    duplicate hash. Indented method spans are dedented before parsing; any
+    parse failure returns False so the funnel proceeds and judges the
+    candidate properly (this check may only ever discard true no-ops, never
+    hide a real mutant)."""
+    try:
+        a = ast.parse(textwrap.dedent(original_span.decode("utf-8")))
+        b = ast.parse(textwrap.dedent(replacement.decode("utf-8")))
+    except (SyntaxError, UnicodeDecodeError, ValueError):
+        return False
+    return ast.dump(a) == ast.dump(b)

--- a/src/swarm/config.py
+++ b/src/swarm/config.py
@@ -111,6 +111,16 @@ def swarm_stale_after_sec() -> float:
     return 3.0 * swarm_eval_timeout()
 
 
+def swarm_ruff_filter() -> bool:
+    """UNIGROK_SWARM_RUFF_FILTER=0/false/no/off disables the $0 ruff static
+    fast-gate between compile() and the sandbox stages. The gate only saves
+    sandbox seconds — the tests stage still catches everything it would
+    have — so disabling it is always safe."""
+    return os.environ.get("UNIGROK_SWARM_RUFF_FILTER", "").strip().lower() not in (
+        "0", "false", "no", "off"
+    )
+
+
 def reset_swarm_state() -> None:
     """Test isolation for module-level flags."""
     global _MODE_WARNED

--- a/src/swarm/engine.py
+++ b/src/swarm/engine.py
@@ -40,7 +40,7 @@ from .pareto import rank_candidates
 from .preflight import noise_floor_pct
 from .router import DiscountedUCBRouter, reward_for
 from .sandbox import SandboxError, SwarmSandbox
-from .static_gate import count_violations
+from .static_gate import violation_counts
 
 
 @dataclass
@@ -93,7 +93,7 @@ class SwarmEngine:
     _front: List[Dict[str, Any]] = field(default_factory=list, init=False)
     _spent: float = field(default=0.0, init=False)
     _noise_floor_pct: float = field(default=5.0, init=False)
-    # Baseline F821/F823 count, computed once on first use ("unset" sentinel;
+    # Baseline F821/F823 diagnostics, computed once on first use ("unset" sentinel;
     # None = ruff unavailable, gate disabled for the task).
     _baseline_lint: Any = field(default="unset", init=False)
 
@@ -283,10 +283,13 @@ class SwarmEngine:
         # unavailable/erroring ruff makes the gate a no-op — the tests stage
         # still catches everything this would have.
         if self.config.ruff_filter:
-            baseline_lint = await self._baseline_lint_count()
+            baseline_lint = await self._baseline_lint_counts()
             if baseline_lint is not None:
-                mutant_lint = await count_violations(patched)
-                if mutant_lint is not None and mutant_lint > baseline_lint:
+                mutant_lint = await violation_counts(patched)
+                # Compare diagnostic multisets, not just totals: replacing a
+                # pre-existing undefined name with a different hallucinated
+                # name must still be rejected even when the count is equal.
+                if mutant_lint is not None and mutant_lint - baseline_lint:
                     candidate["stage_reached"] = "lint"
                     return candidate
 
@@ -317,12 +320,12 @@ class SwarmEngine:
 
     # ── Helpers ──────────────────────────────────────────────────────────────
 
-    async def _baseline_lint_count(self) -> Optional[int]:
-        """The original file's F821/F823 count, computed once per task so the
+    async def _baseline_lint_counts(self):
+        """The original file's F821/F823 diagnostics, computed once per task so the
         gate stays baseline-relative (a pre-existing violation must not kill
         every mutant)."""
         if self._baseline_lint == "unset":
-            self._baseline_lint = await count_violations(self.file_source)
+            self._baseline_lint = await violation_counts(self.file_source)
         return self._baseline_lint
 
     def _apply_noise_floor(self, latency_ms: float) -> float:

--- a/src/swarm/engine.py
+++ b/src/swarm/engine.py
@@ -6,7 +6,8 @@ feed forward only through the folded prompt context, which is why early-stop on
 "no new Pareto point" is meaningful: it is the prompt context that evolves.
 
 The loop is: route arms -> generate mutants (CLI plane) -> funnel each
-(dedupe -> parse[+heal] -> compile -> tests -> bench -> restore+hygiene) ->
+(dedupe/ast-noop -> parse[+heal] -> signature -> compile -> lint -> tests ->
+bench -> restore+hygiene) ->
 Pareto-select -> reward the arms -> fold state -> stop check. Generation is the
 one mockable seam (generate.generate_mutation); everything else is real.
 """
@@ -22,6 +23,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from .ast_utils import (
     apply_byte_replacement,
+    is_ast_identical,
     parse_ok,
     signature_fingerprint,
     span_line_range,
@@ -38,6 +40,7 @@ from .pareto import rank_candidates
 from .preflight import noise_floor_pct
 from .router import DiscountedUCBRouter, reward_for
 from .sandbox import SandboxError, SwarmSandbox
+from .static_gate import count_violations
 
 
 @dataclass
@@ -50,6 +53,9 @@ class EngineConfig:
     budget_usd: float = 2.0
     seed: int = 0
     allow_unstable_bench: bool = False
+    # $0 ruff F821/F823 gate between compile() and the sandbox stages
+    # (baseline-relative; no-ops when ruff is unavailable).
+    ruff_filter: bool = True
 
 
 @dataclass
@@ -87,6 +93,9 @@ class SwarmEngine:
     _front: List[Dict[str, Any]] = field(default_factory=list, init=False)
     _spent: float = field(default=0.0, init=False)
     _noise_floor_pct: float = field(default=5.0, init=False)
+    # Baseline F821/F823 count, computed once on first use ("unset" sentinel;
+    # None = ruff unavailable, gate disabled for the task).
+    _baseline_lint: Any = field(default="unset", init=False)
 
     def __post_init__(self):
         self.router = DiscountedUCBRouter(seed=self.config.seed)
@@ -241,6 +250,11 @@ class SwarmEngine:
         if code_hash in self._seen_hashes:
             return None  # free discard, not persisted
         self._seen_hashes.add(code_hash)
+        if is_ast_identical(self.original_span, replacement_bytes):
+            # Formatting/comment-only no-op: evaluating it would re-measure
+            # the baseline. Discarded free like a duplicate (no row, no
+            # reward — symmetric with the hash dedupe above).
+            return None
         candidate["code"] = replacement
         candidate["code_hash"] = code_hash
         candidate["diff_bytes"] = _byte_diff_size(self.original_span, replacement_bytes)
@@ -261,6 +275,20 @@ class SwarmEngine:
         except SyntaxError:
             candidate["stage_reached"] = "compile"
             return candidate
+
+        # $0 static gate: compile() accepts undefined names (NameError is a
+        # runtime error), so ruff's F821/F823 catch that hallucination class
+        # in milliseconds before seconds of sandbox time. Baseline-relative:
+        # only NEW violations vs the original file kill a candidate, and an
+        # unavailable/erroring ruff makes the gate a no-op — the tests stage
+        # still catches everything this would have.
+        if self.config.ruff_filter:
+            baseline_lint = await self._baseline_lint_count()
+            if baseline_lint is not None:
+                mutant_lint = await count_violations(patched)
+                if mutant_lint is not None and mutant_lint > baseline_lint:
+                    candidate["stage_reached"] = "lint"
+                    return candidate
 
         # Sandbox stages: write -> tests -> bench -> restore + hygiene.
         try:
@@ -288,6 +316,14 @@ class SwarmEngine:
         return candidate
 
     # ── Helpers ──────────────────────────────────────────────────────────────
+
+    async def _baseline_lint_count(self) -> Optional[int]:
+        """The original file's F821/F823 count, computed once per task so the
+        gate stays baseline-relative (a pre-existing violation must not kill
+        every mutant)."""
+        if self._baseline_lint == "unset":
+            self._baseline_lint = await count_violations(self.file_source)
+        return self._baseline_lint
 
     def _apply_noise_floor(self, latency_ms: float) -> float:
         """Improvements below the noise floor are erased (snapped to baseline)

--- a/src/swarm/runner.py
+++ b/src/swarm/runner.py
@@ -127,6 +127,7 @@ class SwarmRunner:
                     budget_usd=spec["budget_usd"],
                     seed=spec["seed"],
                     allow_unstable_bench=spec.get("allow_unstable_bench", False),
+                    ruff_filter=swarm_config.swarm_ruff_filter(),
                 ),
                 goal=spec.get("goal", ""),
                 on_candidate=lambda c: self._persist_candidate(task_id, c),

--- a/src/swarm/static_gate.py
+++ b/src/swarm/static_gate.py
@@ -18,6 +18,7 @@ alone.
 from __future__ import annotations
 
 import asyncio
+from collections import Counter
 import json
 import shutil
 import sys
@@ -36,8 +37,13 @@ def ruff_bin() -> Optional[str]:
     return shutil.which("ruff")
 
 
-async def count_violations(source: bytes, timeout: float = 10.0) -> Optional[int]:
-    """F821/F823 violation count for `source`, or None when the gate cannot
+ViolationCounts = Counter[tuple[str, str]]
+
+
+async def violation_counts(
+    source: bytes, timeout: float = 10.0
+) -> Optional[ViolationCounts]:
+    """F821/F823 diagnostics keyed by rule and message, or None when the gate cannot
     run (ruff missing, timeout, or internal error) — callers must treat None
     as gate-disabled, never as clean."""
     binary = ruff_bin()
@@ -47,6 +53,8 @@ async def count_violations(source: bytes, timeout: float = 10.0) -> Optional[int
         proc = await asyncio.create_subprocess_exec(
             binary, "check",
             "--select", _RUFF_RULES,
+            "--isolated",
+            "--ignore-noqa",
             "--output-format", "json",
             "--stdin-filename", "candidate.py",
             "-",
@@ -69,4 +77,21 @@ async def count_violations(source: bytes, timeout: float = 10.0) -> Optional[int
         findings = json.loads(out.decode("utf-8", errors="replace") or "[]")
     except ValueError:
         return None
-    return len(findings) if isinstance(findings, list) else None
+    if not isinstance(findings, list):
+        return None
+    counts: ViolationCounts = Counter()
+    for finding in findings:
+        if not isinstance(finding, dict):
+            return None
+        code = finding.get("code")
+        message = finding.get("message")
+        if not isinstance(code, str) or not isinstance(message, str):
+            return None
+        counts[(code, message)] += 1
+    return counts
+
+
+async def count_violations(source: bytes, timeout: float = 10.0) -> Optional[int]:
+    """Compatibility helper returning the total F821/F823 diagnostic count."""
+    counts = await violation_counts(source, timeout=timeout)
+    return sum(counts.values()) if counts is not None else None

--- a/src/swarm/static_gate.py
+++ b/src/swarm/static_gate.py
@@ -1,0 +1,72 @@
+"""$0 static fast-gate between compile() and the sandbox stages.
+
+compile() accepts code with undefined names (NameError is a runtime error),
+so an LLM hallucination like a misspelled variable survives compilation and
+burns seconds of sandbox time before the tests kill it. ruff's
+pyflakes-derived F821/F823 checks catch exactly that class statically in
+tens of milliseconds via stdin, for $0 — a strict cheapest-filter-first win.
+
+Deliberately NOT style linting: style rules would cull mutant diversity for
+no objective gain, so the rule selection is correctness-only. The gate is
+BASELINE-RELATIVE — a target file that already trips F-rules (wildcard
+imports, dynamic names) must not have every mutant killed — and it degrades
+to a no-op when ruff is unavailable or errors: the tests stage still catches
+everything this gate would have, so it only ever saves time, never decides
+alone.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import sys
+from pathlib import Path
+from typing import Optional
+
+# Correctness-only pyflakes rules: undefined name / local used before binding.
+_RUFF_RULES = "F821,F823"
+
+
+def ruff_bin() -> Optional[str]:
+    """The venv's ruff first (a pinned project dependency), PATH second."""
+    sibling = Path(sys.executable).parent / "ruff"
+    if sibling.exists():
+        return str(sibling)
+    return shutil.which("ruff")
+
+
+async def count_violations(source: bytes, timeout: float = 10.0) -> Optional[int]:
+    """F821/F823 violation count for `source`, or None when the gate cannot
+    run (ruff missing, timeout, or internal error) — callers must treat None
+    as gate-disabled, never as clean."""
+    binary = ruff_bin()
+    if not binary:
+        return None
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            binary, "check",
+            "--select", _RUFF_RULES,
+            "--output-format", "json",
+            "--stdin-filename", "candidate.py",
+            "-",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except OSError:
+        return None
+    try:
+        out, _err = await asyncio.wait_for(proc.communicate(source), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        return None
+    # ruff: 0 = clean, 1 = violations found, anything else = tool error.
+    if proc.returncode not in (0, 1):
+        return None
+    try:
+        findings = json.loads(out.decode("utf-8", errors="replace") or "[]")
+    except ValueError:
+        return None
+    return len(findings) if isinstance(findings, list) else None

--- a/tests/test_swarm_static_gate.py
+++ b/tests/test_swarm_static_gate.py
@@ -1,5 +1,5 @@
 # tests/test_swarm_static_gate.py
-# The $0 static fast-gate: ruff F821/F823 counting (baseline-relative,
+# The $0 static fast-gate: ruff F821/F823 diagnostics (baseline-relative,
 # degrade-to-no-op) and AST no-op mutant detection. Plus funnel wiring: a
 # compiling-but-undefined-name mutant must die at the "lint" stage without
 # ever booting the sandbox, and a formatting-only no-op must be a free
@@ -15,7 +15,7 @@ from src.swarm.engine import EngineConfig, SwarmEngine
 from src.swarm.generate import GenerationResult
 from src.swarm.preflight import run_preflight
 from src.swarm.sandbox import SwarmSandbox
-from src.swarm.static_gate import count_violations, ruff_bin
+from src.swarm.static_gate import count_violations, ruff_bin, violation_counts
 from src.swarm.ast_utils import span_line_range
 
 FIXTURE = Path(__file__).parent / "fixtures" / "swarm_target"
@@ -50,9 +50,22 @@ class TestCountViolations:
         assert await count_violations(ugly) == 0
 
     @pytest.mark.asyncio
+    async def test_noqa_cannot_suppress_correctness_gate(self):
+        source = b"def f():\n    return hallucinated  # noqa: F821\n"
+        assert await count_violations(source) == 1
+
+    @pytest.mark.asyncio
     async def test_missing_ruff_returns_none(self, monkeypatch):
         monkeypatch.setattr("src.swarm.static_gate.ruff_bin", lambda: None)
         assert await count_violations(b"def f(): pass\n") is None
+
+    @pytest.mark.asyncio
+    async def test_diagnostics_distinguish_equal_count_name_changes(self):
+        old = await violation_counts(b"def f():\n    return old_missing\n")
+        new = await violation_counts(b"def f():\n    return new_missing\n")
+        assert old is not None and new is not None
+        assert sum(old.values()) == sum(new.values()) == 1
+        assert new - old
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -190,6 +203,34 @@ class TestFunnelGate:
         outcomes = await engine.run()
         stages = [c["stage_reached"] for o in outcomes for c in o.candidates]
         assert stages and all(s != "lint" for s in stages)
+
+    @pytest.mark.asyncio
+    async def test_equal_count_different_violation_is_fatal(self, engine_env):
+        # A total-count comparison would let the mutant trade old_missing for
+        # new_missing. Diagnostic multiset comparison must reject the new name.
+        original = b"def slow_sort(items):\n    return sorted(old_missing)\n"
+        engine_env.write_target(original)
+        start, end = extract_node_span(original, "function:slow_sort")
+
+        async def gen(prompt, system, *, remaining_budget_usd, **kw):
+            return GenerationResult(
+                "def slow_sort(items):\n    return sorted(new_missing)\n",
+                "CLI", 0.0, "final_answer",
+            )
+
+        engine = SwarmEngine(
+            sandbox=engine_env, task_id="t-trade", focus_node="function:slow_sort",
+            target_rel="slow_mod.py", test_target="test_slow.py",
+            bench_argv=[engine_env.python_bin(), "bench_slow.py"],
+            baseline={"latency_ms": 5.0, "latency_samples": [5.0, 5.0, 5.0]},
+            span=(start, end), original_span=original[start:end], file_source=original,
+            config=EngineConfig(population=1, max_generations=1, seed=1,
+                                bench_repeats=3, eval_timeout=60.0),
+            generator=gen,
+        )
+        outcomes = await engine.run()
+        stages = [c["stage_reached"] for o in outcomes for c in o.candidates]
+        assert stages == ["lint"]
 
     @pytest.mark.asyncio
     async def test_formatting_noop_mutant_is_free_discard(self, engine_env):

--- a/tests/test_swarm_static_gate.py
+++ b/tests/test_swarm_static_gate.py
@@ -1,0 +1,209 @@
+# tests/test_swarm_static_gate.py
+# The $0 static fast-gate: ruff F821/F823 counting (baseline-relative,
+# degrade-to-no-op) and AST no-op mutant detection. Plus funnel wiring: a
+# compiling-but-undefined-name mutant must die at the "lint" stage without
+# ever booting the sandbox, and a formatting-only no-op must be a free
+# discard.
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from src.swarm.ast_utils import extract_node_span, is_ast_identical
+from src.swarm.engine import EngineConfig, SwarmEngine
+from src.swarm.generate import GenerationResult
+from src.swarm.preflight import run_preflight
+from src.swarm.sandbox import SwarmSandbox
+from src.swarm.static_gate import count_violations, ruff_bin
+from src.swarm.ast_utils import span_line_range
+
+FIXTURE = Path(__file__).parent / "fixtures" / "swarm_target"
+
+# Compiles fine (NameError is runtime) but trips F821 — the exact
+# hallucination class the gate exists for.
+_UNDEFINED_NAME = "def slow_sort(items):\n    return sorted(resultz)\n"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# count_violations
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestCountViolations:
+    def test_ruff_is_a_pinned_dependency(self):
+        assert ruff_bin() is not None, "ruff must ship with the project venv"
+
+    @pytest.mark.asyncio
+    async def test_clean_source_counts_zero(self):
+        assert await count_violations(b"def f(x):\n    return x + 1\n") == 0
+
+    @pytest.mark.asyncio
+    async def test_undefined_name_counted(self):
+        count = await count_violations(_UNDEFINED_NAME.encode())
+        assert count is not None and count >= 1
+
+    @pytest.mark.asyncio
+    async def test_style_violations_do_not_count(self):
+        # Ugly but correct code must pass: the gate is correctness-only, so
+        # style rules never cull mutant diversity.
+        ugly = b"import os\ndef f( x ):\n  y=x;  return  y\n"  # unused import, spacing
+        assert await count_violations(ugly) == 0
+
+    @pytest.mark.asyncio
+    async def test_missing_ruff_returns_none(self, monkeypatch):
+        monkeypatch.setattr("src.swarm.static_gate.ruff_bin", lambda: None)
+        assert await count_violations(b"def f(): pass\n") is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# is_ast_identical
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestAstIdentical:
+    ORIGINAL = b"def f(items):\n    total = 0\n    for i in items:\n        total += i\n    return total\n"
+
+    def test_comment_and_whitespace_only_is_identical(self):
+        variant = (
+            b"def f(items):\n    # accumulate\n    total = 0\n\n"
+            b"    for i in items:\n        total += i\n    return total\n"
+        )
+        assert is_ast_identical(self.ORIGINAL, variant) is True
+
+    def test_real_change_is_not_identical(self):
+        assert is_ast_identical(self.ORIGINAL, b"def f(items):\n    return sum(items)\n") is False
+
+    def test_indented_method_span_handled(self):
+        original = b"    def m(self):\n        return 1\n"
+        same = b"    def m(self):  # noqa\n        return 1\n"
+        assert is_ast_identical(original, same) is True
+
+    def test_unparseable_returns_false_never_raises(self):
+        assert is_ast_identical(b"def f(:\n", b"def f(:\n") is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Funnel wiring (real sandbox, fake generator)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def engine_env(tmp_path):
+    ws = tmp_path / "ws"
+    shutil.copytree(FIXTURE, ws)
+    sb = SwarmSandbox(ws, tmp_path / "wr", "slow_mod.py")
+    sb.create()
+    yield sb
+    sb.destroy()
+
+
+async def _make_engine(sb, generator, **cfg):
+    src = sb.read_target()
+    start, end = extract_node_span(src, "function:slow_sort")
+    oracle = await run_preflight(
+        sb, target_rel="slow_mod.py", span_lines=span_line_range(src, start, end),
+        test_target="test_slow.py", bench_argv=[sb.python_bin(), "bench_slow.py"],
+        bench_repeats=3, eval_timeout=60.0, stage_budget_fraction=0.9,
+    )
+    cfg.setdefault("population", 2)
+    cfg.setdefault("max_generations", 1)
+    cfg.setdefault("seed", 1)
+    cfg.setdefault("bench_repeats", 3)
+    cfg.setdefault("eval_timeout", 60.0)
+    return SwarmEngine(
+        sandbox=sb, task_id="t-gate", focus_node="function:slow_sort",
+        target_rel="slow_mod.py", test_target="test_slow.py",
+        bench_argv=[sb.python_bin(), "bench_slow.py"], baseline=oracle["bench"],
+        span=(start, end), original_span=src[start:end], file_source=src,
+        config=EngineConfig(**cfg), generator=generator,
+    )
+
+
+class TestFunnelGate:
+    @pytest.mark.asyncio
+    async def test_undefined_name_dies_at_lint_without_sandbox(self, engine_env):
+        async def gen(prompt, system, *, remaining_budget_usd, **kw):
+            return GenerationResult(_UNDEFINED_NAME, "CLI", 0.0, "final_answer")
+
+        engine = await _make_engine(engine_env, gen)
+        # Spy: the sandbox tests must never run for a lint-killed mutant.
+        calls = []
+        original_run_tests = engine_env.run_tests
+
+        async def spy(*args, **kw):
+            calls.append(args)
+            return await original_run_tests(*args, **kw)
+
+        engine_env.run_tests = spy
+        outcomes = await engine.run()
+        stages = [c["stage_reached"] for o in outcomes for c in o.candidates]
+        assert stages and all(s == "lint" for s in stages)
+        assert calls == []  # sandbox never booted for these mutants
+
+    @pytest.mark.asyncio
+    async def test_gate_disabled_falls_through_to_tests(self, engine_env):
+        async def gen(prompt, system, *, remaining_budget_usd, **kw):
+            return GenerationResult(_UNDEFINED_NAME, "CLI", 0.0, "final_answer")
+
+        engine = await _make_engine(engine_env, gen, ruff_filter=False)
+        outcomes = await engine.run()
+        stages = [c["stage_reached"] for o in outcomes for c in o.candidates]
+        # Without the gate the tests stage still catches it — the gate only
+        # ever saves time, never decides alone.
+        assert stages and all(s == "tests" for s in stages)
+
+    @pytest.mark.asyncio
+    async def test_gate_noops_when_ruff_missing(self, engine_env, monkeypatch):
+        monkeypatch.setattr("src.swarm.static_gate.ruff_bin", lambda: None)
+
+        async def gen(prompt, system, *, remaining_budget_usd, **kw):
+            return GenerationResult(_UNDEFINED_NAME, "CLI", 0.0, "final_answer")
+
+        engine = await _make_engine(engine_env, gen)
+        outcomes = await engine.run()
+        stages = [c["stage_reached"] for o in outcomes for c in o.candidates]
+        assert stages and all(s == "tests" for s in stages)
+
+    @pytest.mark.asyncio
+    async def test_baseline_relative_preexisting_violation_not_fatal(self, engine_env):
+        # Inject a pre-existing F821 into an UNRELATED function of the file:
+        # the baseline count rises with it, so a clean mutant must pass.
+        src = engine_env.read_target()
+        polluted = src + b"\n\ndef broken_helper():\n    return missing_name\n"
+        engine_env.write_target(polluted)
+
+        fast = "def slow_sort(items):\n    return sorted(list(items))\n"
+
+        async def gen(prompt, system, *, remaining_budget_usd, **kw):
+            return GenerationResult(fast, "CLI", 0.0, "final_answer")
+
+        src2 = engine_env.read_target()
+        start, end = extract_node_span(src2, "function:slow_sort")
+        engine = SwarmEngine(
+            sandbox=engine_env, task_id="t-rel", focus_node="function:slow_sort",
+            target_rel="slow_mod.py", test_target="test_slow.py",
+            bench_argv=[engine_env.python_bin(), "bench_slow.py"],
+            baseline={"latency_ms": 5.0, "latency_samples": [5.0, 5.0, 5.0]},
+            span=(start, end), original_span=src2[start:end], file_source=src2,
+            config=EngineConfig(population=1, max_generations=1, seed=1,
+                                bench_repeats=3, eval_timeout=60.0),
+            generator=gen,
+        )
+        outcomes = await engine.run()
+        stages = [c["stage_reached"] for o in outcomes for c in o.candidates]
+        assert stages and all(s != "lint" for s in stages)
+
+    @pytest.mark.asyncio
+    async def test_formatting_noop_mutant_is_free_discard(self, engine_env):
+        src = engine_env.read_target()
+        start, end = extract_node_span(src, "function:slow_sort")
+        # Same AST, different bytes (added comment) → distinct hash, no-op AST.
+        noop = src[start:end].decode().replace(
+            "def slow_sort(items):", "def slow_sort(items):\n    # cosmetic"
+        )
+
+        async def gen(prompt, system, *, remaining_budget_usd, **kw):
+            return GenerationResult(noop, "CLI", 0.0, "final_answer")
+
+        engine = await _make_engine(engine_env, gen)
+        outcomes = await engine.run()
+        # Discarded like a duplicate: no candidate rows at all.
+        assert all(not o.candidates for o in outcomes)

--- a/uv.lock
+++ b/uv.lock
@@ -851,6 +851,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pytest" },
     { name = "python-dotenv" },
+    { name = "ruff" },
     { name = "starlette" },
     { name = "tiktoken" },
     { name = "tree-sitter" },
@@ -875,6 +876,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "ruff", specifier = ">=0.9" },
     { name = "starlette", specifier = ">=1.3.1" },
     { name = "tiktoken", specifier = ">=0.7.0" },
     { name = "tree-sitter", specifier = ">=0.25,<0.26" },
@@ -1663,6 +1665,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
     { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
     { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/36/6f65aa9989acdec45d417192d8f4e7921931d8a6cf87ac74bce3eed98a8e/ruff-0.15.21.tar.gz", hash = "sha256:d0cfc841c572283c36548f82664a54ce6565567f1b0d5b4cf2caac693d8b7500", size = 4769401, upload-time = "2026-07-09T20:01:34.005Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/c6/ede15cac6839f3dbce52565c8f5164a8210e669c7bc4decb03e5bdf47d0d/ruff-0.15.21-py3-none-linux_armv6l.whl", hash = "sha256:63ea0e965e5d73c90e95b2434beeafc70820536717f561b32ab6e777cb9bdf5d", size = 10854342, upload-time = "2026-07-09T20:00:53.998Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9d/d825b07ee7ea9e2d61df92a860033c94e06e7300d50a1c2653aac27d24fe/ruff-0.15.21-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0f212c5d7d54c01bbfe6dcab02b724a39300f3e34ed7acbe995ccb320a2c58bd", size = 11139539, upload-time = "2026-07-09T20:00:57.809Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/de/3b107712e642f063c7a9e0887c427b22cb44097de5aab36c05f2e280670c/ruff-0.15.21-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e6312e41bc96791299614995ea3a977c5857c3b5662b1ecef6755b02b87cb646", size = 10595437, upload-time = "2026-07-09T20:01:00.006Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/6f/b4523cc90ba239ede441447a19d0c968846a3012e5a0b0c5b62831a3d5e3/ruff-0.15.21-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01d65b4831c6b2a4ba8ee6faa84049d44d982b7a706e622c4094c509e51673be", size = 10990053, upload-time = "2026-07-09T20:01:02.187Z" },
+    { url = "https://files.pythonhosted.org/packages/92/cc/c6a9872a5375f0628875481cf2f66b13d7d865bf3ca2e57f91c7e762d976/ruff-0.15.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2c5a913a589120ce67933d5d05fd6ddbcc2481c6a054980ee767f7414c72b4fd", size = 10666096, upload-time = "2026-07-09T20:01:04.299Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/97/c621f7a17e097f1790fa3af6374138823b330b2d03fc38337945daca212c/ruff-0.15.21-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5ef04b681d02ad4dc9620f00f83ac5c22f652d0e9a9cfe431d219b16ad5ccc41", size = 11537011, upload-time = "2026-07-09T20:01:06.771Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/51/d928727e476e25ccc57c6f449ffd80241a651a973ad949d39cfb2a771d28/ruff-0.15.21-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:16d090c0740916594157e75b80d666eab8e78083b39b3b0e1d698f4670a17b86", size = 12347101, upload-time = "2026-07-09T20:01:08.859Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/88/8cd62026802b16018ad06931d87997cf795ba2a6239ab659606c87d96bf0/ruff-0.15.21-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a10e74757dd65004d779b73e2f3c5210156d9980b41224d50d2ebcf1db51e67", size = 11572001, upload-time = "2026-07-09T20:01:11.092Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/97/f63084cf55444fc110e8cb985ebfcc592af47f597d44453d778cb81bc156/ruff-0.15.21-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bab0905d2f29e0d9fbc3c373ed23db0095edaa3f71f1f4f519ec15134d9e85c8", size = 11549239, upload-time = "2026-07-09T20:01:13.27Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/77/f107da4a2874b7715914b03f09ba9c54424de3ff8a1cc5d015d3ee2ce0ac/ruff-0.15.21-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:00eca240af5789fec6fe7df74c088cc1f9644ed83027113468efba7c92b94075", size = 11535340, upload-time = "2026-07-09T20:01:15.206Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e9/601deb322d3303a7bf212b0100ead6f2ee3f6a044d89c30f2f92bf83c731/ruff-0.15.21-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:262ab31557a75141325e32d3357f3597645a7f084e732b6b054dde428ecd9341", size = 10964048, upload-time = "2026-07-09T20:01:17.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/2e/0f2176d1e99c15192caea19c8c3a0a955246b4cb4de795042eeb616345cd/ruff-0.15.21-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:659c4e7a4212f83306045ec7c5e5a356d16d9a6ef4ae0c7a4d872914fc655d9d", size = 10667055, upload-time = "2026-07-09T20:01:19.73Z" },
+    { url = "https://files.pythonhosted.org/packages/48/60/abd74a02e0c4214f12a68becfd30af7165cfdcb0e661ecdc60bbb949c09a/ruff-0.15.21-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9e866eab611a5f959d36df2d10e446973a3610bc42b0c15b31dc27977d59c233", size = 11242043, upload-time = "2026-07-09T20:01:21.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c6/583075d8ccabb4b229345edcaf1545eb3d8d6be90f686a479d7e94088bbf/ruff-0.15.21-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e89bc93c0d3803ba870b55c29671bad9dc6d94bb1eb181b056b52eb05b52854f", size = 11648064, upload-time = "2026-07-09T20:01:24.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/3c/37d0ecb729a7cc2d393ea7dce316fc585680f35d93b8d62139d7d0a3700c/ruff-0.15.21-py3-none-win32.whl", hash = "sha256:01f8d5be84823c172b389e123174f781f9daf86d6c58719d603f941932195cdd", size = 10896555, upload-time = "2026-07-09T20:01:26.941Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b8/e43466b2a6067ce91e669068f6e28d6c719a920f014b070d5c8731725de3/ruff-0.15.21-py3-none-win_amd64.whl", hash = "sha256:d4b8d9a2f0f12b816b50447f6eccb9f4bb01a6b82c86b50fb3b5354b458dc6d3", size = 12038772, upload-time = "2026-07-09T20:01:29.497Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/75/e90ab9aeece218a9fc5a5bc3ec97d0ee6bb3c4ff95869463c1de58e29a1c/ruff-0.15.21-py3-none-win_arm64.whl", hash = "sha256:6e83115d4b9377c1cbc13abf0e051f069fab0ef815ea0504a8a008cee24dd0a8", size = 11375265, upload-time = "2026-07-09T20:01:31.772Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- add the Claude-originated Ruff F821/F823 fast-gate and AST-equivalent no-op discard
- run Ruff with isolated configuration and ignore generated `noqa` suppressions
- compare baseline-relative diagnostic multisets so equal-count violation swaps cannot evade the gate
- keep the gate correctness-only, fail-open on tool errors, and independently configurable
- regenerate the OKF API reference and update project continuity

## Review findings repaired by Codex

1. Generated `# noqa: F821` comments could suppress the proposed correctness gate.
2. Comparing only total violation counts allowed a mutant to replace a pre-existing violation with a different new violation.

Both are covered by direct and end-to-end regressions.

## Verification

- `uv run pytest -q` — 1,018 passed
- `uv run python -m evals run` — 12/12 passed
- `uv run python scripts/generate_okf.py --check` — clean
- focused swarm regression suite — 41 passed

The repository-mandated UniGrok peer-review call was attempted with a selected diff, but the safety boundary rejected sending private repository code to xAI. No workaround was attempted; Codex completed the review locally.

## Provenance

- originating implementation: Claude via Claude Code (`2b157d74df7a6e35e57b800afab572a89615a92c`)
- review, repairs, verification, and integration: Codex via Codex Desktop
- human sponsor: @djtelicloud