### PR TITLE
Make the Codex handoff main-state check timeless

### DIFF
--- a/.codex/memory/active-work.md
+++ b/.codex/memory/active-work.md
@@ -36,11 +36,11 @@ credentials, OAuth codes, tokens, or private keys here.
 
 ## Runtime and Git state
 
-- The feature content entered protected `main` at
+- The feature content entered protected `origin/main` at
   `b52ed0f187a1969f522ce4bac75d6168afc75d7d`; the handoff update itself lands
   in a later descendant merge, so do not treat that feature SHA as current
   `main`.
-- `scripts/land-status` is the canonical live check for visible `main` and the
+- `./scripts/land-status` is the canonical live check for visible `main` and the
   contributor runtime marker. Both matched after closeout, and each closeout
   merge tree was byte-identical to its certified task head.
 - Stable `127.0.0.1:4765` and contributor `127.0.0.1:4766` health checks pass.

--- a/.codex/memory/active-work.md
+++ b/.codex/memory/active-work.md
@@ -36,10 +36,13 @@ credentials, OAuth codes, tokens, or private keys here.
 
 ## Runtime and Git state
 
-- Visible local `main` and `origin/main` agree at
-  `b52ed0f187a1969f522ce4bac75d6168afc75d7d`.
-- The contributor runtime marker names that merge commit. The merge tree is
-  byte-identical to the certified task head.
+- The feature content entered protected main at
+  `b52ed0f187a1969f522ce4bac75d6168afc75d7d`; the handoff update itself lands
+  in a later descendant merge, so do not treat that feature SHA as current
+  main.
+- `scripts/land-status` is the canonical live check for visible main and the
+  contributor runtime marker. Both matched after closeout, and each closeout
+  merge tree was byte-identical to its certified task head.
 - Stable `127.0.0.1:4765` and contributor `127.0.0.1:4766` health checks pass.
 - No real `refs/unigrok/*` were created before the protocol landed. Bootstrap
   remains an explicit local contributor action after pulling public main.

--- a/.codex/memory/active-work.md
+++ b/.codex/memory/active-work.md
@@ -36,11 +36,11 @@ credentials, OAuth codes, tokens, or private keys here.
 
 ## Runtime and Git state
 
-- The feature content entered protected main at
+- The feature content entered protected `main` at
   `b52ed0f187a1969f522ce4bac75d6168afc75d7d`; the handoff update itself lands
   in a later descendant merge, so do not treat that feature SHA as current
-  main.
-- `scripts/land-status` is the canonical live check for visible main and the
+  `main`.
+- `scripts/land-status` is the canonical live check for visible `main` and the
   contributor runtime marker. Both matched after closeout, and each closeout
   merge tree was byte-identical to its certified task head.
 - Stable `127.0.0.1:4765` and contributor `127.0.0.1:4766` health checks pass.


### PR DESCRIPTION
## What changed

Makes the completed IntelligenceCapsule handoff immune to self-referential merge drift.

The feature integration SHA remains recorded as provenance, but the tracked file no longer claims that SHA is forever the current `main` or runtime marker. It delegates those live identities to `scripts/land-status`, which is the repository's canonical drift check.

## Exact handoff

- Head: `d0aa81f246e56c1f843baffffa240aa2f7bd6a2f`
- Parent closeout merge: `78b6c315edf2739d9ed9c9f2a74530261fb638a4`
- Human sponsor: `djtelicloud`
- Agent-Assisted-By: `Codex`

## Changed path

- `.codex/memory/active-work.md`

## Verification

- live local main, `origin/main`, and runtime marker matched before this branch;
- `git diff --check` passed;
- deterministic OKF check passed;
- no executable/runtime code changed.
