### PR TITLE
Avoid hashing configured client keys

### DIFF
--- a/src/http_server.py
+++ b/src/http_server.py
@@ -181,9 +181,9 @@ def _validate_chat_payload(payload: Any) -> Optional[JSONResponse]:
     return None
 
 
-def _api_keys() -> set[str]:
+def _api_keys() -> tuple[str, ...]:
     raw = os.environ.get("UNIGROK_API_KEYS", "")
-    return {part.strip() for part in raw.split(",") if part.strip()}
+    return tuple(dict.fromkeys(part.strip() for part in raw.split(",") if part.strip()))
 
 
 def _auth_is_active() -> bool:
@@ -614,20 +614,15 @@ class MCPOriginMiddleware:
 
 
 def _caller_key_alias(token: Optional[str]) -> Optional[str]:
-    """Stable, non-reversible alias for the configured API key a bearer token
-    matched: 'key-' + the first 8 hex chars of the key's SHA-256. Keeps
-    per-key attribution without ever echoing key material into telemetry.
+    """Stable alias for the configured API key a bearer token matched:
+    ``key-`` plus its one-based position in ``UNIGROK_API_KEYS``. Keeps per-key
+    attribution without deriving telemetry identifiers from secret material.
     None when the token matches no configured key."""
     if not token:
         return None
-    for key in _api_keys():
+    for index, key in enumerate(_api_keys(), start=1):
         if _tokens_match(token, key):
-            digest = hashlib.blake2s(
-                key.encode("utf-8", "surrogateescape"),
-                digest_size=4,
-                person=b"unigrok",
-            ).hexdigest()
-            return f"key-{digest}"
+            return f"key-{index}"
     return None
 
 

--- a/tests/test_multiagent.py
+++ b/tests/test_multiagent.py
@@ -3,7 +3,6 @@
 # X-Caller/auth-key alias), schema v8 telemetry attribution, per-caller daily
 # budgets, the grok://workspace resource, and per-caller metrics segmentation.
 
-import hashlib
 import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -465,10 +464,12 @@ class TestHttpCallerDerivation:
     def test_auth_key_alias_when_no_header(self, monkeypatch):
         monkeypatch.setenv("UNIGROK_API_KEYS", "sekret-key")
         scope = {"type": "http", "headers": [(b"authorization", b"Bearer sekret-key")]}
-        expected = "http:key-" + hashlib.blake2s(
-            b"sekret-key", digest_size=4, person=b"unigrok"
-        ).hexdigest()
-        assert _derive_http_caller(scope) == expected
+        assert _derive_http_caller(scope) == "http:key-1"
+
+    def test_auth_key_alias_tracks_configured_key_order(self, monkeypatch):
+        monkeypatch.setenv("UNIGROK_API_KEYS", "first-key,second-key")
+        scope = {"type": "http", "headers": [(b"authorization", b"Bearer second-key")]}
+        assert _derive_http_caller(scope) == "http:key-2"
 
     def test_anonymous_fallback(self, monkeypatch):
         monkeypatch.delenv("UNIGROK_API_KEYS", raising=False)
@@ -535,9 +536,7 @@ class TestGatewayCallerPropagation:
         caller = self._run_request(
             monkeypatch, {"Authorization": "Bearer sekret-key"}
         )
-        assert caller == "http:key-" + hashlib.blake2s(
-            b"sekret-key", digest_size=4, person=b"unigrok"
-        ).hexdigest()
+        assert caller == "http:key-1"
 
     def test_anonymous_request_reads_http_anon(self, monkeypatch):
         monkeypatch.delenv("UNIGROK_RUNTIME", raising=False)


### PR DESCRIPTION
## Summary

Close the final CodeQL alert without dismissal by removing all hashing of configured API keys.

## Changes

- preserve configured key order while deduplicating entries
- attribute matching client keys as `key-1`, `key-2`, etc.
- update single-key and multi-key attribution tests

## Head and handoff evidence

Exact head SHA reviewed/tested: `26ea2d88e7d0d75b0670b62ade49637bc03612e9`
Accountable GitHub contributor: `djtelicloud`
Assisting IDE/model (`Agent-Assisted-By`): Codex
Submitting agent-prefixed branch: `codex/codeql-key-alias`
Changed paths: `src/http_server.py`, `tests/test_multiagent.py`
Known risks: telemetry aliases now reflect configured key position; authentication and raw-key handling are unchanged.
Human sponsor: djtelicloud

## Testing

- [x] focused tests: 158 passed
- [x] full suite: 1,076 passed
- [x] `./scripts/land`: `LANDED TO MAIN: 26ea2d88e7d0d75b0670b62ade49637bc03612e9`
- [x] Results apply to the exact head

## Security

- [x] Secret material is neither logged nor hashed for telemetry
- [x] Authentication behavior is unchanged

## Codex/project-admin landing gate

- [ ] Required CI and CODEOWNER review pass
- [x] Codex disposition applies to the exact head
- [ ] Required `Codex Approval` status is present
- [x] Local landing receipt captured above