### PR TITLE
perf(http): bypass json.dumps overhead for string payload sizes

### DIFF
--- a/src/http_server.py
+++ b/src/http_server.py
@@ -135,6 +135,8 @@ def _request_error_message(default: str) -> str:
 
 
 def _message_content_size(content: Any) -> int:
+    if isinstance(content, str):
+        return len(content)
     try:
         return len(json.dumps(content, ensure_ascii=False, separators=(",", ":")))
     except (TypeError, ValueError):

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -135,6 +135,7 @@ def _request_error_message(default: str) -> str:
 
 
 def _message_content_size(content: Any) -> int:
+    """Count text characters directly and structured content as compact JSON."""
     if isinstance(content, str):
         return len(content)
     try:

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -12,8 +12,10 @@ from src.http_server import (
     ModeDialContextMiddleware,
     _ACTIVE_MODE_DIAL,
     _derive_http_caller,
+    _message_content_size,
     _resolve_bind_host,
     _resolve_bind_port,
+    _validate_chat_payload,
     create_app,
     create_public_mcp,
     public_agent,
@@ -723,6 +725,51 @@ def test_chat_completion_rejects_message_limits(monkeypatch):
 
     assert res.status_code == 413
     assert res.json()["error"]["code"] == "request_too_large"
+
+
+def test_message_content_size_uses_semantic_chars_for_text_and_json_for_structures():
+    text = 'say "hello"\nwith a slash \\'
+    structured = [{"type": "text", "text": text}]
+
+    assert _message_content_size(text) == len(text)
+    assert _message_content_size(structured) == len(
+        json.dumps(structured, ensure_ascii=False, separators=(",", ":"))
+    )
+    assert _message_content_size(None) == len("null")
+
+
+def test_chat_payload_enforces_text_character_boundaries(monkeypatch):
+    monkeypatch.setenv("UNIGROK_MAX_MESSAGES", "10")
+    monkeypatch.setenv("UNIGROK_MAX_MESSAGE_CHARS", "256")
+    monkeypatch.setenv("UNIGROK_MAX_TOTAL_MESSAGE_CHARS", "1024")
+
+    at_message_limit = {"messages": [{"role": "user", "content": "\n" * 256}]}
+    assert _validate_chat_payload(at_message_limit) is None
+
+    over_message_limit = {"messages": [{"role": "user", "content": "x" * 257}]}
+    assert _validate_chat_payload(over_message_limit).status_code == 413
+
+    at_total_limit = {
+        "messages": [{"role": "user", "content": "x" * 256} for _ in range(4)]
+    }
+    assert _validate_chat_payload(at_total_limit) is None
+
+    over_total_limit = {
+        "messages": [{"role": "user", "content": "x" * 256} for _ in range(5)]
+    }
+    assert _validate_chat_payload(over_total_limit).status_code == 413
+
+
+def test_chat_payload_keeps_structured_content_on_compact_json_limit(monkeypatch):
+    monkeypatch.setenv("UNIGROK_MAX_MESSAGE_CHARS", "256")
+    structured = [{"type": "text", "text": "x" * 256}]
+
+    assert _message_content_size(structured) > 256
+    response = _validate_chat_payload(
+        {"messages": [{"role": "user", "content": structured}]}
+    )
+
+    assert response.status_code == 413
 
 
 def test_agent_http_errors_do_not_expose_exception_text(monkeypatch):


### PR DESCRIPTION
## Summary

Counts plain-string message content by semantic characters without allocating a serialized copy. Structured/multimodal content continues to use compact JSON length.

## Contract and safety

`UNIGROK_MAX_MESSAGE_CHARS` and `UNIGROK_MAX_TOTAL_MESSAGE_CHARS` now mean content characters for plain text. Escapes and JSON framing do not consume the semantic text budget. The independent `UNIGROK_MAX_REQUEST_BODY_BYTES` limit continues to bound wire bytes.

The maintainer repair makes that contract explicit and tests:

- escaped plain strings at the exact per-message boundary;
- per-message rejection at N+1;
- aggregate acceptance at the total boundary and rejection above it;
- structured content retaining compact-JSON measurement;
- existing `None -> 4` behavior remaining unchanged.

## Exact head and provenance

- Head: `11e0c8c6f7045641221145c9a8833188121016e6`
- Original implementation: `Agent-Assisted-By: Gemini via Antigravity`
- Contract and boundary tests: `Agent-Assisted-By: Codex via Codex Desktop`
- Accountable sponsor: `djtelicloud`

## Verification

- `uv run pytest -q tests/test_http_server.py` — 100 passed
- `git diff --check` — clean
- Bounded 450,000-character benchmark, 1,000 iterations:
  - direct string length: 0.000019s
  - JSON serialization plus length: 1.2739s

## Known risks

This intentionally changes escaped-string accounting from JSON representation length to semantic character length. Structured content and request-body byte enforcement remain unchanged, and the new boundary tests pin all three contracts.