### PR TITLE
perf(routing): optimize image detection overhead

### DIFF
--- a/src/routing.py
+++ b/src/routing.py
@@ -44,17 +44,23 @@ def _term_score(text: str, terms: Iterable[str], cap: int = 3) -> int:
 
 
 def _messages_have_image(messages: Optional[Sequence[Dict[str, Any]]]) -> bool:
-    def contains(value: Any) -> bool:
-        if isinstance(value, dict):
-            kind = str(value.get("type") or "").lower()
-            if kind in {"image", "image_url", "input_image"} or "image_url" in value:
-                return True
-            return any(contains(item) for item in value.values())
-        if isinstance(value, list):
-            return any(contains(item) for item in value)
+    if not messages:
         return False
-
-    return contains(list(messages or []))
+    stack = list(messages)
+    while stack:
+        current = stack.pop()
+        if isinstance(current, dict):
+            kind = current.get("type")
+            if kind:
+                kind = str(kind).lower()
+                if kind in {"image", "image_url", "input_image"}:
+                    return True
+            if "image_url" in current:
+                return True
+            stack.extend(current.values())
+        elif isinstance(current, list):
+            stack.extend(current)
+    return False
 
 
 def extract_routing_features(

--- a/src/routing.py
+++ b/src/routing.py
@@ -57,9 +57,11 @@ def _messages_have_image(messages: Optional[Sequence[Dict[str, Any]]]) -> bool:
                     return True
             if "image_url" in current:
                 return True
-            stack.extend(current.values())
+            stack.extend(
+                value for value in current.values() if isinstance(value, (dict, list))
+            )
         elif isinstance(current, list):
-            stack.extend(current)
+            stack.extend(value for value in current if isinstance(value, (dict, list)))
     return False
 
 

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,4 +1,5 @@
 from src.routing import (
+    _messages_have_image,
     choose_model_candidate,
     classify_route,
     extract_routing_features,
@@ -28,6 +29,41 @@ def test_image_content_hard_routes_to_vision():
     assert classify_route(mode="auto", thinking_mode=False, features=features) == (
         "vision", "vision_capability"
     )
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        {"type": "image"},
+        {"type": "INPUT_IMAGE"},
+        {"image_url": {"url": "data:"}},
+        [{"wrapper": [{"type": "image_url"}]}],
+    ],
+)
+def test_image_detection_preserves_nested_marker_variants(content):
+    assert _messages_have_image([{"role": "user", "content": content}]) is True
+
+
+def test_image_detection_ignores_nested_scalars():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "image_url is only prose"},
+                {"metadata": {"attempts": 3, "ready": True, "value": None}},
+            ],
+        }
+    ]
+
+    assert _messages_have_image(messages) is False
+
+
+def test_image_detection_handles_payloads_deeper_than_python_recursion_limit():
+    content = {"type": "image_url", "image_url": {"url": "data:"}}
+    for _ in range(1500):
+        content = [content]
+
+    assert _messages_have_image([{"role": "user", "content": content}]) is True
 
 
 def test_route_classes_cover_research_planning_coding_and_borderline():


### PR DESCRIPTION
## Summary

Replaces recursive image-marker traversal with an iterative, container-only stack. This preserves routing semantics, avoids Python recursion limits, and skips scalar loop entries.

## Maintainer repair

The original iterative version pushed every scalar string, number, boolean, and null value onto the stack. The repaired version pushes only nested dictionaries and lists.

Focused tests cover:

- all supported image marker variants and nested wrappers;
- image-like prose remaining non-image content;
- nested scalar metadata;
- an image payload nested 1,500 levels deep, beyond Python's recursion limit.

## Exact head and provenance

- Head: `ec477237798e337af5ba091ef72364be8f72a221`
- Original implementation: `Agent-Assisted-By: Gemini via Antigravity`
- Traversal repair and tests: `Agent-Assisted-By: Codex via Codex Desktop`
- Accountable sponsor: `djtelicloud`

## Verification

- `uv run pytest -q tests/test_routing.py` — 21 passed
- `git diff --check` — clean
- Bounded representative non-image benchmark, 20,000 iterations:
  - recursive traversal: 0.2909s
  - repaired iterative traversal: 0.2824s
  - about 2.9% faster on this workload

The measured benefit is smaller than the original 39% claim; recursion-safety and bounded traversal are the primary improvements.

## Known risks

The function expects JSON-shaped acyclic dictionaries/lists. Cyclic in-memory graphs are outside the HTTP JSON contract and remain unsupported.