### PR TITLE
feat(swarm): add hardened Pareto Playground UI

### DIFF
--- a/.codex/memory/active-work.md
+++ b/.codex/memory/active-work.md
@@ -9,6 +9,17 @@ drift-prone values live before acting. Do not copy secrets or OAuth codes here.
 
 ## Current repository state
 
+- The Claude-originated Pareto Playground and
+  `get_swarm_status(task_id, view="json")` contract are integrated through the
+  protected Codex path; resolve the PR and rebased merge commit live. Codex
+  review made the JSON-export picker CSP-safe, prohibited Apply for static
+  exports and non-terminal runs, preserved empty generations in replay, and
+  kept JSON oracle failures secret-redacted. The reviewed head passed 1,021
+  tests, 12/12 offline evals, deterministic OKF verification, JavaScript syntax
+  checking, and a real browser run against persisted engine data with two
+  Pareto elites, honest latency/memory trade-offs, full receipts/diff, and no
+  browser console errors.
+
 - The Claude-originated swarm static fast-gate is integrated through the
   protected Codex path; resolve its PR and rebased merge commit live. Codex
   review hardened Ruff execution with isolated configuration and ignored
@@ -136,8 +147,8 @@ drift-prone values live before acting. Do not copy secrets or OAuth codes here.
 
 ## Remaining gates
 
-The v0.6.0 release, Claude intelligence, swarm optimizer, and static fast-gate
-gates are complete:
+The v0.6.0 release, Claude intelligence, swarm optimizer, static fast-gate, and
+Pareto Playground gates are complete:
 
 1. Sites production environment revision `5` includes the non-secret
    `CONTROL_CENTER_ORIGIN=https://control.grokmcp.org`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to UniGrok MCP will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Swarm Pareto Playground** (`/ui/swarm.html`) and a machine-readable status
+  view: `get_swarm_status(task_id, view="json")` returns the stable
+  `unigrok-swarm-status-v1` payload — generations grouped for replay,
+  color-mappable outcomes (static wall / test wall / dominated / Pareto
+  elite), front ids, and honest aggregates (feasibility rate, best Δlatency/
+  Δmemory vs baseline, cost-to-optimize). The standalone workbench page
+  renders it as an animated generation-by-generation scatter with the front
+  highlighted, a wall gutter (unmeasured candidates are never plotted at
+  invented coordinates), a per-candidate receipt + side-by-side diff panel,
+  and an apply button gated exactly like the tool. The same page consumes a
+  static JSON export of the payload, so a public showcase renders
+  identically to the live workbench with zero extra backend. Unmeasured
+  fields (hardware counters, semantic scores) are absent by design.
 - **Swarm optimizer $0 static fast-gate**: mutants now pass a
   baseline-relative ruff `F821`/`F823` check (undefined names — the
   hallucination class `compile()` cannot catch) between compile and the

--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -1790,14 +1790,23 @@ scripts/swarm_bench.py is the easy path).
 ### Function: `get_swarm_status` {#tools-swarm-get_swarm_status}
 
 ```python
-async def get_swarm_status(task_id: str) -> str
+async def get_swarm_status(task_id: str, view: Literal['text', 'json']='text') -> str
 ```
 
 **Keywords:** get, swarm, status
 
 Report a swarm's status, the oracle-honesty facts (focus-span coverage,
 bench stability), the current Pareto front with relative deltas, and
