### PR TITLE
perf(utils): optimize redact_secrets with fast path substring scan

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1084,7 +1084,21 @@ def load_grok_prompt(prompt_ref: str) -> str:
 
 
 def redact_secrets(text: str) -> str:
-    redacted = str(text or "")
+    if not text:
+        return ""
+        
+    # Fast path: skip regex entirely for safe logs (99% of cases).
+    if (
+        "xai-" not in text 
+        and "sk-" not in text 
+        and "Bearer " not in text 
+        and "bearer " not in text 
+        and "API_KEY" not in text 
+        and "api_key" not in text
+    ):
+        return text
+        
+    redacted = text
     for pattern, replacement in _SECRET_PATTERNS:
         redacted = pattern.sub(replacement, redacted)
     return redacted

--- a/src/utils.py
+++ b/src/utils.py
@@ -1084,21 +1084,14 @@ def load_grok_prompt(prompt_ref: str) -> str:
 
 
 def redact_secrets(text: str) -> str:
-    if not text:
-        return ""
-        
-    # Fast path: skip regex entirely for safe logs (99% of cases).
-    if (
-        "xai-" not in text 
-        and "sk-" not in text 
-        and "Bearer " not in text 
-        and "bearer " not in text 
-        and "API_KEY" not in text 
-        and "api_key" not in text
-    ):
-        return text
-        
-    redacted = text
+    redacted = str(text or "")
+    if "xai-" not in redacted and "sk-" not in redacted:
+        # This guard must remain a conservative superset of the two
+        # case-insensitive regexes below. False positives only cost a regex
+        # pass; a false negative could leak a credential.
+        folded = redacted.lower()
+        if "bearer" not in folded and "api_key" not in folded:
+            return redacted
     for pattern, replacement in _SECRET_PATTERNS:
         redacted = pattern.sub(replacement, redacted)
     return redacted

--- a/tests/test_intelligence_upgrade.py
+++ b/tests/test_intelligence_upgrade.py
@@ -115,6 +115,26 @@ def test_redact_secrets_strips_keys_and_bearer_tokens():
     assert "[REDACTED" in redacted
 
 
+@pytest.mark.parametrize(
+    ("text", "secret"),
+    [
+        ("Authorization: BEARER abc.defghi123456", "abc.defghi123456"),
+        ("Authorization: Bearer\tabc.defghi123456", "abc.defghi123456"),
+        ("OpenAI_Api_Key = secretvalue123", "secretvalue123"),
+    ],
+)
+def test_redact_secrets_fast_path_preserves_case_and_whitespace_coverage(text, secret):
+    redacted = redact_secrets(text)
+
+    assert secret not in redacted
+    assert "[REDACTED" in redacted
+
+
+def test_redact_secrets_fast_path_preserves_benign_text_and_input_coercion():
+    assert redact_secrets("ordinary telemetry") == "ordinary telemetry"
+    assert redact_secrets(123) == "123"
+
+
 @pytest.mark.asyncio
 async def test_dispatch_internal_tool_redacts_and_bounds_output(monkeypatch):
     async def noisy_tool() -> str:


### PR DESCRIPTION
## Summary

Adds a conservative fast path for benign telemetry while preserving the complete secret-redaction surface.

## Safety contract

The negative guard is a strict superset of every trigger in `_SECRET_PATTERNS`:

- raw `xai-` and `sk-` checks cover the case-sensitive key regex;
- one lowercase copy checks broad `bearer` and `api_key` markers before the case-insensitive regexes;
- false positives only run the regexes; a false negative would be a security bug.

The maintainer repair adds regression coverage for uppercase `BEARER`, tab-separated bearer tokens, mixed-case `Api_Key`, benign text, and input coercion.

## Exact head and provenance

- Head: `3ef7a123c245d7d3f957d3c58369c1bc2032989e`
- Original implementation: `Agent-Assisted-By: Gemini via Antigravity`
- Security repair and tests: `Agent-Assisted-By: Codex via Codex Desktop`
- Accountable sponsor: `djtelicloud`

## Verification

- `uv run pytest -q tests/test_intelligence_upgrade.py` — 28 passed
- `git diff --check` — clean
- Bounded benign-payload benchmark, 500 iterations over ~95k characters:
  - original three-regex path: 1.3871s
  - repaired conservative fast path: 0.1269s
  - approximately 10.9x faster on that workload

## Known risks

The benign path allocates one lowercase copy when no raw xAI/OpenAI-style key prefix is present. Secret safety remains authoritative; any future secret regex requires updating or removing the guard and its invariant tests.