### PR TITLE
Claude Code integration: shared using-unigrok skill + allowlist fixes

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,11 @@
   "permissions": {
     "allow": [
       "mcp__unigrok__agent",
+      "mcp__unigrok__grok_mcp_status",
+      "mcp__unigrok__grok_mcp_discover_self",
+      "mcp__grok__agent",
+      "mcp__grok__grok_mcp_status",
+      "mcp__grok__grok_mcp_discover_self",
       "Bash(git status:*)",
       "Bash(git fetch:*)",
       "Bash(git log:*)",
@@ -9,7 +14,8 @@
       "Bash(git branch:*)",
       "Bash(git show:*)",
       "Bash(uv run pytest:*)",
-      "Bash(curl -s http://localhost:8080/healthz:*)",
+      "Bash(curl -s http://localhost:4765/healthz:*)",
+      "Bash(./scripts/land-status)",
       "Bash(ls:*)",
       "Bash(cat:*)"
     ]

--- a/.claude/skills/using-unigrok/SKILL.md
+++ b/.claude/skills/using-unigrok/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: using-unigrok
+description: Claude Code guidance for querying xAI Grok through the shared UniGrok MCP gateway. Activate when the user says "@grok", asks to query Grok, wants a Grok second opinion or peer review, needs web/X search grounding, or wants deferred research or Grok Imagine media.
+---
+
+# Using UniGrok from Claude Code
+
+This is the Claude Code adaptation of the canonical gateway skill
+([skills/using-unigrok/SKILL.md](../../../skills/using-unigrok/SKILL.md));
+it adds only what is specific to Claude Code sessions.
+
+## Tool resolution
+
+The gateway's headline tool is `agent`, but its full Claude Code name depends
+on how the MCP server was registered:
+
+- `mcp__unigrok__agent` — connected through this repository's project
+  `.mcp.json` (server name `unigrok`).
+- `mcp__grok__agent` — connected through a user-scope registration named
+  `grok` (the Codex-compatible name).
+
+Use whichever is connected in the session. `.claude/settings.json` pre-allows
+`agent`, `grok_mcp_status`, and `grok_mcp_discover_self` under both namespaces,
+so calls should not raise permission prompts.
+
+## Calling `agent`
+
+- `prompt` (required); `mode` optional: `auto` (default), `fast`, `reasoning`,
+  `thinking`, `research`.
+- `workspace_context`: the stable service is workspace-neutral and cannot see
+  the open folder — attach selected excerpts, `git diff` output, or errors
+  yourself, with an optional `workspace_label`.
+- `session`: pass a stable per-task name; the server namespaces it by caller
+  (`claude-code:<name>`), and reuse lowers cost on follow-ups.
+- `model`: pin only when asked; pins validate against the live catalog. An
+  explicit `plane=cli|api` should pair with `fallback_policy="same_plane"`
+  when billing planes must not cross.
+
+Every result returns `response` plus `model`, `route`, `plane`, `why`,
+`degraded`, `cost_usd`, `tokens`, `latency_sec`, and `citations` when search
+grounding ran. Surface `cost_usd` when the user cares about spend.
+
+## Claude Code patterns
+
+- **Second opinion before handoff**: send the branch diff via
+  `workspace_context` with `mode=reasoning` for a Grok peer review.
+- **Long calls should not block the turn**: `research` and `thinking` runs can
+  take minutes; wrap them in a background subagent (Agent tool) and keep
+  working, then relay the result.
+- **Health first**: on connection trouble, check `GET /healthz` on port 4765
+  and `grok_mcp_status`; `8080` is container-internal and never reachable from
+  the host.
+
+## Registering in another repository
+
+The gateway is machine-global; projects need no UniGrok files. Teammates run:
+
+```bash
+claude mcp add --transport http unigrok http://localhost:4765/mcp \
+  --header "X-Client-ID: claude-code"
+```
+
+`X-Client-ID` attributes telemetry, budgets, and `/metrics` per IDE and keeps
+session namespaces separate. Control Center: `http://localhost:4765/ui/`.
+
+## Safety
+
+- Never request `XAI_API_KEY` in chat or write it into any IDE config; the
+  credential belongs to the server.
+- Treat `credential_planes` notices from status or agent results as the source
+  of truth; ask the user before device authentication, installation, or secret
+  configuration.
+- Translate provider and transport errors into one concrete next action; the
+  user should not need to understand planes or JSON-RPC.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,11 +45,13 @@ Still-unintegrated CLI surfaces include `grok agent stdio|serve|leader` and
 
 Per AGENTS.md: whenever the user says **"@grok"**, "grok", asks to query Grok,
 or asks for a peer review / architectural audit **of this repo**, call the
-shared UniGrok MCP `agent` tool (`mcp__unigrok__agent`) rather than answering
+shared UniGrok MCP `agent` tool (`mcp__unigrok__agent`, or `mcp__grok__agent`
+when the gateway is registered under the name `grok`) rather than answering
 from your own weights — provided the MCP service is up. The tool is the only
 public entry point; it self-routes and returns `response` plus route/plane/
 model/cost metadata. Modes: `auto` (default), `fast`, `reasoning`, `thinking`,
-`research`.
+`research`. Claude-Code-specific usage patterns live in
+`.claude/skills/using-unigrok/SKILL.md`.
 
 ## Source layout
 


### PR DESCRIPTION
Claude Code counterpart to Gemini's PR #42: distribute UniGrok integration to every team member's Claude Code through git, using the roots Claude Code actually discovers.

### Changes
- `.claude/skills/using-unigrok/SKILL.md` (new): Claude-Code-adapted gateway skill — tool-namespace resolution (`mcp__unigrok__` project registration vs `mcp__grok__` user-scope), `workspace_context` usage, background-subagent wrapping for long `research`/`thinking` calls, per-task sessions, `claude mcp add` registration for other repos, credential-boundary rules. Deliberately IDE-specific rather than a third byte-identical copy of the canonical plugin skill, so it cannot drift against `skills/using-unigrok`.
- `.claude/settings.json`: allow the `agent`/`grok_mcp_status`/`grok_mcp_discover_self` tools under both MCP namespaces (previously only `mcp__unigrok__agent`, so user-scope `grok` registrations prompted on every call); fix the healthz allow rule from container-internal 8080 to host-facing 4765; allow read-only `./scripts/land-status`.
- `CLAUDE.md`: note both tool namespaces and point at the new skill.

### Details
- **Commit SHAs**: 6b0f0c4, b81b4e3 (head)
- **Changed paths**: `.claude/settings.json`, `.claude/skills/using-unigrok/SKILL.md`, `CLAUDE.md`
- **Tests**: full suite `uv run pytest -q`: 1118 passed in 48.83s
- **Risks**: docs/config only; no runtime code touched. Permission-allowlist additions are read-only tools.
- **Human sponsor**: David Johnston (@djtelicloud)
- **Provenance**: `Agent-Assisted-By: Claude via Claude Code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)