-spend.
+spend. ``view="json"`` returns the stable machine-readable payload
+(format ``unigrok-swarm-status-v1``) that the local workbench and any
+static export consume — one call renders the whole run.
+
+The JSON schema is deliberately honest: it carries ONLY measured values.
+No ``instructions_retired``/``allocated_blocks`` (hardware counters are
+the OptiBench harness's domain, not measurable on this stack), no
+``semantic_*`` scores (no judge exists in the v1 funnel by contract), and
+no invented cost comparisons — ``aggregates`` are computed from the same
+SQLite rows the text view reads.
 
 ### Function: `apply_swarm_winner` {#tools-swarm-apply_swarm_winner}
 

--- a/mcp_ui/swarm.html
+++ b/mcp_ui/swarm.html
@@ -70,7 +70,7 @@
           <input id="token" type="password" placeholder="bearer token (optional)" />
           <button id="loadBtn">Load</button>
           <label>
-            <button type="button" onclick="document.getElementById('fileInput').click()">Load JSON export…</button>
+            <button id="fileBtn" type="button">Load JSON export…</button>
             <input id="fileInput" type="file" accept=".json" style="display:none" />
           </label>
           <span id="loadMsg" class="muted"></span>

--- a/mcp_ui/swarm.html
+++ b/mcp_ui/swarm.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>UniGrok Swarm Optimizer — Pareto Playground</title>
+  <style>
+    :root {
+      --bg: #0e1013; --panel: #16191d; --panel2: #1c2026; --border: #2a2f36;
+      --text: #e7e9ec; --muted: #8b8d98;
+      --red: #e5484d; --orange: #f5a623; --gray: #8b8d98; --green: #30a46c;
+      --accent: #4f8cff;
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; background: var(--bg); color: var(--text);
+           font: 14px/1.5 -apple-system, "Segoe UI", Roboto, sans-serif; }
+    header { display: flex; align-items: baseline; gap: 12px; padding: 14px 20px;
+             border-bottom: 1px solid var(--border); }
+    header h1 { font-size: 16px; margin: 0; }
+    header a { color: var(--accent); text-decoration: none; font-size: 12px; }
+    .wrap { display: grid; grid-template-columns: 1fr 340px; gap: 14px;
+            padding: 14px 20px; max-width: 1280px; }
+    .panel { background: var(--panel); border: 1px solid var(--border);
+             border-radius: 8px; padding: 12px; }
+    .controls { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+    input[type=text], input[type=password] { background: var(--panel2); color: var(--text);
+      border: 1px solid var(--border); border-radius: 6px; padding: 6px 8px; min-width: 230px; }
+    button { background: var(--panel2); color: var(--text); border: 1px solid var(--border);
+             border-radius: 6px; padding: 6px 12px; cursor: pointer; }
+    button:hover { border-color: var(--accent); }
+    button:disabled { opacity: .45; cursor: not-allowed; }
+    .scorecard { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+                 gap: 8px; margin-top: 12px; }
+    .stat { background: var(--panel2); border: 1px solid var(--border); border-radius: 8px;
+            padding: 8px 10px; }
+    .stat .k { color: var(--muted); font-size: 11px; text-transform: uppercase;
+               letter-spacing: .04em; }
+    .stat .v { font-size: 16px; font-weight: 600; margin-top: 2px; }
+    .legend { display: flex; gap: 14px; flex-wrap: wrap; margin: 10px 0 4px;
+              color: var(--muted); font-size: 12px; }
+    .legend span::before { content: "●"; margin-right: 5px; }
+    .lg-red::before { color: var(--red); } .lg-orange::before { color: var(--orange); }
+    .lg-gray::before { color: var(--gray); } .lg-green::before { color: var(--green); }
+    #chart { width: 100%; background: var(--panel2); border: 1px solid var(--border);
+             border-radius: 8px; }
+    .timeline { display: flex; gap: 10px; align-items: center; margin-top: 10px; }
+    .timeline input[type=range] { flex: 1; }
+    #detail pre { background: var(--panel2); border: 1px solid var(--border);
+                  border-radius: 6px; padding: 8px; overflow: auto; max-height: 220px;
+                  font-size: 12px; white-space: pre-wrap; }
+    .diff-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+    .muted { color: var(--muted); }
+    .honesty { color: var(--muted); font-size: 11px; padding: 10px 20px 20px; max-width: 1280px; }
+    .err { color: var(--red); }
+    circle.dot { cursor: pointer; }
+    circle.elite { filter: drop-shadow(0 0 4px var(--green)); }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Swarm Optimizer — Pareto Playground</h1>
+    <a href="./index.html">← Control Center</a>
+  </header>
+
+  <div class="wrap">
+    <div>
+      <div class="panel">
+        <div class="controls">
+          <input id="taskId" type="text" placeholder="swarm task id" />
+          <input id="token" type="password" placeholder="bearer token (optional)" />
+          <button id="loadBtn">Load</button>
+          <label>
+            <button type="button" onclick="document.getElementById('fileInput').click()">Load JSON export…</button>
+            <input id="fileInput" type="file" accept=".json" style="display:none" />
+          </label>
+          <span id="loadMsg" class="muted"></span>
+        </div>
+        <div id="scorecard" class="scorecard"></div>
+      </div>
+
+      <div class="panel" style="margin-top:14px">
+        <div class="legend">
+          <span class="lg-red">static wall (parse/signature/compile/lint)</span>
+          <span class="lg-orange">test wall</span>
+          <span class="lg-gray">feasible, dominated</span>
+          <span class="lg-green">Pareto elite</span>
+          <span>★ baseline</span>
+        </div>
+        <svg id="chart" viewBox="0 0 860 420" role="img"
+             aria-label="Latency versus peak memory scatter of swarm candidates"></svg>
+        <div class="timeline">
+          <button id="playBtn">▶ Play</button>
+          <input id="genSlider" type="range" min="1" max="1" value="1" />
+          <span id="genLabel" class="muted">generation –</span>
+        </div>
+        <div class="muted" style="font-size:11px">
+          Unmeasured candidates (killed at a wall before bench) stack in the left
+          gutter — plotting them at invented coordinates would be fiction.
+        </div>
+      </div>
+    </div>
+
+    <div class="panel" id="detail">
+      <div class="muted">Click a dot for its full receipt.</div>
+    </div>
+  </div>
+
+  <div class="honesty">
+    Every value on this page is read from the swarm's SQLite rows via
+    <code>get_swarm_status(view="json")</code> (format
+    <code>unigrok-swarm-status-v1</code>) or a static export of the same payload.
+    Nothing is simulated. Fields this stack does not measure — hardware
+    instruction counters, LLM semantic scores — are absent by design, not
+    hidden. "Verified" means: the task's own <code>test_target</code> passed.
+  </div>
+
+  <script src="./swarm.js"></script>
+</body>
+</html>

--- a/mcp_ui/swarm.js
+++ b/mcp_ui/swarm.js
@@ -16,7 +16,7 @@ const COLORS = {
   pareto_elite: "var(--green)",
 };
 
-const state = { payload: null, maxGen: 1, shownGen: 1, playing: null };
+const state = { payload: null, source: null, maxGen: 1, shownGen: 1, playing: null };
 
 // ── MCP plumbing (same JSON-RPC shape the Control Center uses) ──────────────
 
@@ -61,7 +61,7 @@ async function loadLive() {
     const raw = await mcpCall("get_swarm_status", { task_id: taskId, view: "json" });
     const payload = JSON.parse(raw);
     if (payload.error) { setMsg(payload.error, true); return; }
-    setPayload(payload, "live");
+    setPayload(payload, "live", "live");
   } catch (err) {
     setMsg(String(err.message || err), true);
   }
@@ -76,7 +76,7 @@ function loadFile(file) {
         setMsg("not a unigrok-swarm-status-v1 export", true);
         return;
       }
-      setPayload(payload, `export: ${file.name}`);
+      setPayload(payload, `export: ${file.name}`, "export");
     } catch (err) {
       setMsg(`unreadable export: ${err.message}`, true);
     }
@@ -90,8 +90,9 @@ function setMsg(text, isError) {
   el.className = isError ? "err" : "muted";
 }
 
