### PR TITLE
Optimize JSON sanitize hotspots in src/utils

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1116,6 +1116,18 @@ def _bounded_redacted(text: str, limit: int) -> str:
     return value[:limit] + f"\n[...truncated {len(value) - limit} chars]"
 
 
+def _json_sanitize(
+    value: Any, *, separators: tuple[str, str] = (",", ":")
+) -> tuple[Any, str]:
+    """Round-trip through JSON for plain, contract-safe data.
+
+    Returns ``(plain_obj, text)`` where ``text`` is the serialization used for
+    the round-trip so callers can apply size bounds without a second dumps().
+    """
+    text = json.dumps(value, separators=separators)
+    return json.loads(text), text
+
+
 def _normalize_fact_scope(scope: Any) -> str:
     """Knowledge scope normalized for storage AND lookup: 'global' or a short
     session name. Client-controlled via remember_fact, so it gets the same
@@ -2768,8 +2780,8 @@ class GrokSessionStore:
                 # A receipt contains only bounded features, model slugs, and
                 # evidence counts; never a prompt.  Round-trip through JSON to
                 # prevent custom mapping objects from escaping that contract.
-                clean_routing = json.loads(json.dumps(routing, separators=(",", ":")))
-                if isinstance(clean_routing, dict) and len(json.dumps(clean_routing)) <= 6000:
+                clean_routing, routing_text = _json_sanitize(routing)
+                if isinstance(clean_routing, dict) and len(routing_text) <= 6000:
                     meta["routing"] = clean_routing
             except (TypeError, ValueError):
                 pass
@@ -2817,12 +2829,12 @@ class GrokSessionStore:
         if not clean_id or not isinstance(semantic, dict):
             return False
         try:
-            clean_semantic = json.loads(json.dumps(semantic, separators=(",", ":")))
+            clean_semantic, semantic_text = _json_sanitize(semantic)
         except (TypeError, ValueError):
             return False
         if not isinstance(clean_semantic, dict):
             return False
-        if len(json.dumps(clean_semantic, separators=(",", ":"))) > 1500:
+        if len(semantic_text) > 1500:
             clean_semantic.pop("rationale", None)
             if len(json.dumps(clean_semantic, separators=(",", ":"))) > 1500:
                 return False
@@ -8457,7 +8469,7 @@ async def run_agent_turn(
         or has_image
     )
     if request_requires_api and not credentials["api"]["available"]:
-        request_credentials = json.loads(json.dumps(credentials))
+        request_credentials, _ = _json_sanitize(credentials)
         for notice in request_credentials["notices"]:
             if notice.get("plane") == "API":
                 notice.update({

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timedelta
 
 import pytest
@@ -158,5 +159,26 @@ async def test_save_telemetry_persists_usage_provenance(tmp_path):
         assert metadata["token_kind"] == "local_estimate"
         assert metadata["billing_source"] == "subscription_unmetered"
         assert metadata["routing"]["why_detail"] == "keyless_cli"
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_save_telemetry_bounds_routing_by_persisted_compact_json(tmp_path):
+    store = GrokSessionStore(db_path=tmp_path / "routing-bound.db")
+    try:
+        empty_size = len(json.dumps({"payload": ""}, separators=(",", ":")))
+        bounded = {"payload": "x" * (6000 - empty_size)}
+        oversized = {"payload": bounded["payload"] + "x"}
+
+        assert len(json.dumps(bounded, separators=(",", ":"))) == 6000
+        assert len(json.dumps(bounded)) > 6000
+
+        await store.save_telemetry("bounded", "API", 1, 0.1, 0.0, routing=bounded)
+        await store.save_telemetry("oversized", "API", 1, 0.1, 0.0, routing=oversized)
+
+        rows = {row["intent"]: telemetry_metadata(row) for row in await store.get_telemetry_stats()}
+        assert rows["bounded"]["routing"] == bounded
+        assert "routing" not in rows["oversized"]
     finally:
         await store.close()


### PR DESCRIPTION
## Summary
Reduce repeated JSON serialization in `src/utils.py` while preserving bounded, plain-data contracts.

## Reviewed / landed head
- Exact HEAD SHA: `3be4363e71d88b9df1788b35cf0af76d4d0ca255`
- Original Copilot head: `a2adc44969d3cec5dbf2c29524a4ad7d75382d25`
- Current protected-main base merged into the branch without rewriting contributor history

## Changes
- Added `_json_sanitize` to return the sanitized plain object and its compact serialization.
- Reused the compact serialization for telemetry and semantic size gates.
- Reused the helper for the API credential contract clone.
- Added a boundary regression proving the persisted compact routing JSON is accepted at exactly 6,000 characters and rejected above it.

## Verification
- Focused telemetry, semantic-eval, observability, and credential suite: **101 passed**
- `./scripts/land`: deterministic OKF check passed; **1072 tests passed**
- Contributor runtime restarted and smoke-tested
- Landing receipt: `LANDED TO MAIN: 3be4363e71d88b9df1788b35cf0af76d4d0ca255`

## Behavioral note
The routing bound now measures the exact compact JSON persisted in metadata. This admits payloads at the documented 6,000-character compact boundary that the previous space-added reserialization rejected; the persisted size remains strictly bounded.

## Sponsor and provenance
- Human sponsor: @djtelicloud
- Agent-Assisted-By: GitHub Copilot (GPT-5.3-Codex) with @grok swarm guidance
- Agent-Assisted-By: Codex
