### PR TITLE
feat(swarm): Playground on-ramp — sample run, task picker, one-click demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to UniGrok MCP will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- **Swarm Playground on-ramp**: the Pareto Playground no longer assumes a
+  pasted task id. It gains a one-click sample (a bundled RECORDED run of the
+  golden dedup target whose payload carries its own provenance: scripted
+  candidates, real measurements), a recent-swarms picker backed by the new
+  read-only `list_swarm_tasks` MCP tool (newest first, staleness-aware
+  status), and a "Run demo swarm" button that launches `start_code_swarm` on
+  the golden O(N²) target and live-polls the run to completion — surfacing
+  the tool's own refusal verbatim when the swarm mode or contributor gates
+  say no.
 - **Private cloud control plane completion**: RFC 8414/9728 OAuth discovery,
   dynamic public-client registration, authorization-code PKCE, ten-minute
   scoped tokens, live GitHub membership introspection/revocation, and

--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -1826,6 +1826,19 @@ async def cancel_swarm(task_id: str) -> str
 
 Cooperatively cancel a running swarm; the partial Pareto front is kept.
 
+### Function: `list_swarm_tasks` {#tools-swarm-list_swarm_tasks}
+
+```python
+async def list_swarm_tasks(limit: int=10) -> str
+```
+
+**Keywords:** list, swarm, tasks
+
+List recent swarm tasks newest-first as a JSON array (id, effective
+status incl. staleness override, target, focus node, generations run,
+spend). The Playground's task picker consumes this — read-only, no gate:
+on a service that never ran a swarm it simply returns [].
+
 ## tools/system.py {#tools-system}
 
 ### Function: `grok_mcp_status` {#tools-system-grok_mcp_status}

