### PR TITLE
feat(swarm): turn the Pareto Playground into a guided lab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,18 @@ All notable changes to UniGrok MCP will be documented in this file.
 
 ### Added
 - **Swarm Playground on-ramp**: the Pareto Playground no longer assumes a
-  pasted task id. It gains a one-click sample (a bundled RECORDED run of the
-  golden dedup target whose payload carries its own provenance: scripted
-  candidates, real measurements), a recent-swarms picker backed by the new
-  read-only `list_swarm_tasks` MCP tool (newest first, staleness-aware
+  pasted task id. It opens with a guided, already-rendered sample (a bundled
+  RECORDED run of the golden dedup target whose payload carries its own
+  provenance: scripted candidates, real measurements), a recent-swarms picker
+  backed by the new read-only `list_swarm_tasks` MCP tool (newest first, staleness-aware
   status), and a "Run demo swarm" button that launches `start_code_swarm` on
   the golden O(N²) target and live-polls the run to completion — surfacing
   the tool's own refusal verbatim when the swarm mode or contributor gates
-  say no.
+  say no. The page now detects stable versus contributor runtime, routes live
+  work toward the port-4766 Forge instead of reporting a false offline state,
+  translates signed memory deltas into plain-language trade-offs, selects a
+  useful elite receipt automatically, hides manual IDs/tokens under Advanced,
+  and makes SVG candidates keyboard-operable.
 - **Private cloud control plane completion**: RFC 8414/9728 OAuth discovery,
   dynamic public-client registration, authorization-code PKCE, ten-minute
   scoped tokens, live GitHub membership introspection/revocation, and

--- a/mcp_ui/swarm.html
+++ b/mcp_ui/swarm.html
@@ -9,20 +9,48 @@
       --bg: #0e1013; --panel: #16191d; --panel2: #1c2026; --border: #2a2f36;
       --text: #e7e9ec; --muted: #8b8d98;
       --red: #e5484d; --orange: #f5a623; --gray: #8b8d98; --green: #30a46c;
-      --accent: #4f8cff;
+      --accent: #6e9dff; --accent-soft: rgba(79, 140, 255, .13);
+      --cyan: #63d6c5; --shadow: 0 18px 55px rgba(0, 0, 0, .22);
     }
     * { box-sizing: border-box; }
     body { margin: 0; background: var(--bg); color: var(--text);
            font: 14px/1.5 -apple-system, "Segoe UI", Roboto, sans-serif; }