-function setPayload(payload, sourceLabel) {
+function setPayload(payload, sourceLabel, source) {
   state.payload = payload;
+  state.source = source;
   state.maxGen = Math.max(1, ...(payload.generations || []).map((g) => g.generation));
   state.shownGen = state.maxGen;
   $("genSlider").max = String(state.maxGen);
@@ -299,10 +300,16 @@ function renderDetail(candidate) {
       : (p.original_span || "(unavailable)");
     html += `<div class="muted" style="margin-top:8px">original vs candidate</div>
              <div class="diff-grid"><pre>${esc(original)}</pre><pre>${esc(candidate.code)}</pre></div>`;
-    const applyDisabled = p.mode !== "active" || p.original_span_stale;
-    const reason = p.mode !== "active"
-      ? "apply is disabled outside UNIGROK_SWARM=active"
-      : (p.original_span_stale ? "file changed since the swarm ran" : "");
+    const terminal = p.status === "completed" || p.status === "cancelled";
+    const applyDisabled = state.source !== "live" || p.mode !== "active"
+      || !terminal || p.original_span_stale;
+    const reason = state.source !== "live"
+      ? "apply is disabled for static exports; load the live task"
+      : (p.mode !== "active"
+        ? "apply is disabled outside UNIGROK_SWARM=active"
+        : (!terminal
+          ? "apply is disabled while the swarm is still running"
+          : (p.original_span_stale ? "file changed since the swarm ran" : "")));
     html += `<div style="margin-top:8px">
                <button id="applyBtn" ${applyDisabled ? "disabled" : ""}>Apply optimization</button>
                <span class="muted" style="font-size:11px"> ${esc(reason)}</span>
@@ -355,6 +362,7 @@ $("genSlider").addEventListener("input", (event) => {
 });
 
 $("loadBtn").addEventListener("click", loadLive);
+$("fileBtn").addEventListener("click", () => $("fileInput").click());
 $("taskId").addEventListener("keydown", (e) => { if (e.key === "Enter") loadLive(); });
 $("fileInput").addEventListener("change", (e) => {
   if (e.target.files && e.target.files[0]) loadFile(e.target.files[0]);

--- a/mcp_ui/swarm.js
+++ b/mcp_ui/swarm.js
@@ -1,0 +1,361 @@
+// Swarm Optimizer — Pareto Playground.
+// Renders one unigrok-swarm-status-v1 payload (live via get_swarm_status
+// view="json", or a static JSON export of the same payload — identical
+// rendering is the local/public symmetry). No frameworks, no CDN, no
+// simulated data: unmeasured candidates stack in a gutter instead of being
+// plotted at invented coordinates.
+
+"use strict";
+
+const $ = (id) => document.getElementById(id);
+const SVG_NS = "http://www.w3.org/2000/svg";
+const COLORS = {
+  static_wall: "var(--red)",
+  test_wall: "var(--orange)",
+  dominated: "var(--gray)",
+  pareto_elite: "var(--green)",
+};
+
+const state = { payload: null, maxGen: 1, shownGen: 1, playing: null };
+
+// ── MCP plumbing (same JSON-RPC shape the Control Center uses) ──────────────
+
+let rpcId = 1;
+async function mcpCall(toolName, args) {
+  const headers = {
+    "Content-Type": "application/json",
+    "Accept": "application/json, text/event-stream",
+    "X-Client-ID": "mcp-ui-swarm",
+  };
+  const token = $("token").value.trim();
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  const res = await fetch("/mcp", {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      method: "tools/call",
+      params: { name: toolName, arguments: args },
+      id: rpcId++,
+    }),
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`HTTP ${res.status}: ${text.slice(0, 300)}`);
+  // Server may answer plain JSON or a single SSE data: frame.
+  const jsonText = text.startsWith("event:") || text.startsWith("data:")
+    ? text.split("\n").filter((l) => l.startsWith("data:")).map((l) => l.slice(5)).join("")
+    : text;
+  const rpc = JSON.parse(jsonText);
+  if (rpc.error) throw new Error(rpc.error.message || "MCP error");
+  const content = rpc.result?.content?.[0]?.text ?? "";
+  return content;
+}
+
+// ── Loading ──────────────────────────────────────────────────────────────────
+
+async function loadLive() {
+  const taskId = $("taskId").value.trim();
+  if (!taskId) { setMsg("enter a task id", true); return; }
+  setMsg("loading…");
+  try {
+    const raw = await mcpCall("get_swarm_status", { task_id: taskId, view: "json" });
+    const payload = JSON.parse(raw);
+    if (payload.error) { setMsg(payload.error, true); return; }
+    setPayload(payload, "live");
+  } catch (err) {
+    setMsg(String(err.message || err), true);
+  }
+}
+
+function loadFile(file) {
+  const reader = new FileReader();
+  reader.onload = () => {
+    try {
+      const payload = JSON.parse(String(reader.result));
+      if (payload.format !== "unigrok-swarm-status-v1") {
+        setMsg("not a unigrok-swarm-status-v1 export", true);
+        return;
+      }
+      setPayload(payload, `export: ${file.name}`);
+    } catch (err) {
+      setMsg(`unreadable export: ${err.message}`, true);
+    }
+  };
+  reader.readAsText(file);
+}
+
+function setMsg(text, isError) {
+  const el = $("loadMsg");
+  el.textContent = text;
+  el.className = isError ? "err" : "muted";
+}
+
+function setPayload(payload, sourceLabel) {
+  state.payload = payload;
+  state.maxGen = Math.max(1, ...(payload.generations || []).map((g) => g.generation));
+  state.shownGen = state.maxGen;
+  $("genSlider").max = String(state.maxGen);
+  $("genSlider").value = String(state.maxGen);
+  setMsg(`loaded (${sourceLabel})`);
+  renderScorecard();
+  renderChart();
+  $("detail").innerHTML = '<div class="muted">Click a dot for its full receipt.</div>';
+}
+
+// ── Scorecard ────────────────────────────────────────────────────────────────
+
+function fmtPct(v) { return v == null ? "n/a" : `${v.toFixed(1)}%`; }
+function fmtUsd(v) { return v == null ? "n/a" : `$${Number(v).toFixed(4)}`; }
+
+function renderScorecard() {
+  const p = state.payload;
+  const agg = p.aggregates || {};
+  const oracle = p.oracle || {};
+  const bench = (oracle.bench || {});
+  const cards = [
+    ["status", `${p.status} (${p.mode})`],
+    ["feasibility rate", agg.feasibility_rate == null ? "n/a"
+      : `${(agg.feasibility_rate * 100).toFixed(0)}% of ${agg.candidates_total}`],
+    ["best Δlatency", fmtPct(agg.best_latency_improvement_pct)],
+    ["best Δmemory", fmtPct(agg.best_memory_improvement_pct)],
+    ["cost to optimize", `${fmtUsd(agg.cost_to_optimize_usd)} / $${(p.budget?.budget_usd ?? 0).toFixed(2)}`],
+    ["focus coverage", oracle.focus_coverage_pct == null ? "n/a" : `${oracle.focus_coverage_pct}%`],
+    ["bench", `${bench.stability || "n/a"} (floor ${bench.noise_floor_pct ?? "?"}%)`],
+    ["generations", String(p.budget?.generations_run ?? 0)],
+  ];
+  $("scorecard").innerHTML = cards
+    .map(([k, v]) => `<div class="stat"><div class="k">${esc(k)}</div><div class="v">${esc(v)}</div></div>`)
+    .join("");
+}
+
+function esc(value) {
+  return String(value).replace(/[&<>"]/g, (ch) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[ch]));
+}
+
+// ── Chart ────────────────────────────────────────────────────────────────────
+
+const M = { l: 70, r: 20, t: 16, b: 42 };
+const W = 860, H = 420;
+const GUTTER_X = 34; // unmeasured candidates stack here, outside the axes
+
+function candidatesUpTo(gen) {
+  return (state.payload.generations || [])
+    .filter((g) => g.generation <= gen)
+    .flatMap((g) => g.candidates);
+}
+
+function renderChart() {
+  const svg = $("chart");
+  svg.innerHTML = "";
+  const p = state.payload;
+  const shown = candidatesUpTo(state.shownGen);
+  const measured = shown.filter((c) => c.feasible && c.latency_ms != null);
+  const walls = shown.filter((c) => !(c.feasible && c.latency_ms != null));
+  const baseline = p.baseline || {};
+
+  const xs = measured.map((c) => c.latency_ms).concat(baseline.latency_ms ?? []);
+  const ys = measured.map((c) => c.peak_mem_bytes).concat(baseline.peak_mem_bytes ?? []);
+  const [x0, x1] = pad(Math.min(...xs, Infinity), Math.max(...xs, -Infinity));
+  const [y0, y1] = pad(Math.min(...ys, Infinity), Math.max(...ys, -Infinity));
+  const sx = (v) => M.l + ((v - x0) / (x1 - x0)) * (W - M.l - M.r);
+  const sy = (v) => H - M.b - ((v - y0) / (y1 - y0)) * (H - M.t - M.b);
+
+  drawAxes(svg, x0, x1, y0, y1, sx, sy);
+
+  // Gutter stack: killed-before-measurement candidates, deterministic order.
+  walls.forEach((c, i) => {
+    dot(svg, GUTTER_X, H - M.b - 10 - i * 12, 4, COLORS[c.outcome] || "var(--red)", c, false);
+  });
+  if (walls.length) {
+    label(svg, GUTTER_X, H - M.b + 16, "walls", "middle");
+  }
+
+  // Baseline star.
+  if (baseline.latency_ms != null && baseline.peak_mem_bytes != null) {
+    const el = document.createElementNS(SVG_NS, "text");
+    el.setAttribute("x", sx(baseline.latency_ms));
+    el.setAttribute("y", sy(baseline.peak_mem_bytes) + 5);
+    el.setAttribute("text-anchor", "middle");
+    el.setAttribute("fill", "var(--text)");
+    el.setAttribute("font-size", "16");
+    el.textContent = "★";
+    svg.appendChild(el);
+  }
+
+  // Front polyline (elites shown so far, sorted by latency).
+  const elites = measured
+    .filter((c) => c.outcome === "pareto_elite")
+    .sort((a, b) => a.latency_ms - b.latency_ms);
+  if (elites.length > 1) {
+    const line = document.createElementNS(SVG_NS, "polyline");
+    line.setAttribute("points", elites.map((c) => `${sx(c.latency_ms)},${sy(c.peak_mem_bytes)}`).join(" "));
+    line.setAttribute("fill", "none");
+    line.setAttribute("stroke", "var(--green)");
+    line.setAttribute("stroke-width", "1.5");
+    line.setAttribute("stroke-dasharray", "4 3");
+    svg.appendChild(line);
+  }
+
+  // Measured dots (dominated under elites).
+  measured
+    .sort((a, b) => (a.outcome === "pareto_elite") - (b.outcome === "pareto_elite"))
+    .forEach((c) => {
+      const r = 4 + Math.min(6, Math.sqrt((c.diff_bytes || 0) / 12));
+      dot(svg, sx(c.latency_ms), sy(c.peak_mem_bytes), r,
+          COLORS[c.outcome] || "var(--gray)", c, c.outcome === "pareto_elite");
+    });
+
+  $("genLabel").textContent = `generation ${state.shownGen}/${state.maxGen}`;
+}
+
+function pad(lo, hi) {
+  if (!isFinite(lo) || !isFinite(hi)) return [0, 1];
+  if (lo === hi) return [lo * 0.95 - 1, hi * 1.05 + 1];
+  const span = hi - lo;
+  return [lo - span * 0.08, hi + span * 0.08];
+}
+
+function drawAxes(svg, x0, x1, y0, y1, sx, sy) {
+  const axis = (x1p, y1p, x2p, y2p) => {
+    const l = document.createElementNS(SVG_NS, "line");
+    l.setAttribute("x1", x1p); l.setAttribute("y1", y1p);
+    l.setAttribute("x2", x2p); l.setAttribute("y2", y2p);
+    l.setAttribute("stroke", "var(--border)");
+    svg.appendChild(l);
+  };
+  axis(M.l, H - M.b, W - M.r, H - M.b);
+  axis(M.l, M.t, M.l, H - M.b);
+  for (let i = 0; i <= 4; i++) {
+    const xv = x0 + ((x1 - x0) * i) / 4;
+    const yv = y0 + ((y1 - y0) * i) / 4;
+    label(svg, sx(xv), H - M.b + 16, xv.toFixed(2), "middle");
+    label(svg, M.l - 8, sy(yv) + 4, humanBytes(yv), "end");
+  }
+  label(svg, (M.l + W - M.r) / 2, H - 6, "latency_ms (lower is better)", "middle");
+  const yl = document.createElementNS(SVG_NS, "text");
+  yl.setAttribute("transform", `translate(14 ${(M.t + H - M.b) / 2}) rotate(-90)`);
+  yl.setAttribute("text-anchor", "middle");
+  yl.setAttribute("fill", "var(--muted)");
+  yl.setAttribute("font-size", "11");
+  yl.textContent = "peak_mem_bytes (lower is better)";
+  svg.appendChild(yl);
+}
+
+function label(svg, x, y, text, anchor) {
+  const el = document.createElementNS(SVG_NS, "text");
+  el.setAttribute("x", x); el.setAttribute("y", y);
+  el.setAttribute("text-anchor", anchor);
+  el.setAttribute("fill", "var(--muted)");
+  el.setAttribute("font-size", "10");
+  el.textContent = text;
+  svg.appendChild(el);
+}
+
+function humanBytes(v) {
+  if (v >= 1048576) return `${(v / 1048576).toFixed(1)}M`;
+  if (v >= 1024) return `${(v / 1024).toFixed(1)}K`;
+  return String(Math.round(v));
+}
+
+function dot(svg, x, y, r, color, candidate, elite) {
+  const c = document.createElementNS(SVG_NS, "circle");
+  c.setAttribute("cx", x); c.setAttribute("cy", y); c.setAttribute("r", r);
+  c.setAttribute("fill", color);
+  c.setAttribute("fill-opacity", elite ? "0.95" : "0.75");
+  c.setAttribute("class", elite ? "dot elite" : "dot");
+  c.addEventListener("click", () => renderDetail(candidate));
+  const title = document.createElementNS(SVG_NS, "title");
+  title.textContent = `${candidate.candidate_id} — ${candidate.arm} — ${candidate.outcome}`;
+  c.appendChild(title);
+  svg.appendChild(c);
+}
+
+// ── Detail panel ─────────────────────────────────────────────────────────────
+
+function renderDetail(candidate) {
+  const p = state.payload;
+  const rows = [
+    ["candidate", candidate.candidate_id],
+    ["arm", candidate.arm],
+    ["outcome", candidate.outcome],
+    ["stage reached", candidate.stage],
+    ["latency_ms", candidate.latency_ms ?? "not measured"],
+    ["peak_mem_bytes", candidate.peak_mem_bytes ?? "not measured"],
+    ["diff_bytes", candidate.diff_bytes ?? "n/a"],
+    ["reward", candidate.reward ?? "n/a"],
+    ["token cost", fmtUsd(candidate.token_cost_usd)],
+  ];
+  let html = rows
+    .map(([k, v]) => `<div><span class="muted">${esc(k)}:</span> ${esc(v)}</div>`)
+    .join("");
+  if (candidate.arm_receipt) {
+    html += `<div class="muted" style="margin-top:8px">arm receipt</div>
+             <pre>${esc(JSON.stringify(candidate.arm_receipt, null, 2))}</pre>`;
+  }
+  if (candidate.code) {
+    const original = p.original_span_stale
+      ? "(file changed since the swarm ran — original span unavailable)"
+      : (p.original_span || "(unavailable)");
+    html += `<div class="muted" style="margin-top:8px">original vs candidate</div>
+             <div class="diff-grid"><pre>${esc(original)}</pre><pre>${esc(candidate.code)}</pre></div>`;
+    const applyDisabled = p.mode !== "active" || p.original_span_stale;
+    const reason = p.mode !== "active"
+      ? "apply is disabled outside UNIGROK_SWARM=active"
+      : (p.original_span_stale ? "file changed since the swarm ran" : "");
+    html += `<div style="margin-top:8px">
+               <button id="applyBtn" ${applyDisabled ? "disabled" : ""}>Apply optimization</button>
+               <span class="muted" style="font-size:11px"> ${esc(reason)}</span>
+             </div><div id="applyOut" class="muted" style="margin-top:6px;font-size:12px"></div>`;
+  }
+  $("detail").innerHTML = html;
+  const applyBtn = $("applyBtn");
+  if (applyBtn && !applyBtn.disabled) {
+    applyBtn.addEventListener("click", async () => {
+      if (!window.confirm(
+        `Apply ${candidate.candidate_id} to ${p.target?.path}? Tests re-run before it lands; the file reverts on failure.`
+      )) return;
+      applyBtn.disabled = true;
+      try {
+        $("applyOut").textContent = await mcpCall("apply_swarm_winner", {
+          candidate_id: candidate.candidate_id,
+        });
+      } catch (err) {
+        $("applyOut").textContent = String(err.message || err);
+      }
+    });
+  }
+}
+
+// ── Timeline / play ──────────────────────────────────────────────────────────
+
+function stopPlaying() {
+  if (state.playing) { clearInterval(state.playing); state.playing = null; }
+  $("playBtn").textContent = "▶ Play";
+}
+
+$("playBtn").addEventListener("click", () => {
+  if (!state.payload) return;
+  if (state.playing) { stopPlaying(); return; }
+  state.shownGen = 0;
+  $("playBtn").textContent = "⏸ Stop";
+  state.playing = setInterval(() => {
+    state.shownGen = Math.min(state.maxGen, state.shownGen + 1);
+    $("genSlider").value = String(state.shownGen);
+    renderChart();
+    if (state.shownGen >= state.maxGen) stopPlaying();
+  }, 650);
+});
+
+$("genSlider").addEventListener("input", (event) => {
+  if (!state.payload) return;
+  stopPlaying();
+  state.shownGen = Number(event.target.value);
+  renderChart();
+});
+
+$("loadBtn").addEventListener("click", loadLive);
+$("taskId").addEventListener("keydown", (e) => { if (e.key === "Enter") loadLive(); });
+$("fileInput").addEventListener("change", (e) => {
+  if (e.target.files && e.target.files[0]) loadFile(e.target.files[0]);
+});

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -1790,14 +1790,23 @@ scripts/swarm_bench.py is the easy path).
 ### Function: `get_swarm_status` {#tools-swarm-get_swarm_status}
 
 ```python
-async def get_swarm_status(task_id: str) -> str
+async def get_swarm_status(task_id: str, view: Literal['text', 'json']='text') -> str
 ```
 
 **Keywords:** get, swarm, status
 
 Report a swarm's status, the oracle-honesty facts (focus-span coverage,
 bench stability), the current Pareto front with relative deltas, and
-spend.
+spend. ``view="json"`` returns the stable machine-readable payload
+(format ``unigrok-swarm-status-v1``) that the local workbench and any
+static export consume — one call renders the whole run.
+
+The JSON schema is deliberately honest: it carries ONLY measured values.
+No ``instructions_retired``/``allocated_blocks`` (hardware counters are
+the OptiBench harness's domain, not measurable on this stack), no
+``semantic_*`` scores (no judge exists in the v1 funnel by contract), and
+no invented cost comparisons — ``aggregates`` are computed from the same
+SQLite rows the text view reads.
 
 ### Function: `apply_swarm_winner` {#tools-swarm-apply_swarm_winner}
 

--- a/src/tools/swarm.py
+++ b/src/tools/swarm.py
@@ -20,7 +20,7 @@ import signal
 import tempfile
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
@@ -210,19 +210,36 @@ async def start_code_swarm(
         )
 
 
-async def get_swarm_status(task_id: str) -> str:
+async def get_swarm_status(task_id: str, view: Literal["text", "json"] = "text") -> str:
     """Report a swarm's status, the oracle-honesty facts (focus-span coverage,
     bench stability), the current Pareto front with relative deltas, and
-    spend."""
+    spend. ``view="json"`` returns the stable machine-readable payload
+    (format ``unigrok-swarm-status-v1``) that the local workbench and any
+    static export consume — one call renders the whole run.
+
+    The JSON schema is deliberately honest: it carries ONLY measured values.
+    No ``instructions_retired``/``allocated_blocks`` (hardware counters are
+    the OptiBench harness's domain, not measurable on this stack), no
+    ``semantic_*`` scores (no judge exists in the v1 funnel by contract), and
+    no invented cost comparisons — ``aggregates`` are computed from the same
+    SQLite rows the text view reads."""
     async with GrokInvocationContext("utility", logger, append_signature=False) as ctx:
         task = await store.get_swarm_task(task_id)
         if not task:
+            if view == "json":
+                return json.dumps({"error": f"no swarm task {task_id}"}, separators=(",", ":"))
             return ctx.format_output(f"no swarm task `{task_id}`.")
         status = effective_status(task)
         oracle = _load_json(task.get("oracle_json"))
         baseline = _load_json(task.get("baseline_json"))
         candidates = await store.list_swarm_candidates(task_id, feasible_only=True)
         front = _current_front(candidates)
+
+        if view == "json":
+            return json.dumps(
+                await _status_payload(task, status, oracle, baseline, front),
+                separators=(",", ":"),
+            )
 
         lines = [
             f"# Swarm `{task_id}`",
@@ -373,6 +390,144 @@ async def _find_candidate(task_id: Optional[str], candidate_id: str) -> Optional
 def _current_front(candidates: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     ranked = rank_candidates([dict(candidate) for candidate in candidates])
     return [candidate for candidate in ranked if candidate.get("pareto_rank") == 0]
+
+
+_STATIC_WALL_STAGES = ("generated", "parse", "signature", "compile", "lint")
+
+
+def _candidate_outcome(candidate: Dict[str, Any], front_ids: set) -> str:
+    """Selection outcome the UI colors by: pareto_elite (green) >
+    dominated (gray) > test_wall (orange, ran but broke the oracle) >
+    static_wall (red, never survived the free filters)."""
+    if candidate["id"] in front_ids:
+        return "pareto_elite"
+    if candidate.get("feasible"):
+        return "dominated"
+    if candidate.get("stage_reached") in _STATIC_WALL_STAGES:
+        return "static_wall"
+    return "test_wall"
+
+
+async def _status_payload(
+    task: Dict[str, Any],
+    status: str,
+    oracle: Dict[str, Any],
+    baseline: Dict[str, Any],
+    front: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """The unigrok-swarm-status-v1 payload: every measured fact of one run,
+    grouped generation-by-generation so a frontend can replay the swarm
+    without further backend calls. Candidate ``code`` rides ONLY on Pareto
+    elites (bounded payload; the detail view exists for winners), and the
+    live original span is included only while base_file_hash still matches —
+    never a stale slice."""
+    all_candidates = await store.list_swarm_candidates(str(task["id"]))
+    front_ids = {c["id"] for c in front}
+    front_code = {c["id"]: c.get("code") for c in front}
+
+    generations: Dict[int, List[Dict[str, Any]]] = {}
+    feasible_count = 0
+    for row in all_candidates:
+        entry = {
+            "candidate_id": row["id"],
+            "arm": row.get("mutator"),
+            "stage": row.get("stage_reached"),
+            "outcome": _candidate_outcome(row, front_ids),
+            "feasible": bool(row.get("feasible")),
+            "latency_ms": row.get("latency_ms"),
+            "peak_mem_bytes": row.get("peak_mem_bytes"),
+            "diff_bytes": row.get("diff_bytes"),
+            "reward": row.get("reward"),
+            "token_cost_usd": float(row.get("gen_cost_usd") or 0.0),
+            "arm_receipt": _load_json(row.get("arm_receipt")) or None,
+        }
+        if row["id"] in front_ids:
+            entry["code"] = front_code.get(row["id"])
+        if entry["feasible"]:
+            feasible_count += 1
+        generations.setdefault(int(row.get("generation") or 0), []).append(entry)
+
+    base_latency = float((baseline or {}).get("latency_ms") or 0.0)
+    base_mem = float((baseline or {}).get("peak_mem_bytes") or 0.0)
+    best_latency_pct = None
+    best_mem_pct = None
+    if front and base_latency > 0:
+        best = min(float(c.get("latency_ms") or base_latency) for c in front)
+        best_latency_pct = round((base_latency - best) / base_latency * 100.0, 2)
+    if front and base_mem > 0:
+        best = min(float(c.get("peak_mem_bytes") or base_mem) for c in front)
+        best_mem_pct = round((base_mem - best) / base_mem * 100.0, 2)
+
+    original_span, span_stale = _live_original_span(task)
+    return {
+        "format": "unigrok-swarm-status-v1",
+        "task_id": task["id"],
+        "status": status,
+        "mode": swarm_config.swarm_mode(),
+        "target": {
+            "path": task.get("target_path"),
+            "focus_node": task.get("focus_node"),
+            "test_target": task.get("test_target"),
+            "bench_command": task.get("bench_command"),
+        },
+        "oracle": oracle or None,
+        "baseline": baseline or None,
+        "budget": {
+            "budget_usd": float(task.get("budget_usd") or 0.0),
+            "spent_usd": float(task.get("spent_usd") or 0.0),
+            "generations_run": int(task.get("generation") or 0),
+        },
+        "original_span": original_span,
+        "original_span_stale": span_stale,
+        "generations": [
+            {"generation": gen, "candidates": generations[gen]}
+            for gen in sorted(generations)
+        ],
+        "pareto_front": [
+            c["id"] for c in sorted(front, key=lambda x: float(x.get("latency_ms") or 0.0))
+        ],
+        "aggregates": {
+            "candidates_total": len(all_candidates),
+            "feasibility_rate": (
+                round(feasible_count / len(all_candidates), 4) if all_candidates else None
+            ),
+            "best_latency_improvement_pct": best_latency_pct,
+            "best_memory_improvement_pct": best_mem_pct,
+            "cost_to_optimize_usd": float(task.get("spent_usd") or 0.0),
+        },
+        "folded_state": task.get("folded_state") or None,
+    }
+
+
+def _live_original_span(task: Dict[str, Any]) -> tuple:
+    """(redacted original focus-span text, stale flag). None/True when the
+    workspace is unavailable or the file changed since the swarm ran — the
+    UI must show a staleness notice instead of a wrong diff."""
+    try:
+        target = _resolve_target(str(task.get("target_path") or ""))
+        live = target.read_bytes()
+    except (ValueError, FileNotFoundError, PermissionError, OSError):
+        return None, True
+    if hashlib.sha256(live).hexdigest() != task.get("base_file_hash"):
+        return None, True
+    rows_span = _task_span(task)
+    if rows_span is None:
+        return None, True
+    start, end = rows_span
+    if not (0 <= start < end <= len(live)):
+        return None, True
+    return redact_secrets(live[start:end].decode("utf-8", errors="replace")), False
+
+
+def _task_span(task: Dict[str, Any]) -> Optional[tuple]:
+    """Recover the focus span from the (hash-verified) live file."""
+    from ..swarm.ast_utils import extract_node_span
+
+    try:
+        target = _resolve_target(str(task.get("target_path") or ""))
+        return extract_node_span(target.read_bytes(), str(task.get("focus_node") or ""))
+    except (ValueError, FileNotFoundError, OSError):
+        return None
 
 
 async def _reverify(task: Dict[str, Any], target: Path, original: bytes) -> tuple:

--- a/src/tools/swarm.py
+++ b/src/tools/swarm.py
@@ -304,6 +304,12 @@ async def apply_swarm_winner(candidate_id: str) -> str:
         task = await store.get_swarm_task(candidate["task_id"])
         if not task:
             return ctx.format_output("owning swarm task not found.")
+        task_status = effective_status(task)
+        if task_status not in ("completed", "cancelled"):
+            return ctx.format_output(
+                "refusing to apply: the swarm is still running; wait for completion "
+                "or cancel it before applying a verified Pareto candidate."
+            )
         feasible = await store.list_swarm_candidates(task["id"], feasible_only=True)
         front_ids = {c["id"] for c in _current_front(feasible)}
         if candidate_id not in front_ids:
@@ -458,7 +464,12 @@ async def _status_payload(
         best = min(float(c.get("peak_mem_bytes") or base_mem) for c in front)
         best_mem_pct = round((base_mem - best) / base_mem * 100.0, 2)
 
+    generations_run = int(task.get("generation") or 0)
+    last_generation = max([generations_run, *generations.keys()], default=0)
     original_span, span_stale = _live_original_span(task)
+    safe_oracle = dict(oracle) if oracle else None
+    if safe_oracle and safe_oracle.get("error") is not None:
+        safe_oracle["error"] = redact_secrets(str(safe_oracle["error"]))[:400]
     return {
         "format": "unigrok-swarm-status-v1",
         "task_id": task["id"],
@@ -470,18 +481,18 @@ async def _status_payload(
             "test_target": task.get("test_target"),
             "bench_command": task.get("bench_command"),
         },
-        "oracle": oracle or None,
+        "oracle": safe_oracle,
         "baseline": baseline or None,
         "budget": {
             "budget_usd": float(task.get("budget_usd") or 0.0),
             "spent_usd": float(task.get("spent_usd") or 0.0),
-            "generations_run": int(task.get("generation") or 0),
+            "generations_run": generations_run,
         },
         "original_span": original_span,
         "original_span_stale": span_stale,
         "generations": [
-            {"generation": gen, "candidates": generations[gen]}
-            for gen in sorted(generations)
+            {"generation": gen, "candidates": generations.get(gen, [])}
+            for gen in range(1, last_generation + 1)
         ],
         "pareto_front": [
             c["id"] for c in sorted(front, key=lambda x: float(x.get("latency_ms") or 0.0))

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -98,6 +98,29 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert 'fallback_policy: $("fallbackPolicyInput").value' in script.text
 
 
+def test_mcp_ui_swarm_playground_is_served_and_honest(monkeypatch):
+    """The swarm Pareto Playground: served statically, consumes the
+    unigrok-swarm-status-v1 payload (live or static export — the local/public
+    symmetry), and keeps the no-simulated-data stance in its own copy."""
+    monkeypatch.delenv("UNIGROK_RUNTIME", raising=False)
+    monkeypatch.delenv("UNIGROK_API_KEYS", raising=False)
+
+    with TestClient(create_app(), base_url="http://localhost:8080") as client:
+        page = client.get("/ui/swarm.html")
+        script = client.get("/ui/swarm.js")
+
+    assert page.status_code == 200
+    assert "Pareto Playground" in page.text
+    assert "Nothing is simulated" in page.text
+    assert script.status_code == 200
+    assert "unigrok-swarm-status-v1" in script.text
+    assert "get_swarm_status" in script.text
+    # Walls are never plotted at invented coordinates.
+    assert "gutter" in script.text
+    # Apply stays gated by mode in the UI exactly like the tool.
+    assert "apply is disabled outside UNIGROK_SWARM=active" in script.text
+
+
 def test_mcp_ui_layout_engine_is_local_and_ide_first():
     with TestClient(create_app(), base_url="http://localhost:8080") as client:
         index = client.get("/ui/")

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -115,10 +115,15 @@ def test_mcp_ui_swarm_playground_is_served_and_honest(monkeypatch):
     assert script.status_code == 200
     assert "unigrok-swarm-status-v1" in script.text
     assert "get_swarm_status" in script.text
+    assert 'id="fileBtn"' in page.text
+    assert "onclick=" not in page.text  # blocked by the server's script-src CSP
+    assert 'state.source !== "live"' in script.text
+    assert "apply is disabled for static exports" in script.text
     # Walls are never plotted at invented coordinates.
     assert "gutter" in script.text
     # Apply stays gated by mode in the UI exactly like the tool.
     assert "apply is disabled outside UNIGROK_SWARM=active" in script.text
+    assert "apply is disabled while the swarm is still running" in script.text
 
 
 def test_mcp_ui_layout_engine_is_local_and_ide_first():

--- a/tests/test_swarm_tools.py
+++ b/tests/test_swarm_tools.py
@@ -139,6 +139,71 @@ class TestEndToEnd:
         assert "dry_run" in apply_out or "disabled" in apply_out
 
     @pytest.mark.asyncio
+    async def test_json_view_carries_the_full_replayable_run(self, wired, monkeypatch):
+        """unigrok-swarm-status-v1: one payload renders the whole run —
+        generations, outcomes for color mapping, front ids, honest aggregates
+        — and carries ONLY measured fields (no hardware counters, no
+        semantic scores, no invented cost comparisons)."""
+        import json as jsonlib
+
+        store, _ws = wired
+        monkeypatch.setenv("UNIGROK_SWARM", "dry_run")
+        monkeypatch.setenv("UNIGROK_SWARM_MAX_GENERATIONS", "2")
+        monkeypatch.setenv("UNIGROK_SWARM_POPULATION", "4")
+        monkeypatch.setenv("UNIGROK_SWARM_BENCH_REPEATS", "3")
+
+        out = await swarm_tools.start_code_swarm(
+            "pkg/dedup.py", "function:dedup", "pkg/test_dedup.py", "python pkg/bench_dedup.py",
+            allow_unstable_bench=True,
+        )
+        task_id = out.split("`")[1]
+        await swarm_tools._get_runner().wait(task_id, timeout=60.0)
+
+        payload = jsonlib.loads(await swarm_tools.get_swarm_status(task_id, view="json"))
+        assert payload["format"] == "unigrok-swarm-status-v1"
+        assert payload["task_id"] == task_id
+        assert payload["mode"] == "dry_run"
+        assert payload["target"]["focus_node"] == "function:dedup"
+        assert payload["oracle"]["focus_coverage_pct"] > 0
+        assert payload["baseline"]["latency_ms"] > 0
+
+        candidates = [c for g in payload["generations"] for c in g["candidates"]]
+        assert candidates
+        assert {c["outcome"] for c in candidates} <= {
+            "pareto_elite", "dominated", "static_wall", "test_wall"
+        }
+        front_ids = set(payload["pareto_front"])
+        assert front_ids  # the fast dedup wins
+        for c in candidates:
+            if c["candidate_id"] in front_ids:
+                assert c["outcome"] == "pareto_elite"
+                assert c.get("code")  # elites carry code for the diff view
+            else:
+                assert "code" not in c  # bounded payload: non-elites don't
+
+        agg = payload["aggregates"]
+        assert agg["candidates_total"] == len(candidates)
+        assert 0 < agg["feasibility_rate"] <= 1
+        assert agg["cost_to_optimize_usd"] == pytest.approx(0.0)  # CLI plane
+        # Honest omissions: unmeasured fields must not exist at all.
+        for c in candidates:
+            for absent in ("instructions_retired", "allocated_blocks",
+                           "semantic_correctness", "semantic_safety"):
+                assert absent not in c
+        assert "kv_cache_savings_pct" not in agg
+
+        # File untouched (dry_run) → live span present and not stale.
+        assert payload["original_span_stale"] is False
+        assert "def dedup" in payload["original_span"]
+
+    @pytest.mark.asyncio
+    async def test_json_view_unknown_task(self, wired):
+        import json as jsonlib
+
+        payload = jsonlib.loads(await swarm_tools.get_swarm_status("nope", view="json"))
+        assert "error" in payload
+
+    @pytest.mark.asyncio
     async def test_active_apply_lands_and_reverifies(self, wired, monkeypatch):
         store, workspace = wired
         monkeypatch.setenv("UNIGROK_SWARM", "active")

--- a/tests/test_swarm_tools.py
+++ b/tests/test_swarm_tools.py
@@ -166,6 +166,7 @@ class TestEndToEnd:
         assert payload["target"]["focus_node"] == "function:dedup"
         assert payload["oracle"]["focus_coverage_pct"] > 0
         assert payload["baseline"]["latency_ms"] > 0
+        assert [g["generation"] for g in payload["generations"]] == [1, 2]
 
         candidates = [c for g in payload["generations"] for c in g["candidates"]]
         assert candidates
@@ -196,6 +197,19 @@ class TestEndToEnd:
         assert payload["original_span_stale"] is False
         assert "def dedup" in payload["original_span"]
 
+        # The text view already redacts oracle failures; the JSON view must
+        # not reopen that secret-bearing output channel.
+        await store.update_swarm_task(
+            task_id,
+            oracle_json=jsonlib.dumps(
+                {"error": "failed with XAI_API_KEY=xai-supersecret123456"}
+            ),
+        )
+        redacted = jsonlib.loads(
+            await swarm_tools.get_swarm_status(task_id, view="json")
+        )
+        assert "xai-supersecret123456" not in redacted["oracle"]["error"]
+
     @pytest.mark.asyncio
     async def test_json_view_unknown_task(self, wired):
         import json as jsonlib
@@ -219,6 +233,14 @@ class TestEndToEnd:
         candidates = await store.list_swarm_candidates(task_id, feasible_only=True)
         assert candidates
         winner = candidates[0]
+
+        # A current front is provisional while later candidates can still
+        # arrive. Applying it mid-run would mutate the workspace underneath
+        # the active search.
+        monkeypatch.setattr(swarm_tools, "effective_status", lambda _task: "running")
+        early = await swarm_tools.apply_swarm_winner(winner["id"])
+        assert "still running" in early
+        monkeypatch.setattr(swarm_tools, "effective_status", lambda _task: "completed")
 
         before = (workspace / "pkg" / "dedup.py").read_text()
         apply_out = await swarm_tools.apply_swarm_winner(winner["id"])


### PR DESCRIPTION
## Summary

- add `get_swarm_status(task_id, view="json")` with the stable `unigrok-swarm-status-v1` replay contract
- add the dependency-free `/ui/swarm.html` Pareto Playground for live tasks and static exports
- retain only measured claims: candidate outcomes, Pareto membership, receipts, costs, latency/memory trade-offs, coverage, and benchmark stability
- integrate over the landed Ruff static gate and regenerate the canonical OKF bundle

## Codex landing-review repairs

1. Replaced the JSON-export button's CSP-blocked inline handler with external-script wiring.
2. Prevented static exports from enabling Apply, even when the exported payload says `active`.
3. Prevented backend/UI Apply while a swarm is still running and its front remains provisional.
4. Preserved empty generations so replay matches `generations_run` when every candidate was freely discarded.
5. Kept JSON oracle failures secret-redacted, matching the existing text view.

## Verification

- `uv run pytest -q` — 1,021 passed
- `uv run python -m evals run` — 12/12 passed
- `uv run python scripts/generate_okf.py --check` — clean
- `node --check mcp_ui/swarm.js` — clean
- real browser against persisted real engine data — completed 2-generation run, two Pareto elites, 98.5% latency improvement, −791% memory trade-off, full receipt/diff, correct 2/2 replay, dry-run Apply refusal, working CSP-safe file picker, no console errors

A fresh model-driven run was not repeated because the safety boundary rejected sending private repository code to xAI. The browser verification used Claude's already-persisted completed engine run; no workaround or new external transmission occurred. The controlled browser also refused uploading a synthetic local export, so export-source Apply gating remains locally code/test verified rather than upload-driven.

## Provenance

- originating implementation: Claude via Claude Code (`345c976a88fc8d2894deff5b5e5fcf454f35e4ee`)
- review, repairs, integration, and browser verification: Codex via Codex Desktop
- human sponsor: @djtelicloud