### PR TITLE
perf(utils): replace deepcopy serialization anti-pattern

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1,5 +1,6 @@
 import os
 import json
+import copy
 import base64
 import sys
 import inspect
@@ -2734,7 +2735,7 @@ class GrokSessionStore:
                 # A receipt contains only bounded features, model slugs, and
                 # evidence counts; never a prompt.  Round-trip through JSON to
                 # prevent custom mapping objects from escaping that contract.
-                clean_routing = json.loads(json.dumps(routing, separators=(",", ":")))
+                clean_routing = copy.deepcopy(routing)
                 if isinstance(clean_routing, dict) and len(json.dumps(clean_routing)) <= 6000:
                     meta["routing"] = clean_routing
             except (TypeError, ValueError):
@@ -2783,7 +2784,7 @@ class GrokSessionStore:
         if not clean_id or not isinstance(semantic, dict):
             return False
         try:
-            clean_semantic = json.loads(json.dumps(semantic, separators=(",", ":")))
+            clean_semantic = copy.deepcopy(semantic)
         except (TypeError, ValueError):
             return False
         if not isinstance(clean_semantic, dict):
@@ -8397,7 +8398,7 @@ async def run_agent_turn(
         or has_image
     )
     if request_requires_api and not credentials["api"]["available"]:
-        request_credentials = json.loads(json.dumps(credentials))
+        request_credentials = copy.deepcopy(credentials)
         for notice in request_credentials["notices"]:
             if notice.get("plane") == "API":
                 notice.update({


### PR DESCRIPTION
## Maintainer disposition

Closed without merge after exact-head review.

The proposed replacements treat JSON round-trips as generic deep copies, but those call sites use serialization as a validation and normalization boundary. `copy.deepcopy()`:

- permits non-JSON objects beyond the guarded block and can introduce an unhandled semantic-attachment failure;
- violates the routing receipt's documented plain-JSON contract;
- still leaves JSON sizing/final serialization in the hot telemetry path, adding a traversal;
- appears favorable in the submitted benchmark because its sample repeats shared object references and benefits from deepcopy memoization, unlike typical routing receipts.

The only safe repair is to restore the existing implementation at every changed site, leaving no meaningful change to merge.

- Reviewed head: `4c86c0cdcb67cea4a26b35e32c6266b0f11c866d`
- Original provenance: `Agent-Assisted-By: Gemini via Antigravity`
- Peer review: Grok 4.5 via UniGrok plus GitHub Codex, Copilot, and Gemini review findings
- Accountable sponsor: `djtelicloud`