### PR TITLE
feat(ui): link the Swarm Optimizer from the Control Center sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to UniGrok MCP will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Control Center → Swarm Optimizer navigation**: the sidebar gains a
+  "Contributor" group with a page link to the Pareto Playground
+  (`/ui/swarm.html`). Deliberately a `.nav-link` anchor, not a `.nav-btn`,
+  so the tab router and its arrow-key traversal never bind it.
 - **Swarm Pareto Playground** (`/ui/swarm.html`) and a machine-readable status
   view: `get_swarm_status(task_id, view="json")` returns the stable
   `unigrok-swarm-status-v1` payload — generations grouped for replay,

--- a/mcp_ui/index.html
+++ b/mcp_ui/index.html
@@ -73,6 +73,13 @@
           <button id="tab-btn-metrics" type="button" class="nav-btn" data-tab="tab-metrics" role="tab" aria-selected="false" aria-controls="tab-metrics" tabindex="-1" title="Usage &amp; Telemetry">
             <span class="btn-icon" aria-hidden="true">📊</span><span class="btn-label">Usage &amp; Telemetry</span>
           </button>
+          <div class="nav-title nav-title-group">Contributor</div>
+          <!-- A real page link, deliberately NOT a .nav-btn: the tab router
+               and its arrow-key traversal bind .nav-btn only, so this never
+               hijacks tab switching or navigates during keyboard cycling. -->
+          <a id="nav-link-swarm" class="nav-link" href="./swarm.html" title="Swarm Optimizer — Pareto Playground">
+            <span class="btn-icon" aria-hidden="true">🐝</span><span class="btn-label">Swarm Optimizer</span>
+          </a>
           <details id="advancedNav" class="nav-advanced">
           <summary class="nav-title nav-title-group">Advanced</summary>
           <div class="nav-advanced-items">

--- a/mcp_ui/styles.css
+++ b/mcp_ui/styles.css
@@ -1869,3 +1869,30 @@ pre {
     display: none !important;
   }
 }
+
+/* Sidebar page links (Swarm Optimizer): nav-btn look, real navigation, inert
+   to the tab router (which binds .nav-btn only). */
+.nav-link {
+  background: transparent;
+  border: none;
+  text-align: left;
+  min-height: 38px;
+  padding: 9px 10px;
+  font-size: 13px;
+  font-weight: 500;
+  border-radius: var(--radius);
+  color: var(--ink-soft);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  transition: color 120ms ease, background-color 120ms ease;
+  white-space: nowrap;
+  overflow: hidden;
+  cursor: pointer;
+  text-decoration: none;
+}
+.nav-link:hover {
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--ink);
+}
+.console-grid[data-nav="rail"] .nav-link { justify-content: center; padding-inline: 5px; }

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -114,6 +114,14 @@ def test_mcp_ui_swarm_playground_is_served_and_honest(monkeypatch):
     assert "Nothing is simulated" in page.text
     assert script.status_code == 200
     assert "unigrok-swarm-status-v1" in script.text
+    # Discoverable from the Control Center sidebar — as a page LINK, not a
+    # .nav-btn, so the tab router and its keyboard traversal never bind it.
+    with TestClient(create_app(), base_url="http://localhost:8080") as client:
+        index = client.get("/ui/")
+    assert 'id="nav-link-swarm"' in index.text
+    assert 'href="./swarm.html"' in index.text
+    assert 'class="nav-link"' in index.text
+    assert "Swarm Optimizer" in index.text
     assert "get_swarm_status" in script.text
     assert 'id="fileBtn"' in page.text
     assert "onclick=" not in page.text  # blocked by the server's script-src CSP


### PR DESCRIPTION
## Handoff evidence (Codex landing gate)

**Commit:** `390ba09` (single commit on `main` @ `cfd7681`)
**Human sponsor:** @djtelicloud (authorized agent-published draft PRs, 2026-07-12)
**Provenance:** `Originating-Agent: Claude via Claude Code`

### What
The Pareto Playground (`/ui/swarm.html`) shipped reachable only by typing its URL. This adds a **Contributor** group to the Control Center sidebar with a page link to it.

### Why it's safe
- Deliberately an `<a class="nav-link">`, **not** a `.nav-btn`: the tab router binds `.nav-btn` for click handling and arrow-key traversal, so a page link sharing that class would call `switchTab(null)` and navigate away during keyboard tab cycling.
- CSS is **append-only** (`.nav-link` mirrors `.nav-btn` incl. rail-mode icon collapse) so every pinned Control Center test assertion stays byte-intact.
- New test pins the link (`id`, `href`, class) in `test_mcp_ui_swarm_playground_is_served_and_honest`.

### Changed paths
`mcp_ui/index.html`, `mcp_ui/styles.css`, `tests/test_mcp_ui.py`, `CHANGELOG.md`

### Verification
- `uv run pytest -q`: **1021 passed** (all pinned `test_mcp_ui` assertions green)
- `python -m evals run`: **12/12 PASS** byte-stable
- `generate_okf.py --check`: clean (no docstring surface touched)
- In-browser: renders in rail mode (🐝 icon centered), link navigates to the Playground

### Risks
Low — additive markup + append-only CSS; no server code touched. Worst case is a visual nit in an unusual layout mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)