-    header { display: flex; align-items: baseline; gap: 12px; padding: 14px 20px;
-             border-bottom: 1px solid var(--border); }
-    header h1 { font-size: 16px; margin: 0; }
-    header a { color: var(--accent); text-decoration: none; font-size: 12px; }
+    header { display: flex; align-items: center; justify-content: space-between; gap: 24px;
+             padding: 24px 20px 18px; border-bottom: 1px solid var(--border);
+             background: radial-gradient(circle at 16% -40%, rgba(79, 140, 255, .24), transparent 42%); }
+    header h1 { font-size: clamp(21px, 3vw, 30px); line-height: 1.15; margin: 3px 0 5px; letter-spacing: -.03em; }
+    header p { color: var(--muted); margin: 0; max-width: 700px; }
+    header a { color: var(--text); text-decoration: none; font-size: 12px; border: 1px solid var(--border);
+               background: var(--panel); border-radius: 999px; padding: 7px 12px; white-space: nowrap; }
+    header a:hover { border-color: var(--accent); }
+    .eyebrow { color: var(--cyan); font-size: 10px; font-weight: 700; letter-spacing: .16em; text-transform: uppercase; }
+    .runtime-banner { display: flex; align-items: center; gap: 11px; margin: 14px 20px 0; padding: 11px 14px;
+                      max-width: 1240px; background: var(--panel); border: 1px solid var(--border); border-radius: 9px; }
+    .runtime-banner .dot { width: 9px; height: 9px; border-radius: 50%; background: var(--muted); flex: 0 0 auto; }
+    .runtime-banner.ready .dot { background: var(--green); box-shadow: 0 0 10px var(--green); }
+    .runtime-banner strong { display: block; font-size: 12px; }
+    .runtime-banner span { color: var(--muted); font-size: 11px; }
+    .runtime-banner a { color: var(--accent); font-size: 11px; margin-left: auto; text-decoration: none; white-space: nowrap; }
     .wrap { display: grid; grid-template-columns: 1fr 340px; gap: 14px;
             padding: 14px 20px; max-width: 1280px; }
     .panel { background: var(--panel); border: 1px solid var(--border);
-             border-radius: 8px; padding: 12px; }
+             border-radius: 10px; padding: 14px; box-shadow: var(--shadow); }
+    .section-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
+    .section-head h2 { font-size: 17px; margin: 2px 0 0; }
+    .source-badge { color: var(--muted); border: 1px solid var(--border); border-radius: 999px;
+                    padding: 3px 8px; font-size: 10px; letter-spacing: .06em; text-transform: uppercase; }
+    .source-badge.live { color: var(--green); border-color: rgba(48, 164, 108, .45); }
+    .journeys { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 9px; }
+    .journey { display: flex; flex-direction: column; min-height: 144px; background: var(--panel2);
+               border: 1px solid var(--border); border-radius: 9px; padding: 11px; }
+    .journey.primary { border-color: rgba(79, 140, 255, .52); background: linear-gradient(145deg, var(--accent-soft), var(--panel2) 65%); }
+    .journey .step { color: var(--muted); font-size: 10px; letter-spacing: .12em; }
+    .journey h3 { font-size: 13px; margin: 5px 0 3px; }
+    .journey p { color: var(--muted); font-size: 11px; margin: 0 0 10px; flex: 1; }
+    .journey .controls { gap: 6px; }
+    .journey select { min-width: 0; width: 100%; }
     .controls { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+    button, input, select { font: inherit; }
     input[type=text], input[type=password] { background: var(--panel2); color: var(--text);
       border: 1px solid var(--border); border-radius: 6px; padding: 6px 8px; min-width: 230px; }
     select { background: var(--panel2); color: var(--text); border: 1px solid var(--border);
@@ -30,9 +58,16 @@
     button { background: var(--panel2); color: var(--text); border: 1px solid var(--border);
              border-radius: 6px; padding: 6px 12px; cursor: pointer; }
     button:hover { border-color: var(--accent); }
+    button.primary { background: var(--accent); border-color: var(--accent); color: #08101f; font-weight: 700; }
     button:disabled { opacity: .45; cursor: not-allowed; }
     .scorecard { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
                  gap: 8px; margin-top: 12px; }
+    .advanced { margin-top: 10px; border-top: 1px solid var(--border); padding-top: 9px; }
+    .advanced summary { color: var(--muted); cursor: pointer; font-size: 11px; user-select: none; }
+    .advanced .controls { margin-top: 9px; }
+    #loadMsg { display: block; min-height: 20px; margin-top: 9px; font-size: 11px; }
+    .insight { margin: 10px 0 2px; padding: 9px 11px; background: var(--accent-soft);
+               border-left: 3px solid var(--accent); border-radius: 6px; font-size: 12px; }
     .stat { background: var(--panel2); border: 1px solid var(--border); border-radius: 8px;
             padding: 8px 10px; }
     .stat .k { color: var(--muted); font-size: 11px; text-transform: uppercase;
@@ -50,41 +85,86 @@
     #detail pre { background: var(--panel2); border: 1px solid var(--border);
                   border-radius: 6px; padding: 8px; overflow: auto; max-height: 220px;
                   font-size: 12px; white-space: pre-wrap; }
-    .diff-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+    .diff-grid { display: grid; grid-template-columns: 1fr; gap: 8px; }
     .muted { color: var(--muted); }
     .honesty { color: var(--muted); font-size: 11px; padding: 10px 20px 20px; max-width: 1280px; }
     .err { color: var(--red); }
-    circle.dot { cursor: pointer; }
+    circle.dot { cursor: pointer; outline: none; }
+    circle.dot:focus { stroke: #fff; stroke-width: 2px; }
     circle.elite { filter: drop-shadow(0 0 4px var(--green)); }
+    #detail { min-width: 0; align-self: start; }
+    #detail h2 { font-size: 15px; margin: 0 0 10px; }
+    .outcome-pill { display: inline-block; border: 1px solid var(--border); border-radius: 999px;
+                    padding: 2px 7px; font-size: 10px; margin-bottom: 9px; }
+    .receipt-grid { display: grid; grid-template-columns: 96px minmax(0, 1fr); gap: 5px 8px; }
+    .receipt-value { overflow-wrap: anywhere; }
+    .receipt-json { margin-top: 10px; }
+    .receipt-json summary { color: var(--muted); cursor: pointer; font-size: 11px; }
+    .code-label { color: var(--muted); font-size: 10px; letter-spacing: .08em; text-transform: uppercase; margin-bottom: -3px; }
+    @media (max-width: 900px) {
+      .wrap { grid-template-columns: 1fr; }
+      .journeys { grid-template-columns: 1fr; }
+      .journey { min-height: 0; }
+      .runtime-banner { align-items: flex-start; }
+    }
   </style>
 </head>
 <body>
   <header>
-    <h1>Swarm Optimizer — Pareto Playground</h1>
+    <div>
+      <div class="eyebrow">Contributor lab · verified optimization</div>
+      <h1>Swarm Optimizer</h1>
+      <p>Watch candidate rewrites hit static, test, and performance gates—then inspect the verified Pareto trade-offs.</p>
+    </div>
     <a href="./index.html">← Control Center</a>
   </header>
+
+  <div id="runtimeBanner" class="runtime-banner" role="status" aria-live="polite">
+    <span class="dot" aria-hidden="true"></span>
+    <div><strong id="runtimeTitle">Checking this gateway…</strong><span id="runtimeCopy">Finding live Swarm capabilities.</span></div>
+    <a id="forgeLink" href="http://127.0.0.1:4766/ui/swarm.html" hidden>Open contributor Forge →</a>
+  </div>
 
   <div class="wrap">
     <div>
       <div class="panel">
-        <div class="controls">
-          <button id="sampleBtn" type="button" title="Recorded run of the golden dedup target — scripted candidates, real measurements">▶ Load sample run</button>
-          <button id="demoBtn" type="button" title="Runs start_code_swarm on the golden O(N²) dedup target (contributor mode + UNIGROK_SWARM=dry_run required)">🐝 Run demo swarm</button>
-          <select id="taskPicker" title="Recent swarms on this gateway">
-            <option value="">recent swarms…</option>
-          </select>
-          <button id="refreshTasksBtn" type="button" title="Refresh the recent-swarm list">⟳</button>
+        <div class="section-head">
+          <div><div class="eyebrow">Start here</div><h2>Choose how you want to explore</h2></div>
+          <span id="sourceBadge" class="source-badge">loading</span>
         </div>
-        <div class="controls" style="margin-top:8px">
-          <input id="taskId" type="text" placeholder="swarm task id" />
-          <input id="token" type="password" placeholder="bearer token (optional)" />
-          <button id="loadBtn">Load</button>
-          <label>
-            <button id="fileBtn" type="button">Load JSON export…</button>
-            <input id="fileInput" type="file" accept=".json" style="display:none" />
-          </label>
-          <span id="loadMsg" class="muted"></span>
+        <div class="journeys">
+          <article class="journey primary">
+            <span class="step">01 · instant tour</span>
+            <h3>Explore a verified run</h3>
+            <p>Already loaded: two real Pareto elites, one test-wall candidate, and the honest speed-versus-memory trade-off.</p>
+            <button id="sampleBtn" class="primary" type="button" title="Recorded run of the golden dedup target — scripted candidates, real measurements">Replay recorded run</button>
+          </article>
+          <article class="journey">
+            <span class="step">02 · your history</span>
+            <h3>Open a recent swarm</h3>
+            <p>Choose a persisted live run from this contributor gateway.</p>
+            <div class="controls">
+              <select id="taskPicker" title="Recent swarms on this gateway"><option value="">checking gateway…</option></select>
+              <button id="refreshTasksBtn" type="button" title="Refresh recent swarms" aria-label="Refresh recent swarms">⟳</button>
+            </div>
+          </article>
+          <article class="journey">
+            <span class="step">03 · live experiment</span>
+            <h3>Run the golden demo</h3>
+            <p id="demoHint">Requires contributor mode and <code>UNIGROK_SWARM=dry_run</code>. Gate refusals stay visible.</p>
+            <button id="demoBtn" type="button" title="Runs start_code_swarm on the golden O(N²) dedup target">🐝 Run demo swarm</button>
+          </article>
         </div>
+        <details class="advanced">
+          <summary>Advanced: task ID, bearer token, or JSON export</summary>
+          <div class="controls">
+            <input id="taskId" type="text" placeholder="swarm task id" />
+            <input id="token" type="password" placeholder="bearer token (optional)" />
+            <button id="loadBtn">Load task</button>
+            <label><button id="fileBtn" type="button">Load JSON export…</button><input id="fileInput" type="file" accept=".json" style="display:none" /></label>
+          </div>
+        </details>
+        <span id="loadMsg" class="muted" role="status" aria-live="polite"></span>
         <div id="scorecard" class="scorecard"></div>
       </div>
 
@@ -96,6 +176,7 @@
           <span class="lg-green">Pareto elite</span>
           <span>★ baseline</span>
         </div>
+        <div id="tradeoffSummary" class="insight">Loading the recorded golden run…</div>
         <svg id="chart" viewBox="0 0 860 420" role="img"
              aria-label="Latency versus peak memory scatter of swarm candidates"></svg>
         <div class="timeline">
@@ -111,7 +192,7 @@
     </div>
 
     <div class="panel" id="detail">
-      <div class="muted">Click a dot for its full receipt.</div>
+      <div class="muted">Loading the best verified candidate…</div>
     </div>
   </div>
 

--- a/mcp_ui/swarm.js
+++ b/mcp_ui/swarm.js
@@ -16,7 +16,14 @@ const COLORS = {
   pareto_elite: "var(--green)",
 };
 
-const state = { payload: null, source: null, maxGen: 1, shownGen: 1, playing: null };
+const state = {
+  payload: null,
+  source: null,
+  maxGen: 1,
+  shownGen: 1,
+  playing: null,
+  runtimeMode: "unknown",
+};
 
 // ── MCP plumbing (same JSON-RPC shape the Control Center uses) ──────────────
 
@@ -48,6 +55,7 @@ async function mcpCall(toolName, args) {
   const rpc = JSON.parse(jsonText);
   if (rpc.error) throw new Error(rpc.error.message || "MCP error");
   const content = rpc.result?.content?.[0]?.text ?? "";
+  if (rpc.result?.isError) throw new Error(content || "MCP tool failed");
   return content;
 }
 
@@ -98,15 +106,34 @@ function setPayload(payload, sourceLabel, source) {
   $("genSlider").max = String(state.maxGen);
   $("genSlider").value = String(state.maxGen);
   setMsg(`loaded (${sourceLabel})`);
+  const badge = $("sourceBadge");
+  badge.textContent = source === "live" ? "live gateway data" : sourceLabel;
+  badge.className = source === "live" ? "source-badge live" : "source-badge";
   renderScorecard();
+  renderTradeoffSummary();
   renderChart();
-  $("detail").innerHTML = '<div class="muted">Click a dot for its full receipt.</div>';
+  const candidates = (payload.generations || []).flatMap((generation) => generation.candidates || []);
+  const leadingFrontId = payload.pareto_front?.[0];
+  const firstUseful = candidates.find((candidate) => candidate.candidate_id === leadingFrontId && candidate.code)
+    || candidates.find((candidate) => candidate.outcome === "pareto_elite" && candidate.code)
+    || candidates.find((candidate) => candidate.code)
+    || candidates[0];
+  if (firstUseful) renderDetail(firstUseful);
+  else $("detail").innerHTML = '<div class="muted">No candidates have landed yet.</div>';
 }
 
 // ── Scorecard ────────────────────────────────────────────────────────────────
 
-function fmtPct(v) { return v == null ? "n/a" : `${v.toFixed(1)}%`; }
+function fmtPct(v) { return v == null ? "n/a" : `${Number(v).toFixed(1)}%`; }
 function fmtUsd(v) { return v == null ? "n/a" : `$${Number(v).toFixed(4)}`; }
+function fmtLatencyImprovement(v) {
+  if (v == null) return "n/a";
+  return v >= 0 ? `${fmtPct(v)} faster` : `${fmtPct(Math.abs(v))} slower`;
+}
+function fmtMemoryImprovement(v) {
+  if (v == null) return "n/a";
+  return v >= 0 ? `${fmtPct(v)} less` : `${fmtPct(Math.abs(v))} more`;
+}
 
 function renderScorecard() {
   const p = state.payload;
@@ -117,8 +144,8 @@ function renderScorecard() {
     ["status", `${p.status} (${p.mode})`],
     ["feasibility rate", agg.feasibility_rate == null ? "n/a"
       : `${(agg.feasibility_rate * 100).toFixed(0)}% of ${agg.candidates_total}`],
-    ["best Δlatency", fmtPct(agg.best_latency_improvement_pct)],
-    ["best Δmemory", fmtPct(agg.best_memory_improvement_pct)],
+    ["best latency", fmtLatencyImprovement(agg.best_latency_improvement_pct)],
+    ["memory impact", fmtMemoryImprovement(agg.best_memory_improvement_pct)],
     ["cost to optimize", `${fmtUsd(agg.cost_to_optimize_usd)} / $${(p.budget?.budget_usd ?? 0).toFixed(2)}`],
     ["focus coverage", oracle.focus_coverage_pct == null ? "n/a" : `${oracle.focus_coverage_pct}%`],
     ["bench", `${bench.stability || "n/a"} (floor ${bench.noise_floor_pct ?? "?"}%)`],
@@ -127,6 +154,15 @@ function renderScorecard() {
   $("scorecard").innerHTML = cards
     .map(([k, v]) => `<div class="stat"><div class="k">${esc(k)}</div><div class="v">${esc(v)}</div></div>`)
     .join("");
+}
+
+function renderTradeoffSummary() {
+  const agg = state.payload?.aggregates || {};
+  const latency = fmtLatencyImprovement(agg.best_latency_improvement_pct);
+  const memory = fmtMemoryImprovement(agg.best_memory_improvement_pct);
+  $("tradeoffSummary").textContent = latency === "n/a"
+    ? "No benchmark-qualified candidate is available yet."
+    : `Pareto readout: the fastest verified candidate is ${latency} and uses ${memory} peak memory. Neither axis is hidden.`;
 }
 
 function esc(value) {
@@ -207,14 +243,16 @@ function renderChart() {
           COLORS[c.outcome] || "var(--gray)", c, c.outcome === "pareto_elite");
     });
 
-  $("genLabel").textContent = `generation ${state.shownGen}/${state.maxGen}`;
+  const newCandidates = (p.generations || [])
+    .find((generation) => generation.generation === state.shownGen)?.candidates?.length || 0;
+  $("genLabel").textContent = `generation ${state.shownGen}/${state.maxGen} · ${newCandidates ? `${newCandidates} new` : "no new candidates"}`;
 }
 
 function pad(lo, hi) {
   if (!isFinite(lo) || !isFinite(hi)) return [0, 1];
-  if (lo === hi) return [lo * 0.95 - 1, hi * 1.05 + 1];
+  if (lo === hi) return [Math.max(0, lo * 0.95), Math.max(1, hi * 1.05)];
   const span = hi - lo;
-  return [lo - span * 0.08, hi + span * 0.08];
+  return [Math.max(0, lo - span * 0.08), hi + span * 0.08];
 }
 
 function drawAxes(svg, x0, x1, y0, y1, sx, sy) {
@@ -265,7 +303,18 @@ function dot(svg, x, y, r, color, candidate, elite) {
   c.setAttribute("fill", color);
   c.setAttribute("fill-opacity", elite ? "0.95" : "0.75");
   c.setAttribute("class", elite ? "dot elite" : "dot");
-  c.addEventListener("click", () => renderDetail(candidate));
+  c.setAttribute("tabindex", "0");
+  c.setAttribute("role", "button");
+  const accessibleName = `${candidate.arm} candidate, ${candidate.outcome}`;
+  c.setAttribute("aria-label", accessibleName);
+  const openReceipt = () => renderDetail(candidate);
+  c.addEventListener("click", openReceipt);
+  c.addEventListener("keydown", (event) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      openReceipt();
+    }
+  });
   const title = document.createElementNS(SVG_NS, "title");
   title.textContent = `${candidate.candidate_id} — ${candidate.arm} — ${candidate.outcome}`;
   c.appendChild(title);
@@ -281,25 +330,26 @@ function renderDetail(candidate) {
     ["arm", candidate.arm],
     ["outcome", candidate.outcome],
     ["stage reached", candidate.stage],
-    ["latency_ms", candidate.latency_ms ?? "not measured"],
-    ["peak_mem_bytes", candidate.peak_mem_bytes ?? "not measured"],
+    ["latency", candidate.latency_ms == null ? "not measured" : `${Number(candidate.latency_ms).toFixed(6)} ms`],
+    ["peak memory", candidate.peak_mem_bytes == null ? "not measured" : `${humanBytes(candidate.peak_mem_bytes)} bytes`],
     ["diff_bytes", candidate.diff_bytes ?? "n/a"],
     ["reward", candidate.reward ?? "n/a"],
     ["token cost", fmtUsd(candidate.token_cost_usd)],
   ];
-  let html = rows
-    .map(([k, v]) => `<div><span class="muted">${esc(k)}:</span> ${esc(v)}</div>`)
-    .join("");
+  let html = `<h2>Candidate receipt</h2><span class="outcome-pill">${esc(candidate.outcome)}</span><div class="receipt-grid">` + rows
+    .map(([k, v]) => `<span class="muted">${esc(k)}</span><span class="receipt-value">${esc(v)}</span>`)
+    .join("") + "</div>";
   if (candidate.arm_receipt) {
-    html += `<div class="muted" style="margin-top:8px">arm receipt</div>
-             <pre>${esc(JSON.stringify(candidate.arm_receipt, null, 2))}</pre>`;
+    html += `<details class="receipt-json"><summary>Bandit selection receipt</summary>
+             <pre>${esc(JSON.stringify(candidate.arm_receipt, null, 2))}</pre></details>`;
   }
   if (candidate.code) {
     const original = p.original_span_stale
       ? "(file changed since the swarm ran — original span unavailable)"
       : (p.original_span || "(unavailable)");
-    html += `<div class="muted" style="margin-top:8px">original vs candidate</div>
-             <div class="diff-grid"><pre>${esc(original)}</pre><pre>${esc(candidate.code)}</pre></div>`;
+    html += `<div class="muted" style="margin-top:10px">verified code comparison</div>
+             <div class="diff-grid"><div><div class="code-label">original span</div><pre>${esc(original)}</pre></div>
+             <div><div class="code-label">candidate rewrite</div><pre>${esc(candidate.code)}</pre></div></div>`;
     const terminal = p.status === "completed" || p.status === "cancelled";
     const applyDisabled = state.source !== "live" || p.mode !== "active"
       || !terminal || p.original_span_stale;
@@ -402,6 +452,12 @@ async function loadSample() {
 
 async function refreshTaskPicker() {
   const picker = $("taskPicker");
+  if (state.runtimeMode !== "contributor") {
+    picker.replaceChildren(new Option("live runs are available in contributor Forge", ""));
+    picker.disabled = true;
+    return;
+  }
+  picker.disabled = false;
   try {
     const raw = await mcpCall("list_swarm_tasks", { limit: 15 });
     const tasks = JSON.parse(raw);
@@ -409,11 +465,49 @@ async function refreshTaskPicker() {
       tasks.length ? "recent swarms…" : "no swarms on this gateway yet", ""
     ));
     for (const task of tasks) {
-      const label = `${task.status} · ${task.focus_node} · ${task.task_id.slice(0, 8)}…`;
+      const created = task.created_at ? new Date(task.created_at).toLocaleString([], {
+        month: "short", day: "numeric", hour: "numeric", minute: "2-digit",
+      }) : "time unknown";
+      const label = `${task.status} · ${task.focus_node} · ${created} · ${task.task_id.slice(0, 8)}…`;
       picker.appendChild(new Option(label, task.task_id));
     }
   } catch (err) {
-    picker.replaceChildren(new Option("recent swarms unavailable (offline?)", ""));
+    picker.replaceChildren(new Option("could not read recent swarms — refresh to retry", ""));
+  }
+}
+
+async function discoverRuntime() {
+  const banner = $("runtimeBanner");
+  try {
+    const response = await fetch("/runtimez", { headers: { Accept: "application/json" } });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const runtime = await response.json();
+    state.runtimeMode = runtime.service?.mode || "unknown";
+    banner.classList.add("ready");
+    if (state.runtimeMode === "contributor" && runtime.service?.workspace_attached) {
+      $("runtimeTitle").textContent = "Contributor Forge connected";
+      $("runtimeCopy").textContent = "Live task history and real demo runs are available from the attached workspace.";
+      $("forgeLink").hidden = true;
+      $("demoBtn").disabled = false;
+      $("refreshTasksBtn").disabled = false;
+      $("demoHint").innerHTML = "Runs against the attached golden target. If Swarm is off, the exact gate instruction appears below.";
+    } else {
+      $("runtimeTitle").textContent = "Stable gateway connected — exploration mode";
+      $("runtimeCopy").textContent = "The recorded tour works here. Live Swarm tools stay isolated in contributor Forge on port 4766.";
+      $("demoBtn").disabled = true;
+      $("refreshTasksBtn").disabled = true;
+      $("demoHint").textContent = "Live execution is intentionally unavailable on the workspace-neutral stable service.";
+      if (["127.0.0.1", "localhost"].includes(window.location.hostname)) {
+        $("forgeLink").href = `${window.location.protocol}//${window.location.hostname}:4766/ui/swarm.html`;
+        $("forgeLink").hidden = false;
+      }
+    }
+  } catch (err) {
+    state.runtimeMode = "unknown";
+    $("runtimeTitle").textContent = "Gateway capability check unavailable";
+    $("runtimeCopy").textContent = "The recorded tour still works; live controls may not.";
+    $("demoBtn").disabled = true;
+    $("refreshTasksBtn").disabled = true;
   }
 }
 
@@ -465,4 +559,11 @@ $("taskPicker").addEventListener("change", (event) => {
   $("taskId").value = event.target.value;
   loadLive();
 });
-refreshTaskPicker();
+
+async function bootstrap() {
+  await loadSample();
+  await discoverRuntime();
+  await refreshTaskPicker();
+}
+
+bootstrap();

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -133,9 +133,24 @@ def test_mcp_ui_swarm_playground_is_served_and_honest(monkeypatch):
     assert 'id="demoBtn"' in page.text
     assert 'id="taskPicker"' in page.text
     assert 'id="refreshTasksBtn"' in page.text
+    assert 'id="runtimeBanner"' in page.text
+    assert 'id="sourceBadge"' in page.text
+    assert 'id="tradeoffSummary"' in page.text
+    assert "Already loaded" in page.text
+    assert "Advanced: task ID" in page.text
     assert "list_swarm_tasks" in script.text
     assert "./swarm-sample.json" in script.text
     assert "nsquared_dedup" in script.text  # the golden demo target
+    assert 'fetch("/runtimez"' in script.text
+    assert "Stable gateway connected" in script.text
+    assert ":4766/ui/swarm.html" in script.text
+    assert "await loadSample()" in script.text  # useful content, not empty boxes, on arrival
+    assert "rpc.result?.isError" in script.text
+    assert 'c.setAttribute("tabindex", "0")' in script.text
+    assert "leadingFrontId" in script.text
+    assert "no new candidates" in script.text
+    assert "Math.max(0, lo - span * 0.08)" in script.text
+    assert "Bandit selection receipt" in script.text
     # The bundled sample is a REAL recorded run and says so inside itself.
     with TestClient(create_app(), base_url="http://localhost:8080") as client:
         sample = client.get("/ui/swarm-sample.json")


### PR DESCRIPTION
## Outcome
The Playground no longer opens as an empty viewer or asks a human to understand task IDs first.

- auto-load the provenance-labeled verified sample and front-ranked elite receipt
- present three explicit journeys: recorded tour, recent live run, and real golden demo
- detect stable versus contributor runtime and route live work to Forge instead of showing a false offline state
- translate signed benchmark deltas into plain-language speed/memory trade-offs
- hide task IDs, tokens, and JSON import under Advanced
- make SVG candidates keyboard-operable and receipt code readable in the narrow inspector
- clamp chart axes at zero and mark generations with no new candidates
- treat MCP `isError` results as failures instead of successful text

## Live review
Verified in a real browser against isolated contributor and stable runtimes. Contributor mode showed the persisted-run picker and exact `UNIGROK_SWARM` gate; stable mode auto-rendered the sample, disabled mutation controls, and linked to port-4766 Forge.

## Verification
- `uv run pytest -q` — 1027 passed
- `uv run python -m evals run` — 12/12 passed
- deterministic OKF check — clean
- JavaScript syntax and patch-integrity checks — clean

Agent-Assisted-By: Codex via Codex Desktop