--- a/mcp_ui/swarm-sample.json
+++ b/mcp_ui/swarm-sample.json
@@ -1,0 +1,162 @@
+{
+ "format": "unigrok-swarm-status-v1",
+ "task_id": "f6ebeacbd1e743d9a994e0d122d66119",
+ "status": "completed",
+ "mode": "dry_run",
+ "target": {
+  "path": "pkg/dedup.py",
+  "focus_node": "function:dedup",
+  "test_target": "pkg/test_dedup.py",
+  "bench_command": "python pkg/bench_dedup.py"
+ },
+ "oracle": {
+  "module": "pkg.dedup",
+  "import_provenance": "ok",
+  "baseline_test_seconds": 0.146,
+  "focus_coverage_pct": 100.0,
+  "bench": {
+   "latency_ms": 1.1251917007029988,
+   "peak_mem_bytes": 3200,
+   "noise_floor_pct": 5.0,
+   "drift_pct": 4.35,
+   "stability": "stable"
+  }
+ },
+ "baseline": {
+  "latency_ms": 1.1251917007029988,
+  "peak_mem_bytes": 3200,
+  "noise_floor_pct": 5.0,
+  "drift_pct": 4.35,
+  "stability": "stable"
+ },
+ "budget": {
+  "budget_usd": 2.0,
+  "spent_usd": 0.0,
+  "generations_run": 3
+ },
+ "original_span": "def dedup(items):\n    result = []\n    for item in items:\n        if item not in result:  # O(N) scan per element -> O(N^2) overall\n            result.append(item)\n    return result",
+ "original_span_stale": false,
+ "generations": [
+  {
+   "generation": 1,
+   "candidates": [
+    {
+     "candidate_id": "f6ebeacbd1e743d9a994e0d122d66119-g1-s1-algorithmic",
+     "arm": "algorithmic",
+     "stage": "bench",
+     "outcome": "pareto_elite",
+     "feasible": true,
+     "latency_ms": 0.020156250684522092,
+     "peak_mem_bytes": 43640,
+     "diff_bytes": 64,
+     "reward": 1.0,
+     "token_cost_usd": 0.0,
+     "arm_receipt": {
+      "arm": "algorithmic",
+      "reason": "round_robin_cold_start",
+      "step": 1,
+      "generation": 1,
+      "decay": 0.95,
+      "scores": {
+       "algorithmic": null,
+       "allocation": null,
+       "hot_loop": null,
+       "simplify": null
+      },
+      "pulls": {
+       "algorithmic": 1,
+       "allocation": 0,
+       "hot_loop": 0,
+       "simplify": 0
+      }
+     },
+     "code": "def dedup(items):\n    seen = set()\n    result = []\n    for item in items:\n        if item not in seen:\n            seen.add(item)\n            result.append(item)\n    return result"
+    },
+    {
+     "candidate_id": "f6ebeacbd1e743d9a994e0d122d66119-g1-s2-allocation",
+     "arm": "allocation",
+     "stage": "bench",
+     "outcome": "pareto_elite",
+     "feasible": true,
+     "latency_ms": 0.013639598910231143,
+     "peak_mem_bytes": 30032,
+     "diff_bytes": 164,
+     "reward": 1.0,
+     "token_cost_usd": 0.0,
+     "arm_receipt": {
+      "arm": "allocation",
+      "reason": "round_robin_cold_start",
+      "step": 2,
+      "generation": 1,
+      "decay": 0.95,
+      "scores": {
+       "algorithmic": null,
+       "allocation": null,
+       "hot_loop": null,
+       "simplify": null
+      },
+      "pulls": {
+       "algorithmic": 1,
+       "allocation": 1,
+       "hot_loop": 0,
+       "simplify": 0
+      }
+     },
+     "code": "def dedup(items):\n    return list(dict.fromkeys(items))"
+    },
+    {
+     "candidate_id": "f6ebeacbd1e743d9a994e0d122d66119-g1-s3-hot_loop",
+     "arm": "hot_loop",
+     "stage": "tests",
+     "outcome": "test_wall",
+     "feasible": false,
+     "latency_ms": null,
+     "peak_mem_bytes": null,
+     "diff_bytes": 151,
+     "reward": 0.15,
+     "token_cost_usd": 0.0,
+     "arm_receipt": {
+      "arm": "hot_loop",
+      "reason": "round_robin_cold_start",
+      "step": 3,
+      "generation": 1,
+      "decay": 0.95,
+      "scores": {
+       "algorithmic": null,
+       "allocation": null,
+       "hot_loop": null,
+       "simplify": null
+      },
+      "pulls": {
+       "algorithmic": 1,
+       "allocation": 1,
+       "hot_loop": 1,
+       "simplify": 0
+      }
+     }
+    }
+   ]
+  },
+  {
+   "generation": 2,
+   "candidates": []
+  },
+  {
+   "generation": 3,
+   "candidates": []
+  }
+ ],
+ "pareto_front": [
+  "f6ebeacbd1e743d9a994e0d122d66119-g1-s2-allocation",
+  "f6ebeacbd1e743d9a994e0d122d66119-g1-s1-algorithmic"
+ ],
+ "aggregates": {
+  "candidates_total": 3,
+  "feasibility_rate": 0.6667,
+  "best_latency_improvement_pct": 98.79,
+  "best_memory_improvement_pct": -838.5,
+  "cost_to_optimize_usd": 0.0
+ },
+ "folded_state": "[Compacted state fold of 2 earlier messages in this session]\nGOAL: optimize function:dedup in pkg/dedup.py\nCONSTRAINTS:\n- tests that must pass: pkg/test_dedup.py\n- benchmark: /Users/djtelicloud/Documents/agentixai/grok-mcp-server/.claude/worktrees/project-setup-af34d0/.venv/bin/python3 pkg/bench_dedup.py\n- improvements below the noise floor do not count\nACTIVE FILES:\n- pkg/dedup.py\nNARRATIVE: Generation 3. Pareto front holds 2 candidate(s); best latency improvement so far: 98.8% faster.",
+ "provenance": "Recorded demo run on the golden nsquared_dedup target. Candidate CODE was scripted for reproducibility; every measurement (tests, benchmarks, Pareto ranks, rewards) is real engine output."
+}

