### PR TITLE
docs(codex): record completed swarm v2 rollout

### DIFF
--- a/.codex/memory/active-work.md
+++ b/.codex/memory/active-work.md
@@ -2,7 +2,7 @@
 
 Last updated: 2026-07-12
 Owner: Codex
-Status: Cloud control, private remote MCP, and guided Swarm UI rollout complete
+Status: Swarm v2, local runtimes, and public Playground rollout complete
 
 This is the project-scoped handoff for new Codex chats. Resolve drift-prone
 Git, CI, runtime, DNS, and cloud identifiers live before acting. Never record
@@ -11,12 +11,13 @@ credentials, OAuth codes, tokens, or private keys here.
 ## Completed repository state
 
 - Protected `origin/main` and visible local `main` were synchronized after PR
-  #19. Use `scripts/land-status` for the current merge commit; this tracked file
+  #25. Use `scripts/land-status` for the current merge commit; this tracked file
   cannot name the merge commit that contains its own update.
-- Open GitHub issues and pull requests were zero at closeout. Completed agent
-  branches and worktrees were removed after their patches were integrated or
-  proven superseded.
-- The full landing suite passed 1,027 tests. Offline evals passed 12/12 and the
+- The Swarm v2 implementation is integrated: bounded paste-code analysis,
+  function-aware search setup, goal-specific champion selection, strict status
+  v2 receipts, elite-offspring lineage, deterministic AST transforms, and the
+  copy-only paste workflow all ship from protected main.
+- The full landing suite passed 1,045 tests. Offline evals passed 12/12 and the
   deterministic OKF bundle was clean.
 
 ## Local runtime state
@@ -27,19 +28,23 @@ credentials, OAuth codes, tokens, or private keys here.
 - The attached contributor service was rebuilt from protected main and is
   healthy at `http://127.0.0.1:4766`; `UNIGROK_SWARM=dry_run` remains the local
   setting, so search and scoring are enabled while Apply remains disabled.
-- A real browser-launched golden demo completed three generations with 100%
-  focus coverage, a stable benchmark, 100% candidate feasibility, one verified
-  Pareto elite, a 97.9% latency improvement, an explicit 1229.9% peak-memory
-  increase, and $0.0000 model cost.
-- The guided Playground opens with useful data, selects the front-ranked elite,
-  explains speed/memory trade-offs, distinguishes stable from contributor mode,
-  keeps manual task IDs/tokens under Advanced, and exposes keyboard-operable
-  candidate receipts.
+- A real browser-launched paste run completed two elite-offspring generations
+  with 100% focus coverage, a stable benchmark, 75% candidate feasibility, two
+  verified Pareto elites, a 98.8% latency improvement, an explicit 838.5%
+  peak-memory increase, and $0.0000 model cost.
+- The guided Playground now accepts a large Python paste, computes exact local
+  analytics, lets the user select a function, goal, and search strategy, runs a
+  verified local search, explains code and runtime trade-offs, and copies the
+  best verified code. Paste tasks remain deliberately copy-only.
 
 ## Production state
 
-- `https://grokmcp.org` is published with Sites version 6. Public project JSON
-  now reports `https://mcp.grokmcp.org/mcp` as a private OAuth API-plane MCP.
+- `https://grokmcp.org` is published with Sites version 7. The public
+  `https://grokmcp.org/swarm/` route serves the same Playground UI with
+  browser-only analysis, an honest recorded run, and a clear path to verified
+  local execution; the homepage links it directly.
+- Public project JSON reports `https://mcp.grokmcp.org/mcp` as a private OAuth
+  API-plane MCP.
 - `https://control.grokmcp.org` serves the GitHub role-gated control plane and
   OAuth authorization server. Its RFC 8414 metadata is live.
 - `https://mcp.grokmcp.org` has active Google-managed TLS. `/healthz` returns


### PR DESCRIPTION
Records the exact verified Swarm v2 landing, local runtime state, real browser-run metrics, and Sites version 7 production deployment. Documentation-only closeout required by the project continuity contract.