--- a/mcp_ui/swarm.html
+++ b/mcp_ui/swarm.html
@@ -25,6 +25,8 @@
     .controls { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
     input[type=text], input[type=password] { background: var(--panel2); color: var(--text);
       border: 1px solid var(--border); border-radius: 6px; padding: 6px 8px; min-width: 230px; }
+    select { background: var(--panel2); color: var(--text); border: 1px solid var(--border);
+             border-radius: 6px; padding: 6px 8px; max-width: 340px; }
     button { background: var(--panel2); color: var(--text); border: 1px solid var(--border);
              border-radius: 6px; padding: 6px 12px; cursor: pointer; }
     button:hover { border-color: var(--accent); }
@@ -66,6 +68,14 @@
     <div>
       <div class="panel">
         <div class="controls">
+          <button id="sampleBtn" type="button" title="Recorded run of the golden dedup target — scripted candidates, real measurements">▶ Load sample run</button>
+          <button id="demoBtn" type="button" title="Runs start_code_swarm on the golden O(N²) dedup target (contributor mode + UNIGROK_SWARM=dry_run required)">🐝 Run demo swarm</button>
+          <select id="taskPicker" title="Recent swarms on this gateway">
+            <option value="">recent swarms…</option>
+          </select>
+          <button id="refreshTasksBtn" type="button" title="Refresh the recent-swarm list">⟳</button>
+        </div>
+        <div class="controls" style="margin-top:8px">
           <input id="taskId" type="text" placeholder="swarm task id" />
           <input id="token" type="password" placeholder="bearer token (optional)" />
           <button id="loadBtn">Load</button>

--- a/mcp_ui/swarm.js
+++ b/mcp_ui/swarm.js
@@ -367,3 +367,102 @@ $("taskId").addEventListener("keydown", (e) => { if (e.key === "Enter") loadLive
 $("fileInput").addEventListener("change", (e) => {
   if (e.target.files && e.target.files[0]) loadFile(e.target.files[0]);
 });
+
+// ── On-ramp: sample run, recent-swarm picker, one-click golden demo ──────────
+// Three ways to see the instrument without pasting a task id. The sample is a
+// RECORDED run (its payload carries a `provenance` field: scripted candidates,
+// real measurements); it loads as source "export", so apply stays disabled.
+
+const GOLDEN_DEMO = {
+  target_path: "evals/tasks/swarm_targets/nsquared_dedup/dedup.py",
+  focus_node: "function:dedup",
+  test_target: "evals/tasks/swarm_targets/nsquared_dedup/test_dedup.py",
+  bench_command: "python evals/tasks/swarm_targets/nsquared_dedup/bench_dedup.py",
+  allow_unstable_bench: true,
+};
+const TERMINAL_STATUSES = new Set(
+  ["completed", "failed", "failed_stale", "cancelled", "stopped_budget"]
+);
+
+async function loadSample() {
+  setMsg("loading sample…");
+  try {
+    const res = await fetch("./swarm-sample.json");
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const payload = await res.json();
+    if (payload.format !== "unigrok-swarm-status-v1") {
+      throw new Error("sample is not a unigrok-swarm-status-v1 export");
+    }
+    setPayload(payload, "sample: recorded golden-dedup run", "export");
+    if (payload.provenance) setMsg(payload.provenance);
+  } catch (err) {
+    setMsg(`sample unavailable: ${err.message || err}`, true);
+  }
+}
+
+async function refreshTaskPicker() {
+  const picker = $("taskPicker");
+  try {
+    const raw = await mcpCall("list_swarm_tasks", { limit: 15 });
+    const tasks = JSON.parse(raw);
+    picker.replaceChildren(new Option(
+      tasks.length ? "recent swarms…" : "no swarms on this gateway yet", ""
+    ));
+    for (const task of tasks) {
+      const label = `${task.status} · ${task.focus_node} · ${task.task_id.slice(0, 8)}…`;
+      picker.appendChild(new Option(label, task.task_id));
+    }
+  } catch (err) {
+    picker.replaceChildren(new Option("recent swarms unavailable (offline?)", ""));
+  }
+}
+
+async function runGoldenDemo() {
+  const btn = $("demoBtn");
+  btn.disabled = true;
+  setMsg("starting demo swarm on the golden O(N²) dedup target…");
+  try {
+    const out = await mcpCall("start_code_swarm", GOLDEN_DEMO);
+    const match = out.match(/`([0-9a-f]{16,})`/);
+    if (!match) {
+      // Refusals (mode off, stable service, no workspace) are instructive —
+      // show the tool's own words verbatim.
+      setMsg(out.replace(/\s+/g, " ").trim(), true);
+      return;
+    }
+    const taskId = match[1];
+    $("taskId").value = taskId;
+    await pollUntilDone(taskId);
+    refreshTaskPicker();
+  } catch (err) {
+    setMsg(String(err.message || err), true);
+  } finally {
+    btn.disabled = false;
+  }
+}
+
+async function pollUntilDone(taskId, intervalMs = 3000, maxPolls = 200) {
+  for (let i = 0; i < maxPolls; i++) {
+    const raw = await mcpCall("get_swarm_status", { task_id: taskId, view: "json" });
+    const payload = JSON.parse(raw);
+    if (payload.error) { setMsg(payload.error, true); return; }
+    setPayload(payload, "live", "live");
+    if (TERMINAL_STATUSES.has(payload.status)) {
+      setMsg(`demo ${payload.status} — ${payload.pareto_front.length} elite(s) on the front`);
+      return;
+    }
+    setMsg(`demo running… (${payload.status}, generation ${payload.budget?.generations_run ?? 0})`);
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  setMsg("stopped polling — the swarm is still running; reload manually.", true);
+}
+
+$("sampleBtn").addEventListener("click", loadSample);
+$("demoBtn").addEventListener("click", runGoldenDemo);
+$("refreshTasksBtn").addEventListener("click", refreshTaskPicker);
+$("taskPicker").addEventListener("change", (event) => {
+  if (!event.target.value) return;
+  $("taskId").value = event.target.value;
+  loadLive();
+});
+refreshTaskPicker();

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -1826,6 +1826,19 @@ async def cancel_swarm(task_id: str) -> str
 
 Cooperatively cancel a running swarm; the partial Pareto front is kept.
 
+### Function: `list_swarm_tasks` {#tools-swarm-list_swarm_tasks}
+
+```python
+async def list_swarm_tasks(limit: int=10) -> str
+```
+
+**Keywords:** list, swarm, tasks
+
+List recent swarm tasks newest-first as a JSON array (id, effective
+status incl. staleness override, target, focus node, generations run,
+spend). The Playground's task picker consumes this — read-only, no gate:
+on a service that never ran a swarm it simply returns [].
+
 ## tools/system.py {#tools-system}
 
 ### Function: `grok_mcp_status` {#tools-system-grok_mcp_status}

--- a/src/tools/swarm.py
+++ b/src/tools/swarm.py
@@ -368,6 +368,28 @@ async def cancel_swarm(task_id: str) -> str:
         )
 
 
+async def list_swarm_tasks(limit: int = 10) -> str:
+    """List recent swarm tasks newest-first as a JSON array (id, effective
+    status incl. staleness override, target, focus node, generations run,
+    spend). The Playground's task picker consumes this — read-only, no gate:
+    on a service that never ran a swarm it simply returns []."""
+    async with GrokInvocationContext("utility", logger, append_signature=False) as ctx:  # noqa: F841
+        rows = await store.list_swarm_tasks(limit=max(1, min(int(limit or 10), 50)))
+        items = [
+            {
+                "task_id": row["id"],
+                "status": effective_status(row),
+                "target": row.get("target_path"),
+                "focus_node": row.get("focus_node"),
+                "generations": int(row.get("generation") or 0),
+                "spent_usd": float(row.get("spent_usd") or 0.0),
+                "created_at": row.get("created_at"),
+            }
+            for row in rows
+        ]
+        return json.dumps(items, separators=(",", ":"))
+
+
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 def _load_json(raw: Any) -> Dict[str, Any]:
@@ -594,11 +616,13 @@ async def _reverify(task: Dict[str, Any], target: Path, original: bytes) -> tupl
 def register_swarm_tools(mcp: FastMCP) -> None:
     mcp.add_tool(start_code_swarm)
     mcp.add_tool(get_swarm_status, annotations=READONLY_TOOL)
+    mcp.add_tool(list_swarm_tasks, annotations=READONLY_TOOL)
     mcp.add_tool(apply_swarm_winner, annotations=DESTRUCTIVE_TOOL)
     mcp.add_tool(cancel_swarm)
 
 
 register_internal_tool("start_code_swarm", start_code_swarm)
 register_internal_tool("get_swarm_status", get_swarm_status)
+register_internal_tool("list_swarm_tasks", list_swarm_tasks)
 register_internal_tool("apply_swarm_winner", apply_swarm_winner)
 register_internal_tool("cancel_swarm", cancel_swarm)

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -119,6 +119,24 @@ def test_mcp_ui_swarm_playground_is_served_and_honest(monkeypatch):
     assert "onclick=" not in page.text  # blocked by the server's script-src CSP
     assert 'state.source !== "live"' in script.text
     assert "apply is disabled for static exports" in script.text
+    # On-ramp: sample run, recent-swarm picker, one-click golden demo — a
+    # human can test the instrument without pasting a task id.
+    assert 'id="sampleBtn"' in page.text
+    assert 'id="demoBtn"' in page.text
+    assert 'id="taskPicker"' in page.text
+    assert 'id="refreshTasksBtn"' in page.text
+    assert "list_swarm_tasks" in script.text
+    assert "./swarm-sample.json" in script.text
+    assert "nsquared_dedup" in script.text  # the golden demo target
+    # The bundled sample is a REAL recorded run and says so inside itself.
+    with TestClient(create_app(), base_url="http://localhost:8080") as client:
+        sample = client.get("/ui/swarm-sample.json")
+    assert sample.status_code == 200
+    payload = sample.json()
+    assert payload["format"] == "unigrok-swarm-status-v1"
+    assert "scripted for reproducibility" in payload["provenance"]
+    assert payload["pareto_front"]  # non-empty front to explore
+    assert payload["aggregates"]["best_latency_improvement_pct"] > 0
     # Walls are never plotted at invented coordinates.
     assert "gutter" in script.text
     # Apply stays gated by mode in the UI exactly like the tool.

--- a/tests/test_swarm_tools.py
+++ b/tests/test_swarm_tools.py
@@ -218,6 +218,39 @@ class TestEndToEnd:
         assert "error" in payload
 
     @pytest.mark.asyncio
+    async def test_list_swarm_tasks_newest_first_with_effective_status(self, wired):
+        """The Playground's task picker: JSON array, newest first, staleness
+        override applied, empty array on a fresh gateway."""
+        import asyncio as aio
+        import json as jsonlib
+
+        store, _ws = wired
+        assert jsonlib.loads(await swarm_tools.list_swarm_tasks()) == []
+
+        await store.create_swarm_task(
+            "task-old", target_path="a.py", focus_node="function:f",
+            base_file_hash="h", test_target="t", bench_command="b",
+            budget_usd=1.0, seed=1,
+        )
+        await aio.sleep(0.02)
+        await store.create_swarm_task(
+            "task-new", target_path="b.py", focus_node="function:g",
+            base_file_hash="h", test_target="t", bench_command="b",
+            budget_usd=1.0, seed=2,
+        )
+        await store.update_swarm_task("task-new", status="completed", generation=3)
+
+        items = jsonlib.loads(await swarm_tools.list_swarm_tasks())
+        assert [i["task_id"] for i in items] == ["task-new", "task-old"]
+        newest = items[0]
+        assert newest["status"] == "completed"
+        assert newest["focus_node"] == "function:g"
+        assert newest["generations"] == 3
+        assert newest["spent_usd"] == pytest.approx(0.0)
+        # A queued row with a fresh heartbeat reads as queued, not stale.
+        assert items[1]["status"] == "queued"
+
+    @pytest.mark.asyncio
     async def test_active_apply_lands_and_reverifies(self, wired, monkeypatch):
         store, workspace = wired
         monkeypatch.setenv("UNIGROK_SWARM", "active")


### PR DESCRIPTION
## Handoff evidence (Codex landing gate)

**Commit:** `668b08b` (single commit on `main` @ `cfd7681`)
**Human sponsor:** @djtelicloud (asked: *"Why would it have boxes for me to put stuff in and no other way to test it?"*)
**Provenance:** `Originating-Agent: Claude via Claude Code`

### What
The Playground shipped as a pure viewer — it assumed an agent had already run `start_code_swarm` over MCP and handed you a task id. This adds three human on-ramps:

1. **Load sample run** — bundled `mcp_ui/swarm-sample.json`, a **recorded** run of the golden dedup target whose payload carries its own `provenance` field (scripted candidates for reproducibility; all measurements are real engine output). The page surfaces that sentence on load. Loads as source `export` → apply stays disabled per the existing hardening.
2. **Recent-swarms picker** — backed by a new read-only `list_swarm_tasks` MCP tool (newest first, staleness-aware effective status, `[]` on a fresh gateway). Degrades to an "unavailable (offline?)" option with no backend.
3. **Run demo swarm** — one click launches `start_code_swarm` on the golden O(N²) target (repo-root import path verified) and live-polls `get_swarm_status` to completion. Gate refusals are shown in the tool's own words.

### Changed paths
`mcp_ui/swarm.html`, `mcp_ui/swarm.js`, `mcp_ui/swarm-sample.json` (new), `src/tools/swarm.py` (new read-only tool), `tests/test_swarm_tools.py`, `tests/test_mcp_ui.py`, `CHANGELOG.md`, OKF mirrors.

### Verification
- `uv run pytest -q`: **1027 passed** (new pins: on-ramp controls, sample validity + in-payload provenance, `list_swarm_tasks` ordering/status)
- `python -m evals run`: **12/12 PASS** byte-stable; OKF `--check` clean
- In-browser: sample renders 2 glowing elites + 98.8% Δlatency with the provenance line; picker degrades cleanly offline; no inline handlers (CSP pin holds)

### Risks
Low. New tool is read-only and ungated by design (returns `[]` where swarms can't exist). Demo button only reaches the existing triple-gated `start_code_swarm`. No conflict with #16 (different files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)