### PR TITLE
Freeze Insider intelligence payload protocols

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,18 @@ jobs:
           missing=required-names;
           assert not missing, f'missing wheel assets: {sorted(missing)}'"
 
+      - name: Verify bounded source distribution
+        if: matrix.python-version == '3.12'
+        run: >-
+          uv run python -c "import glob, os, tarfile;
+          archive=glob.glob('dist/*.tar.gz')[0];
+          names=tarfile.open(archive, 'r:gz').getnames();
+          forbidden=('node_modules/','/.sites-runtime/','/.next/','/.wrangler/','/__pycache__/');
+          leaked=[name for name in names if any(marker in name for marker in forbidden)];
+          assert not leaked, f'sdist contains generated/local files: {leaked[:20]}';
+          assert os.path.getsize(archive) < 10*1024*1024, 'sdist exceeds 10 MiB';
+          assert len(names) < 2000, f'sdist has suspicious entry count: {len(names)}'"
+
       - name: Static security scan
         if: matrix.python-version == '3.12'
         run: uvx bandit -r src -ll -q

--- a/docs/okf/agentic-dpo-pair-v1.schema.json
+++ b/docs/okf/agentic-dpo-pair-v1.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://grokmcp.org/docs/okf/agentic-dpo-pair-v1.schema.json",
+  "title": "UniGrok direct-Pareto preference pair payload data v1",
+  "description": "The data object carried by payload schema org.grokmcp.agentic_dpo_pair.v1. V1 records only directly proven Pareto dominance between two feasible candidates in one closed cohort.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "chosen",
+    "cohort_proof_manifest",
+    "export_profile",
+    "population_manifest",
+    "preference",
+    "prompt",
+    "rejected",
+    "task_capsule"
+  ],
+  "properties": {
+    "chosen": { "$ref": "#/$defs/side" },
+    "cohort_proof_manifest": { "$ref": "#/$defs/evidenceRef" },
+    "export_profile": { "const": "preference_jsonl_v1" },
+    "population_manifest": { "$ref": "#/$defs/evidenceRef" },
+    "preference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["basis", "dominance_receipt", "policy"],
+      "properties": {
+        "basis": { "const": "pareto_dominance" },
+        "dominance_receipt": { "$ref": "#/$defs/evidenceRef" },
+        "policy": { "const": "nsga2_direct_dominance_v1" }
+      }
+    },
+    "prompt": { "$ref": "#/$defs/evidenceRef" },
+    "rejected": { "$ref": "#/$defs/side" },
+    "task_capsule": { "$ref": "#/$defs/capsuleId" }
+  },
+  "$defs": {
+    "side": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifact", "benchmark_capsule", "candidate_capsule"],
+      "properties": {
+        "artifact": { "$ref": "#/$defs/evidenceRef" },
+        "benchmark_capsule": { "$ref": "#/$defs/capsuleId" },
+        "candidate_capsule": { "$ref": "#/$defs/capsuleId" }
+      }
+    },
+    "evidenceRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["evidence_name", "sha256"],
+      "properties": {
+        "evidence_name": { "$ref": "#/$defs/identifier" },
+        "sha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "capsuleId": {
+      "type": "string",
+      "pattern": "^ucap1:sha256:[a-f0-9]{64}$"
+    },
+    "identifier": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  }
+}

--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -393,6 +393,139 @@ def validate_body(value: Mapping[str, Any]) -> None
 
 Validate the normative IntelligenceCapsule v1 body schema.
 
+## intelligence_payloads.py {#intelligence_payloads}
+
+### Function: `validate_known_payload_profile` {#intelligence_payloads-validate_known_payload_profile}
+
+```python
+def validate_known_payload_profile(body: Mapping[str, Any]) -> bool
+```
+
+**Keywords:** validate, known, payload, profile
+
+Validate a registered payload profile and return whether it was known.
+
+The caller must first apply the generic IntelligenceCapsule v1 validator.
+Unknown versioned payloads remain structurally valid capsules, but this
+function returns ``False`` so a materializer can quarantine them instead
+of executing or promoting semantics it does not understand.
+
+### Function: `payload_profile_schema_sha256` {#intelligence_payloads-payload_profile_schema_sha256}
+
+```python
+def payload_profile_schema_sha256(schema: str) -> str
+```
+
+**Keywords:** payload, profile, schema, sha, 256
+
+Return the pinned raw-schema digest for a registered payload profile.
+
+### Function: `validate_optibench_evidence` {#intelligence_payloads-validate_optibench_evidence}
+
+```python
+def validate_optibench_evidence(body: Mapping[str, Any], evidence_blobs: Mapping[str, bytes]) -> dict[str, tuple[int, ...]]
+```
+
+**Keywords:** validate, optibench, evidence
+
+Verify OptiBench receipts and recompute every published objective.
+
+This consistency verifier does not prove that hardware executed; signed
+publication identifies the runner that made that claim.  It does prove
+that the closed population, passing gates, raw samples, aggregation, and
+canonical body metrics agree byte-for-byte.
+
+### Function: `validate_optibench_population` {#intelligence_payloads-validate_optibench_population}
+
+```python
+def validate_optibench_population(benchmark_bodies: Mapping[str, Mapping[str, Any]], evidence_blobs: Mapping[str, Mapping[str, bytes]]) -> dict[str, dict[str, Any]]
+```
+
+**Keywords:** validate, optibench, population
+
+Verify one complete cohort and recompute exact NSGA-II fields.
+
+Individual counter receipts can prove a candidate's objective tuple, but
+Pareto rank and crowding are properties of a closed population.  This gate
+therefore requires exactly one benchmark capsule for every candidate in
+the shared population, verifies every evidence set, and recomputes both
+rank and exact rational crowding before any result is promotable.
+
+### Function: `validate_gno_dispatch_evidence` {#intelligence_payloads-validate_gno_dispatch_evidence}
+
+```python
+def validate_gno_dispatch_evidence(body: Mapping[str, Any], evidence_blobs: Mapping[str, bytes]) -> None
+```
+
+**Keywords:** validate, gno, dispatch, evidence
+
+Verify the declared GNO input manifest and every referenced input blob.
+
+### Function: `validate_gno_result_graph` {#intelligence_payloads-validate_gno_result_graph}
+
+```python
+def validate_gno_result_graph(result: Mapping[str, Any], dispatch: Mapping[str, Any], *, result_evidence_blobs: Mapping[str, bytes], dispatch_evidence_blobs: Mapping[str, bytes]) -> None
+```
+
+**Keywords:** validate, gno, result, graph
+
+Bind a GNO result to the exact verified dispatch it answers.
+
+### Function: `validate_dpo_preference_graph` {#intelligence_payloads-validate_dpo_preference_graph}
+
+```python
+def validate_dpo_preference_graph(body: Mapping[str, Any], graph_bodies: Mapping[str, Mapping[str, Any]], evidence_blobs: Mapping[str, bytes], graph_evidence_blobs: Mapping[str, Mapping[str, bytes]]) -> None
+```
+
+**Keywords:** validate, dpo, preference, graph
+
+Resolve a closed OptiBench cohort and prove one direct preference.
+
+The supplied graph closure must contain the task, every candidate in the
+population, and exactly one verified OptiBench result for every candidate.
+Ranks are recomputed from the final metrics; stored online Swarm reward or
+provisional rank is never accepted as preference evidence.
+
+### Function: `build_preference_example` {#intelligence_payloads-build_preference_example}
+
+```python
+def build_preference_example(body: Mapping[str, Any], evidence_blobs: Mapping[str, bytes], *, graph_bodies: Mapping[str, Mapping[str, Any]], graph_evidence_blobs: Mapping[str, Mapping[str, bytes]]) -> dict[str, str]
+```
+
+**Keywords:** build, preference, example
+
+Build one verified preference example for nested inference context.
+
+Blob bytes are resolved by evidence name, checked against the capsule's
+byte count and SHA-256 descriptor, and decoded as strict UTF-8.  The
+returned record can be nested into an executor's JSON context.  This is
+in-context conditioning, not a parameter update.
+
+### Function: `render_preference_jsonl` {#intelligence_payloads-render_preference_jsonl}
+
+```python
+def render_preference_jsonl(body: Mapping[str, Any], evidence_blobs: Mapping[str, bytes], *, graph_bodies: Mapping[str, Mapping[str, Any]], graph_evidence_blobs: Mapping[str, Mapping[str, bytes]]) -> bytes
+```
+
+**Keywords:** render, preference, jsonl
+
+Render one verified preference example as canonical JSONL.
+
+### Function: `build_needle_tools_context` {#intelligence_payloads-build_needle_tools_context}
+
+```python
+def build_needle_tools_context(query: str, examples: Sequence[Mapping[str, str]], *, tokenizer: str, token_counter: Callable[[str], int], max_encoder_tokens: int=1024, max_examples: int=8) -> dict[str, Any]
+```
+
+**Keywords:** build, needle, tools, context
+
+Fit whole verified examples into Needle's actual tools-JSON channel.
+
+``token_counter`` must use the pinned Needle tokenizer.  Selection is
+deterministic: examples are deduplicated and sorted by source capsule,
+then whole records are admitted while they fit beside the query and the
+``<tools>`` separator.  Records are never string-sliced.
+
 ## jobs.py {#jobs}
 
 ### Class: `JobManager` {#jobs-jobmanager}

--- a/docs/okf/gno-envelope-v1.schema.json
+++ b/docs/okf/gno-envelope-v1.schema.json
@@ -1,0 +1,184 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://grokmcp.org/docs/okf/gno-envelope-v1.schema.json",
+  "title": "UniGrok GNO input-manifest envelope payload data v1",
+  "description": "The data object carried by payload schema org.grokmcp.gno_envelope.v1. Cross-capsule, evidence, kind, and ordering invariants are enforced by the normative semantic validator.",
+  "oneOf": [
+    { "$ref": "#/$defs/dispatch" },
+    { "$ref": "#/$defs/result" }
+  ],
+  "$defs": {
+    "artifactBase": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["evidence_name", "role", "sha256"],
+      "properties": {
+        "evidence_name": { "$ref": "#/$defs/identifier" },
+        "role": { "type": "string" },
+        "sha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "dispatchArtifact": {
+      "allOf": [
+        { "$ref": "#/$defs/artifactBase" },
+        {
+          "properties": {
+            "role": {
+              "enum": [
+                "context",
+                "input_diff",
+                "input_manifest",
+                "policy",
+                "system_prompt",
+                "task_spec",
+                "tool_manifest"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "resultArtifact": {
+      "allOf": [
+        { "$ref": "#/$defs/artifactBase" },
+        {
+          "properties": {
+            "role": {
+              "enum": ["failure_receipt", "output_diff", "test_receipt", "trace"]
+            }
+          }
+        }
+      ]
+    },
+    "dispatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifacts",
+        "generation",
+        "mutator",
+        "node_id",
+        "phase",
+        "routing",
+        "slot"
+      ],
+      "properties": {
+        "artifacts": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 64,
+          "items": { "$ref": "#/$defs/dispatchArtifact" }
+        },
+        "generation": { "$ref": "#/$defs/positiveSafeInteger" },
+        "mutator": { "$ref": "#/$defs/mutator" },
+        "node_id": { "$ref": "#/$defs/identifier" },
+        "phase": { "const": "dispatch" },
+        "routing": { "$ref": "#/$defs/routing" },
+        "slot": { "$ref": "#/$defs/positiveSafeInteger" }
+      }
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifacts",
+        "dispatch_capsule",
+        "generation",
+        "node_id",
+        "outcome",
+        "phase",
+        "slot"
+      ],
+      "properties": {
+        "artifacts": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 64,
+          "items": { "$ref": "#/$defs/resultArtifact" }
+        },
+        "dispatch_capsule": { "$ref": "#/$defs/capsuleId" },
+        "generation": { "$ref": "#/$defs/positiveSafeInteger" },
+        "node_id": { "$ref": "#/$defs/identifier" },
+        "outcome": { "enum": ["candidate", "failure"] },
+        "phase": { "const": "result" },
+        "slot": { "$ref": "#/$defs/positiveSafeInteger" }
+      }
+    },
+    "mutator": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["origin", "profile"],
+      "properties": {
+        "origin": { "enum": ["agent", "ast", "baseline"] },
+        "profile": { "$ref": "#/$defs/identifier" }
+      }
+    },
+    "routing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "algorithm",
+        "arm",
+        "arm_pull",
+        "parameters",
+        "reason",
+        "seed",
+        "step"
+      ],
+      "properties": {
+        "algorithm": {
+          "enum": [
+            "deterministic_v1",
+            "discounted_ucb_v1",
+            "round_robin_v1",
+            "ucb1_v1"
+          ]
+        },
+        "arm": { "$ref": "#/$defs/identifier" },
+        "arm_pull": { "$ref": "#/$defs/positiveSafeInteger" },
+        "parameters": {
+          "type": "array",
+          "maxItems": 32,
+          "items": { "$ref": "#/$defs/parameter" }
+        },
+        "reason": { "$ref": "#/$defs/identifier" },
+        "seed": { "$ref": "#/$defs/nonnegativeSafeInteger" },
+        "step": { "$ref": "#/$defs/positiveSafeInteger" }
+      }
+    },
+    "parameter": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "value"],
+      "properties": {
+        "name": { "$ref": "#/$defs/identifier" },
+        "value": {
+          "type": "string",
+          "pattern": "^-?(?:0|[1-9][0-9]*)(?:\\.[0-9]+)?$"
+        }
+      }
+    },
+    "capsuleId": {
+      "type": "string",
+      "pattern": "^ucap1:sha256:[a-f0-9]{64}$"
+    },
+    "identifier": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+    },
+    "nonnegativeSafeInteger": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "positiveSafeInteger": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 9007199254740991
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  }
+}

--- a/docs/okf/index.md
+++ b/docs/okf/index.md
@@ -10,6 +10,7 @@ topics:
   - "grok-4.5-pinning"
   - "media-imagine"
   - "metrics-tool"
+  - "intelligence-payload-profiles-v1"
   - "faq"
   - "api-reference"
 ---
@@ -29,5 +30,6 @@ Use this bundle to discover tool schemas, routing details, reasoning levels, med
 - [Model Pinning & Profiles](grok-4.5-pinning.md): API vs CLI paths, fallback parameters, and Grok 4.5 capabilities.
 - [Media Generation](media-imagine.md): Image and video generation schemas.
 - [Observability & Metrics](metrics-tool.md): Aggregated telemetry and status monitoring.
+- [Insider Intelligence Payload Profiles](intelligence-payload-profiles-v1.md): Manifest-closed GNO envelopes, evidenced OptiBench cohorts, direct-Pareto preference pairs, and bounded Needle projections carried beside the immutable Capsule v1 format.
 - [Verified FAQ](faq.md): Curated operational answers that Grok consults only when relevant.
 - [Generated API Reference](api-reference.md): Deterministic signatures and docstrings for documented public Python APIs.

--- a/docs/okf/intelligence-payload-conformance-v1.json
+++ b/docs/okf/intelligence-payload-conformance-v1.json
@@ -1,0 +1,173 @@
+{
+  "accepted_body_sha256": {
+    "org.grokmcp.agentic_dpo_pair.v1": "995484b8eac65ce2e77e296d43ba3b9ab9ae6d8cc8ffb88ed7049f465dc41f07",
+    "org.grokmcp.gno_envelope.v1": "c8fdb027a0382799ab19a8d032a559de1ca33f2a972377776ef2dc3866f47224",
+    "org.grokmcp.optibench_result.v1": "5005fc5ba7bd6d89da786bf9ffc8c287ec0fb331c271cbfe642583c230b346e8"
+  },
+  "reject_vectors": [
+    {
+      "error": "numerator",
+      "mutation": "crowding_numerator_digits",
+      "profile": "org.grokmcp.optibench_result.v1",
+      "value": 129
+    },
+    {
+      "error": "profile and tool disagree",
+      "mutation": "mixed_counter_tool",
+      "profile": "org.grokmcp.optibench_result.v1"
+    },
+    {
+      "error": "does not match",
+      "mutation": "substituted_evidence_digest",
+      "profile": "org.grokmcp.gno_envelope.v1"
+    },
+    {
+      "error": "parents must be",
+      "mutation": "missing_preference_parent",
+      "profile": "org.grokmcp.agentic_dpo_pair.v1"
+    },
+    {
+      "error": "secret-like",
+      "mutation": "secret_identifier",
+      "profile": "org.grokmcp.gno_envelope.v1",
+      "target": "extra_evidence_name",
+      "value_parts": ["ghp_", "abcdefghijklmnopqrstuvwxyz123456"]
+    },
+    {
+      "error": "origin is unsupported",
+      "mutation": "enum_type_confusion",
+      "profile": "org.grokmcp.gno_envelope.v1",
+      "target": "mutator.origin",
+      "value": ["agent"]
+    },
+    {
+      "error": "secret-like",
+      "mutation": "secret_mapping_text",
+      "profile": "org.grokmcp.gno_envelope.v1",
+      "target": "resolved_context_evidence",
+      "value_parts": ["\"client", "Secret\":\"verysecretvalue123\""]
+    }
+  ],
+  "semantic_vectors": {
+    "dpo_cohort_proof_v1": {
+      "expected_sha256": "02d294446a1dafdcd62057a573d6f7ea711c338c52d4602fb92ecf2152bad004",
+      "manifest": {
+        "benchmarks": [
+          {
+            "benchmark_capsule": "ucap1:sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            "candidate_capsule": "ucap1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          },
+          {
+            "benchmark_capsule": "ucap1:sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+            "candidate_capsule": "ucap1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          }
+        ],
+        "cohort_sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "population_manifest_sha256": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+      }
+    },
+    "needle_tools_context_v1": {
+      "examples": [
+        {
+          "chosen": "fast",
+          "prompt": "optimize",
+          "rejected": "slow",
+          "source_capsule": "ucap1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        {
+          "chosen": "small",
+          "prompt": "shrink",
+          "rejected": "large",
+          "source_capsule": "ucap1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        }
+      ],
+      "expected_encoder_tokens": 623,
+      "expected_projection_sha256": "e3b3e31e9258bc391e0fa5ae99cfb72da182a993225f464b722d4a6ff09a551c",
+      "expected_used_source_capsules": [
+        "ucap1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "ucap1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      ],
+      "max_encoder_tokens": 1024,
+      "query": " rank context　",
+      "token_counter": "utf8_byte_length",
+      "tokenizer": "utf8-bytes-v1"
+    },
+    "nsga2_exact_v1": {
+      "expected": [
+        {
+          "candidate_capsule": "ucap1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "crowding": {"kind": "boundary"},
+          "pareto_rank": 0
+        },
+        {
+          "candidate_capsule": "ucap1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "crowding": {"denominator": "1", "kind": "finite", "numerator": "2"},
+          "pareto_rank": 0
+        },
+        {
+          "candidate_capsule": "ucap1:sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "crowding": {"denominator": "1", "kind": "finite", "numerator": "2"},
+          "pareto_rank": 0
+        },
+        {
+          "candidate_capsule": "ucap1:sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "crowding": {"kind": "boundary"},
+          "pareto_rank": 0
+        }
+      ],
+      "objective_order": ["o1", "o2", "constant"],
+      "points": [
+        {
+          "candidate_capsule": "ucap1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "values": ["0", "10", "7"]
+        },
+        {
+          "candidate_capsule": "ucap1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "values": ["5", "5", "7"]
+        },
+        {
+          "candidate_capsule": "ucap1:sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "values": ["5", "5", "7"]
+        },
+        {
+          "candidate_capsule": "ucap1:sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "values": ["10", "0", "7"]
+        }
+      ]
+    },
+    "optibench_receipts_v1": {
+      "counter": {
+        "baseline": {
+          "cpu_instructions_retired": "1100",
+          "diff_tokens": "11",
+          "peak_memory_bytes": "105"
+        },
+        "counter_profile": "perf_stat_instructions_v1",
+        "samples": [
+          {"cpu_instructions_retired": "1002", "diff_tokens": "10", "peak_memory_bytes": "102"},
+          {"cpu_instructions_retired": "999", "diff_tokens": "11", "peak_memory_bytes": "101"},
+          {"cpu_instructions_retired": "1000", "diff_tokens": "10", "peak_memory_bytes": "100"},
+          {"cpu_instructions_retired": "1001", "diff_tokens": "9", "peak_memory_bytes": "99"},
+          {"cpu_instructions_retired": "998", "diff_tokens": "10", "peak_memory_bytes": "98"}
+        ]
+      },
+      "environment": {
+        "architecture": "x86_64",
+        "cpu_model": "zen4",
+        "kernel": "linux-6.8.0",
+        "operating_system": "ubuntu-24.04",
+        "runner": "linux-x86_64"
+      },
+      "expected_baseline_relation": "dominates_baseline",
+      "expected_medians": ["1000", "10", "100"],
+      "harness": {
+        "diff_metric": "token_count",
+        "peak_memory_method": "max_rss",
+        "source_commit": "aa1daa2de2a2bc1d1dab6c2e053022287aa63157",
+        "tokenizer": "pinned-v1",
+        "version": "1.0.0"
+      }
+    }
+  },
+  "version": 1
+}

--- a/docs/okf/intelligence-payload-profiles-v1.md
+++ b/docs/okf/intelligence-payload-profiles-v1.md
@@ -1,0 +1,269 @@
+# UniGrok Insider Intelligence payload profiles v1
+
+These profiles evolve the Insider Intelligence DAG without changing the pinned
+`IntelligenceCapsule` v1 envelope. Each profile occupies the existing
+`body.payload = {"schema": ..., "data": ...}` seam and has its own immutable
+schema digest:
+
+| payload schema | JSON Schema | raw SHA-256 |
+| --- | --- | --- |
+| `org.grokmcp.gno_envelope.v1` | [`gno-envelope-v1.schema.json`](gno-envelope-v1.schema.json) | `4c7fb150b3f82738ae43d52669c8c663283807d42add1f4532f01527a4d70665` |
+| `org.grokmcp.optibench_result.v1` | [`optibench-result-v1.schema.json`](optibench-result-v1.schema.json) | `dfc216d1855eb36e54829c3aca00434f0dc9845a6efc205c2c49016531accf81` |
+| `org.grokmcp.agentic_dpo_pair.v1` | [`agentic-dpo-pair-v1.schema.json`](agentic-dpo-pair-v1.schema.json) | `7db601ccc11aaa94409383f88c7305a46b63a705176897aaa313f835b24bed84` |
+
+The raw file digests are pinned in both language registries. Normative
+cross-capsule rules are separately frozen in
+[`intelligence-payload-semantics-v1.json`](intelligence-payload-semantics-v1.json),
+SHA-256 `7464c2343c3edaadc21a14a880e689ef8e4b4ac0fa3fc07b2b6f37b08733545a`.
+The public, digest-bound
+[`intelligence-payload-conformance-v1.json`](intelligence-payload-conformance-v1.json)
+at SHA-256 `6a0df82c82cd3bfbadc6ff1febf1e43b2d2a6446acd1b977ae7d3262de8d98f4`
+contains shared body identities, receipt examples, exact NSGA-II outcomes, a
+Needle projection identity, and adversarial reject vectors. Any semantic
+change requires a new profile/spec version;
+editing a `.v1` contract in place is a protocol fork.
+
+## Scope and trust boundary
+
+These are protocol contracts, not claims that every producer exists today.
+The current local Swarm still stores its working state in contributor SQLite,
+uses wall-clock latency and `tracemalloc`, ranks
+`latency_ms`/`peak_mem_bytes`/`diff_bytes`, and routes with discounted UCB.
+It does not currently emit GNO capsules, hardware-counter OptiBench capsules,
+or preference pairs.
+
+A capsule with a known profile becomes eligible for promotion only after all
+of these independent gates succeed:
+
+1. canonical envelope parsing and body-digest verification;
+2. the registered profile schema and semantic validator;
+3. evidence byte-count and SHA-256 verification;
+4. complete parent-graph closure, bounds, and acyclicity checks;
+5. signed-Git-commit or approved cloud-attestation publication authentication;
+6. repository promotion policy.
+
+An unknown payload schema may be retained in quarantine, but it must not be
+executed, materialized, promoted, or exported. The envelope `signatures` array
+does not authorize publication in v1.
+
+The Python module is the current executable implementation of every v1
+evidence and complete-graph gate. The browser TypeScript module performs the
+same envelope/profile structural checks, but it is not a promotion authority
+and does not independently resolve evidence blobs or recompute cohort graphs.
+
+## GNO input-manifest envelope
+
+`org.grokmcp.gno_envelope.v1` alternates task dispatch capsules with candidate
+or failure result capsules.
+
+- A dispatch has `body.kind = task`, explicit execution identity, and required
+  `task_spec` plus `input_manifest` evidence. Its parents are the complete
+  graph dependencies. The canonical manifest binds routing, execution, and
+  every other declared non-secret artifact, including any Git input diff,
+  context, system prompt, tool manifest, and policy.
+- A result has `body.kind = candidate` or `failure`, matching its `outcome`.
+  Its sole parent is its dispatch capsule. A candidate carries an
+  `output_diff` evidence reference; a failure carries a `failure_receipt`.
+  It must omit `body.execution`: executor identity is inherited from the
+  manifest-bound dispatch and cannot be contradicted downstream.
+- Every artifact reference binds both evidence name and SHA-256. Name-only
+  lookup is forbidden, and evidence names are unique inside a known profile.
+- Routing labels are literal. The existing Swarm is
+  `discounted_ucb_v1`; it cannot be relabeled as UCB1. Decimal routing
+  parameters are strings, never floats or nulls.
+- The resolver verifies every declared byte count and SHA-256 and rejects
+  secret-like shared text. Credentials and private consumer SQLite state are
+  never evidence.
+
+"Manifest-closed and stateless" does not mean mathematically deterministic. A
+remote model, provider implementation, or sampling path may change. The
+envelope makes every declared input replayable and every result attributable;
+it does not promise byte-identical model output. Promotion also requires an
+executor receipt proving the agent was sandboxed from undeclared ambient reads:
+a manifest alone cannot prove that a process did not cheat.
+
+The DPO proof resolver enforces bounded transitive parent closure and
+acyclicity. General GNO TaskGraph admission and total evidence-byte limits
+remain additional promotion-time rules. A parallelism index and a `1 -> 2`
+branching policy are intentionally not serialized: neither has a frozen
+definition or current implementation.
+
+## Closed-population OptiBench result
+
+`org.grokmcp.optibench_result.v1` is deliberately impossible to mint from the
+current wall-clock Swarm result. It requires a closed population, canonical
+counter samples, an environment manifest, a harness manifest, and successful
+gate receipts. The evidence verifier recomputes population/cohort binding,
+requires a passing tests gate, and derives every published median from the raw
+samples before the capsule can enter a trusted graph.
+
+Two non-interchangeable cohorts are supported:
+
+| cohort | exact objective metrics in `body.metrics` |
+| --- | --- |
+| `perf_stat_instructions_v1` | `cpu_instructions_retired/instruction`, `diff_tokens/token`, `peak_memory_bytes/byte` |
+| `callgrind_ir_v1` | `callgrind_ir/instruction_reference`, `diff_tokens/token`, `peak_memory_bytes/byte` |
+
+All objectives minimize nonnegative integer values. `perf` instructions and
+Callgrind instruction references are different physical measurements and
+must never share a cohort or be compared as though they were identical. The
+harness evidence fixes tokenizer identity for `diff_tokens` and measurement
+method for peak memory.
+
+Environment receipts have exactly `architecture`, `cpu_model`, `kernel`,
+`operating_system`, and `runner`. Harness receipts have exactly `diff_metric`,
+`peak_memory_method`, `source_commit`, `tokenizer`, and `version`; the source
+commit is a full lowercase SHA-1 or SHA-256 object id. Identifier syntax alone
+is not treated as safe: all shared textual receipt values also pass the pinned
+secret detector.
+
+NSGA-II ranking occurs only after the population closes. Finite crowding is a
+reduced nonnegative rational `{numerator, denominator}`; a boundary point uses
+`{"kind":"boundary"}`. IEEE infinity and floating-point crowding never enter
+canonical bytes. Rational components are bounded to 128 decimal digits.
+Repetition counts are odd, so an integer-valued median has one exact middle
+sample and no hidden rounding rule.
+
+Rank and crowding are not properties of one result, so the single-receipt
+verifier cannot authorize promotion by itself. The closed-population verifier
+requires exactly one evidence-verified benchmark per population candidate,
+then recomputes every final rank and crowding value. It groups tied objective
+values symmetrically: all tied nonconstant extrema are boundaries; tied
+interior values receive the same nearest-distinct-neighbor fraction; constant
+objectives add zero. Candidate IDs order output but never break mathematical
+ties.
+
+`baseline_relation` is mandatory because nondominated among mutants does not
+mean better than the original program. The canonical counter receipt carries
+the baseline objective tuple; the verifier recomputes whether the candidate
+dominates, equals, is incomparable with, or is dominated by that baseline.
+
+## Direct-Pareto preference pair
+
+`org.grokmcp.agentic_dpo_pair.v1` records one conservative training/evaluation
+label:
+
+- chosen and rejected candidates are distinct, feasible members of the same
+  closed population and measurement cohort;
+- the chosen benchmark is final Pareto rank zero;
+- the rejected benchmark has a worse final rank;
+- the chosen objective tuple directly dominates that specific rejected tuple;
+- the task plus chosen/rejected candidate and benchmark IDs are the five direct
+  parents; the cohort proof hash-binds every additional population benchmark;
+- task and candidates are evidence-verified GNO dispatch/result capsules;
+- prompt binds the dispatch's sole `task_spec`, while chosen and rejected text
+  bind the candidates' sole `output_diff` artifacts by SHA-256;
+- prompt, outputs, population manifest, complete candidate-to-benchmark cohort
+  proof, and dominance receipt are hash-bound evidence.
+
+An arbitrary elite cannot be paired against an arbitrary dominated candidate:
+front membership alone does not prove pairwise dominance. Infeasible mutants
+are constraint failures, not objective-preference negatives. Online rewards or
+provisional ranks are not admissible; the producer must recompute the final
+closed front. V1 therefore supports only `pareto_dominance` under
+`nsga2_direct_dominance_v1`. Human, judge, champion-policy, and constraint
+preferences require later profiles with their own proof rules.
+
+`build_preference_example` accepts a complete graph closure, verifies every
+OptiBench receipt, recomputes final fronts and direct dominance, checks that the
+chosen candidate beats baseline, verifies every transitive dependency uses a
+registered GNO or OptiBench profile, and rejects secret-like shared text. The
+cohort proof manifest binds the exact benchmark capsule selected for every
+candidate, including candidates that are not one of the exported pair. Only
+then does it return one provider-neutral record.
+`render_preference_jsonl` emits that record with canonical key order and a
+single trailing LF for storage or batch transport:
+
+```json
+{"chosen":"...","prompt":"...","rejected":"...","source_capsule":"ucap1:sha256:..."}
+```
+
+The record and JSONL are disposable projections, not second sources of truth.
+Time decay or relevance weighting belongs in the Insider
+materialized-view query policy; it never mutates immutable pair provenance.
+
+## Canonical hashing and publication authentication in Python
+
+```python
+import hashlib
+
+from src.intelligence_capsule import (
+    build_envelope,
+    canonicalize,
+    capsule_id,
+    validate_envelope_integrity,
+)
+from src.intelligence_payloads import validate_known_payload_profile
+
+# `body` includes a registered payload and only SHA-256 evidence descriptors.
+body_bytes = canonicalize(body)                 # restricted RFC 8785 profile
+body_sha256 = hashlib.sha256(body_bytes).hexdigest()
+identity = capsule_id(body)                     # ucap1:sha256:<body_sha256>
+
+envelope = build_envelope(body)                 # signatures remains [] in v1
+validate_envelope_integrity(envelope)
+assert validate_known_payload_profile(body)       # separate semantic gate
+wire_bytes = canonicalize(envelope)
+
+assert envelope["digest"] == {
+    "algorithm": "sha-256",
+    "value": body_sha256,
+}
+assert identity == f"ucap1:sha256:{body_sha256}"
+```
+
+The signed publication object is the Git commit containing `wire_bytes`, not an
+ad-hoc signature over a framework JSON object. Local publication uses the
+contributor's configured SSH/GPG Git signing identity; cloud publication uses
+an approved workflow attestation. The v1 `signatures` field is reserved until a
+future protocol freezes a signature domain, key discovery, and trust roots.
+
+## Needle conditioning boundary
+
+Needle's playground accepts `tools` as a JSON string or array whose parsed top
+level is an array. The server compacts it, and `generate` normalizes only
+top-level tool names while preserving nested fields. The encoder receives the
+query, a tools separator, and the serialized tools, truncated to the space
+remaining in its 1,024-token encoder budget. Consequently, nested examples in
+a valid tool definition are mechanically supported inference-time context.
+They have no dedicated chosen/rejected semantics, so their ranking benefit must
+be benchmarked. [UI request](https://github.com/cactus-compute/needle/blob/ffb1c5144c5a16cb8ec650dbc8a6f6fd3854f8f2/needle/ui/static/app.js#L69-L92),
+[server normalization](https://github.com/cactus-compute/needle/blob/ffb1c5144c5a16cb8ec650dbc8a6f6fd3854f8f2/needle/ui/server.py#L156-L187),
+[encoder path](https://github.com/cactus-compute/needle/blob/ffb1c5144c5a16cb8ec650dbc8a6f6fd3854f8f2/needle/model/run.py#L92-L137).
+
+The provider-neutral DPO capsule does not claim Needle compatibility.
+`org.grokmcp.needle_tools_context.v1` is a separate executor-only projection,
+pinned by [`needle-tools-context-v1.schema.json`](needle-tools-context-v1.schema.json)
+at SHA-256 `ac92a88b87e35254a7eef4a151d8743418ef102402022b228609743cbcbf7496`.
+`build_needle_tools_context` wraps verified records inside one valid tool,
+counts the exact compacted tools string with a caller-supplied pinned Needle
+tokenizer, admits only whole examples in source-capsule order, and never exceeds
+the shared query/tools budget. The wrapper is non-parametric inference-time
+conditioning, not a weight or optimizer update. Query normalization trims only
+the explicit CPython Unicode whitespace set used by the upstream server
+(including NBSP and U+3000), requires strict UTF-8, and applies the same pinned
+secret detector as the nested examples before any token count is accepted.
+Input is bounded before regex/tokenizer work: at most 64 examples, 16 KiB of
+query text, and 64 KiB per example record.
+
+The separate playground fine-tune action generates `query`/`tools`/`answers`
+JSONL and runs an actual training job that writes a new checkpoint. UniGrok
+keeps that path distinct from ephemeral nested-example conditioning.
+[Fine-tune implementation](https://github.com/cactus-compute/needle/blob/ffb1c5144c5a16cb8ec650dbc8a6f6fd3854f8f2/needle/ui/server.py#L520-L647).
+
+Needle remains a non-authoritative shadow ranker. It may score sanitized,
+pre-enumerated candidate summaries, but its output cannot authorize reads,
+execution, mutation, or promotion. Exact source and model artifacts must be
+pinned and isolated before loading; benchmark recall and end-to-end answer
+quality against simpler retrieval baselines first. Needle's dedicated repo and
+model are MIT-licensed; its 26M/6,000-prefill/1,200-decode figures are vendor
+claims until UniGrok reproduces them, and they are not retrieval or
+nested-example benchmarks.
+
+## SQLite boundary
+
+Nothing in these profiles opens or changes the public consumer database. Public
+MCP consumers retain private local SQLite as runtime truth. A future Insider
+SQLite query view may index only trusted Git-DAG capsules; it must remain
+deletable and reconstructible from trusted refs without tunnels or cloud calls
+into localhost.

--- a/docs/okf/intelligence-payload-semantics-v1.json
+++ b/docs/okf/intelligence-payload-semantics-v1.json
@@ -1,0 +1,276 @@
+{
+  "protocol": "org.grokmcp.intelligence-payload-semantics",
+  "version": 1,
+  "normative_language": "MUST, MUST NOT, REQUIRED, and EXACT are normative. Any unrecognized field or receipt shape is rejected.",
+  "capsule_schema_sha256": "10c2ec4638bd6c4e303b3e2c4c7d91ae582554f48aaa01fac2d9370062b98d4c",
+  "conformance": {
+    "file": "intelligence-payload-conformance-v1.json",
+    "sha256": "6a0df82c82cd3bfbadc6ff1febf1e43b2d2a6446acd1b977ae7d3262de8d98f4"
+  },
+  "limits": {
+    "graph_bodies": 129,
+    "jsonl_artifact_bytes": 262144,
+    "jsonl_record_bytes": 786432,
+    "needle_encoder_tokens": 1024,
+    "needle_example_bytes": 65536,
+    "needle_input_examples": 64,
+    "needle_query_bytes": 16384,
+    "objective_decimal_digits": 32,
+    "population_candidates": 64,
+    "rational_decimal_digits": 128
+  },
+  "receipt_contracts": [
+    {
+      "id": "gno_input_manifest_v1",
+      "encoding": "IntelligenceCapsule restricted-JCS canonical bytes",
+      "exact_keys": ["declared_artifacts", "execution", "routing"],
+      "bindings": {
+        "declared_artifacts": "body.payload.data.artifacts in canonical array order excluding the sole input_manifest role",
+        "execution": "body.execution by deep JSON equality",
+        "routing": "body.payload.data.routing by deep JSON equality"
+      }
+    },
+    {
+      "id": "optibench_environment_v1",
+      "encoding": "IntelligenceCapsule restricted-JCS canonical bytes",
+      "exact_keys": ["architecture", "cpu_model", "kernel", "operating_system", "runner"],
+      "value_rule": "Every value matches ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ and passes shared_secret_detector_v1."
+    },
+    {
+      "id": "optibench_harness_v1",
+      "encoding": "IntelligenceCapsule restricted-JCS canonical bytes",
+      "exact_keys": ["diff_metric", "peak_memory_method", "source_commit", "tokenizer", "version"],
+      "bindings": {
+        "source_commit": "lowercase hexadecimal Git object id matching ^(?:[a-f0-9]{40}|[a-f0-9]{64})$",
+        "other_values": "Each matches ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ and passes shared_secret_detector_v1."
+      }
+    },
+    {
+      "id": "optibench_population_manifest_v1",
+      "encoding": "IntelligenceCapsule restricted-JCS canonical bytes",
+      "exact_keys": ["candidate_capsules", "closed", "cohort_sha256"],
+      "bindings": {
+        "candidate_capsules": "body.parents by exact ordered-array equality",
+        "closed": true,
+        "cohort_sha256": "lowercase SHA-256 hex of restricted-JCS canonical body.payload.data.cohort"
+      }
+    },
+    {
+      "id": "optibench_gate_receipt_v1",
+      "encoding": "IntelligenceCapsule restricted-JCS canonical bytes",
+      "exact_keys": ["gate", "passed"],
+      "bindings": {
+        "gate": "identifier matching ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$; unique across receipts; tests is REQUIRED",
+        "passed": true
+      }
+    },
+    {
+      "id": "optibench_counter_receipt_v1",
+      "encoding": "IntelligenceCapsule restricted-JCS canonical bytes",
+      "exact_keys": ["baseline", "counter_profile", "samples"],
+      "bindings": {
+        "baseline": "Object with exactly objective_metrics keys; values are nonnegative base-10 integer strings of at most 32 digits.",
+        "counter_profile": "Exact equality with body.payload.data.cohort.counter_profile.",
+        "samples": "Array length equals repetitions; each object has exactly objective_metrics keys and bounded nonnegative base-10 integer-string values."
+      }
+    },
+    {
+      "id": "dpo_cohort_proof_manifest_v1",
+      "encoding": "IntelligenceCapsule restricted-JCS canonical bytes",
+      "exact_keys": ["benchmarks", "cohort_sha256", "population_manifest_sha256"],
+      "bindings": {
+        "benchmarks": "Exactly one object with exact keys benchmark_capsule,candidate_capsule for every candidate in the closed population, ordered by candidate_capsule; each benchmark id is the unique evidence-verified OptiBench result selected for that candidate.",
+        "cohort_sha256": "lowercase SHA-256 hex of restricted-JCS canonical shared cohort object",
+        "population_manifest_sha256": "SHA-256 from the shared OptiBench population_manifest evidence reference"
+      }
+    },
+    {
+      "id": "dpo_dominance_receipt_v1",
+      "encoding": "IntelligenceCapsule restricted-JCS canonical bytes",
+      "exact_keys": ["chosen_benchmark", "metrics", "rejected_benchmark", "relation"],
+      "bindings": {
+        "chosen_benchmark": "body.payload.data.chosen.benchmark_capsule",
+        "metrics": "One object per objective in declared order with exact keys chosen,name,rejected,unit and values copied from verified benchmark tuples.",
+        "rejected_benchmark": "body.payload.data.rejected.benchmark_capsule",
+        "relation": "dominates"
+      }
+    }
+  ],
+  "algorithms": [
+    {
+      "id": "dominates_minimize_v1",
+      "input": "Two equal-length ordered tuples of nonnegative integers.",
+      "result": "left dominates right iff every left[i] <= right[i] and at least one left[i] < right[i]."
+    },
+    {
+      "id": "integer_median_v1",
+      "input": "An odd nonempty multiset of bounded nonnegative integers.",
+      "steps": [
+        "Sort integers in ascending numeric order.",
+        "Return element at zero-based index floor(length / 2).",
+        "The resulting tuple MUST exactly equal body.metrics in objective_metrics order."
+      ]
+    },
+    {
+      "id": "nsga2_exact_v1",
+      "input": "Exactly one verified benchmark per candidate in a nonempty closed population; all ordered objectives minimize.",
+      "rank_steps": [
+        "Set remaining to all candidate capsule ids and rank to 0.",
+        "The next front is every remaining candidate not dominated by any other remaining candidate under dominates_minimize_v1.",
+        "Sort the front by candidate capsule id for deterministic output, assign rank, remove it, increment rank, and repeat until remaining is empty."
+      ],
+      "crowding_steps": [
+        "Compute crowding separately inside each final Pareto front.",
+        "A singleton front publishes {kind:boundary}.",
+        "For a larger front initialize every exact rational distance to 0/1 and boundary=false.",
+        "For each objective in objective_metrics order, group candidates by exact integer value and sort the distinct values ascending.",
+        "If the objective is constant, it contributes zero and marks no boundary.",
+        "Otherwise mark every candidate tied at the minimum or maximum value as boundary.",
+        "For every interior distinct value v[j], add (v[j+1]-v[j-1])/(maximum-minimum) to every candidate tied at v[j].",
+        "A candidate marked by any objective publishes {kind:boundary}; every other candidate publishes the summed Fraction reduced by positive gcd as {denominator,kind:finite,numerator} using unsigned base-10 strings.",
+        "Zero MUST serialize as numerator 0 and denominator 1. Numerator and denominator MUST each fit the 128-digit bound."
+      ],
+      "tie_policy": "Candidate ids never break mathematical ties; all tied extrema share boundary status and all tied interior values receive the same nearest-distinct-neighbor contribution."
+    },
+    {
+      "id": "complete_parent_graph_v1",
+      "input": "At most 129 canonical capsule bodies keyed by their exact capsule ids.",
+      "steps": [
+        "Every parent id of every supplied body MUST resolve to another supplied body.",
+        "Depth-first traversal uses unseen,visiting,complete states; an edge to visiting rejects a cycle.",
+        "Traversal depth MUST NOT exceed 129.",
+        "For DPO, the reachable closure starts from the declared task, every population candidate, and every cohort-proof benchmark; unrelated supplied bodies reject.",
+        "Every reachable dependency MUST use a registered GNO or OptiBench profile and pass its profile plus evidence verifier."
+      ]
+    },
+    {
+      "id": "needle_tools_context_v1",
+      "input": "Strict-UTF-8 query, verified preference records, pinned tokenizer id, exact token counter, max_encoder_tokens=1024, and max_examples in [1,64].",
+      "steps": [
+        "Before encoding, regex, sorting, or tokenization, reject a raw query longer than 16384 code points, more than 64 input examples, or an example whose three text fields exceed 65536 aggregate code points.",
+        "Trim exactly Unicode code points U+0009..U+000D,U+001C..U+001F,U+0020,U+0085,U+00A0,U+1680,U+2000..U+200A,U+2028,U+2029,U+202F,U+205F,U+3000 from both query ends, matching the pinned upstream Python strip behavior; reject an empty result.",
+        "Require normalized query UTF-8 bytes <=16384 and each canonical example record <=65536 bytes; reject invalid Unicode scalars.",
+        "Reject secret-like query or example text with shared_secret_detector_v1.",
+        "Require exact example keys chosen,prompt,rejected,source_capsule; sort by source_capsule and reject duplicates.",
+        "Construct exactly one tool named select_unigrok_context using the field values and insertion order frozen by the conformance vector.",
+        "Serialize the tools array with Python json.dumps separators=(',',':') and ensure_ascii=true; no trailing LF.",
+        "Token cost is token_counter(query)+1+token_counter(serialized_tools), where 1 is the Needle tools separator.",
+        "Start with no examples. Inspect at most max_examples sorted records; append a whole record iff the resulting cost is <=1024, otherwise continue without slicing it.",
+        "Publish query_sha256 over normalized strict-UTF-8 query bytes and the final exact token count."
+      ]
+    }
+  ],
+  "secret_rejection": {
+    "id": "shared_secret_detector_v1",
+    "action": "For every known profile, recursively inspect every string in the capsule body plus every resolved shared text blob. Reject matches; never redact hash-bound bytes because redaction would change provenance.",
+    "patterns": [
+      {"expression": "github_pat_[A-Za-z0-9_]{10,}|gh[pousr]_[A-Za-z0-9]{10,}", "ignore_case": false},
+      {"expression": "glpat-[A-Za-z0-9_-]{10,}", "ignore_case": false},
+      {"expression": "\\bsk-(?:proj-|svcacct-)?[A-Za-z0-9_-]{12,}", "ignore_case": false},
+      {"expression": "\\bxai-[A-Za-z0-9_-]{12,}", "ignore_case": true},
+      {"expression": "\\bAIza[A-Za-z0-9_-]{25,}", "ignore_case": false},
+      {"expression": "\\b(?:AKIA|ASIA)[A-Z0-9]{16}\\b", "ignore_case": false},
+      {"expression": "\\bnpm_[A-Za-z0-9]{20,}", "ignore_case": false},
+      {"expression": "\\bpypi-[A-Za-z0-9_-]{20,}", "ignore_case": false},
+      {"expression": "\\bxox[baprs]-[A-Za-z0-9-]{12,}", "ignore_case": false},
+      {"expression": "\\bsk_live_[A-Za-z0-9]{16,}", "ignore_case": false},
+      {"expression": "-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----", "ignore_case": false},
+      {"expression": "\\beyJ[A-Za-z0-9_-]{20,}\\.[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\b", "ignore_case": false},
+      {"expression": "\\bBearer\\s+(?!<|\\$\\{|\\[)[A-Za-z0-9._~+/=-]{8,}", "ignore_case": true},
+      {"expression": "Authorization\\s*:\\s*Bearer\\s+(?!<|\\$\\{|\\[)[A-Za-z0-9._~+/-]{8,}", "ignore_case": true},
+      {"expression": "Authorization\\s*:\\s*Basic\\s+(?!<|\\$\\{|\\[)[A-Za-z0-9+/=]{8,}", "ignore_case": true},
+      {"expression": "(?:^|[^A-Za-z0-9_])[\"']?[A-Z0-9_-]*(?:API[_-]?KEY|SECRET[_-]?ACCESS[_-]?KEY|SESSION[_-]?TOKEN|ACCESS[_-]?TOKEN|AUTH[_-]?TOKEN|PASSWORD|PRIVATE[_-]?KEY|CLIENT[_-]?SECRET)[\"']?\\s*[:=]\\s*(?![\"']?(?:<|\\$\\{|\\[))(?:\"[^\"\\r\\n]{8,}\"|'[^'\\r\\n]{8,}'|[A-Za-z0-9._~+/=@!#$%^&*()-]{8,})", "ignore_case": true}
+    ]
+  },
+  "profiles": [
+    {
+      "schema": "org.grokmcp.agentic_dpo_pair.v1",
+      "schema_sha256": "7db601ccc11aaa94409383f88c7305a46b63a705176897aaa313f835b24bed84",
+      "rules": [
+        "dpo.artifacts_match_candidates",
+        "dpo.baseline_victory",
+        "dpo.candidates_link_declared_task",
+        "dpo.cohort_proof_binds_every_benchmark",
+        "dpo.closed_cohort",
+        "dpo.complete_parent_graph",
+        "dpo.direct_dominance",
+        "dpo.export_after_graph_verification",
+        "dpo.final_rank_and_crowding_recomputed",
+        "dpo.parents_exact",
+        "dpo.prompt_matches_task",
+        "dpo.requires_registered_gno_dependencies",
+        "dpo.receipt_recomputed",
+        "dpo.same_run_subject",
+        "dpo.shared_baseline",
+        "dpo.text_evidence_verified",
+        "dpo.text_sha_matches_gno_semantic_roles"
+      ]
+    },
+    {
+      "schema": "org.grokmcp.gno_envelope.v1",
+      "schema_sha256": "4c7fb150b3f82738ae43d52669c8c663283807d42add1f4532f01527a4d70665",
+      "rules": [
+        "gno.artifacts_hash_bound",
+        "gno.dispatch_execution_explicit",
+        "gno.input_manifest_recomputed",
+        "gno.kind_matches_phase",
+        "gno.no_secret_like_shared_text",
+        "gno.result_dispatch_fields_match",
+        "gno.result_execution_inherited_only",
+        "gno.result_opposite_role_forbidden",
+        "gno.result_parent_exact",
+        "gno.role_cardinality",
+        "gno.same_run_subject"
+      ]
+    },
+    {
+      "schema": "org.grokmcp.optibench_result.v1",
+      "schema_sha256": "dfc216d1855eb36e54829c3aca00434f0dc9845a6efc205c2c49016531accf81",
+      "rules": [
+        "optibench.baseline_relation_recomputed",
+        "optibench.cohort_metric_set_exact",
+        "optibench.counter_samples_recomputed",
+        "optibench.environment_manifest_exact",
+        "optibench.gates_passed",
+        "optibench.harness_manifest_exact",
+        "optibench.integer_median_odd_repetitions",
+        "optibench.population_manifest_recomputed",
+        "optibench.rank_and_crowding_recomputed_from_closed_population",
+        "optibench.rational_digits_bounded",
+        "optibench.rational_reduced",
+        "optibench.shared_baseline"
+      ]
+    }
+  ],
+  "projections": [
+    {
+      "profile": "org.grokmcp.needle_tools_context.v1",
+      "schema_sha256": "ac92a88b87e35254a7eef4a151d8743418ef102402022b228609743cbcbf7496",
+      "rules": [
+        "needle.pinned_secret_scan",
+        "needle.examples_whole_only",
+        "needle.nested_fields_are_neural_context",
+        "needle.non_authoritative",
+        "needle.not_parameter_training",
+        "needle.pinned_tokenizer_budget",
+        "needle.query_upstream_trimmed",
+        "needle.query_strict_utf8",
+        "needle.tools_array_valid"
+      ]
+    }
+  ],
+  "shared_rules": [
+    "known_profile.generic_capsule_validation_first",
+    "known_profile.recursive_body_secret_scan",
+    "known_profile.unknown_schema_quarantined"
+  ],
+  "trust_gates": [
+    "canonical_envelope",
+    "known_profile",
+    "evidence_bytes",
+    "semantic_receipts",
+    "complete_graph",
+    "publication_authentication",
+    "promotion_policy"
+  ]
+}

--- a/docs/okf/needle-tools-context-v1.schema.json
+++ b/docs/okf/needle-tools-context-v1.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://grokmcp.org/docs/okf/needle-tools-context-v1.schema.json",
+  "title": "UniGrok Needle tools-array conditioning projection v1",
+  "description": "Executor-only projection. The tools array is valid Needle playground input; examples are neural encoder context, not constrained-decoder semantics or parameter updates.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "encoder_tokens",
+    "max_encoder_tokens",
+    "profile",
+    "query_sha256",
+    "tokenizer",
+    "tools",
+    "used_source_capsules"
+  ],
+  "properties": {
+    "encoder_tokens": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 1024
+    },
+    "max_encoder_tokens": { "const": 1024 },
+    "profile": { "const": "org.grokmcp.needle_tools_context.v1" },
+    "query_sha256": { "$ref": "#/$defs/sha256" },
+    "tokenizer": { "$ref": "#/$defs/identifier" },
+    "tools": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1,
+      "prefixItems": [{ "$ref": "#/$defs/tool" }]
+    },
+    "used_source_capsules": {
+      "type": "array",
+      "maxItems": 64,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/capsuleId" }
+    }
+  },
+  "$defs": {
+    "tool": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["description", "examples", "name", "parameters"],
+      "properties": {
+        "description": {
+          "const": "Select relevant verified UniGrok context. Examples are non-authoritative preference context; return capsule ids only."
+        },
+        "examples": {
+          "type": "array",
+          "maxItems": 64,
+          "items": { "$ref": "#/$defs/example" }
+        },
+        "name": { "const": "select_unigrok_context" },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["capsule_id"],
+          "properties": {
+            "capsule_id": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["description", "required", "type"],
+              "properties": {
+                "description": {
+                  "const": "A relevant ucap1:sha256 capsule identifier."
+                },
+                "required": { "const": true },
+                "type": { "const": "string" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "example": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["chosen", "prompt", "rejected", "source_capsule"],
+      "properties": {
+        "chosen": { "type": "string" },
+        "prompt": { "type": "string" },
+        "rejected": { "type": "string" },
+        "source_capsule": { "$ref": "#/$defs/capsuleId" }
+      }
+    },
+    "capsuleId": {
+      "type": "string",
+      "pattern": "^ucap1:sha256:[a-f0-9]{64}$"
+    },
+    "identifier": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+    },
+    "nonnegativeSafeInteger": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "positiveSafeInteger": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 9007199254740991
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  }
+}

--- a/docs/okf/okf-manifest.json
+++ b/docs/okf/okf-manifest.json
@@ -14,6 +14,13 @@
     "metrics-tool.md",
     "intelligence-capsule-v1.md",
     "intelligence-capsule-v1.schema.json",
+    "intelligence-payload-profiles-v1.md",
+    "gno-envelope-v1.schema.json",
+    "optibench-result-v1.schema.json",
+    "agentic-dpo-pair-v1.schema.json",
+    "needle-tools-context-v1.schema.json",
+    "intelligence-payload-semantics-v1.json",
+    "intelligence-payload-conformance-v1.json",
     "faq.md",
     "api-reference.md"
   ]

--- a/docs/okf/optibench-result-v1.schema.json
+++ b/docs/okf/optibench-result-v1.schema.json
@@ -1,0 +1,189 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://grokmcp.org/docs/okf/optibench-result-v1.schema.json",
+  "title": "UniGrok OptiBench closed-population result payload data v1",
+  "description": "The data object carried by payload schema org.grokmcp.optibench_result.v1. Numeric objective truth is stored once in the containing capsule body.metrics.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "aggregation",
+    "baseline_relation",
+    "candidate_capsule",
+    "cohort",
+    "counter_output",
+    "gate_receipts",
+    "nsga2",
+    "objective_metrics",
+    "population_closed",
+    "population_manifest",
+    "repetitions"
+  ],
+  "properties": {
+    "aggregation": { "const": "median" },
+    "baseline_relation": {
+      "enum": [
+        "dominated_by_baseline",
+        "dominates_baseline",
+        "equal_baseline",
+        "incomparable_to_baseline"
+      ]
+    },
+    "candidate_capsule": { "$ref": "#/$defs/capsuleId" },
+    "cohort": { "$ref": "#/$defs/cohort" },
+    "counter_output": { "$ref": "#/$defs/evidenceRef" },
+    "gate_receipts": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 32,
+      "items": { "$ref": "#/$defs/evidenceRef" }
+    },
+    "nsga2": { "$ref": "#/$defs/nsga2" },
+    "objective_metrics": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "enum": [
+          "callgrind_ir",
+          "cpu_instructions_retired",
+          "diff_tokens",
+          "peak_memory_bytes"
+        ]
+      }
+    },
+    "population_closed": { "const": true },
+    "population_manifest": { "$ref": "#/$defs/evidenceRef" },
+    "repetitions": {
+      "allOf": [
+        { "$ref": "#/$defs/positiveSafeInteger" },
+        { "not": { "multipleOf": 2 } }
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "cohort": {
+            "properties": {
+              "counter_profile": { "const": "perf_stat_instructions_v1" }
+            },
+            "required": ["counter_profile"]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "objective_metrics": {
+            "prefixItems": [
+              { "const": "cpu_instructions_retired" },
+              { "const": "diff_tokens" },
+              { "const": "peak_memory_bytes" }
+            ]
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "objective_metrics": {
+            "prefixItems": [
+              { "const": "callgrind_ir" },
+              { "const": "diff_tokens" },
+              { "const": "peak_memory_bytes" }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "cohort": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "counter_profile",
+        "environment",
+        "harness",
+        "tool",
+        "tool_version"
+      ],
+      "properties": {
+        "counter_profile": {
+          "enum": ["callgrind_ir_v1", "perf_stat_instructions_v1"]
+        },
+        "environment": { "$ref": "#/$defs/evidenceRef" },
+        "harness": { "$ref": "#/$defs/evidenceRef" },
+        "tool": { "enum": ["perf", "valgrind"] },
+        "tool_version": { "$ref": "#/$defs/identifier" }
+      }
+    },
+    "nsga2": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "crowding", "pareto_rank"],
+      "properties": {
+        "algorithm": { "const": "nsga2_exact_v1" },
+        "crowding": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["kind"],
+              "properties": { "kind": { "const": "boundary" } }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["denominator", "kind", "numerator"],
+              "properties": {
+                "denominator": {
+                  "type": "string",
+                  "maxLength": 128,
+                  "pattern": "^[1-9][0-9]*$"
+                },
+                "kind": { "const": "finite" },
+                "numerator": {
+                  "type": "string",
+                  "maxLength": 128,
+                  "pattern": "^(?:0|[1-9][0-9]*)$"
+                }
+              }
+            }
+          ]
+        },
+        "pareto_rank": { "$ref": "#/$defs/nonnegativeSafeInteger" }
+      }
+    },
+    "evidenceRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["evidence_name", "sha256"],
+      "properties": {
+        "evidence_name": { "$ref": "#/$defs/identifier" },
+        "sha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "capsuleId": {
+      "type": "string",
+      "pattern": "^ucap1:sha256:[a-f0-9]{64}$"
+    },
+    "identifier": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+    },
+    "nonnegativeSafeInteger": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "positiveSafeInteger": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 9007199254740991
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,29 @@ packages = ["src"]
 ".grok" = ".grok"
 "example.env" = "example.env"
 
+[tool.hatch.build.targets.sdist]
+exclude = [
+    "/.codex",
+    "/.pytest_cache",
+    "/.ruff_cache",
+    "/.venv",
+    "/build",
+    "/dist",
+    "/htmlcov",
+    "/node_modules",
+    "/sites/**/.next",
+    "/sites/**/.npm",
+    "/sites/**/.sites-runtime",
+    "/sites/**/.vinext",
+    "/sites/**/.wrangler",
+    "/sites/**/coverage",
+    "/sites/**/dist",
+    "/sites/**/node_modules",
+    "/sites/**/npm-cache",
+    "/**/.DS_Store",
+    "/**/__pycache__",
+]
+
 [dependency-groups]
 dev = [
     "httpx2>=2.5.0",

--- a/sites/unigrok-control-center/app/lib/intelligence-payloads.ts
+++ b/sites/unigrok-control-center/app/lib/intelligence-payloads.ts
@@ -1,0 +1,396 @@
+export const GNO_ENVELOPE_SCHEMA = "org.grokmcp.gno_envelope.v1";
+export const OPTIBENCH_RESULT_SCHEMA = "org.grokmcp.optibench_result.v1";
+export const AGENTIC_DPO_PAIR_SCHEMA = "org.grokmcp.agentic_dpo_pair.v1";
+export const NEEDLE_CONTEXT_PROFILE = "org.grokmcp.needle_tools_context.v1";
+
+export const PROFILE_SCHEMA_FILES = Object.freeze({
+  [GNO_ENVELOPE_SCHEMA]: "gno-envelope-v1.schema.json",
+  [OPTIBENCH_RESULT_SCHEMA]: "optibench-result-v1.schema.json",
+  [AGENTIC_DPO_PAIR_SCHEMA]: "agentic-dpo-pair-v1.schema.json",
+} as const);
+
+export const PROFILE_SCHEMA_SHA256 = Object.freeze({
+  [GNO_ENVELOPE_SCHEMA]: "4c7fb150b3f82738ae43d52669c8c663283807d42add1f4532f01527a4d70665",
+  [OPTIBENCH_RESULT_SCHEMA]: "dfc216d1855eb36e54829c3aca00434f0dc9845a6efc205c2c49016531accf81",
+  [AGENTIC_DPO_PAIR_SCHEMA]: "7db601ccc11aaa94409383f88c7305a46b63a705176897aaa313f835b24bed84",
+} as const);
+
+export const PROJECTION_SCHEMA_FILES = Object.freeze({
+  [NEEDLE_CONTEXT_PROFILE]: "needle-tools-context-v1.schema.json",
+} as const);
+
+export const PROJECTION_SCHEMA_SHA256 = Object.freeze({
+  [NEEDLE_CONTEXT_PROFILE]: "ac92a88b87e35254a7eef4a151d8743418ef102402022b228609743cbcbf7496",
+} as const);
+
+export const SEMANTIC_SPEC_FILE = "intelligence-payload-semantics-v1.json";
+export const SEMANTIC_SPEC_SHA256 = "7464c2343c3edaadc21a14a880e689ef8e4b4ac0fa3fc07b2b6f37b08733545a";
+export const CONFORMANCE_FILE = "intelligence-payload-conformance-v1.json";
+export const CONFORMANCE_SHA256 = "6a0df82c82cd3bfbadc6ff1febf1e43b2d2a6446acd1b977ae7d3262de8d98f4";
+
+const KNOWN = new Set(Object.keys(PROFILE_SCHEMA_FILES));
+const CAPSULE_ID_RE = /^ucap1:sha256:[a-f0-9]{64}$/;
+const DECIMAL_RE = /^-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?$/;
+const DIGEST_RE = /^[a-f0-9]{64}$/;
+const IDENTIFIER_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const NONNEGATIVE_INTEGER_RE = /^(?:0|[1-9][0-9]*)$/;
+const POSITIVE_INTEGER_RE = /^[1-9][0-9]*$/;
+const MAX_RATIONAL_DIGITS = 128;
+const MAX_OBJECTIVE_DIGITS = 32;
+export const SHARED_SECRET_PATTERNS = Object.freeze([
+  /github_pat_[A-Za-z0-9_]{10,}|gh[pousr]_[A-Za-z0-9]{10,}/,
+  /glpat-[A-Za-z0-9_-]{10,}/,
+  /\bsk-(?:proj-|svcacct-)?[A-Za-z0-9_-]{12,}/,
+  /\bxai-[A-Za-z0-9_-]{12,}/i,
+  /\bAIza[A-Za-z0-9_-]{25,}/,
+  /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/,
+  /\bnpm_[A-Za-z0-9]{20,}/,
+  /\bpypi-[A-Za-z0-9_-]{20,}/,
+  /\bxox[baprs]-[A-Za-z0-9-]{12,}/,
+  /\bsk_live_[A-Za-z0-9]{16,}/,
+  /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----/,
+  /\beyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/,
+  /\bBearer\s+(?!<|\$\{|\[)[A-Za-z0-9._~+/=-]{8,}/i,
+  /Authorization\s*:\s*Bearer\s+(?!<|\$\{|\[)[A-Za-z0-9._~+/-]{8,}/i,
+  /Authorization\s*:\s*Basic\s+(?!<|\$\{|\[)[A-Za-z0-9+/=]{8,}/i,
+  /(?:^|[^A-Za-z0-9_])["']?[A-Z0-9_-]*(?:API[_-]?KEY|SECRET[_-]?ACCESS[_-]?KEY|SESSION[_-]?TOKEN|ACCESS[_-]?TOKEN|AUTH[_-]?TOKEN|PASSWORD|PRIVATE[_-]?KEY|CLIENT[_-]?SECRET)["']?\s*[:=]\s*(?!["']?(?:<|\$\{|\[))(?:"[^"\r\n]{8,}"|'[^'\r\n]{8,}'|[A-Za-z0-9._~+/=@!#$%^&*()-]{8,})/i,
+] as const);
+
+const PERF_OBJECTIVES = [
+  ["cpu_instructions_retired", "instruction"],
+  ["diff_tokens", "token"],
+  ["peak_memory_bytes", "byte"],
+] as const;
+const CALLGRIND_OBJECTIVES = [
+  ["callgrind_ir", "instruction_reference"],
+  ["diff_tokens", "token"],
+  ["peak_memory_bytes", "byte"],
+] as const;
+
+type Fail = (message: string) => never;
+type EvidenceIndex = Map<string, Record<string, unknown>>;
+
+/** Validate a known profile after generic Capsule v1 validation. */
+export function validateKnownPayloadProfile(
+  body: Record<string, unknown>,
+  fail: Fail = (message) => { throw new Error(message); },
+): boolean {
+  const payload = body.payload;
+  if (!isRecord(payload) || typeof payload.schema !== "string" || !KNOWN.has(payload.schema)) return false;
+  rejectSecretStrings(body, "$.body", fail);
+  const evidence = evidenceIndex(body.evidence, fail);
+  if (payload.schema === GNO_ENVELOPE_SCHEMA) validateGno(body, payload.data, evidence, fail);
+  else if (payload.schema === OPTIBENCH_RESULT_SCHEMA) validateOptibench(body, payload.data, evidence, fail);
+  else validateDpo(body, payload.data, evidence, fail);
+  return true;
+}
+
+function validateGno(body: Record<string, unknown>, raw: unknown, evidence: EvidenceIndex, fail: Fail): void {
+  const path = "$.body.payload.data";
+  const value = record(raw, path, fail);
+  const phase = value.phase;
+  const common = ["artifacts", "generation", "node_id", "phase", "slot"];
+  if (phase === "dispatch") {
+    exactKeys(value, [...common, "mutator", "routing"], path, fail);
+    if (body.kind !== "task") fail("gno dispatch requires body.kind task");
+    if (!isRecord(body.execution)) fail("gno dispatch requires explicit execution metadata");
+  } else if (phase === "result") {
+    exactKeys(value, [...common, "dispatch_capsule", "outcome"], path, fail);
+    const expectedKind = value.outcome === "candidate" ? "candidate" : value.outcome === "failure" ? "failure" : undefined;
+    if (!expectedKind || body.kind !== expectedKind) fail("gno result outcome must match candidate or failure body.kind");
+    const dispatch = capsuleId(value.dispatch_capsule, `${path}.dispatch_capsule`, fail);
+    if (!Array.isArray(body.parents) || body.parents.length !== 1 || body.parents[0] !== dispatch) {
+      fail("gno result must have its dispatch capsule as its sole parent");
+    }
+    if (Object.hasOwn(body, "execution")) {
+      fail("gno result inherits execution from its dispatch and must not duplicate it");
+    }
+  } else fail("gno envelope phase must be dispatch or result");
+
+  identifier(value.node_id, `${path}.node_id`, fail);
+  positiveSafeInt(value.generation, `${path}.generation`, fail);
+  positiveSafeInt(value.slot, `${path}.slot`, fail);
+  const allowed = phase === "dispatch"
+    ? new Set(["context", "input_diff", "input_manifest", "policy", "system_prompt", "task_spec", "tool_manifest"])
+    : new Set(["failure_receipt", "output_diff", "test_receipt", "trace"]);
+  const artifacts = artifactRefs(value.artifacts, evidence, `${path}.artifacts`, allowed, fail);
+  const roleCount = (role: string) => artifacts.filter((item) => item.role === role).length;
+  if (phase === "dispatch") {
+    if (roleCount("task_spec") !== 1 || roleCount("input_manifest") !== 1) {
+      fail("gno dispatch requires exactly one input_manifest and task_spec");
+    }
+    for (const singleton of ["input_diff", "policy", "system_prompt", "tool_manifest"]) {
+      if (roleCount(singleton) > 1) fail(`gno dispatch permits at most one ${singleton} artifact`);
+    }
+  }
+  if (phase === "result") {
+    const required = value.outcome === "candidate" ? "output_diff" : "failure_receipt";
+    const forbidden = value.outcome === "candidate" ? "failure_receipt" : "output_diff";
+    if (roleCount(required) !== 1) fail(`gno ${String(value.outcome)} result requires exactly one ${required}`);
+    if (roleCount(forbidden) !== 0) fail(`gno ${String(value.outcome)} result forbids ${forbidden}`);
+    for (const singleton of ["test_receipt", "trace"]) {
+      if (roleCount(singleton) > 1) fail(`gno result permits at most one ${singleton} artifact`);
+    }
+  }
+  if (phase === "dispatch") {
+    const mutator = record(value.mutator, `${path}.mutator`, fail);
+    exactKeys(mutator, ["origin", "profile"], `${path}.mutator`, fail);
+    if (typeof mutator.origin !== "string" || !new Set(["agent", "ast", "baseline"]).has(mutator.origin)) fail("gno mutator.origin is unsupported");
+    identifier(mutator.profile, `${path}.mutator.profile`, fail);
+    routing(value.routing, fail);
+  }
+}
+
+function routing(raw: unknown, fail: Fail): void {
+  const path = "$.body.payload.data.routing";
+  const value = record(raw, path, fail);
+  exactKeys(value, ["algorithm", "arm", "arm_pull", "parameters", "reason", "seed", "step"], path, fail);
+  const algorithms = new Set(["deterministic_v1", "discounted_ucb_v1", "round_robin_v1", "ucb1_v1"]);
+  if (typeof value.algorithm !== "string" || !algorithms.has(value.algorithm)) fail(`${path}.algorithm is unsupported`);
+  identifier(value.arm, `${path}.arm`, fail);
+  identifier(value.reason, `${path}.reason`, fail);
+  nonnegativeSafeInt(value.seed, `${path}.seed`, fail);
+  positiveSafeInt(value.step, `${path}.step`, fail);
+  positiveSafeInt(value.arm_pull, `${path}.arm_pull`, fail);
+  const parameters = array(value.parameters, `${path}.parameters`, 32, fail);
+  const order: string[] = [];
+  parameters.forEach((rawParameter, index) => {
+    const itemPath = `${path}.parameters[${index}]`;
+    const item = record(rawParameter, itemPath, fail);
+    exactKeys(item, ["name", "value"], itemPath, fail);
+    order.push(identifier(item.name, `${itemPath}.name`, fail));
+    if (typeof item.value !== "string" || !DECIMAL_RE.test(item.value)) fail(`${itemPath}.value must be a decimal string`);
+  });
+  sortedUnique(order, `${path}.parameters`, fail);
+}
+
+function validateOptibench(body: Record<string, unknown>, raw: unknown, evidence: EvidenceIndex, fail: Fail): void {
+  const path = "$.body.payload.data";
+  const value = record(raw, path, fail);
+  exactKeys(value, [
+    "aggregation", "baseline_relation", "candidate_capsule", "cohort", "counter_output", "gate_receipts",
+    "nsga2", "objective_metrics", "population_closed", "population_manifest", "repetitions",
+  ], path, fail);
+  if (body.kind !== "benchmark") fail("optibench result requires body.kind benchmark");
+  if (value.population_closed !== true) fail("optibench population must be closed before ranking");
+  const candidate = capsuleId(value.candidate_capsule, `${path}.candidate_capsule`, fail);
+  if (!Array.isArray(body.parents) || !body.parents.includes(candidate) || body.parents.length === 0) {
+    fail("optibench candidate must be a population parent");
+  }
+  matchEvidenceRef(value.population_manifest, evidence, `${path}.population_manifest`, fail);
+  matchEvidenceRef(value.counter_output, evidence, `${path}.counter_output`, fail);
+
+  const cohort = record(value.cohort, `${path}.cohort`, fail);
+  exactKeys(cohort, ["counter_profile", "environment", "harness", "tool", "tool_version"], `${path}.cohort`, fail);
+  let objectives: ReadonlyArray<readonly [string, string]>;
+  let tool: string;
+  if (cohort.counter_profile === "perf_stat_instructions_v1") {
+    objectives = PERF_OBJECTIVES;
+    tool = "perf";
+  } else if (cohort.counter_profile === "callgrind_ir_v1") {
+    objectives = CALLGRIND_OBJECTIVES;
+    tool = "valgrind";
+  } else fail("optibench counter_profile is unsupported");
+  if (cohort.tool !== tool) fail("optibench counter_profile and tool disagree");
+  identifier(cohort.tool_version, `${path}.cohort.tool_version`, fail);
+  for (const field of ["environment", "harness"]) {
+    matchEvidenceRef(cohort[field], evidence, `${path}.cohort.${field}`, fail);
+  }
+
+  const receipts = array(value.gate_receipts, `${path}.gate_receipts`, 32, fail);
+  if (receipts.length === 0) fail("optibench requires at least one gate receipt");
+  const receiptOrder = receipts.map((receipt, index) => {
+    const descriptor = matchEvidenceRef(receipt, evidence, `${path}.gate_receipts[${index}]`, fail);
+    return `${String(descriptor.name)}\0${String(descriptor.sha256)}`;
+  });
+  sortedUnique(receiptOrder, `${path}.gate_receipts`, fail);
+
+  const expectedNames = objectives!.map(([name]) => name);
+  if (!sameStringArray(value.objective_metrics, expectedNames)) fail("optibench objective_metrics must exactly match its counter cohort");
+  if (!Array.isArray(body.metrics)) fail("optibench requires body.metrics");
+  const actual = body.metrics.map((rawMetric) => {
+    const metric = record(rawMetric, "$.body.metrics[]", fail);
+    if (typeof metric.value !== "string" || metric.value.length > MAX_OBJECTIVE_DIGITS || !NONNEGATIVE_INTEGER_RE.test(metric.value)) {
+      fail("optibench objective values must be nonnegative integer strings");
+    }
+    return [String(metric.name), String(metric.unit)] as const;
+  });
+  if (JSON.stringify(actual) !== JSON.stringify(objectives!)) fail("optibench body.metrics must exactly match its counter cohort");
+  if (value.aggregation !== "median") fail("optibench aggregation must be median");
+  const repetitions = positiveSafeInt(value.repetitions, `${path}.repetitions`, fail);
+  if (repetitions % 2 === 0) fail("optibench repetitions must be odd for an integer median");
+  const relations = new Set(["dominated_by_baseline", "dominates_baseline", "equal_baseline", "incomparable_to_baseline"]);
+  if (typeof value.baseline_relation !== "string" || !relations.has(value.baseline_relation)) fail("optibench baseline_relation is unsupported");
+
+  const nsga2 = record(value.nsga2, `${path}.nsga2`, fail);
+  exactKeys(nsga2, ["algorithm", "crowding", "pareto_rank"], `${path}.nsga2`, fail);
+  if (nsga2.algorithm !== "nsga2_exact_v1") fail("optibench nsga2 algorithm must be nsga2_exact_v1");
+  nonnegativeSafeInt(nsga2.pareto_rank, `${path}.nsga2.pareto_rank`, fail);
+  crowding(nsga2.crowding, `${path}.nsga2.crowding`, fail);
+}
+
+function crowding(raw: unknown, path: string, fail: Fail): void {
+  const value = record(raw, path, fail);
+  if (value.kind === "boundary") {
+    exactKeys(value, ["kind"], path, fail);
+    return;
+  }
+  if (value.kind !== "finite") fail(`${path}.kind must be boundary or finite`);
+  exactKeys(value, ["denominator", "kind", "numerator"], path, fail);
+  if (typeof value.numerator !== "string" || value.numerator.length > MAX_RATIONAL_DIGITS || !NONNEGATIVE_INTEGER_RE.test(value.numerator)) fail(`${path}.numerator must be a nonnegative integer string`);
+  if (typeof value.denominator !== "string" || value.denominator.length > MAX_RATIONAL_DIGITS || !POSITIVE_INTEGER_RE.test(value.denominator)) fail(`${path}.denominator must be a positive integer string`);
+  if (gcd(BigInt(value.numerator), BigInt(value.denominator)) !== BigInt(1)) fail(`${path} finite rational must be reduced`);
+}
+
+function validateDpo(body: Record<string, unknown>, raw: unknown, evidence: EvidenceIndex, fail: Fail): void {
+  const path = "$.body.payload.data";
+  const value = record(raw, path, fail);
+  exactKeys(value, ["chosen", "cohort_proof_manifest", "export_profile", "population_manifest", "preference", "prompt", "rejected", "task_capsule"], path, fail);
+  if (body.kind !== "evaluation") fail("agentic DPO pair requires body.kind evaluation");
+  if (Array.isArray(body.metrics) && body.metrics.length > 0) fail("agentic DPO pair does not duplicate benchmark metrics");
+  const task = capsuleId(value.task_capsule, `${path}.task_capsule`, fail);
+  matchEvidenceRef(value.cohort_proof_manifest, evidence, `${path}.cohort_proof_manifest`, fail);
+  matchEvidenceRef(value.population_manifest, evidence, `${path}.population_manifest`, fail);
+  matchEvidenceRef(value.prompt, evidence, `${path}.prompt`, fail);
+  const expected = new Set([task]);
+  const sides: Record<string, Record<string, unknown>> = {};
+  for (const side of ["chosen", "rejected"]) {
+    const itemPath = `${path}.${side}`;
+    const item = record(value[side], itemPath, fail);
+    exactKeys(item, ["artifact", "benchmark_capsule", "candidate_capsule"], itemPath, fail);
+    expected.add(capsuleId(item.candidate_capsule, `${itemPath}.candidate_capsule`, fail));
+    expected.add(capsuleId(item.benchmark_capsule, `${itemPath}.benchmark_capsule`, fail));
+    matchEvidenceRef(item.artifact, evidence, `${itemPath}.artifact`, fail);
+    sides[side] = item;
+  }
+  const expectedParents = [...expected].sort();
+  if (expected.size !== 5 || !sameStringArray(body.parents, expectedParents)) {
+    fail("agentic DPO parents must be the task and distinct chosen/rejected candidate and benchmark capsules");
+  }
+  const chosenArtifact = record(sides.chosen.artifact, `${path}.chosen.artifact`, fail);
+  const rejectedArtifact = record(sides.rejected.artifact, `${path}.rejected.artifact`, fail);
+  if (chosenArtifact.sha256 === rejectedArtifact.sha256) fail("agentic DPO chosen and rejected artifacts must differ");
+
+  const preference = record(value.preference, `${path}.preference`, fail);
+  exactKeys(preference, ["basis", "dominance_receipt", "policy"], `${path}.preference`, fail);
+  if (preference.basis !== "pareto_dominance") fail("agentic DPO v1 only supports direct Pareto dominance");
+  if (preference.policy !== "nsga2_direct_dominance_v1") fail("agentic DPO preference policy is unsupported");
+  matchEvidenceRef(preference.dominance_receipt, evidence, `${path}.preference.dominance_receipt`, fail);
+  if (value.export_profile !== "preference_jsonl_v1") fail("agentic DPO export_profile is unsupported");
+}
+
+function evidenceIndex(raw: unknown, fail: Fail): EvidenceIndex {
+  const values = array(raw, "$.body.evidence", 256, fail);
+  const result: EvidenceIndex = new Map();
+  values.forEach((rawItem, index) => {
+    const item = record(rawItem, `$.body.evidence[${index}]`, fail);
+    const name = identifier(item.name, `$.body.evidence[${index}].name`, fail);
+    if (result.has(name)) fail("known payload profiles require unique evidence names");
+    result.set(name, item);
+  });
+  return result;
+}
+
+function artifactRefs(raw: unknown, evidence: EvidenceIndex, path: string, allowed: Set<string>, fail: Fail): Record<string, unknown>[] {
+  const values = array(raw, path, 64, fail);
+  if (values.length === 0) fail(`${path} must not be empty`);
+  const order: string[] = [];
+  const result = values.map((rawItem, index) => {
+    const itemPath = `${path}[${index}]`;
+    const item = record(rawItem, itemPath, fail);
+    exactKeys(item, ["evidence_name", "role", "sha256"], itemPath, fail);
+    if (typeof item.role !== "string" || !allowed.has(item.role)) fail(`${itemPath}.role is unsupported`);
+    const descriptor = matchEvidenceRef(item, evidence, itemPath, fail, true);
+    order.push(`${String(item.role)}\0${String(descriptor.name)}\0${String(descriptor.sha256)}`);
+    return item;
+  });
+  sortedUnique(order, path, fail);
+  return result;
+}
+
+function matchEvidenceRef(raw: unknown, evidence: EvidenceIndex, path: string, fail: Fail, allowRole = false): Record<string, unknown> {
+  const ref = record(raw, path, fail);
+  exactKeys(ref, allowRole ? ["evidence_name", "role", "sha256"] : ["evidence_name", "sha256"], path, fail);
+  const name = identifier(ref.evidence_name, `${path}.evidence_name`, fail);
+  if (typeof ref.sha256 !== "string" || !DIGEST_RE.test(ref.sha256)) fail(`${path}.sha256 is invalid`);
+  const descriptor = evidence.get(name);
+  if (!descriptor || descriptor.sha256 !== ref.sha256) fail(`${path} does not match a body.evidence descriptor`);
+  return descriptor;
+}
+
+function record(raw: unknown, path: string, fail: Fail): Record<string, unknown> {
+  if (!isRecord(raw)) fail(`${path} must be an object`);
+  return raw;
+}
+
+function array(raw: unknown, path: string, maximum: number, fail: Fail): unknown[] {
+  if (!Array.isArray(raw)) fail(`${path} must be an array`);
+  if (raw.length > maximum) fail(`${path} exceeds its maximum of ${maximum} items`);
+  return raw;
+}
+
+function exactKeys(value: Record<string, unknown>, expected: string[], path: string, fail: Fail): void {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (!sameStringArray(actual, wanted)) fail(`${path} fields do not match profile`);
+}
+
+function identifier(raw: unknown, path: string, fail: Fail): string {
+  if (typeof raw !== "string" || !IDENTIFIER_RE.test(raw)) fail(`${path} is not a valid identifier`);
+  if (SHARED_SECRET_PATTERNS.some((pattern) => pattern.test(raw))) {
+    fail(`${path} contains secret-like content`);
+  }
+  return raw;
+}
+
+function rejectSecretStrings(raw: unknown, path: string, fail: Fail): void {
+  if (typeof raw === "string") {
+    if (SHARED_SECRET_PATTERNS.some((pattern) => pattern.test(raw))) {
+      fail(`${path} contains secret-like content`);
+    }
+    return;
+  }
+  if (Array.isArray(raw)) {
+    raw.forEach((value, index) => rejectSecretStrings(value, `${path}[${index}]`, fail));
+    return;
+  }
+  if (isRecord(raw)) {
+    for (const [key, value] of Object.entries(raw)) {
+      rejectSecretStrings(key, `${path}.<key>`, fail);
+      rejectSecretStrings(value, `${path}.${key}`, fail);
+    }
+  }
+}
+
+function capsuleId(raw: unknown, path: string, fail: Fail): string {
+  if (typeof raw !== "string" || !CAPSULE_ID_RE.test(raw)) fail(`${path} is not a valid capsule id`);
+  return raw;
+}
+
+function positiveSafeInt(raw: unknown, path: string, fail: Fail): number {
+  if (!Number.isSafeInteger(raw) || (raw as number) < 1) fail(`${path} must be a positive safe integer`);
+  return raw as number;
+}
+
+function nonnegativeSafeInt(raw: unknown, path: string, fail: Fail): number {
+  if (!Number.isSafeInteger(raw) || (raw as number) < 0) fail(`${path} must be a nonnegative safe integer`);
+  return raw as number;
+}
+
+function sortedUnique(values: string[], path: string, fail: Fail): void {
+  const sorted = [...values].sort();
+  if (!sameStringArray(values, sorted) || new Set(values).size !== values.length) fail(`${path} must be unique and canonically sorted`);
+}
+
+function sameStringArray(raw: unknown, expected: ReadonlyArray<string>): boolean {
+  return Array.isArray(raw) && raw.length === expected.length && raw.every((item, index) => item === expected[index]);
+}
+
+function gcd(left: bigint, right: bigint): bigint {
+  while (right !== BigInt(0)) [left, right] = [right, left % right];
+  return left;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value) && Object.getPrototypeOf(value) === Object.prototype;
+}

--- a/sites/unigrok-control-center/public/docs/okf/agentic-dpo-pair-v1.schema.json
+++ b/sites/unigrok-control-center/public/docs/okf/agentic-dpo-pair-v1.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://grokmcp.org/docs/okf/agentic-dpo-pair-v1.schema.json",
+  "title": "UniGrok direct-Pareto preference pair payload data v1",
+  "description": "The data object carried by payload schema org.grokmcp.agentic_dpo_pair.v1. V1 records only directly proven Pareto dominance between two feasible candidates in one closed cohort.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "chosen",
+    "cohort_proof_manifest",
+    "export_profile",
+    "population_manifest",
+    "preference",
+    "prompt",
+    "rejected",
+    "task_capsule"
+  ],
+  "properties": {
+    "chosen": { "$ref": "#/$defs/side" },
+    "cohort_proof_manifest": { "$ref": "#/$defs/evidenceRef" },
+    "export_profile": { "const": "preference_jsonl_v1" },
+    "population_manifest": { "$ref": "#/$defs/evidenceRef" },
+    "preference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["basis", "dominance_receipt", "policy"],
+      "properties": {
+        "basis": { "const": "pareto_dominance" },
+        "dominance_receipt": { "$ref": "#/$defs/evidenceRef" },
+        "policy": { "const": "nsga2_direct_dominance_v1" }
+      }
+    },
+    "prompt": { "$ref": "#/$defs/evidenceRef" },
+    "rejected": { "$ref": "#/$defs/side" },
+    "task_capsule": { "$ref": "#/$defs/capsuleId" }
+  },
+  "$defs": {
+    "side": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifact", "benchmark_capsule", "candidate_capsule"],
+      "properties": {
+        "artifact": { "$ref": "#/$defs/evidenceRef" },
+        "benchmark_capsule": { "$ref": "#/$defs/capsuleId" },
+        "candidate_capsule": { "$ref": "#/$defs/capsuleId" }
+      }
+    },
+    "evidenceRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["evidence_name", "sha256"],
+      "properties": {
+        "evidence_name": { "$ref": "#/$defs/identifier" },
+        "sha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "capsuleId": {
+      "type": "string",
+      "pattern": "^ucap1:sha256:[a-f0-9]{64}$"
+    },
+    "identifier": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  }
+}

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -393,6 +393,139 @@ def validate_body(value: Mapping[str, Any]) -> None
 
 Validate the normative IntelligenceCapsule v1 body schema.
 
+## intelligence_payloads.py {#intelligence_payloads}
+
+### Function: `validate_known_payload_profile` {#intelligence_payloads-validate_known_payload_profile}
+
+```python
+def validate_known_payload_profile(body: Mapping[str, Any]) -> bool
+```
+
+**Keywords:** validate, known, payload, profile
+
+Validate a registered payload profile and return whether it was known.
+
+The caller must first apply the generic IntelligenceCapsule v1 validator.
+Unknown versioned payloads remain structurally valid capsules, but this
+function returns ``False`` so a materializer can quarantine them instead
+of executing or promoting semantics it does not understand.
+
+### Function: `payload_profile_schema_sha256` {#intelligence_payloads-payload_profile_schema_sha256}
+
+```python
+def payload_profile_schema_sha256(schema: str) -> str
+```
+
+**Keywords:** payload, profile, schema, sha, 256
+
+Return the pinned raw-schema digest for a registered payload profile.
+
+### Function: `validate_optibench_evidence` {#intelligence_payloads-validate_optibench_evidence}
+
+```python
+def validate_optibench_evidence(body: Mapping[str, Any], evidence_blobs: Mapping[str, bytes]) -> dict[str, tuple[int, ...]]
+```
+
+**Keywords:** validate, optibench, evidence
+
+Verify OptiBench receipts and recompute every published objective.
+
+This consistency verifier does not prove that hardware executed; signed
+publication identifies the runner that made that claim.  It does prove
+that the closed population, passing gates, raw samples, aggregation, and
+canonical body metrics agree byte-for-byte.
+
+### Function: `validate_optibench_population` {#intelligence_payloads-validate_optibench_population}
+
+```python
+def validate_optibench_population(benchmark_bodies: Mapping[str, Mapping[str, Any]], evidence_blobs: Mapping[str, Mapping[str, bytes]]) -> dict[str, dict[str, Any]]
+```
+
+**Keywords:** validate, optibench, population
+
+Verify one complete cohort and recompute exact NSGA-II fields.
+
+Individual counter receipts can prove a candidate's objective tuple, but
+Pareto rank and crowding are properties of a closed population.  This gate
+therefore requires exactly one benchmark capsule for every candidate in
+the shared population, verifies every evidence set, and recomputes both
+rank and exact rational crowding before any result is promotable.
+
+### Function: `validate_gno_dispatch_evidence` {#intelligence_payloads-validate_gno_dispatch_evidence}
+
+```python
+def validate_gno_dispatch_evidence(body: Mapping[str, Any], evidence_blobs: Mapping[str, bytes]) -> None
+```
+
+**Keywords:** validate, gno, dispatch, evidence
+
+Verify the declared GNO input manifest and every referenced input blob.
+
+### Function: `validate_gno_result_graph` {#intelligence_payloads-validate_gno_result_graph}
+
+```python
+def validate_gno_result_graph(result: Mapping[str, Any], dispatch: Mapping[str, Any], *, result_evidence_blobs: Mapping[str, bytes], dispatch_evidence_blobs: Mapping[str, bytes]) -> None
+```
+
+**Keywords:** validate, gno, result, graph
+
+Bind a GNO result to the exact verified dispatch it answers.
+
+### Function: `validate_dpo_preference_graph` {#intelligence_payloads-validate_dpo_preference_graph}
+
+```python
+def validate_dpo_preference_graph(body: Mapping[str, Any], graph_bodies: Mapping[str, Mapping[str, Any]], evidence_blobs: Mapping[str, bytes], graph_evidence_blobs: Mapping[str, Mapping[str, bytes]]) -> None
+```
+
+**Keywords:** validate, dpo, preference, graph
+
+Resolve a closed OptiBench cohort and prove one direct preference.
+
+The supplied graph closure must contain the task, every candidate in the
+population, and exactly one verified OptiBench result for every candidate.
+Ranks are recomputed from the final metrics; stored online Swarm reward or
+provisional rank is never accepted as preference evidence.
+
+### Function: `build_preference_example` {#intelligence_payloads-build_preference_example}
+
+```python
+def build_preference_example(body: Mapping[str, Any], evidence_blobs: Mapping[str, bytes], *, graph_bodies: Mapping[str, Mapping[str, Any]], graph_evidence_blobs: Mapping[str, Mapping[str, bytes]]) -> dict[str, str]
+```
+
+**Keywords:** build, preference, example
+
+Build one verified preference example for nested inference context.
+
+Blob bytes are resolved by evidence name, checked against the capsule's
+byte count and SHA-256 descriptor, and decoded as strict UTF-8.  The
+returned record can be nested into an executor's JSON context.  This is
+in-context conditioning, not a parameter update.
+
+### Function: `render_preference_jsonl` {#intelligence_payloads-render_preference_jsonl}
+
+```python
+def render_preference_jsonl(body: Mapping[str, Any], evidence_blobs: Mapping[str, bytes], *, graph_bodies: Mapping[str, Mapping[str, Any]], graph_evidence_blobs: Mapping[str, Mapping[str, bytes]]) -> bytes
+```
+
+**Keywords:** render, preference, jsonl
+
+Render one verified preference example as canonical JSONL.
+
+### Function: `build_needle_tools_context` {#intelligence_payloads-build_needle_tools_context}
+
+```python
+def build_needle_tools_context(query: str, examples: Sequence[Mapping[str, str]], *, tokenizer: str, token_counter: Callable[[str], int], max_encoder_tokens: int=1024, max_examples: int=8) -> dict[str, Any]
+```
+
+**Keywords:** build, needle, tools, context
+
+Fit whole verified examples into Needle's actual tools-JSON channel.
+
+``token_counter`` must use the pinned Needle tokenizer.  Selection is
+deterministic: examples are deduplicated and sorted by source capsule,
+then whole records are admitted while they fit beside the query and the
+``<tools>`` separator.  Records are never string-sliced.
+
 ## jobs.py {#jobs}
 
 ### Class: `JobManager` {#jobs-jobmanager}

--- a/sites/unigrok-control-center/public/docs/okf/gno-envelope-v1.schema.json
+++ b/sites/unigrok-control-center/public/docs/okf/gno-envelope-v1.schema.json
@@ -1,0 +1,184 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://grokmcp.org/docs/okf/gno-envelope-v1.schema.json",
+  "title": "UniGrok GNO input-manifest envelope payload data v1",
+  "description": "The data object carried by payload schema org.grokmcp.gno_envelope.v1. Cross-capsule, evidence, kind, and ordering invariants are enforced by the normative semantic validator.",
+  "oneOf": [
+    { "$ref": "#/$defs/dispatch" },
+    { "$ref": "#/$defs/result" }
+  ],
+  "$defs": {
+    "artifactBase": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["evidence_name", "role", "sha256"],
+      "properties": {
+        "evidence_name": { "$ref": "#/$defs/identifier" },
+        "role": { "type": "string" },
+        "sha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "dispatchArtifact": {
+      "allOf": [
+        { "$ref": "#/$defs/artifactBase" },
+        {
+          "properties": {
+            "role": {
+              "enum": [
+                "context",
+                "input_diff",
+                "input_manifest",
+                "policy",
+                "system_prompt",
+                "task_spec",
+                "tool_manifest"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    "resultArtifact": {
+      "allOf": [
+        { "$ref": "#/$defs/artifactBase" },
+        {
+          "properties": {
+            "role": {
+              "enum": ["failure_receipt", "output_diff", "test_receipt", "trace"]
+            }
+          }
+        }
+      ]
+    },
+    "dispatch": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifacts",
+        "generation",
+        "mutator",
+        "node_id",
+        "phase",
+        "routing",
+        "slot"
+      ],
+      "properties": {
+        "artifacts": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 64,
+          "items": { "$ref": "#/$defs/dispatchArtifact" }
+        },
+        "generation": { "$ref": "#/$defs/positiveSafeInteger" },
+        "mutator": { "$ref": "#/$defs/mutator" },
+        "node_id": { "$ref": "#/$defs/identifier" },
+        "phase": { "const": "dispatch" },
+        "routing": { "$ref": "#/$defs/routing" },
+        "slot": { "$ref": "#/$defs/positiveSafeInteger" }
+      }
+    },
+    "result": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "artifacts",
+        "dispatch_capsule",
+        "generation",
+        "node_id",
+        "outcome",
+        "phase",
+        "slot"
+      ],
+      "properties": {
+        "artifacts": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 64,
+          "items": { "$ref": "#/$defs/resultArtifact" }
+        },
+        "dispatch_capsule": { "$ref": "#/$defs/capsuleId" },
+        "generation": { "$ref": "#/$defs/positiveSafeInteger" },
+        "node_id": { "$ref": "#/$defs/identifier" },
+        "outcome": { "enum": ["candidate", "failure"] },
+        "phase": { "const": "result" },
+        "slot": { "$ref": "#/$defs/positiveSafeInteger" }
+      }
+    },
+    "mutator": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["origin", "profile"],
+      "properties": {
+        "origin": { "enum": ["agent", "ast", "baseline"] },
+        "profile": { "$ref": "#/$defs/identifier" }
+      }
+    },
+    "routing": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "algorithm",
+        "arm",
+        "arm_pull",
+        "parameters",
+        "reason",
+        "seed",
+        "step"
+      ],
+      "properties": {
+        "algorithm": {
+          "enum": [
+            "deterministic_v1",
+            "discounted_ucb_v1",
+            "round_robin_v1",
+            "ucb1_v1"
+          ]
+        },
+        "arm": { "$ref": "#/$defs/identifier" },
+        "arm_pull": { "$ref": "#/$defs/positiveSafeInteger" },
+        "parameters": {
+          "type": "array",
+          "maxItems": 32,
+          "items": { "$ref": "#/$defs/parameter" }
+        },
+        "reason": { "$ref": "#/$defs/identifier" },
+        "seed": { "$ref": "#/$defs/nonnegativeSafeInteger" },
+        "step": { "$ref": "#/$defs/positiveSafeInteger" }
+      }
+    },
+    "parameter": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "value"],
+      "properties": {
+        "name": { "$ref": "#/$defs/identifier" },
+        "value": {
+          "type": "string",
+          "pattern": "^-?(?:0|[1-9][0-9]*)(?:\\.[0-9]+)?$"
+        }
+      }
+    },
+    "capsuleId": {
+      "type": "string",
+      "pattern": "^ucap1:sha256:[a-f0-9]{64}$"
+    },
+    "identifier": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+    },
+    "nonnegativeSafeInteger": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "positiveSafeInteger": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 9007199254740991
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  }
+}

--- a/sites/unigrok-control-center/public/docs/okf/index.md
+++ b/sites/unigrok-control-center/public/docs/okf/index.md
@@ -10,6 +10,7 @@ topics:
   - "grok-4.5-pinning"
   - "media-imagine"
   - "metrics-tool"
+  - "intelligence-payload-profiles-v1"
   - "faq"
   - "api-reference"
 ---
@@ -29,5 +30,6 @@ Use this bundle to discover tool schemas, routing details, reasoning levels, med
 - [Model Pinning & Profiles](grok-4.5-pinning.md): API vs CLI paths, fallback parameters, and Grok 4.5 capabilities.
 - [Media Generation](media-imagine.md): Image and video generation schemas.
 - [Observability & Metrics](metrics-tool.md): Aggregated telemetry and status monitoring.
+- [Insider Intelligence Payload Profiles](intelligence-payload-profiles-v1.md): Manifest-closed GNO envelopes, evidenced OptiBench cohorts, direct-Pareto preference pairs, and bounded Needle projections carried beside the immutable Capsule v1 format.
 - [Verified FAQ](faq.md): Curated operational answers that Grok consults only when relevant.
 - [Generated API Reference](api-reference.md): Deterministic signatures and docstrings for documented public Python APIs.

--- a/sites/unigrok-control-center/public/docs/okf/intelligence-payload-conformance-v1.json
+++ b/sites/unigrok-control-center/public/docs/okf/intelligence-payload-conformance-v1.json
@@ -1,0 +1,173 @@
+{
+  "accepted_body_sha256": {
+    "org.grokmcp.agentic_dpo_pair.v1": "995484b8eac65ce2e77e296d43ba3b9ab9ae6d8cc8ffb88ed7049f465dc41f07",
+    "org.grokmcp.gno_envelope.v1": "c8fdb027a0382799ab19a8d032a559de1ca33f2a972377776ef2dc3866f47224",
+    "org.grokmcp.optibench_result.v1": "5005fc5ba7bd6d89da786bf9ffc8c287ec0fb331c271cbfe642583c230b346e8"
+  },
+  "reject_vectors": [
+    {
+      "error": "numerator",
+      "mutation": "crowding_numerator_digits",
+      "profile": "org.grokmcp.optibench_result.v1",
+      "value": 129
+    },
+    {
+      "error": "profile and tool disagree",
+      "mutation": "mixed_counter_tool",
+      "profile": "org.grokmcp.optibench_result.v1"
+    },
+    {
+      "error": "does not match",
+      "mutation": "substituted_evidence_digest",
+      "profile": "org.grokmcp.gno_envelope.v1"
+    },
+    {
+      "error": "parents must be",
+      "mutation": "missing_preference_parent",
+      "profile": "org.grokmcp.agentic_dpo_pair.v1"
+    },
+    {
+      "error": "secret-like",
+      "mutation": "secret_identifier",
+      "profile": "org.grokmcp.gno_envelope.v1",
+      "target": "extra_evidence_name",
+      "value_parts": ["ghp_", "abcdefghijklmnopqrstuvwxyz123456"]
+    },
+    {
+      "error": "origin is unsupported",
+      "mutation": "enum_type_confusion",
+      "profile": "org.grokmcp.gno_envelope.v1",
+      "target": "mutator.origin",
+      "value": ["agent"]
+    },
+    {
+      "error": "secret-like",
+      "mutation": "secret_mapping_text",
+      "profile": "org.grokmcp.gno_envelope.v1",
+      "target": "resolved_context_evidence",
+      "value_parts": ["\"client", "Secret\":\"verysecretvalue123\""]
+    }
+  ],
+  "semantic_vectors": {
+    "dpo_cohort_proof_v1": {
+      "expected_sha256": "02d294446a1dafdcd62057a573d6f7ea711c338c52d4602fb92ecf2152bad004",
+      "manifest": {
+        "benchmarks": [
+          {
+            "benchmark_capsule": "ucap1:sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+            "candidate_capsule": "ucap1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          },
+          {
+            "benchmark_capsule": "ucap1:sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+            "candidate_capsule": "ucap1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+          }
+        ],
+        "cohort_sha256": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "population_manifest_sha256": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+      }
+    },
+    "needle_tools_context_v1": {
+      "examples": [
+        {
+          "chosen": "fast",
+          "prompt": "optimize",
+          "rejected": "slow",
+          "source_capsule": "ucap1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        {
+          "chosen": "small",
+          "prompt": "shrink",
+          "rejected": "large",
+          "source_capsule": "ucap1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        }
+      ],
+      "expected_encoder_tokens": 623,
+      "expected_projection_sha256": "e3b3e31e9258bc391e0fa5ae99cfb72da182a993225f464b722d4a6ff09a551c",
+      "expected_used_source_capsules": [
+        "ucap1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "ucap1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+      ],
+      "max_encoder_tokens": 1024,
+      "query": " rank context　",
+      "token_counter": "utf8_byte_length",
+      "tokenizer": "utf8-bytes-v1"
+    },
+    "nsga2_exact_v1": {
+      "expected": [
+        {
+          "candidate_capsule": "ucap1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "crowding": {"kind": "boundary"},
+          "pareto_rank": 0
+        },
+        {
+          "candidate_capsule": "ucap1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "crowding": {"denominator": "1", "kind": "finite", "numerator": "2"},
+          "pareto_rank": 0
+        },
+        {
+          "candidate_capsule": "ucap1:sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "crowding": {"denominator": "1", "kind": "finite", "numerator": "2"},
+          "pareto_rank": 0
+        },
+        {
+          "candidate_capsule": "ucap1:sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "crowding": {"kind": "boundary"},
+          "pareto_rank": 0
+        }
+      ],
+      "objective_order": ["o1", "o2", "constant"],
+      "points": [
+        {
+          "candidate_capsule": "ucap1:sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "values": ["0", "10", "7"]
+        },
+        {
+          "candidate_capsule": "ucap1:sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "values": ["5", "5", "7"]
+        },
+        {
+          "candidate_capsule": "ucap1:sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "values": ["5", "5", "7"]
+        },
+        {
+          "candidate_capsule": "ucap1:sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+          "values": ["10", "0", "7"]
+        }
+      ]
+    },
+    "optibench_receipts_v1": {
+      "counter": {
+        "baseline": {
+          "cpu_instructions_retired": "1100",
+          "diff_tokens": "11",
+          "peak_memory_bytes": "105"
+        },
+        "counter_profile": "perf_stat_instructions_v1",
+        "samples": [
+          {"cpu_instructions_retired": "1002", "diff_tokens": "10", "peak_memory_bytes": "102"},
+          {"cpu_instructions_retired": "999", "diff_tokens": "11", "peak_memory_bytes": "101"},
+          {"cpu_instructions_retired": "1000", "diff_tokens": "10", "peak_memory_bytes": "100"},
+          {"cpu_instructions_retired": "1001", "diff_tokens": "9", "peak_memory_bytes": "99"},
+          {"cpu_instructions_retired": "998", "diff_tokens": "10", "peak_memory_bytes": "98"}
+        ]
+      },
+      "environment": {
+        "architecture": "x86_64",
+        "cpu_model": "zen4",
+        "kernel": "linux-6.8.0",
+        "operating_system": "ubuntu-24.04",
+        "runner": "linux-x86_64"
+      },
+      "expected_baseline_relation": "dominates_baseline",
+      "expected_medians": ["1000", "10", "100"],
+      "harness": {
+        "diff_metric": "token_count",
+        "peak_memory_method": "max_rss",
+        "source_commit": "aa1daa2de2a2bc1d1dab6c2e053022287aa63157",
+        "tokenizer": "pinned-v1",
+        "version": "1.0.0"
+      }
+    }
+  },
+  "version": 1
+}

--- a/sites/unigrok-control-center/public/docs/okf/intelligence-payload-profiles-v1.md
+++ b/sites/unigrok-control-center/public/docs/okf/intelligence-payload-profiles-v1.md
@@ -1,0 +1,269 @@
+# UniGrok Insider Intelligence payload profiles v1
+
+These profiles evolve the Insider Intelligence DAG without changing the pinned
+`IntelligenceCapsule` v1 envelope. Each profile occupies the existing
+`body.payload = {"schema": ..., "data": ...}` seam and has its own immutable
+schema digest:
+
+| payload schema | JSON Schema | raw SHA-256 |
+| --- | --- | --- |
+| `org.grokmcp.gno_envelope.v1` | [`gno-envelope-v1.schema.json`](gno-envelope-v1.schema.json) | `4c7fb150b3f82738ae43d52669c8c663283807d42add1f4532f01527a4d70665` |
+| `org.grokmcp.optibench_result.v1` | [`optibench-result-v1.schema.json`](optibench-result-v1.schema.json) | `dfc216d1855eb36e54829c3aca00434f0dc9845a6efc205c2c49016531accf81` |
+| `org.grokmcp.agentic_dpo_pair.v1` | [`agentic-dpo-pair-v1.schema.json`](agentic-dpo-pair-v1.schema.json) | `7db601ccc11aaa94409383f88c7305a46b63a705176897aaa313f835b24bed84` |
+
+The raw file digests are pinned in both language registries. Normative
+cross-capsule rules are separately frozen in
+[`intelligence-payload-semantics-v1.json`](intelligence-payload-semantics-v1.json),
+SHA-256 `7464c2343c3edaadc21a14a880e689ef8e4b4ac0fa3fc07b2b6f37b08733545a`.
+The public, digest-bound
+[`intelligence-payload-conformance-v1.json`](intelligence-payload-conformance-v1.json)
+at SHA-256 `6a0df82c82cd3bfbadc6ff1febf1e43b2d2a6446acd1b977ae7d3262de8d98f4`
+contains shared body identities, receipt examples, exact NSGA-II outcomes, a
+Needle projection identity, and adversarial reject vectors. Any semantic
+change requires a new profile/spec version;
+editing a `.v1` contract in place is a protocol fork.
+
+## Scope and trust boundary
+
+These are protocol contracts, not claims that every producer exists today.
+The current local Swarm still stores its working state in contributor SQLite,
+uses wall-clock latency and `tracemalloc`, ranks
+`latency_ms`/`peak_mem_bytes`/`diff_bytes`, and routes with discounted UCB.
+It does not currently emit GNO capsules, hardware-counter OptiBench capsules,
+or preference pairs.
+
+A capsule with a known profile becomes eligible for promotion only after all
+of these independent gates succeed:
+
+1. canonical envelope parsing and body-digest verification;
+2. the registered profile schema and semantic validator;
+3. evidence byte-count and SHA-256 verification;
+4. complete parent-graph closure, bounds, and acyclicity checks;
+5. signed-Git-commit or approved cloud-attestation publication authentication;
+6. repository promotion policy.
+
+An unknown payload schema may be retained in quarantine, but it must not be
+executed, materialized, promoted, or exported. The envelope `signatures` array
+does not authorize publication in v1.
+
+The Python module is the current executable implementation of every v1
+evidence and complete-graph gate. The browser TypeScript module performs the
+same envelope/profile structural checks, but it is not a promotion authority
+and does not independently resolve evidence blobs or recompute cohort graphs.
+
+## GNO input-manifest envelope
+
+`org.grokmcp.gno_envelope.v1` alternates task dispatch capsules with candidate
+or failure result capsules.
+
+- A dispatch has `body.kind = task`, explicit execution identity, and required
+  `task_spec` plus `input_manifest` evidence. Its parents are the complete
+  graph dependencies. The canonical manifest binds routing, execution, and
+  every other declared non-secret artifact, including any Git input diff,
+  context, system prompt, tool manifest, and policy.
+- A result has `body.kind = candidate` or `failure`, matching its `outcome`.
+  Its sole parent is its dispatch capsule. A candidate carries an
+  `output_diff` evidence reference; a failure carries a `failure_receipt`.
+  It must omit `body.execution`: executor identity is inherited from the
+  manifest-bound dispatch and cannot be contradicted downstream.
+- Every artifact reference binds both evidence name and SHA-256. Name-only
+  lookup is forbidden, and evidence names are unique inside a known profile.
+- Routing labels are literal. The existing Swarm is
+  `discounted_ucb_v1`; it cannot be relabeled as UCB1. Decimal routing
+  parameters are strings, never floats or nulls.
+- The resolver verifies every declared byte count and SHA-256 and rejects
+  secret-like shared text. Credentials and private consumer SQLite state are
+  never evidence.
+
+"Manifest-closed and stateless" does not mean mathematically deterministic. A
+remote model, provider implementation, or sampling path may change. The
+envelope makes every declared input replayable and every result attributable;
+it does not promise byte-identical model output. Promotion also requires an
+executor receipt proving the agent was sandboxed from undeclared ambient reads:
+a manifest alone cannot prove that a process did not cheat.
+
+The DPO proof resolver enforces bounded transitive parent closure and
+acyclicity. General GNO TaskGraph admission and total evidence-byte limits
+remain additional promotion-time rules. A parallelism index and a `1 -> 2`
+branching policy are intentionally not serialized: neither has a frozen
+definition or current implementation.
+
+## Closed-population OptiBench result
+
+`org.grokmcp.optibench_result.v1` is deliberately impossible to mint from the
+current wall-clock Swarm result. It requires a closed population, canonical
+counter samples, an environment manifest, a harness manifest, and successful
+gate receipts. The evidence verifier recomputes population/cohort binding,
+requires a passing tests gate, and derives every published median from the raw
+samples before the capsule can enter a trusted graph.
+
+Two non-interchangeable cohorts are supported:
+
+| cohort | exact objective metrics in `body.metrics` |
+| --- | --- |
+| `perf_stat_instructions_v1` | `cpu_instructions_retired/instruction`, `diff_tokens/token`, `peak_memory_bytes/byte` |
+| `callgrind_ir_v1` | `callgrind_ir/instruction_reference`, `diff_tokens/token`, `peak_memory_bytes/byte` |
+
+All objectives minimize nonnegative integer values. `perf` instructions and
+Callgrind instruction references are different physical measurements and
+must never share a cohort or be compared as though they were identical. The
+harness evidence fixes tokenizer identity for `diff_tokens` and measurement
+method for peak memory.
+
+Environment receipts have exactly `architecture`, `cpu_model`, `kernel`,
+`operating_system`, and `runner`. Harness receipts have exactly `diff_metric`,
+`peak_memory_method`, `source_commit`, `tokenizer`, and `version`; the source
+commit is a full lowercase SHA-1 or SHA-256 object id. Identifier syntax alone
+is not treated as safe: all shared textual receipt values also pass the pinned
+secret detector.
+
+NSGA-II ranking occurs only after the population closes. Finite crowding is a
+reduced nonnegative rational `{numerator, denominator}`; a boundary point uses
+`{"kind":"boundary"}`. IEEE infinity and floating-point crowding never enter
+canonical bytes. Rational components are bounded to 128 decimal digits.
+Repetition counts are odd, so an integer-valued median has one exact middle
+sample and no hidden rounding rule.
+
+Rank and crowding are not properties of one result, so the single-receipt
+verifier cannot authorize promotion by itself. The closed-population verifier
+requires exactly one evidence-verified benchmark per population candidate,
+then recomputes every final rank and crowding value. It groups tied objective
+values symmetrically: all tied nonconstant extrema are boundaries; tied
+interior values receive the same nearest-distinct-neighbor fraction; constant
+objectives add zero. Candidate IDs order output but never break mathematical
+ties.
+
+`baseline_relation` is mandatory because nondominated among mutants does not
+mean better than the original program. The canonical counter receipt carries
+the baseline objective tuple; the verifier recomputes whether the candidate
+dominates, equals, is incomparable with, or is dominated by that baseline.
+
+## Direct-Pareto preference pair
+
+`org.grokmcp.agentic_dpo_pair.v1` records one conservative training/evaluation
+label:
+
+- chosen and rejected candidates are distinct, feasible members of the same
+  closed population and measurement cohort;
+- the chosen benchmark is final Pareto rank zero;
+- the rejected benchmark has a worse final rank;
+- the chosen objective tuple directly dominates that specific rejected tuple;
+- the task plus chosen/rejected candidate and benchmark IDs are the five direct
+  parents; the cohort proof hash-binds every additional population benchmark;
+- task and candidates are evidence-verified GNO dispatch/result capsules;
+- prompt binds the dispatch's sole `task_spec`, while chosen and rejected text
+  bind the candidates' sole `output_diff` artifacts by SHA-256;
+- prompt, outputs, population manifest, complete candidate-to-benchmark cohort
+  proof, and dominance receipt are hash-bound evidence.
+
+An arbitrary elite cannot be paired against an arbitrary dominated candidate:
+front membership alone does not prove pairwise dominance. Infeasible mutants
+are constraint failures, not objective-preference negatives. Online rewards or
+provisional ranks are not admissible; the producer must recompute the final
+closed front. V1 therefore supports only `pareto_dominance` under
+`nsga2_direct_dominance_v1`. Human, judge, champion-policy, and constraint
+preferences require later profiles with their own proof rules.
+
+`build_preference_example` accepts a complete graph closure, verifies every
+OptiBench receipt, recomputes final fronts and direct dominance, checks that the
+chosen candidate beats baseline, verifies every transitive dependency uses a
+registered GNO or OptiBench profile, and rejects secret-like shared text. The
+cohort proof manifest binds the exact benchmark capsule selected for every
+candidate, including candidates that are not one of the exported pair. Only
+then does it return one provider-neutral record.
+`render_preference_jsonl` emits that record with canonical key order and a
+single trailing LF for storage or batch transport:
+
+```json
+{"chosen":"...","prompt":"...","rejected":"...","source_capsule":"ucap1:sha256:..."}
+```
+
+The record and JSONL are disposable projections, not second sources of truth.
+Time decay or relevance weighting belongs in the Insider
+materialized-view query policy; it never mutates immutable pair provenance.
+
+## Canonical hashing and publication authentication in Python
+
+```python
+import hashlib
+
+from src.intelligence_capsule import (
+    build_envelope,
+    canonicalize,
+    capsule_id,
+    validate_envelope_integrity,
+)
+from src.intelligence_payloads import validate_known_payload_profile
+
+# `body` includes a registered payload and only SHA-256 evidence descriptors.
+body_bytes = canonicalize(body)                 # restricted RFC 8785 profile
+body_sha256 = hashlib.sha256(body_bytes).hexdigest()
+identity = capsule_id(body)                     # ucap1:sha256:<body_sha256>
+
+envelope = build_envelope(body)                 # signatures remains [] in v1
+validate_envelope_integrity(envelope)
+assert validate_known_payload_profile(body)       # separate semantic gate
+wire_bytes = canonicalize(envelope)
+
+assert envelope["digest"] == {
+    "algorithm": "sha-256",
+    "value": body_sha256,
+}
+assert identity == f"ucap1:sha256:{body_sha256}"
+```
+
+The signed publication object is the Git commit containing `wire_bytes`, not an
+ad-hoc signature over a framework JSON object. Local publication uses the
+contributor's configured SSH/GPG Git signing identity; cloud publication uses
+an approved workflow attestation. The v1 `signatures` field is reserved until a
+future protocol freezes a signature domain, key discovery, and trust roots.
+
+## Needle conditioning boundary
+
+Needle's playground accepts `tools` as a JSON string or array whose parsed top
+level is an array. The server compacts it, and `generate` normalizes only
+top-level tool names while preserving nested fields. The encoder receives the
+query, a tools separator, and the serialized tools, truncated to the space
+remaining in its 1,024-token encoder budget. Consequently, nested examples in
+a valid tool definition are mechanically supported inference-time context.
+They have no dedicated chosen/rejected semantics, so their ranking benefit must
+be benchmarked. [UI request](https://github.com/cactus-compute/needle/blob/ffb1c5144c5a16cb8ec650dbc8a6f6fd3854f8f2/needle/ui/static/app.js#L69-L92),
+[server normalization](https://github.com/cactus-compute/needle/blob/ffb1c5144c5a16cb8ec650dbc8a6f6fd3854f8f2/needle/ui/server.py#L156-L187),
+[encoder path](https://github.com/cactus-compute/needle/blob/ffb1c5144c5a16cb8ec650dbc8a6f6fd3854f8f2/needle/model/run.py#L92-L137).
+
+The provider-neutral DPO capsule does not claim Needle compatibility.
+`org.grokmcp.needle_tools_context.v1` is a separate executor-only projection,
+pinned by [`needle-tools-context-v1.schema.json`](needle-tools-context-v1.schema.json)
+at SHA-256 `ac92a88b87e35254a7eef4a151d8743418ef102402022b228609743cbcbf7496`.
+`build_needle_tools_context` wraps verified records inside one valid tool,
+counts the exact compacted tools string with a caller-supplied pinned Needle
+tokenizer, admits only whole examples in source-capsule order, and never exceeds
+the shared query/tools budget. The wrapper is non-parametric inference-time
+conditioning, not a weight or optimizer update. Query normalization trims only
+the explicit CPython Unicode whitespace set used by the upstream server
+(including NBSP and U+3000), requires strict UTF-8, and applies the same pinned
+secret detector as the nested examples before any token count is accepted.
+Input is bounded before regex/tokenizer work: at most 64 examples, 16 KiB of
+query text, and 64 KiB per example record.
+
+The separate playground fine-tune action generates `query`/`tools`/`answers`
+JSONL and runs an actual training job that writes a new checkpoint. UniGrok
+keeps that path distinct from ephemeral nested-example conditioning.
+[Fine-tune implementation](https://github.com/cactus-compute/needle/blob/ffb1c5144c5a16cb8ec650dbc8a6f6fd3854f8f2/needle/ui/server.py#L520-L647).
+
+Needle remains a non-authoritative shadow ranker. It may score sanitized,
+pre-enumerated candidate summaries, but its output cannot authorize reads,
+execution, mutation, or promotion. Exact source and model artifacts must be
+pinned and isolated before loading; benchmark recall and end-to-end answer
+quality against simpler retrieval baselines first. Needle's dedicated repo and
+model are MIT-licensed; its 26M/6,000-prefill/1,200-decode figures are vendor
+claims until UniGrok reproduces them, and they are not retrieval or
+nested-example benchmarks.
+
+## SQLite boundary
+
+Nothing in these profiles opens or changes the public consumer database. Public
+MCP consumers retain private local SQLite as runtime truth. A future Insider
+SQLite query view may index only trusted Git-DAG capsules; it must remain
+deletable and reconstructible from trusted refs without tunnels or cloud calls
+into localhost.

--- a/sites/unigrok-control-center/public/docs/okf/intelligence-payload-semantics-v1.json
+++ b/sites/unigrok-control-center/public/docs/okf/intelligence-payload-semantics-v1.json
@@ -1,0 +1,276 @@
+{
+  "protocol": "org.grokmcp.intelligence-payload-semantics",
+  "version": 1,
+  "normative_language": "MUST, MUST NOT, REQUIRED, and EXACT are normative. Any unrecognized field or receipt shape is rejected.",
+  "capsule_schema_sha256": "10c2ec4638bd6c4e303b3e2c4c7d91ae582554f48aaa01fac2d9370062b98d4c",
+  "conformance": {
+    "file": "intelligence-payload-conformance-v1.json",
+    "sha256": "6a0df82c82cd3bfbadc6ff1febf1e43b2d2a6446acd1b977ae7d3262de8d98f4"
+  },
+  "limits": {
+    "graph_bodies": 129,
+    "jsonl_artifact_bytes": 262144,
+    "jsonl_record_bytes": 786432,
+    "needle_encoder_tokens": 1024,
+    "needle_example_bytes": 65536,
+    "needle_input_examples": 64,
+    "needle_query_bytes": 16384,
+    "objective_decimal_digits": 32,
+    "population_candidates": 64,
+    "rational_decimal_digits": 128
+  },
+  "receipt_contracts": [
+    {
+      "id": "gno_input_manifest_v1",
+      "encoding": "IntelligenceCapsule restricted-JCS canonical bytes",
+      "exact_keys": ["declared_artifacts", "execution", "routing"],
+      "bindings": {
+        "declared_artifacts": "body.payload.data.artifacts in canonical array order excluding the sole input_manifest role",
+        "execution": "body.execution by deep JSON equality",
+        "routing": "body.payload.data.routing by deep JSON equality"
+      }
+    },
+    {
+      "id": "optibench_environment_v1",
+      "encoding": "IntelligenceCapsule restricted-JCS canonical bytes",
+      "exact_keys": ["architecture", "cpu_model", "kernel", "operating_system", "runner"],
+      "value_rule": "Every value matches ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ and passes shared_secret_detector_v1."
+    },
+    {
+      "id": "optibench_harness_v1",
+      "encoding": "IntelligenceCapsule restricted-JCS canonical bytes",
+      "exact_keys": ["diff_metric", "peak_memory_method", "source_commit", "tokenizer", "version"],
+      "bindings": {
+        "source_commit": "lowercase hexadecimal Git object id matching ^(?:[a-f0-9]{40}|[a-f0-9]{64})$",
+        "other_values": "Each matches ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ and passes shared_secret_detector_v1."
+      }
+    },
+    {
+      "id": "optibench_population_manifest_v1",
+      "encoding": "IntelligenceCapsule restricted-JCS canonical bytes",
+      "exact_keys": ["candidate_capsules", "closed", "cohort_sha256"],
+      "bindings": {
+        "candidate_capsules": "body.parents by exact ordered-array equality",
+        "closed": true,
+        "cohort_sha256": "lowercase SHA-256 hex of restricted-JCS canonical body.payload.data.cohort"
+      }
+    },
+    {
+      "id": "optibench_gate_receipt_v1",
+      "encoding": "IntelligenceCapsule restricted-JCS canonical bytes",
+      "exact_keys": ["gate", "passed"],
+      "bindings": {
+        "gate": "identifier matching ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$; unique across receipts; tests is REQUIRED",
+        "passed": true
+      }
+    },
+    {
+      "id": "optibench_counter_receipt_v1",
+      "encoding": "IntelligenceCapsule restricted-JCS canonical bytes",
+      "exact_keys": ["baseline", "counter_profile", "samples"],
+      "bindings": {
+        "baseline": "Object with exactly objective_metrics keys; values are nonnegative base-10 integer strings of at most 32 digits.",
+        "counter_profile": "Exact equality with body.payload.data.cohort.counter_profile.",
+        "samples": "Array length equals repetitions; each object has exactly objective_metrics keys and bounded nonnegative base-10 integer-string values."
+      }
+    },
+    {
+      "id": "dpo_cohort_proof_manifest_v1",
+      "encoding": "IntelligenceCapsule restricted-JCS canonical bytes",
+      "exact_keys": ["benchmarks", "cohort_sha256", "population_manifest_sha256"],
+      "bindings": {
+        "benchmarks": "Exactly one object with exact keys benchmark_capsule,candidate_capsule for every candidate in the closed population, ordered by candidate_capsule; each benchmark id is the unique evidence-verified OptiBench result selected for that candidate.",
+        "cohort_sha256": "lowercase SHA-256 hex of restricted-JCS canonical shared cohort object",
+        "population_manifest_sha256": "SHA-256 from the shared OptiBench population_manifest evidence reference"
+      }
+    },
+    {
+      "id": "dpo_dominance_receipt_v1",
+      "encoding": "IntelligenceCapsule restricted-JCS canonical bytes",
+      "exact_keys": ["chosen_benchmark", "metrics", "rejected_benchmark", "relation"],
+      "bindings": {
+        "chosen_benchmark": "body.payload.data.chosen.benchmark_capsule",
+        "metrics": "One object per objective in declared order with exact keys chosen,name,rejected,unit and values copied from verified benchmark tuples.",
+        "rejected_benchmark": "body.payload.data.rejected.benchmark_capsule",
+        "relation": "dominates"
+      }
+    }
+  ],
+  "algorithms": [
+    {
+      "id": "dominates_minimize_v1",
+      "input": "Two equal-length ordered tuples of nonnegative integers.",
+      "result": "left dominates right iff every left[i] <= right[i] and at least one left[i] < right[i]."
+    },
+    {
+      "id": "integer_median_v1",
+      "input": "An odd nonempty multiset of bounded nonnegative integers.",
+      "steps": [
+        "Sort integers in ascending numeric order.",
+        "Return element at zero-based index floor(length / 2).",
+        "The resulting tuple MUST exactly equal body.metrics in objective_metrics order."
+      ]
+    },
+    {
+      "id": "nsga2_exact_v1",
+      "input": "Exactly one verified benchmark per candidate in a nonempty closed population; all ordered objectives minimize.",
+      "rank_steps": [
+        "Set remaining to all candidate capsule ids and rank to 0.",
+        "The next front is every remaining candidate not dominated by any other remaining candidate under dominates_minimize_v1.",
+        "Sort the front by candidate capsule id for deterministic output, assign rank, remove it, increment rank, and repeat until remaining is empty."
+      ],
+      "crowding_steps": [
+        "Compute crowding separately inside each final Pareto front.",
+        "A singleton front publishes {kind:boundary}.",
+        "For a larger front initialize every exact rational distance to 0/1 and boundary=false.",
+        "For each objective in objective_metrics order, group candidates by exact integer value and sort the distinct values ascending.",
+        "If the objective is constant, it contributes zero and marks no boundary.",
+        "Otherwise mark every candidate tied at the minimum or maximum value as boundary.",
+        "For every interior distinct value v[j], add (v[j+1]-v[j-1])/(maximum-minimum) to every candidate tied at v[j].",
+        "A candidate marked by any objective publishes {kind:boundary}; every other candidate publishes the summed Fraction reduced by positive gcd as {denominator,kind:finite,numerator} using unsigned base-10 strings.",
+        "Zero MUST serialize as numerator 0 and denominator 1. Numerator and denominator MUST each fit the 128-digit bound."
+      ],
+      "tie_policy": "Candidate ids never break mathematical ties; all tied extrema share boundary status and all tied interior values receive the same nearest-distinct-neighbor contribution."
+    },
+    {
+      "id": "complete_parent_graph_v1",
+      "input": "At most 129 canonical capsule bodies keyed by their exact capsule ids.",
+      "steps": [
+        "Every parent id of every supplied body MUST resolve to another supplied body.",
+        "Depth-first traversal uses unseen,visiting,complete states; an edge to visiting rejects a cycle.",
+        "Traversal depth MUST NOT exceed 129.",
+        "For DPO, the reachable closure starts from the declared task, every population candidate, and every cohort-proof benchmark; unrelated supplied bodies reject.",
+        "Every reachable dependency MUST use a registered GNO or OptiBench profile and pass its profile plus evidence verifier."
+      ]
+    },
+    {
+      "id": "needle_tools_context_v1",
+      "input": "Strict-UTF-8 query, verified preference records, pinned tokenizer id, exact token counter, max_encoder_tokens=1024, and max_examples in [1,64].",
+      "steps": [
+        "Before encoding, regex, sorting, or tokenization, reject a raw query longer than 16384 code points, more than 64 input examples, or an example whose three text fields exceed 65536 aggregate code points.",
+        "Trim exactly Unicode code points U+0009..U+000D,U+001C..U+001F,U+0020,U+0085,U+00A0,U+1680,U+2000..U+200A,U+2028,U+2029,U+202F,U+205F,U+3000 from both query ends, matching the pinned upstream Python strip behavior; reject an empty result.",
+        "Require normalized query UTF-8 bytes <=16384 and each canonical example record <=65536 bytes; reject invalid Unicode scalars.",
+        "Reject secret-like query or example text with shared_secret_detector_v1.",
+        "Require exact example keys chosen,prompt,rejected,source_capsule; sort by source_capsule and reject duplicates.",
+        "Construct exactly one tool named select_unigrok_context using the field values and insertion order frozen by the conformance vector.",
+        "Serialize the tools array with Python json.dumps separators=(',',':') and ensure_ascii=true; no trailing LF.",
+        "Token cost is token_counter(query)+1+token_counter(serialized_tools), where 1 is the Needle tools separator.",
+        "Start with no examples. Inspect at most max_examples sorted records; append a whole record iff the resulting cost is <=1024, otherwise continue without slicing it.",
+        "Publish query_sha256 over normalized strict-UTF-8 query bytes and the final exact token count."
+      ]
+    }
+  ],
+  "secret_rejection": {
+    "id": "shared_secret_detector_v1",
+    "action": "For every known profile, recursively inspect every string in the capsule body plus every resolved shared text blob. Reject matches; never redact hash-bound bytes because redaction would change provenance.",
+    "patterns": [
+      {"expression": "github_pat_[A-Za-z0-9_]{10,}|gh[pousr]_[A-Za-z0-9]{10,}", "ignore_case": false},
+      {"expression": "glpat-[A-Za-z0-9_-]{10,}", "ignore_case": false},
+      {"expression": "\\bsk-(?:proj-|svcacct-)?[A-Za-z0-9_-]{12,}", "ignore_case": false},
+      {"expression": "\\bxai-[A-Za-z0-9_-]{12,}", "ignore_case": true},
+      {"expression": "\\bAIza[A-Za-z0-9_-]{25,}", "ignore_case": false},
+      {"expression": "\\b(?:AKIA|ASIA)[A-Z0-9]{16}\\b", "ignore_case": false},
+      {"expression": "\\bnpm_[A-Za-z0-9]{20,}", "ignore_case": false},
+      {"expression": "\\bpypi-[A-Za-z0-9_-]{20,}", "ignore_case": false},
+      {"expression": "\\bxox[baprs]-[A-Za-z0-9-]{12,}", "ignore_case": false},
+      {"expression": "\\bsk_live_[A-Za-z0-9]{16,}", "ignore_case": false},
+      {"expression": "-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----", "ignore_case": false},
+      {"expression": "\\beyJ[A-Za-z0-9_-]{20,}\\.[A-Za-z0-9_-]{10,}\\.[A-Za-z0-9_-]{10,}\\b", "ignore_case": false},
+      {"expression": "\\bBearer\\s+(?!<|\\$\\{|\\[)[A-Za-z0-9._~+/=-]{8,}", "ignore_case": true},
+      {"expression": "Authorization\\s*:\\s*Bearer\\s+(?!<|\\$\\{|\\[)[A-Za-z0-9._~+/-]{8,}", "ignore_case": true},
+      {"expression": "Authorization\\s*:\\s*Basic\\s+(?!<|\\$\\{|\\[)[A-Za-z0-9+/=]{8,}", "ignore_case": true},
+      {"expression": "(?:^|[^A-Za-z0-9_])[\"']?[A-Z0-9_-]*(?:API[_-]?KEY|SECRET[_-]?ACCESS[_-]?KEY|SESSION[_-]?TOKEN|ACCESS[_-]?TOKEN|AUTH[_-]?TOKEN|PASSWORD|PRIVATE[_-]?KEY|CLIENT[_-]?SECRET)[\"']?\\s*[:=]\\s*(?![\"']?(?:<|\\$\\{|\\[))(?:\"[^\"\\r\\n]{8,}\"|'[^'\\r\\n]{8,}'|[A-Za-z0-9._~+/=@!#$%^&*()-]{8,})", "ignore_case": true}
+    ]
+  },
+  "profiles": [
+    {
+      "schema": "org.grokmcp.agentic_dpo_pair.v1",
+      "schema_sha256": "7db601ccc11aaa94409383f88c7305a46b63a705176897aaa313f835b24bed84",
+      "rules": [
+        "dpo.artifacts_match_candidates",
+        "dpo.baseline_victory",
+        "dpo.candidates_link_declared_task",
+        "dpo.cohort_proof_binds_every_benchmark",
+        "dpo.closed_cohort",
+        "dpo.complete_parent_graph",
+        "dpo.direct_dominance",
+        "dpo.export_after_graph_verification",
+        "dpo.final_rank_and_crowding_recomputed",
+        "dpo.parents_exact",
+        "dpo.prompt_matches_task",
+        "dpo.requires_registered_gno_dependencies",
+        "dpo.receipt_recomputed",
+        "dpo.same_run_subject",
+        "dpo.shared_baseline",
+        "dpo.text_evidence_verified",
+        "dpo.text_sha_matches_gno_semantic_roles"
+      ]
+    },
+    {
+      "schema": "org.grokmcp.gno_envelope.v1",
+      "schema_sha256": "4c7fb150b3f82738ae43d52669c8c663283807d42add1f4532f01527a4d70665",
+      "rules": [
+        "gno.artifacts_hash_bound",
+        "gno.dispatch_execution_explicit",
+        "gno.input_manifest_recomputed",
+        "gno.kind_matches_phase",
+        "gno.no_secret_like_shared_text",
+        "gno.result_dispatch_fields_match",
+        "gno.result_execution_inherited_only",
+        "gno.result_opposite_role_forbidden",
+        "gno.result_parent_exact",
+        "gno.role_cardinality",
+        "gno.same_run_subject"
+      ]
+    },
+    {
+      "schema": "org.grokmcp.optibench_result.v1",
+      "schema_sha256": "dfc216d1855eb36e54829c3aca00434f0dc9845a6efc205c2c49016531accf81",
+      "rules": [
+        "optibench.baseline_relation_recomputed",
+        "optibench.cohort_metric_set_exact",
+        "optibench.counter_samples_recomputed",
+        "optibench.environment_manifest_exact",
+        "optibench.gates_passed",
+        "optibench.harness_manifest_exact",
+        "optibench.integer_median_odd_repetitions",
+        "optibench.population_manifest_recomputed",
+        "optibench.rank_and_crowding_recomputed_from_closed_population",
+        "optibench.rational_digits_bounded",
+        "optibench.rational_reduced",
+        "optibench.shared_baseline"
+      ]
+    }
+  ],
+  "projections": [
+    {
+      "profile": "org.grokmcp.needle_tools_context.v1",
+      "schema_sha256": "ac92a88b87e35254a7eef4a151d8743418ef102402022b228609743cbcbf7496",
+      "rules": [
+        "needle.pinned_secret_scan",
+        "needle.examples_whole_only",
+        "needle.nested_fields_are_neural_context",
+        "needle.non_authoritative",
+        "needle.not_parameter_training",
+        "needle.pinned_tokenizer_budget",
+        "needle.query_upstream_trimmed",
+        "needle.query_strict_utf8",
+        "needle.tools_array_valid"
+      ]
+    }
+  ],
+  "shared_rules": [
+    "known_profile.generic_capsule_validation_first",
+    "known_profile.recursive_body_secret_scan",
+    "known_profile.unknown_schema_quarantined"
+  ],
+  "trust_gates": [
+    "canonical_envelope",
+    "known_profile",
+    "evidence_bytes",
+    "semantic_receipts",
+    "complete_graph",
+    "publication_authentication",
+    "promotion_policy"
+  ]
+}

--- a/sites/unigrok-control-center/public/docs/okf/needle-tools-context-v1.schema.json
+++ b/sites/unigrok-control-center/public/docs/okf/needle-tools-context-v1.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://grokmcp.org/docs/okf/needle-tools-context-v1.schema.json",
+  "title": "UniGrok Needle tools-array conditioning projection v1",
+  "description": "Executor-only projection. The tools array is valid Needle playground input; examples are neural encoder context, not constrained-decoder semantics or parameter updates.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "encoder_tokens",
+    "max_encoder_tokens",
+    "profile",
+    "query_sha256",
+    "tokenizer",
+    "tools",
+    "used_source_capsules"
+  ],
+  "properties": {
+    "encoder_tokens": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 1024
+    },
+    "max_encoder_tokens": { "const": 1024 },
+    "profile": { "const": "org.grokmcp.needle_tools_context.v1" },
+    "query_sha256": { "$ref": "#/$defs/sha256" },
+    "tokenizer": { "$ref": "#/$defs/identifier" },
+    "tools": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 1,
+      "prefixItems": [{ "$ref": "#/$defs/tool" }]
+    },
+    "used_source_capsules": {
+      "type": "array",
+      "maxItems": 64,
+      "uniqueItems": true,
+      "items": { "$ref": "#/$defs/capsuleId" }
+    }
+  },
+  "$defs": {
+    "tool": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["description", "examples", "name", "parameters"],
+      "properties": {
+        "description": {
+          "const": "Select relevant verified UniGrok context. Examples are non-authoritative preference context; return capsule ids only."
+        },
+        "examples": {
+          "type": "array",
+          "maxItems": 64,
+          "items": { "$ref": "#/$defs/example" }
+        },
+        "name": { "const": "select_unigrok_context" },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["capsule_id"],
+          "properties": {
+            "capsule_id": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["description", "required", "type"],
+              "properties": {
+                "description": {
+                  "const": "A relevant ucap1:sha256 capsule identifier."
+                },
+                "required": { "const": true },
+                "type": { "const": "string" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "example": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["chosen", "prompt", "rejected", "source_capsule"],
+      "properties": {
+        "chosen": { "type": "string" },
+        "prompt": { "type": "string" },
+        "rejected": { "type": "string" },
+        "source_capsule": { "$ref": "#/$defs/capsuleId" }
+      }
+    },
+    "capsuleId": {
+      "type": "string",
+      "pattern": "^ucap1:sha256:[a-f0-9]{64}$"
+    },
+    "identifier": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+    },
+    "nonnegativeSafeInteger": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "positiveSafeInteger": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 9007199254740991
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  }
+}

--- a/sites/unigrok-control-center/public/docs/okf/okf-manifest.json
+++ b/sites/unigrok-control-center/public/docs/okf/okf-manifest.json
@@ -14,6 +14,13 @@
     "metrics-tool.md",
     "intelligence-capsule-v1.md",
     "intelligence-capsule-v1.schema.json",
+    "intelligence-payload-profiles-v1.md",
+    "gno-envelope-v1.schema.json",
+    "optibench-result-v1.schema.json",
+    "agentic-dpo-pair-v1.schema.json",
+    "needle-tools-context-v1.schema.json",
+    "intelligence-payload-semantics-v1.json",
+    "intelligence-payload-conformance-v1.json",
     "faq.md",
     "api-reference.md"
   ]

--- a/sites/unigrok-control-center/public/docs/okf/optibench-result-v1.schema.json
+++ b/sites/unigrok-control-center/public/docs/okf/optibench-result-v1.schema.json
@@ -1,0 +1,189 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://grokmcp.org/docs/okf/optibench-result-v1.schema.json",
+  "title": "UniGrok OptiBench closed-population result payload data v1",
+  "description": "The data object carried by payload schema org.grokmcp.optibench_result.v1. Numeric objective truth is stored once in the containing capsule body.metrics.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "aggregation",
+    "baseline_relation",
+    "candidate_capsule",
+    "cohort",
+    "counter_output",
+    "gate_receipts",
+    "nsga2",
+    "objective_metrics",
+    "population_closed",
+    "population_manifest",
+    "repetitions"
+  ],
+  "properties": {
+    "aggregation": { "const": "median" },
+    "baseline_relation": {
+      "enum": [
+        "dominated_by_baseline",
+        "dominates_baseline",
+        "equal_baseline",
+        "incomparable_to_baseline"
+      ]
+    },
+    "candidate_capsule": { "$ref": "#/$defs/capsuleId" },
+    "cohort": { "$ref": "#/$defs/cohort" },
+    "counter_output": { "$ref": "#/$defs/evidenceRef" },
+    "gate_receipts": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 32,
+      "items": { "$ref": "#/$defs/evidenceRef" }
+    },
+    "nsga2": { "$ref": "#/$defs/nsga2" },
+    "objective_metrics": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": {
+        "enum": [
+          "callgrind_ir",
+          "cpu_instructions_retired",
+          "diff_tokens",
+          "peak_memory_bytes"
+        ]
+      }
+    },
+    "population_closed": { "const": true },
+    "population_manifest": { "$ref": "#/$defs/evidenceRef" },
+    "repetitions": {
+      "allOf": [
+        { "$ref": "#/$defs/positiveSafeInteger" },
+        { "not": { "multipleOf": 2 } }
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "cohort": {
+            "properties": {
+              "counter_profile": { "const": "perf_stat_instructions_v1" }
+            },
+            "required": ["counter_profile"]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "objective_metrics": {
+            "prefixItems": [
+              { "const": "cpu_instructions_retired" },
+              { "const": "diff_tokens" },
+              { "const": "peak_memory_bytes" }
+            ]
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "objective_metrics": {
+            "prefixItems": [
+              { "const": "callgrind_ir" },
+              { "const": "diff_tokens" },
+              { "const": "peak_memory_bytes" }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "cohort": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "counter_profile",
+        "environment",
+        "harness",
+        "tool",
+        "tool_version"
+      ],
+      "properties": {
+        "counter_profile": {
+          "enum": ["callgrind_ir_v1", "perf_stat_instructions_v1"]
+        },
+        "environment": { "$ref": "#/$defs/evidenceRef" },
+        "harness": { "$ref": "#/$defs/evidenceRef" },
+        "tool": { "enum": ["perf", "valgrind"] },
+        "tool_version": { "$ref": "#/$defs/identifier" }
+      }
+    },
+    "nsga2": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "crowding", "pareto_rank"],
+      "properties": {
+        "algorithm": { "const": "nsga2_exact_v1" },
+        "crowding": {
+          "oneOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["kind"],
+              "properties": { "kind": { "const": "boundary" } }
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["denominator", "kind", "numerator"],
+              "properties": {
+                "denominator": {
+                  "type": "string",
+                  "maxLength": 128,
+                  "pattern": "^[1-9][0-9]*$"
+                },
+                "kind": { "const": "finite" },
+                "numerator": {
+                  "type": "string",
+                  "maxLength": 128,
+                  "pattern": "^(?:0|[1-9][0-9]*)$"
+                }
+              }
+            }
+          ]
+        },
+        "pareto_rank": { "$ref": "#/$defs/nonnegativeSafeInteger" }
+      }
+    },
+    "evidenceRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["evidence_name", "sha256"],
+      "properties": {
+        "evidence_name": { "$ref": "#/$defs/identifier" },
+        "sha256": { "$ref": "#/$defs/sha256" }
+      }
+    },
+    "capsuleId": {
+      "type": "string",
+      "pattern": "^ucap1:sha256:[a-f0-9]{64}$"
+    },
+    "identifier": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$"
+    },
+    "nonnegativeSafeInteger": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 9007199254740991
+    },
+    "positiveSafeInteger": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 9007199254740991
+    },
+    "sha256": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{64}$"
+    }
+  }
+}

--- a/sites/unigrok-control-center/tests/intelligence-payloads.test.ts
+++ b/sites/unigrok-control-center/tests/intelligence-payloads.test.ts
@@ -1,0 +1,259 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import { canonicalize, capsuleId, digestBody, validateBody } from "../app/lib/intelligence-capsule";
+import {
+  AGENTIC_DPO_PAIR_SCHEMA,
+  CONFORMANCE_FILE,
+  CONFORMANCE_SHA256,
+  GNO_ENVELOPE_SCHEMA,
+  OPTIBENCH_RESULT_SCHEMA,
+  PROFILE_SCHEMA_FILES,
+  PROFILE_SCHEMA_SHA256,
+  PROJECTION_SCHEMA_FILES,
+  PROJECTION_SCHEMA_SHA256,
+  SEMANTIC_SPEC_FILE,
+  SEMANTIC_SPEC_SHA256,
+  SHARED_SECRET_PATTERNS,
+  validateKnownPayloadProfile,
+} from "../app/lib/intelligence-payloads";
+
+type RecordValue = Record<string, unknown>;
+
+const fixtureUrl = new URL("../../../tests/fixtures/intelligence_capsule/v1/golden-envelope.json", import.meta.url);
+const conformanceUrl = new URL(`../../../docs/okf/${CONFORMANCE_FILE}`, import.meta.url);
+
+const id = (digit: string) => `ucap1:sha256:${digit.repeat(64)}`;
+const sha256 = (raw: Uint8Array | string) => createHash("sha256").update(raw).digest("hex");
+
+function evidence(name: string, text: string, mediaType = "text/plain"): RecordValue {
+  return { bytes: Buffer.byteLength(text), media_type: mediaType, name, sha256: sha256(text) };
+}
+
+function ref(item: RecordValue): RecordValue {
+  return { evidence_name: item.name, sha256: item.sha256 };
+}
+
+async function baseBody(): Promise<RecordValue> {
+  const envelope = JSON.parse(await readFile(fixtureUrl, "utf8"));
+  return envelope.body;
+}
+
+async function body(
+  kind: string,
+  schema: string,
+  data: RecordValue,
+  evidenceItems: RecordValue[],
+  parents: string[],
+  metrics?: RecordValue[],
+): Promise<RecordValue> {
+  const value = await baseBody();
+  value.kind = kind;
+  value.parents = [...parents].sort();
+  value.evidence = [...evidenceItems].sort((left, right) =>
+    `${String(left.name)}\0${String(left.sha256)}`.localeCompare(`${String(right.name)}\0${String(right.sha256)}`));
+  value.payload = { data, schema };
+  if (metrics) value.metrics = metrics;
+  else delete value.metrics;
+  return value;
+}
+
+async function gnoBody(): Promise<RecordValue> {
+  const taskSpec = evidence("task-spec", "optimize foo without ambient reads");
+  const routing = {
+    algorithm: "discounted_ucb_v1",
+    arm: "hot_loop",
+    arm_pull: 7,
+    parameters: [{ name: "decay", value: "0.95" }, { name: "exploration", value: "1" }],
+    reason: "discounted_ucb",
+    seed: 42,
+    step: 25,
+  };
+  const execution = (await baseBody()).execution;
+  const declared = [{ role: "task_spec", ...ref(taskSpec) }];
+  const inputManifestText = Buffer.from(canonicalize({
+    declared_artifacts: declared,
+    execution,
+    routing,
+  })).toString("utf8");
+  const inputManifest = evidence("input-manifest", inputManifestText, "application/json");
+  return body("task", GNO_ENVELOPE_SCHEMA, {
+    artifacts: [
+      { role: "input_manifest", ...ref(inputManifest) },
+      ...declared,
+    ],
+    generation: 1,
+    mutator: { origin: "agent", profile: "hot_loop" },
+    node_id: "node-01",
+    phase: "dispatch",
+    routing,
+    slot: 2,
+  }, [inputManifest, taskSpec], [id("1")]);
+}
+
+async function optibenchBody(): Promise<RecordValue> {
+  const items = Object.fromEntries(Object.entries({
+    "counter-output": "1,234 instructions",
+    environment: '{"runner":"linux-x86_64"}',
+    harness: '{"tokenizer":"pinned-v1"}',
+    population: '{"closed":true}',
+    tests: '{"passed":true}',
+  }).map(([name, text]) => [name, evidence(name, text)]));
+  const candidate = id("2");
+  return body("benchmark", OPTIBENCH_RESULT_SCHEMA, {
+    aggregation: "median",
+    baseline_relation: "dominates_baseline",
+    candidate_capsule: candidate,
+    cohort: {
+      counter_profile: "perf_stat_instructions_v1",
+      environment: ref(items.environment),
+      harness: ref(items.harness),
+      tool: "perf",
+      tool_version: "6.8.0",
+    },
+    counter_output: ref(items["counter-output"]),
+    gate_receipts: [ref(items.tests)],
+    nsga2: { algorithm: "nsga2_exact_v1", crowding: { kind: "boundary" }, pareto_rank: 0 },
+    objective_metrics: ["cpu_instructions_retired", "diff_tokens", "peak_memory_bytes"],
+    population_closed: true,
+    population_manifest: ref(items.population),
+    repetitions: 5,
+  }, Object.values(items), [candidate], [
+    { name: "cpu_instructions_retired", unit: "instruction", value: "1234" },
+    { name: "diff_tokens", unit: "token", value: "18" },
+    { name: "peak_memory_bytes", unit: "byte", value: "29300" },
+  ]);
+}
+
+async function dpoBody(): Promise<RecordValue> {
+  const items = Object.fromEntries(Object.entries({
+    "chosen-output": "optimized implementation",
+    "cohort-proof": '{"benchmarks":[]}',
+    dominance: '{"chosen":[10,20,3],"rejected":[12,25,4]}',
+    population: '{"closed":true,"cohort":"abc"}',
+    prompt: "Optimize the focus function.",
+    "rejected-output": "slower implementation",
+  }).map(([name, text]) => [name, evidence(name, text)]));
+  const task = id("1");
+  const chosenCandidate = id("2");
+  const chosenBenchmark = id("3");
+  const rejectedCandidate = id("4");
+  const rejectedBenchmark = id("5");
+  return body("evaluation", AGENTIC_DPO_PAIR_SCHEMA, {
+    chosen: {
+      artifact: ref(items["chosen-output"]),
+      benchmark_capsule: chosenBenchmark,
+      candidate_capsule: chosenCandidate,
+    },
+    cohort_proof_manifest: ref(items["cohort-proof"]),
+    export_profile: "preference_jsonl_v1",
+    population_manifest: ref(items.population),
+    preference: {
+      basis: "pareto_dominance",
+      dominance_receipt: ref(items.dominance),
+      policy: "nsga2_direct_dominance_v1",
+    },
+    prompt: ref(items.prompt),
+    rejected: {
+      artifact: ref(items["rejected-output"]),
+      benchmark_capsule: rejectedBenchmark,
+      candidate_capsule: rejectedCandidate,
+    },
+    task_capsule: task,
+  }, Object.values(items), [task, chosenCandidate, chosenBenchmark, rejectedCandidate, rejectedBenchmark]);
+}
+
+function validateKnownBody(value: RecordValue): void {
+  validateBody(value);
+  assert.equal(validateKnownPayloadProfile(value), true);
+}
+
+test("payload schema files are independently digest pinned", async () => {
+  for (const [schema, fileName] of Object.entries(PROFILE_SCHEMA_FILES)) {
+    const raw = await readFile(new URL(`../../../docs/okf/${fileName}`, import.meta.url));
+    assert.equal(sha256(raw), PROFILE_SCHEMA_SHA256[schema as keyof typeof PROFILE_SCHEMA_SHA256]);
+  }
+  for (const [schema, fileName] of Object.entries(PROJECTION_SCHEMA_FILES)) {
+    const raw = await readFile(new URL(`../../../docs/okf/${fileName}`, import.meta.url));
+    assert.equal(sha256(raw), PROJECTION_SCHEMA_SHA256[schema as keyof typeof PROJECTION_SCHEMA_SHA256]);
+  }
+  const semanticSpec = await readFile(new URL(`../../../docs/okf/${SEMANTIC_SPEC_FILE}`, import.meta.url));
+  assert.equal(sha256(semanticSpec), SEMANTIC_SPEC_SHA256);
+  assert.equal(sha256(await readFile(conformanceUrl)), CONFORMANCE_SHA256);
+  const semanticDocument = JSON.parse(semanticSpec.toString("utf8"));
+  assert.deepEqual(
+    SHARED_SECRET_PATTERNS.map((pattern) => ({
+      expression: pattern.source,
+      ignore_case: pattern.ignoreCase,
+    })),
+    semanticDocument.secret_rejection.patterns,
+  );
+});
+
+test("TypeScript and Python accept identical known-profile bodies and identities", async () => {
+  const vectors = JSON.parse(await readFile(conformanceUrl, "utf8"));
+  for (const knownBody of [await gnoBody(), await optibenchBody(), await dpoBody()]) {
+    validateKnownBody(knownBody);
+    const schema = (knownBody.payload as RecordValue).schema as string;
+    const expected = vectors.accepted_body_sha256[schema];
+    assert.equal(await digestBody(knownBody), expected);
+    assert.equal(await capsuleId(knownBody), `ucap1:sha256:${expected}`);
+  }
+});
+
+test("known-profile validation rejects substituted evidence and mixed cohorts", async () => {
+  const vectors = JSON.parse(await readFile(conformanceUrl, "utf8"));
+  const oversizedDigits = vectors.reject_vectors.find(
+    (item: RecordValue) => item.mutation === "crowding_numerator_digits",
+  ).value as number;
+  const gno = await gnoBody();
+  ((((gno.payload as RecordValue).data as RecordValue).artifacts as RecordValue[])[0]).sha256 = "f".repeat(64);
+  assert.throws(() => validateKnownBody(gno), /does not match/);
+
+  const optibench = await optibenchBody();
+  (((optibench.payload as RecordValue).data as RecordValue).cohort as RecordValue).counter_profile = "callgrind_ir_v1";
+  assert.throws(() => validateKnownBody(optibench), /profile and tool disagree/);
+
+  const oversized = await optibenchBody();
+  ((((oversized.payload as RecordValue).data as RecordValue).nsga2 as RecordValue).crowding as RecordValue) = {
+    denominator: "1",
+    kind: "finite",
+    numerator: "9".repeat(oversizedDigits),
+  };
+  assert.throws(() => validateKnownBody(oversized), /numerator/);
+
+  const secretVector = vectors.reject_vectors.find(
+    (item: RecordValue) => item.mutation === "secret_identifier",
+  );
+  assert.ok(secretVector);
+  const secretValue = (secretVector.value_parts as string[]).join("");
+  const secretName = await gnoBody();
+  (secretName.evidence as RecordValue[]).push(
+    evidence(secretValue, "unused non-secret evidence"),
+  );
+  (secretName.evidence as RecordValue[]).sort((left, right) =>
+    `${String(left.name)}\0${String(left.sha256)}`.localeCompare(`${String(right.name)}\0${String(right.sha256)}`));
+  assert.throws(() => validateKnownBody(secretName), /secret-like/);
+
+  const secretActor = await gnoBody();
+  (secretActor.actor as RecordValue).agent_id = secretValue;
+  validateBody(secretActor);
+  assert.throws(() => validateKnownPayloadProfile(secretActor), /secret-like/);
+
+  const enumVector = vectors.reject_vectors.find(
+    (item: RecordValue) => item.mutation === "enum_type_confusion",
+  );
+  assert.ok(enumVector);
+  const confused = await gnoBody();
+  ((((confused.payload as RecordValue).data as RecordValue).mutator as RecordValue).origin) = enumVector.value;
+  validateBody(confused);
+  assert.throws(() => validateKnownPayloadProfile(confused), /origin is unsupported/);
+});
+
+test("known-profile validation rejects arbitrary preference parents", async () => {
+  const dpo = await dpoBody();
+  (dpo.parents as string[]).pop();
+  assert.throws(() => validateKnownBody(dpo), /parents must be/);
+});

--- a/src/intelligence_payloads.py
+++ b/src/intelligence_payloads.py
@@ -1,0 +1,1749 @@
+"""Strict payload profiles carried by an IntelligenceCapsule v1 body.
+
+The capsule envelope is deliberately stable.  New Insider protocols evolve
+through the existing ``body.payload = {schema, data}`` seam instead of changing
+the byte format or its bootstrapped Git refs.  This module validates the first
+three profiles used by the intelligence DAG:
+
+* a manifest-closed GNO dispatch/result envelope;
+* a closed-population OptiBench result backed by real counter evidence; and
+* a directly proven Pareto preference pair with nested/JSONL projections.
+
+These validators establish structural and profile integrity.  Publication
+authorization, signature verification, evidence retrieval, and complete-graph
+promotion checks remain separate trust gates.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from collections.abc import Callable, Mapping, Sequence
+from fractions import Fraction
+from typing import Any
+
+from .intelligence_capsule import (
+    MAX_PARENTS,
+    MAX_SAFE_INTEGER,
+    CapsuleValidationError,
+    canonicalize,
+    capsule_id,
+)
+
+
+GNO_ENVELOPE_SCHEMA = "org.grokmcp.gno_envelope.v1"
+OPTIBENCH_RESULT_SCHEMA = "org.grokmcp.optibench_result.v1"
+AGENTIC_DPO_PAIR_SCHEMA = "org.grokmcp.agentic_dpo_pair.v1"
+NEEDLE_CONTEXT_PROFILE = "org.grokmcp.needle_tools_context.v1"
+
+PROFILE_SCHEMA_FILES = {
+    GNO_ENVELOPE_SCHEMA: "gno-envelope-v1.schema.json",
+    OPTIBENCH_RESULT_SCHEMA: "optibench-result-v1.schema.json",
+    AGENTIC_DPO_PAIR_SCHEMA: "agentic-dpo-pair-v1.schema.json",
+}
+
+# Filled with raw-file SHA-256 values.  A semantic schema edit requires a new
+# payload version; tests fail if a v1 file is changed without changing its ID.
+PROFILE_SCHEMA_SHA256 = {
+    GNO_ENVELOPE_SCHEMA: "4c7fb150b3f82738ae43d52669c8c663283807d42add1f4532f01527a4d70665",
+    OPTIBENCH_RESULT_SCHEMA: "dfc216d1855eb36e54829c3aca00434f0dc9845a6efc205c2c49016531accf81",
+    AGENTIC_DPO_PAIR_SCHEMA: "7db601ccc11aaa94409383f88c7305a46b63a705176897aaa313f835b24bed84",
+}
+
+PROJECTION_SCHEMA_FILES = {
+    NEEDLE_CONTEXT_PROFILE: "needle-tools-context-v1.schema.json",
+}
+PROJECTION_SCHEMA_SHA256 = {
+    NEEDLE_CONTEXT_PROFILE: "ac92a88b87e35254a7eef4a151d8743418ef102402022b228609743cbcbf7496",
+}
+SEMANTIC_SPEC_FILE = "intelligence-payload-semantics-v1.json"
+SEMANTIC_SPEC_SHA256 = "7464c2343c3edaadc21a14a880e689ef8e4b4ac0fa3fc07b2b6f37b08733545a"
+CONFORMANCE_FILE = "intelligence-payload-conformance-v1.json"
+CONFORMANCE_SHA256 = "6a0df82c82cd3bfbadc6ff1febf1e43b2d2a6446acd1b977ae7d3262de8d98f4"
+
+KNOWN_PAYLOAD_SCHEMAS = frozenset(PROFILE_SCHEMA_FILES)
+
+PERF_OBJECTIVES = (
+    ("cpu_instructions_retired", "instruction"),
+    ("diff_tokens", "token"),
+    ("peak_memory_bytes", "byte"),
+)
+CALLGRIND_OBJECTIVES = (
+    ("callgrind_ir", "instruction_reference"),
+    ("diff_tokens", "token"),
+    ("peak_memory_bytes", "byte"),
+)
+
+MAX_JSONL_ARTIFACT_BYTES = 256 * 1024
+MAX_JSONL_RECORD_BYTES = 768 * 1024
+MAX_RATIONAL_DIGITS = 128
+MAX_OBJECTIVE_DIGITS = 32
+MAX_GRAPH_BODIES = 2 * MAX_PARENTS + 1
+MAX_NEEDLE_QUERY_BYTES = 16 * 1024
+MAX_NEEDLE_EXAMPLE_BYTES = 64 * 1024
+MAX_NEEDLE_INPUT_EXAMPLES = 64
+
+_CAPSULE_ID_RE = re.compile(r"^ucap1:sha256:[a-f0-9]{64}$")
+_COMMIT_RE = re.compile(r"^(?:[a-f0-9]{40}|[a-f0-9]{64})$")
+_DECIMAL_RE = re.compile(r"^-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?$")
+_DIGEST_RE = re.compile(r"^[a-f0-9]{64}$")
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_NONNEGATIVE_INTEGER_RE = re.compile(r"^(?:0|[1-9][0-9]*)$")
+_POSITIVE_INTEGER_RE = re.compile(r"^[1-9][0-9]*$")
+_NEEDLE_TRIM_CHARS = "".join(
+    chr(codepoint)
+    for codepoint in (
+        *range(0x0009, 0x000E),
+        *range(0x001C, 0x0020),
+        0x0020,
+        0x0085,
+        0x00A0,
+        0x1680,
+        *range(0x2000, 0x200B),
+        0x2028,
+        0x2029,
+        0x202F,
+        0x205F,
+        0x3000,
+    )
+)
+_SHARED_SECRET_PATTERNS = (
+    re.compile(r"github_pat_[A-Za-z0-9_]{10,}|gh[pousr]_[A-Za-z0-9]{10,}"),
+    re.compile(r"glpat-[A-Za-z0-9_-]{10,}"),
+    re.compile(r"\bsk-(?:proj-|svcacct-)?[A-Za-z0-9_-]{12,}"),
+    re.compile(r"\bxai-[A-Za-z0-9_-]{12,}", re.IGNORECASE),
+    re.compile(r"\bAIza[A-Za-z0-9_-]{25,}"),
+    re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b"),
+    re.compile(r"\bnpm_[A-Za-z0-9]{20,}"),
+    re.compile(r"\bpypi-[A-Za-z0-9_-]{20,}"),
+    re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{12,}"),
+    re.compile(r"\bsk_live_[A-Za-z0-9]{16,}"),
+    re.compile(r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----"),
+    re.compile(r"\beyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b"),
+    re.compile(
+        r"\bBearer\s+(?!<|\$\{|\[)[A-Za-z0-9._~+/=-]{8,}",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"Authorization\s*:\s*Bearer\s+(?!<|\$\{|\[)[A-Za-z0-9._~+/-]{8,}",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"Authorization\s*:\s*Basic\s+(?!<|\$\{|\[)[A-Za-z0-9+/=]{8,}",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r'''(?:^|[^A-Za-z0-9_])["']?[A-Z0-9_-]*(?:API[_-]?KEY|SECRET[_-]?ACCESS[_-]?KEY|SESSION[_-]?TOKEN|ACCESS[_-]?TOKEN|AUTH[_-]?TOKEN|PASSWORD|PRIVATE[_-]?KEY|CLIENT[_-]?SECRET)["']?\s*[:=]\s*(?!["']?(?:<|\$\{|\[))(?:"[^"\r\n]{8,}"|'[^'\r\n]{8,}'|[A-Za-z0-9._~+/=@!#$%^&*()-]{8,})''',
+        re.IGNORECASE,
+    ),
+)
+
+
+def validate_known_payload_profile(body: Mapping[str, Any]) -> bool:
+    """Validate a registered payload profile and return whether it was known.
+
+    The caller must first apply the generic IntelligenceCapsule v1 validator.
+    Unknown versioned payloads remain structurally valid capsules, but this
+    function returns ``False`` so a materializer can quarantine them instead
+    of executing or promoting semantics it does not understand.
+    """
+
+    payload = body.get("payload")
+    if type(payload) is not dict:
+        return False
+    schema = payload.get("schema")
+    if schema not in KNOWN_PAYLOAD_SCHEMAS:
+        return False
+
+    _reject_secret_strings(body, "$.body")
+    evidence = body.get("evidence")
+    evidence_index = _evidence_index(evidence)
+    data = payload.get("data")
+    if schema == GNO_ENVELOPE_SCHEMA:
+        _validate_gno(body, data, evidence_index)
+    elif schema == OPTIBENCH_RESULT_SCHEMA:
+        _validate_optibench(body, data, evidence_index)
+    else:
+        _validate_dpo(body, data, evidence_index)
+    return True
+
+
+def payload_profile_schema_sha256(schema: str) -> str:
+    """Return the pinned raw-schema digest for a registered payload profile."""
+
+    try:
+        return PROFILE_SCHEMA_SHA256[schema]
+    except KeyError as exc:
+        raise CapsuleValidationError(f"unknown payload profile {schema!r}") from exc
+
+
+def validate_optibench_evidence(
+    body: Mapping[str, Any], evidence_blobs: Mapping[str, bytes]
+) -> dict[str, tuple[int, ...]]:
+    """Verify OptiBench receipts and recompute every published objective.
+
+    This consistency verifier does not prove that hardware executed; signed
+    publication identifies the runner that made that claim.  It does prove
+    that the closed population, passing gates, raw samples, aggregation, and
+    canonical body metrics agree byte-for-byte.
+    """
+
+    from .intelligence_capsule import parse_canonical, validate_body
+
+    validate_body(body)
+    validate_known_payload_profile(body)
+    payload = body["payload"]
+    if payload["schema"] != OPTIBENCH_RESULT_SCHEMA:
+        raise CapsuleValidationError(
+            "OptiBench evidence verification requires org.grokmcp.optibench_result.v1"
+        )
+    data = payload["data"]
+    evidence = _evidence_index(body["evidence"])
+
+    environment = _verified_evidence_bytes(
+        data["cohort"]["environment"], evidence, evidence_blobs, "$.body.payload.data.cohort.environment"
+    )
+    harness = _verified_evidence_bytes(
+        data["cohort"]["harness"], evidence, evidence_blobs, "$.body.payload.data.cohort.harness"
+    )
+    environment_data = _object(
+        parse_canonical(environment), "optibench environment evidence"
+    )
+    _exact_keys(
+        environment_data,
+        {"architecture", "cpu_model", "kernel", "operating_system", "runner"},
+        "optibench environment evidence",
+    )
+    for field in ("architecture", "cpu_model", "kernel", "operating_system", "runner"):
+        value = _identifier(
+            environment_data.get(field), f"optibench environment evidence.{field}"
+        )
+        if _contains_secret_like(value):
+            raise CapsuleValidationError(
+                f"optibench environment evidence.{field} contains secret-like content"
+            )
+    harness_data = _object(parse_canonical(harness), "optibench harness evidence")
+    _exact_keys(
+        harness_data,
+        {"diff_metric", "peak_memory_method", "source_commit", "tokenizer", "version"},
+        "optibench harness evidence",
+    )
+    for field in ("diff_metric", "peak_memory_method", "tokenizer", "version"):
+        value = _identifier(
+            harness_data.get(field), f"optibench harness evidence.{field}"
+        )
+        if _contains_secret_like(value):
+            raise CapsuleValidationError(
+                f"optibench harness evidence.{field} contains secret-like content"
+            )
+    source_commit = harness_data.get("source_commit")
+    if type(source_commit) is not str or not _COMMIT_RE.fullmatch(source_commit):
+        raise CapsuleValidationError("optibench harness source_commit is invalid")
+
+    population_raw = _verified_evidence_bytes(
+        data["population_manifest"],
+        evidence,
+        evidence_blobs,
+        "$.body.payload.data.population_manifest",
+    )
+    population = parse_canonical(population_raw)
+    expected_population = {
+        "candidate_capsules": list(body["parents"]),
+        "closed": True,
+        "cohort_sha256": hashlib.sha256(canonicalize(data["cohort"])).hexdigest(),
+    }
+    if population != expected_population:
+        raise CapsuleValidationError(
+            "optibench population manifest does not match parents and cohort"
+        )
+
+    gates: set[str] = set()
+    for index, ref in enumerate(data["gate_receipts"]):
+        raw = _verified_evidence_bytes(
+            ref,
+            evidence,
+            evidence_blobs,
+            f"$.body.payload.data.gate_receipts[{index}]",
+        )
+        receipt = parse_canonical(raw)
+        receipt = _object(receipt, f"optibench gate receipt {index}")
+        _exact_keys(receipt, {"gate", "passed"}, f"optibench gate receipt {index}")
+        gate = _identifier(receipt.get("gate"), f"optibench gate receipt {index}.gate")
+        if receipt.get("passed") is not True:
+            raise CapsuleValidationError("optibench gate receipts must record passed=true")
+        if gate in gates:
+            raise CapsuleValidationError("optibench gate receipts contain a duplicate gate")
+        gates.add(gate)
+    if "tests" not in gates:
+        raise CapsuleValidationError("optibench requires a passing tests gate receipt")
+
+    counter_raw = _verified_evidence_bytes(
+        data["counter_output"], evidence, evidence_blobs, "$.body.payload.data.counter_output"
+    )
+    counter = _object(parse_canonical(counter_raw), "optibench counter receipt")
+    _exact_keys(
+        counter,
+        {"baseline", "counter_profile", "samples"},
+        "optibench counter receipt",
+    )
+    if counter.get("counter_profile") != data["cohort"]["counter_profile"]:
+        raise CapsuleValidationError("optibench counter receipt profile disagrees with cohort")
+    samples = _array(counter.get("samples"), "optibench counter receipt.samples", maximum=1024)
+    if len(samples) != data["repetitions"]:
+        raise CapsuleValidationError("optibench sample count does not match repetitions")
+    objective_names = list(data["objective_metrics"])
+    baseline = _object(counter.get("baseline"), "optibench counter receipt.baseline")
+    _exact_keys(
+        baseline,
+        set(objective_names),
+        "optibench counter receipt.baseline",
+    )
+    baseline_point: list[int] = []
+    for name in objective_names:
+        value = baseline[name]
+        if (
+            type(value) is not str
+            or len(value) > MAX_OBJECTIVE_DIGITS
+            or not _NONNEGATIVE_INTEGER_RE.fullmatch(value)
+        ):
+            raise CapsuleValidationError(
+                "optibench baseline metrics must be bounded nonnegative integer strings"
+            )
+        baseline_point.append(int(value))
+    values: dict[str, list[int]] = {name: [] for name in objective_names}
+    for index, raw_sample in enumerate(samples):
+        sample = _object(raw_sample, f"optibench counter receipt.samples[{index}]")
+        _exact_keys(sample, set(objective_names), f"optibench counter receipt.samples[{index}]")
+        for name in objective_names:
+            value = sample[name]
+            if (
+                type(value) is not str
+                or len(value) > MAX_OBJECTIVE_DIGITS
+                or not _NONNEGATIVE_INTEGER_RE.fullmatch(value)
+            ):
+                raise CapsuleValidationError(
+                    "optibench counter samples must be bounded nonnegative integer strings"
+                )
+            values[name].append(int(value))
+    medians = {
+        name: str(sorted(samples_for_metric)[len(samples_for_metric) // 2])
+        for name, samples_for_metric in values.items()
+    }
+    published = {metric["name"]: metric["value"] for metric in body["metrics"]}
+    if published != medians:
+        raise CapsuleValidationError(
+            "optibench body.metrics do not equal the median counter samples"
+        )
+    candidate_point = tuple(int(medians[name]) for name in objective_names)
+    baseline_tuple = tuple(baseline_point)
+    if candidate_point == baseline_tuple:
+        baseline_relation = "equal_baseline"
+    elif _dominates(candidate_point, baseline_tuple):
+        baseline_relation = "dominates_baseline"
+    elif _dominates(baseline_tuple, candidate_point):
+        baseline_relation = "dominated_by_baseline"
+    else:
+        baseline_relation = "incomparable_to_baseline"
+    if data["baseline_relation"] != baseline_relation:
+        raise CapsuleValidationError(
+            "optibench baseline_relation does not match baseline evidence"
+        )
+    return {"baseline": baseline_tuple, "candidate": candidate_point}
+
+
+def validate_optibench_population(
+    benchmark_bodies: Mapping[str, Mapping[str, Any]],
+    evidence_blobs: Mapping[str, Mapping[str, bytes]],
+) -> dict[str, dict[str, Any]]:
+    """Verify one complete cohort and recompute exact NSGA-II fields.
+
+    Individual counter receipts can prove a candidate's objective tuple, but
+    Pareto rank and crowding are properties of a closed population.  This gate
+    therefore requires exactly one benchmark capsule for every candidate in
+    the shared population, verifies every evidence set, and recomputes both
+    rank and exact rational crowding before any result is promotable.
+    """
+
+    from .intelligence_capsule import validate_body
+
+    if not benchmark_bodies:
+        raise CapsuleValidationError("OptiBench population must not be empty")
+    if len(benchmark_bodies) > MAX_PARENTS:
+        raise CapsuleValidationError("OptiBench population exceeds the capsule parent limit")
+
+    expected_population: list[str] | None = None
+    expected_cohort: bytes | None = None
+    expected_objectives: list[str] | None = None
+    expected_manifest: bytes | None = None
+    expected_run: str | None = None
+    expected_subject: dict[str, Any] | None = None
+    benchmarks_by_candidate: dict[str, Mapping[str, Any]] = {}
+    benchmark_ids_by_candidate: dict[str, str] = {}
+    summaries: dict[str, dict[str, tuple[int, ...]]] = {}
+
+    for benchmark_id in sorted(benchmark_bodies):
+        benchmark = benchmark_bodies[benchmark_id]
+        validate_body(benchmark)
+        validate_known_payload_profile(benchmark)
+        if capsule_id(benchmark) != benchmark_id:
+            raise CapsuleValidationError(
+                "OptiBench population key does not match canonical capsule id"
+            )
+        if (
+            benchmark.get("kind") != "benchmark"
+            or benchmark["payload"]["schema"] != OPTIBENCH_RESULT_SCHEMA
+        ):
+            raise CapsuleValidationError(
+                "OptiBench population contains a non-benchmark profile"
+            )
+
+        data = benchmark["payload"]["data"]
+        population = list(benchmark["parents"])
+        cohort = canonicalize(data["cohort"])
+        objectives = list(data["objective_metrics"])
+        manifest = canonicalize(data["population_manifest"])
+        if expected_population is None:
+            expected_population = population
+            expected_cohort = cohort
+            expected_objectives = objectives
+            expected_manifest = manifest
+            expected_run = benchmark["run_id"]
+            expected_subject = dict(benchmark["subject"])
+        elif (
+            population != expected_population
+            or cohort != expected_cohort
+            or objectives != expected_objectives
+            or manifest != expected_manifest
+            or benchmark["run_id"] != expected_run
+            or benchmark["subject"] != expected_subject
+        ):
+            raise CapsuleValidationError(
+                "OptiBench population benchmarks do not share one cohort"
+            )
+
+        candidate_id = data["candidate_capsule"]
+        if candidate_id in benchmarks_by_candidate:
+            raise CapsuleValidationError(
+                "OptiBench population has duplicate candidate benchmarks"
+            )
+        blobs = evidence_blobs.get(benchmark_id)
+        if blobs is None:
+            raise CapsuleValidationError(
+                "OptiBench population is missing benchmark evidence bytes"
+            )
+        summaries[candidate_id] = validate_optibench_evidence(benchmark, blobs)
+        benchmarks_by_candidate[candidate_id] = benchmark
+        benchmark_ids_by_candidate[candidate_id] = benchmark_id
+
+    if expected_population is None:
+        raise CapsuleValidationError("OptiBench population must not be empty")
+    if set(benchmarks_by_candidate) != set(expected_population):
+        raise CapsuleValidationError(
+            "OptiBench population requires exactly one benchmark per candidate"
+        )
+    if len({summary["baseline"] for summary in summaries.values()}) != 1:
+        raise CapsuleValidationError(
+            "OptiBench population benchmarks use different baselines"
+        )
+
+    points = {
+        candidate_id: summary["candidate"]
+        for candidate_id, summary in summaries.items()
+    }
+    ranks = _nondominated_ranks(points)
+    crowding = _exact_crowding(points, ranks)
+    result: dict[str, dict[str, Any]] = {}
+    for candidate_id in sorted(benchmarks_by_candidate):
+        published = benchmarks_by_candidate[candidate_id]["payload"]["data"]["nsga2"]
+        if published["pareto_rank"] != ranks[candidate_id]:
+            raise CapsuleValidationError(
+                "published Pareto rank does not match the closed cohort"
+            )
+        if published["crowding"] != crowding[candidate_id]:
+            raise CapsuleValidationError(
+                "published crowding does not match the closed cohort"
+            )
+        result[candidate_id] = {
+            "baseline": summaries[candidate_id]["baseline"],
+            "benchmark_capsule": benchmark_ids_by_candidate[candidate_id],
+            "candidate": points[candidate_id],
+            "crowding": crowding[candidate_id],
+            "pareto_rank": ranks[candidate_id],
+        }
+    return result
+
+
+def validate_gno_dispatch_evidence(
+    body: Mapping[str, Any], evidence_blobs: Mapping[str, bytes]
+) -> None:
+    """Verify the declared GNO input manifest and every referenced input blob."""
+
+    from .intelligence_capsule import parse_canonical, validate_body
+
+    validate_body(body)
+    validate_known_payload_profile(body)
+    payload = body["payload"]
+    data = payload["data"]
+    if payload["schema"] != GNO_ENVELOPE_SCHEMA or data["phase"] != "dispatch":
+        raise CapsuleValidationError("GNO input verification requires a dispatch capsule")
+    evidence = _evidence_index(body["evidence"])
+    manifest_ref = next(
+        item for item in data["artifacts"] if item["role"] == "input_manifest"
+    )
+    declared = [
+        dict(item)
+        for item in data["artifacts"]
+        if item["role"] != "input_manifest"
+    ]
+    expected = {
+        "declared_artifacts": declared,
+        "execution": dict(body["execution"]),
+        "routing": dict(data["routing"]),
+    }
+    manifest_raw = _verified_evidence_bytes(
+        manifest_ref,
+        evidence,
+        evidence_blobs,
+        "GNO input_manifest",
+        allow_role=True,
+    )
+    if parse_canonical(manifest_raw) != expected:
+        raise CapsuleValidationError("GNO input manifest does not close over dispatch inputs")
+    for index, ref in enumerate(data["artifacts"]):
+        raw = _verified_evidence_bytes(
+            ref,
+            evidence,
+            evidence_blobs,
+            f"GNO dispatch artifact {index}",
+            allow_role=True,
+        )
+        try:
+            text = raw.decode("utf-8", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise CapsuleValidationError("GNO shared artifacts must be strict UTF-8") from exc
+        if _contains_secret_like(text):
+            raise CapsuleValidationError("GNO shared artifacts contain secret-like content")
+
+
+def validate_gno_result_graph(
+    result: Mapping[str, Any],
+    dispatch: Mapping[str, Any],
+    *,
+    result_evidence_blobs: Mapping[str, bytes],
+    dispatch_evidence_blobs: Mapping[str, bytes],
+) -> None:
+    """Bind a GNO result to the exact verified dispatch it answers."""
+
+    from .intelligence_capsule import validate_body
+
+    validate_body(result)
+    validate_body(dispatch)
+    validate_known_payload_profile(result)
+    validate_known_payload_profile(dispatch)
+    result_data = result["payload"]["data"]
+    dispatch_data = dispatch["payload"]["data"]
+    if (
+        result["payload"]["schema"] != GNO_ENVELOPE_SCHEMA
+        or result_data["phase"] != "result"
+        or dispatch["payload"]["schema"] != GNO_ENVELOPE_SCHEMA
+        or dispatch_data["phase"] != "dispatch"
+    ):
+        raise CapsuleValidationError("GNO graph verification requires dispatch and result")
+    if result_data["dispatch_capsule"] != capsule_id(dispatch):
+        raise CapsuleValidationError("GNO result does not identify the supplied dispatch")
+    if result["run_id"] != dispatch["run_id"] or result["subject"] != dispatch["subject"]:
+        raise CapsuleValidationError("GNO result crosses run or subject boundaries")
+    for field in ("generation", "node_id", "slot"):
+        if result_data[field] != dispatch_data[field]:
+            raise CapsuleValidationError(f"GNO result {field} does not match dispatch")
+    validate_gno_dispatch_evidence(dispatch, dispatch_evidence_blobs)
+    evidence = _evidence_index(result["evidence"])
+    for index, ref in enumerate(result_data["artifacts"]):
+        raw = _verified_evidence_bytes(
+            ref,
+            evidence,
+            result_evidence_blobs,
+            f"GNO result artifact {index}",
+            allow_role=True,
+        )
+        try:
+            text = raw.decode("utf-8", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise CapsuleValidationError("GNO result artifacts must be strict UTF-8") from exc
+        if _contains_secret_like(text):
+            raise CapsuleValidationError("GNO result artifacts contain secret-like content")
+
+
+def validate_dpo_preference_graph(
+    body: Mapping[str, Any],
+    graph_bodies: Mapping[str, Mapping[str, Any]],
+    evidence_blobs: Mapping[str, bytes],
+    graph_evidence_blobs: Mapping[str, Mapping[str, bytes]],
+) -> None:
+    """Resolve a closed OptiBench cohort and prove one direct preference.
+
+    The supplied graph closure must contain the task, every candidate in the
+    population, and exactly one verified OptiBench result for every candidate.
+    Ranks are recomputed from the final metrics; stored online Swarm reward or
+    provisional rank is never accepted as preference evidence.
+    """
+
+    from .intelligence_capsule import parse_canonical, validate_body
+
+    validate_body(body)
+    validate_known_payload_profile(body)
+    payload = body["payload"]
+    if payload["schema"] != AGENTIC_DPO_PAIR_SCHEMA:
+        raise CapsuleValidationError(
+            "preference graph verification requires org.grokmcp.agentic_dpo_pair.v1"
+        )
+    data = payload["data"]
+    if len(graph_bodies) > MAX_GRAPH_BODIES:
+        raise CapsuleValidationError("preference graph exceeds the v1 body limit")
+    resolved: dict[str, Mapping[str, Any]] = {}
+    for identifier, parent in graph_bodies.items():
+        validate_body(parent)
+        if capsule_id(parent) != identifier:
+            raise CapsuleValidationError("graph body key does not match canonical capsule id")
+        if parent["run_id"] != body["run_id"] or parent["subject"] != body["subject"]:
+            raise CapsuleValidationError("preference graph crosses run or subject boundaries")
+        resolved[identifier] = parent
+    _validate_closed_graph(resolved)
+
+    task_id = data["task_capsule"]
+    task = resolved.get(task_id)
+    if (
+        task is None
+        or task.get("kind") != "task"
+        or task["payload"]["schema"] != GNO_ENVELOPE_SCHEMA
+        or task["payload"]["data"].get("phase") != "dispatch"
+    ):
+        raise CapsuleValidationError("preference graph is missing its task capsule")
+    validate_known_payload_profile(task)
+    task_spec = next(
+        item
+        for item in task["payload"]["data"]["artifacts"]
+        if item["role"] == "task_spec"
+    )
+    if data["prompt"]["sha256"] != task_spec["sha256"]:
+        raise CapsuleValidationError(
+            "preference prompt is not the declared GNO task_spec"
+        )
+
+    chosen_data = data["chosen"]
+    rejected_data = data["rejected"]
+    chosen_candidate_id = chosen_data["candidate_capsule"]
+    rejected_candidate_id = rejected_data["candidate_capsule"]
+    for side, candidate_id, ref in (
+        ("chosen", chosen_candidate_id, chosen_data["artifact"]),
+        ("rejected", rejected_candidate_id, rejected_data["artifact"]),
+    ):
+        candidate = resolved.get(candidate_id)
+        if (
+            candidate is None
+            or candidate.get("kind") != "candidate"
+            or candidate["payload"]["schema"] != GNO_ENVELOPE_SCHEMA
+            or candidate["payload"]["data"].get("phase") != "result"
+        ):
+            raise CapsuleValidationError(f"preference graph is missing the {side} candidate")
+        validate_known_payload_profile(candidate)
+        output_diff = next(
+            item
+            for item in candidate["payload"]["data"]["artifacts"]
+            if item["role"] == "output_diff"
+        )
+        if ref["sha256"] != output_diff["sha256"]:
+            raise CapsuleValidationError(
+                f"preference {side} artifact is not the candidate GNO output_diff"
+            )
+
+    chosen_benchmark_id = chosen_data["benchmark_capsule"]
+    rejected_benchmark_id = rejected_data["benchmark_capsule"]
+    declared = {
+        chosen_candidate_id: chosen_benchmark_id,
+        rejected_candidate_id: rejected_benchmark_id,
+    }
+    declared_benchmarks: dict[str, Mapping[str, Any]] = {}
+    for candidate_id, benchmark_id in declared.items():
+        benchmark = resolved.get(benchmark_id)
+        if benchmark is None or benchmark.get("kind") != "benchmark":
+            raise CapsuleValidationError("preference graph is missing a declared benchmark")
+        if benchmark["payload"]["schema"] != OPTIBENCH_RESULT_SCHEMA:
+            raise CapsuleValidationError("preference benchmark uses the wrong payload profile")
+        validate_known_payload_profile(benchmark)
+        if benchmark["payload"]["data"]["candidate_capsule"] != candidate_id:
+            raise CapsuleValidationError("preference benchmark is bound to another candidate")
+        declared_benchmarks[candidate_id] = benchmark
+
+    population = list(declared_benchmarks[chosen_candidate_id]["parents"])
+    if declared_benchmarks[rejected_candidate_id]["parents"] != population:
+        raise CapsuleValidationError("preference benchmarks use different populations")
+    for candidate_id in population:
+        candidate = resolved.get(candidate_id)
+        if candidate is None or candidate.get("kind") != "candidate":
+            raise CapsuleValidationError("preference graph has an incomplete candidate population")
+        if task_id not in candidate["parents"]:
+            raise CapsuleValidationError(
+                "preference population candidate is not linked to the declared task"
+            )
+
+    cohort = declared_benchmarks[chosen_candidate_id]["payload"]["data"]["cohort"]
+    objective_names = declared_benchmarks[chosen_candidate_id]["payload"]["data"][
+        "objective_metrics"
+    ]
+    manifest_sha = declared_benchmarks[chosen_candidate_id]["payload"]["data"][
+        "population_manifest"
+    ]["sha256"]
+    population_benchmarks: dict[str, Mapping[str, Any]] = {}
+    population_benchmark_ids: dict[str, str] = {}
+    population_benchmark_bodies: dict[str, Mapping[str, Any]] = {}
+    for benchmark_id, candidate_body in resolved.items():
+        if candidate_body.get("kind") != "benchmark":
+            continue
+        candidate_payload = candidate_body["payload"]
+        if candidate_payload["schema"] != OPTIBENCH_RESULT_SCHEMA:
+            continue
+        validate_known_payload_profile(candidate_body)
+        candidate_data = candidate_payload["data"]
+        candidate_id = candidate_data["candidate_capsule"]
+        if candidate_id not in population:
+            continue
+        if candidate_body["parents"] != population:
+            continue
+        if canonicalize(candidate_data["cohort"]) != canonicalize(cohort):
+            continue
+        if candidate_data["population_manifest"]["sha256"] != manifest_sha:
+            continue
+        if candidate_id in population_benchmarks:
+            raise CapsuleValidationError("preference graph has duplicate cohort benchmarks")
+        population_benchmarks[candidate_id] = candidate_body
+        population_benchmark_ids[candidate_id] = benchmark_id
+        population_benchmark_bodies[benchmark_id] = candidate_body
+    if set(population_benchmarks) != set(population):
+        raise CapsuleValidationError("preference graph lacks a benchmark for every population candidate")
+    if population_benchmark_ids[chosen_candidate_id] != chosen_benchmark_id:
+        raise CapsuleValidationError("chosen benchmark is not the cohort benchmark")
+    if population_benchmark_ids[rejected_candidate_id] != rejected_benchmark_id:
+        raise CapsuleValidationError("rejected benchmark is not the cohort benchmark")
+    population_summaries = validate_optibench_population(
+        population_benchmark_bodies, graph_evidence_blobs
+    )
+
+    required = {
+        task_id,
+        *population,
+        *population_benchmark_bodies,
+    }
+    reachable: set[str] = set()
+    pending = list(required)
+    while pending:
+        identifier = pending.pop()
+        if identifier in reachable:
+            continue
+        reachable.add(identifier)
+        pending.extend(resolved[identifier]["parents"])
+    if reachable != set(resolved):
+        raise CapsuleValidationError("preference graph contains unrelated bodies")
+    for identifier in sorted(reachable):
+        graph_body = resolved[identifier]
+        schema = graph_body["payload"]["schema"]
+        if schema == GNO_ENVELOPE_SCHEMA:
+            blobs = graph_evidence_blobs.get(identifier)
+            if blobs is None:
+                raise CapsuleValidationError(
+                    "preference graph is missing GNO evidence bytes"
+                )
+            phase = graph_body["payload"]["data"]["phase"]
+            if phase == "dispatch":
+                validate_gno_dispatch_evidence(graph_body, blobs)
+            else:
+                dispatch_id = graph_body["payload"]["data"]["dispatch_capsule"]
+                dispatch = resolved.get(dispatch_id)
+                dispatch_blobs = graph_evidence_blobs.get(dispatch_id)
+                if dispatch is None or dispatch_blobs is None:
+                    raise CapsuleValidationError(
+                        "preference GNO result is missing its dispatch closure"
+                    )
+                validate_gno_result_graph(
+                    graph_body,
+                    dispatch,
+                    result_evidence_blobs=blobs,
+                    dispatch_evidence_blobs=dispatch_blobs,
+                )
+        elif schema == OPTIBENCH_RESULT_SCHEMA:
+            if identifier not in population_benchmark_bodies:
+                raise CapsuleValidationError(
+                    "preference graph contains an unrelated OptiBench result"
+                )
+        else:
+            raise CapsuleValidationError(
+                "preference graph contains an unknown parent payload profile"
+            )
+
+    points = {
+        candidate_id: summary["candidate"]
+        for candidate_id, summary in population_summaries.items()
+    }
+    if (
+        population_summaries[chosen_candidate_id]["pareto_rank"] != 0
+        or population_summaries[rejected_candidate_id]["pareto_rank"] == 0
+    ):
+        raise CapsuleValidationError("preference pair is not final-front chosen versus dominated")
+    chosen_point = points[chosen_candidate_id]
+    rejected_point = points[rejected_candidate_id]
+    if not _dominates(chosen_point, rejected_point):
+        raise CapsuleValidationError("chosen candidate does not directly dominate rejected")
+    if declared_benchmarks[chosen_candidate_id]["payload"]["data"]["baseline_relation"] != "dominates_baseline":
+        raise CapsuleValidationError("chosen preference candidate does not dominate baseline")
+
+    dpo_evidence = _evidence_index(body["evidence"])
+    cohort_proof_raw = _verified_evidence_bytes(
+        data["cohort_proof_manifest"],
+        dpo_evidence,
+        evidence_blobs,
+        "$.body.payload.data.cohort_proof_manifest",
+    )
+    expected_cohort_proof = {
+        "benchmarks": [
+            {
+                "benchmark_capsule": population_benchmark_ids[candidate_id],
+                "candidate_capsule": candidate_id,
+            }
+            for candidate_id in population
+        ],
+        "cohort_sha256": hashlib.sha256(canonicalize(cohort)).hexdigest(),
+        "population_manifest_sha256": manifest_sha,
+    }
+    if parse_canonical(cohort_proof_raw) != expected_cohort_proof:
+        raise CapsuleValidationError(
+            "preference cohort proof does not bind the complete benchmark population"
+        )
+    for role, ref in (
+        ("prompt", data["prompt"]),
+        ("chosen", chosen_data["artifact"]),
+        ("rejected", rejected_data["artifact"]),
+    ):
+        raw = _verified_evidence_bytes(
+            ref,
+            dpo_evidence,
+            evidence_blobs,
+            f"$.body.payload.data.{role}",
+        )
+        if len(raw) > MAX_JSONL_ARTIFACT_BYTES:
+            raise CapsuleValidationError(
+                f"preference {role} evidence exceeds the artifact byte limit"
+            )
+        try:
+            text = raw.decode("utf-8", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise CapsuleValidationError(
+                f"preference {role} evidence must be strict UTF-8"
+            ) from exc
+        if _contains_secret_like(text):
+            raise CapsuleValidationError(
+                f"preference {role} evidence contains secret-like content"
+            )
+    dpo_population_raw = _verified_evidence_bytes(
+        data["population_manifest"],
+        dpo_evidence,
+        evidence_blobs,
+        "$.body.payload.data.population_manifest",
+    )
+    chosen_population_ref = declared_benchmarks[chosen_candidate_id]["payload"]["data"][
+        "population_manifest"
+    ]
+    chosen_population_raw = _verified_evidence_bytes(
+        chosen_population_ref,
+        _evidence_index(declared_benchmarks[chosen_candidate_id]["evidence"]),
+        graph_evidence_blobs[chosen_benchmark_id],
+        "chosen benchmark population_manifest",
+    )
+    if dpo_population_raw != chosen_population_raw:
+        raise CapsuleValidationError("preference pair population evidence differs from benchmark")
+
+    units = {metric["name"]: metric["unit"] for metric in declared_benchmarks[chosen_candidate_id]["metrics"]}
+    expected_receipt = {
+        "chosen_benchmark": chosen_benchmark_id,
+        "metrics": [
+            {
+                "chosen": str(chosen_point[index]),
+                "name": name,
+                "rejected": str(rejected_point[index]),
+                "unit": units[name],
+            }
+            for index, name in enumerate(objective_names)
+        ],
+        "rejected_benchmark": rejected_benchmark_id,
+        "relation": "dominates",
+    }
+    receipt_raw = _verified_evidence_bytes(
+        data["preference"]["dominance_receipt"],
+        dpo_evidence,
+        evidence_blobs,
+        "$.body.payload.data.preference.dominance_receipt",
+    )
+    if parse_canonical(receipt_raw) != expected_receipt:
+        raise CapsuleValidationError("dominance receipt does not match resolved benchmarks")
+
+
+def build_preference_example(
+    body: Mapping[str, Any],
+    evidence_blobs: Mapping[str, bytes],
+    *,
+    graph_bodies: Mapping[str, Mapping[str, Any]],
+    graph_evidence_blobs: Mapping[str, Mapping[str, bytes]],
+) -> dict[str, str]:
+    """Build one verified preference example for nested inference context.
+
+    Blob bytes are resolved by evidence name, checked against the capsule's
+    byte count and SHA-256 descriptor, and decoded as strict UTF-8.  The
+    returned record can be nested into an executor's JSON context.  This is
+    in-context conditioning, not a parameter update.
+    """
+
+    # Late import avoids a module cycle while preserving one public validation
+    # entrypoint for callers.
+    from .intelligence_capsule import validate_body
+
+    validate_body(body)
+    validate_dpo_preference_graph(
+        body, graph_bodies, evidence_blobs, graph_evidence_blobs
+    )
+    payload = body["payload"]
+    if payload["schema"] != AGENTIC_DPO_PAIR_SCHEMA:
+        raise CapsuleValidationError(
+            "preference example requires org.grokmcp.agentic_dpo_pair.v1"
+        )
+    data = payload["data"]
+    refs = {
+        "prompt": data["prompt"],
+        "chosen": data["chosen"]["artifact"],
+        "rejected": data["rejected"]["artifact"],
+    }
+    evidence_index = _evidence_index(body["evidence"])
+    text: dict[str, str] = {}
+    for role, ref in refs.items():
+        descriptor = _match_evidence_ref(ref, evidence_index, f"$.body.payload.data.{role}")
+        name = descriptor["name"]
+        raw = evidence_blobs.get(name)
+        if type(raw) is not bytes:
+            raise CapsuleValidationError(f"missing byte evidence {name!r} for {role}")
+        if len(raw) > MAX_JSONL_ARTIFACT_BYTES:
+            raise CapsuleValidationError(f"{role} evidence exceeds the JSONL artifact limit")
+        if len(raw) != descriptor["bytes"]:
+            raise CapsuleValidationError(f"{role} evidence byte count does not match descriptor")
+        if hashlib.sha256(raw).hexdigest() != descriptor["sha256"]:
+            raise CapsuleValidationError(f"{role} evidence digest does not match descriptor")
+        try:
+            text[role] = raw.decode("utf-8", errors="strict")
+        except UnicodeDecodeError as exc:
+            raise CapsuleValidationError(f"{role} evidence must be strict UTF-8") from exc
+        if _contains_secret_like(text[role]):
+            raise CapsuleValidationError(f"{role} evidence contains secret-like content")
+
+    record = {
+        "chosen": text["chosen"],
+        "prompt": text["prompt"],
+        "rejected": text["rejected"],
+        "source_capsule": capsule_id(body),
+    }
+    if len(canonicalize(record)) + 1 > MAX_JSONL_RECORD_BYTES:
+        raise CapsuleValidationError("preference example exceeds its byte limit")
+    return record
+
+
+def render_preference_jsonl(
+    body: Mapping[str, Any],
+    evidence_blobs: Mapping[str, bytes],
+    *,
+    graph_bodies: Mapping[str, Mapping[str, Any]],
+    graph_evidence_blobs: Mapping[str, Mapping[str, bytes]],
+) -> bytes:
+    """Render one verified preference example as canonical JSONL."""
+
+    record = canonicalize(
+        build_preference_example(
+            body,
+            evidence_blobs,
+            graph_bodies=graph_bodies,
+            graph_evidence_blobs=graph_evidence_blobs,
+        )
+    ) + b"\n"
+    if len(record) > MAX_JSONL_RECORD_BYTES:
+        raise CapsuleValidationError("preference JSONL record exceeds its byte limit")
+    return record
+
+
+def build_needle_tools_context(
+    query: str,
+    examples: Sequence[Mapping[str, str]],
+    *,
+    tokenizer: str,
+    token_counter: Callable[[str], int],
+    max_encoder_tokens: int = 1024,
+    max_examples: int = 8,
+) -> dict[str, Any]:
+    """Fit whole verified examples into Needle's actual tools-JSON channel.
+
+    ``token_counter`` must use the pinned Needle tokenizer.  Selection is
+    deterministic: examples are deduplicated and sorted by source capsule,
+    then whole records are admitted while they fit beside the query and the
+    ``<tools>`` separator.  Records are never string-sliced.
+    """
+
+    if type(query) is not str:
+        raise CapsuleValidationError("Needle context query must be a string")
+    if len(query) > MAX_NEEDLE_QUERY_BYTES:
+        raise CapsuleValidationError("Needle context query exceeds its byte limit")
+    query = query.strip(_NEEDLE_TRIM_CHARS)
+    if not query:
+        raise CapsuleValidationError("Needle context query must be a non-empty string")
+    try:
+        query_bytes = query.encode("utf-8", errors="strict")
+    except UnicodeEncodeError as exc:
+        raise CapsuleValidationError("Needle context query must be strict UTF-8") from exc
+    if _contains_secret_like(query):
+        raise CapsuleValidationError("Needle context query contains secret-like content")
+    if len(query_bytes) > MAX_NEEDLE_QUERY_BYTES:
+        raise CapsuleValidationError("Needle context query exceeds its byte limit")
+    tokenizer = _identifier(tokenizer, "Needle context tokenizer")
+    if _contains_secret_like(tokenizer):
+        raise CapsuleValidationError("Needle context tokenizer contains secret-like content")
+    if not callable(token_counter):
+        raise CapsuleValidationError("Needle context token_counter must be callable")
+    if max_encoder_tokens != 1024:
+        raise CapsuleValidationError("Needle v1 max_encoder_tokens must be 1024")
+    if type(max_examples) is not int or not 1 <= max_examples <= 64:
+        raise CapsuleValidationError("Needle max_examples is invalid")
+    try:
+        input_count = len(examples)
+    except (TypeError, OverflowError) as exc:
+        raise CapsuleValidationError("Needle examples must be a bounded sequence") from exc
+    if input_count > MAX_NEEDLE_INPUT_EXAMPLES:
+        raise CapsuleValidationError("Needle examples exceed the input count limit")
+
+    normalized: list[dict[str, str]] = []
+    for index, raw in enumerate(examples):
+        item = _object(raw, f"Needle examples[{index}]")
+        _exact_keys(
+            item,
+            {"chosen", "prompt", "rejected", "source_capsule"},
+            f"Needle examples[{index}]",
+        )
+        character_count = 0
+        for field in ("chosen", "prompt", "rejected"):
+            if type(item[field]) is not str:
+                raise CapsuleValidationError(
+                    f"Needle examples[{index}].{field} must be a string"
+                )
+            character_count += len(item[field])
+            if character_count > MAX_NEEDLE_EXAMPLE_BYTES:
+                raise CapsuleValidationError(
+                    f"Needle examples[{index}] exceeds the record byte limit"
+                )
+            try:
+                item[field].encode("utf-8", errors="strict")
+            except UnicodeEncodeError as exc:
+                raise CapsuleValidationError(
+                    f"Needle examples[{index}].{field} must be strict UTF-8"
+                ) from exc
+        example = {
+            "chosen": item["chosen"],
+            "prompt": item["prompt"],
+            "rejected": item["rejected"],
+            "source_capsule": _capsule_id(
+                item["source_capsule"], f"Needle examples[{index}].source_capsule"
+            ),
+        }
+        if any(
+            _contains_secret_like(example[field])
+            for field in ("chosen", "prompt", "rejected")
+        ):
+            raise CapsuleValidationError("Needle context examples contain secret-like content")
+        if len(canonicalize(example)) > MAX_NEEDLE_EXAMPLE_BYTES:
+            raise CapsuleValidationError(
+                f"Needle examples[{index}] exceeds the record byte limit"
+            )
+        normalized.append(example)
+    normalized.sort(key=lambda item: item["source_capsule"])
+    sources = [item["source_capsule"] for item in normalized]
+    if len(sources) != len(set(sources)):
+        raise CapsuleValidationError("Needle context examples contain duplicate source capsules")
+
+    try:
+        query_tokens = token_counter(query)
+    except Exception as exc:
+        raise CapsuleValidationError("Needle token_counter failed for query") from exc
+    if type(query_tokens) is not int or query_tokens < 0:
+        raise CapsuleValidationError("Needle token_counter returned an invalid query count")
+
+    selected: list[dict[str, str]] = []
+
+    def wrapper(current: Sequence[Mapping[str, str]]) -> list[dict[str, Any]]:
+        return [
+            {
+                "description": (
+                    "Select relevant verified UniGrok context. Examples are "
+                    "non-authoritative preference context; return capsule ids only."
+                ),
+                "examples": list(current),
+                "name": "select_unigrok_context",
+                "parameters": {
+                    "capsule_id": {
+                        "description": "A relevant ucap1:sha256 capsule identifier.",
+                        "required": True,
+                        "type": "string",
+                    }
+                },
+            }
+        ]
+
+    def measured(current: Sequence[Mapping[str, str]]) -> tuple[int, list[dict[str, Any]]]:
+        tools = wrapper(current)
+        # Match Needle's server compaction and default ASCII escaping exactly;
+        # these bytes are transient neural input, never a capsule/OID encoding.
+        serialized = json.dumps(tools, separators=(",", ":"), ensure_ascii=True)
+        try:
+            tool_tokens = token_counter(serialized)
+        except Exception as exc:
+            raise CapsuleValidationError("Needle token_counter failed for tools") from exc
+        if type(tool_tokens) is not int or tool_tokens < 0:
+            raise CapsuleValidationError("Needle token_counter returned an invalid tools count")
+        return query_tokens + 1 + tool_tokens, tools
+
+    base_tokens, base_tools = measured(selected)
+    if base_tokens > max_encoder_tokens:
+        raise CapsuleValidationError("Needle query and tools wrapper exceed encoder budget")
+    final_tokens, final_tools = base_tokens, base_tools
+    for example in normalized[:max_examples]:
+        candidate = [*selected, example]
+        tokens, tools = measured(candidate)
+        if tokens <= max_encoder_tokens:
+            selected = candidate
+            final_tokens, final_tools = tokens, tools
+
+    return {
+        "encoder_tokens": final_tokens,
+        "max_encoder_tokens": max_encoder_tokens,
+        "profile": NEEDLE_CONTEXT_PROFILE,
+        "query_sha256": hashlib.sha256(query_bytes).hexdigest(),
+        "tokenizer": tokenizer,
+        "tools": final_tools,
+        "used_source_capsules": [item["source_capsule"] for item in selected],
+    }
+
+
+def _validate_gno(
+    body: Mapping[str, Any], data: Any, evidence: Mapping[str, Mapping[str, Any]]
+) -> None:
+    value = _object(data, "$.body.payload.data")
+    phase = value.get("phase")
+    common = {"artifacts", "generation", "node_id", "phase", "slot"}
+    if phase == "dispatch":
+        _exact_keys(value, common | {"mutator", "routing"}, "$.body.payload.data")
+        if body.get("kind") != "task":
+            raise CapsuleValidationError("gno dispatch requires body.kind task")
+        if body.get("execution") is None:
+            raise CapsuleValidationError("gno dispatch requires explicit execution metadata")
+    elif phase == "result":
+        _exact_keys(
+            value,
+            common | {"dispatch_capsule", "outcome"},
+            "$.body.payload.data",
+        )
+        outcome = value.get("outcome")
+        expected_kind = (
+            {"candidate": "candidate", "failure": "failure"}.get(outcome)
+            if type(outcome) is str
+            else None
+        )
+        if expected_kind is None or body.get("kind") != expected_kind:
+            raise CapsuleValidationError(
+                "gno result outcome must match candidate or failure body.kind"
+            )
+        dispatch = _capsule_id(value.get("dispatch_capsule"), "$.body.payload.data.dispatch_capsule")
+        if body.get("parents") != [dispatch]:
+            raise CapsuleValidationError(
+                "gno result must have its dispatch capsule as its sole parent"
+            )
+        if "execution" in body:
+            raise CapsuleValidationError(
+                "gno result inherits execution from its dispatch and must not duplicate it"
+            )
+    else:
+        raise CapsuleValidationError("gno envelope phase must be dispatch or result")
+
+    _identifier(value.get("node_id"), "$.body.payload.data.node_id")
+    _positive_safe_int(value.get("generation"), "$.body.payload.data.generation")
+    _positive_safe_int(value.get("slot"), "$.body.payload.data.slot")
+
+    artifact_roles = (
+        {
+            "context",
+            "input_diff",
+            "input_manifest",
+            "policy",
+            "system_prompt",
+            "task_spec",
+            "tool_manifest",
+        }
+        if phase == "dispatch"
+        else {"failure_receipt", "output_diff", "test_receipt", "trace"}
+    )
+    artifacts = _artifact_refs(
+        value.get("artifacts"),
+        evidence,
+        "$.body.payload.data.artifacts",
+        allowed_roles=artifact_roles,
+    )
+    roles = {item["role"] for item in artifacts}
+    role_counts = {
+        role: sum(item["role"] == role for item in artifacts) for role in roles
+    }
+    if phase == "dispatch":
+        if role_counts.get("input_manifest") != 1 or role_counts.get("task_spec") != 1:
+            raise CapsuleValidationError(
+                "gno dispatch requires exactly one input_manifest and task_spec"
+            )
+        for singleton in ("input_diff", "policy", "system_prompt", "tool_manifest"):
+            if role_counts.get(singleton, 0) > 1:
+                raise CapsuleValidationError(
+                    f"gno dispatch permits at most one {singleton} artifact"
+                )
+    if phase == "result":
+        required_role = "output_diff" if value["outcome"] == "candidate" else "failure_receipt"
+        forbidden_role = "failure_receipt" if value["outcome"] == "candidate" else "output_diff"
+        if role_counts.get(required_role) != 1:
+            raise CapsuleValidationError(
+                f"gno {value['outcome']} result requires exactly one {required_role}"
+            )
+        if role_counts.get(forbidden_role, 0) != 0:
+            raise CapsuleValidationError(
+                f"gno {value['outcome']} result forbids {forbidden_role}"
+            )
+        for singleton in ("test_receipt", "trace"):
+            if role_counts.get(singleton, 0) > 1:
+                raise CapsuleValidationError(
+                    f"gno result permits at most one {singleton} artifact"
+                )
+
+    if phase == "dispatch":
+        mutator = _object(value.get("mutator"), "$.body.payload.data.mutator")
+        _exact_keys(mutator, {"origin", "profile"}, "$.body.payload.data.mutator")
+        origin = mutator.get("origin")
+        if type(origin) is not str or origin not in {"agent", "ast", "baseline"}:
+            raise CapsuleValidationError("gno mutator.origin is unsupported")
+        _identifier(mutator.get("profile"), "$.body.payload.data.mutator.profile")
+        _routing(value.get("routing"))
+
+
+def _routing(raw: Any) -> None:
+    path = "$.body.payload.data.routing"
+    value = _object(raw, path)
+    _exact_keys(
+        value,
+        {"algorithm", "arm", "arm_pull", "parameters", "reason", "seed", "step"},
+        path,
+    )
+    algorithm = value.get("algorithm")
+    if type(algorithm) is not str or algorithm not in {
+        "deterministic_v1",
+        "discounted_ucb_v1",
+        "round_robin_v1",
+        "ucb1_v1",
+    }:
+        raise CapsuleValidationError(f"{path}.algorithm is unsupported")
+    _identifier(value.get("arm"), f"{path}.arm")
+    _identifier(value.get("reason"), f"{path}.reason")
+    _nonnegative_safe_int(value.get("seed"), f"{path}.seed")
+    _positive_safe_int(value.get("step"), f"{path}.step")
+    _positive_safe_int(value.get("arm_pull"), f"{path}.arm_pull")
+    parameters = _array(value.get("parameters"), f"{path}.parameters", maximum=32)
+    order: list[str] = []
+    for index, raw_parameter in enumerate(parameters):
+        item_path = f"{path}.parameters[{index}]"
+        parameter = _object(raw_parameter, item_path)
+        _exact_keys(parameter, {"name", "value"}, item_path)
+        order.append(_identifier(parameter.get("name"), f"{item_path}.name"))
+        if type(parameter.get("value")) is not str or not _DECIMAL_RE.fullmatch(
+            parameter["value"]
+        ):
+            raise CapsuleValidationError(f"{item_path}.value must be a decimal string")
+    _sorted_unique(order, f"{path}.parameters")
+
+
+def _validate_optibench(
+    body: Mapping[str, Any], data: Any, evidence: Mapping[str, Mapping[str, Any]]
+) -> None:
+    path = "$.body.payload.data"
+    value = _object(data, path)
+    _exact_keys(
+        value,
+        {
+            "aggregation",
+            "baseline_relation",
+            "candidate_capsule",
+            "cohort",
+            "counter_output",
+            "gate_receipts",
+            "nsga2",
+            "objective_metrics",
+            "population_closed",
+            "population_manifest",
+            "repetitions",
+        },
+        path,
+    )
+    if body.get("kind") != "benchmark":
+        raise CapsuleValidationError("optibench result requires body.kind benchmark")
+    if value.get("population_closed") is not True:
+        raise CapsuleValidationError("optibench population must be closed before ranking")
+    candidate = _capsule_id(value.get("candidate_capsule"), f"{path}.candidate_capsule")
+    if candidate not in body.get("parents", []):
+        raise CapsuleValidationError("optibench candidate must be a population parent")
+    if not body.get("parents"):
+        raise CapsuleValidationError("optibench requires a non-empty closed population")
+    _match_evidence_ref(value.get("population_manifest"), evidence, f"{path}.population_manifest")
+    _match_evidence_ref(value.get("counter_output"), evidence, f"{path}.counter_output")
+
+    cohort = _object(value.get("cohort"), f"{path}.cohort")
+    _exact_keys(
+        cohort,
+        {"counter_profile", "environment", "harness", "tool", "tool_version"},
+        f"{path}.cohort",
+    )
+    profile = cohort.get("counter_profile")
+    if profile == "perf_stat_instructions_v1":
+        expected_objectives = PERF_OBJECTIVES
+        expected_tool = "perf"
+    elif profile == "callgrind_ir_v1":
+        expected_objectives = CALLGRIND_OBJECTIVES
+        expected_tool = "valgrind"
+    else:
+        raise CapsuleValidationError("optibench counter_profile is unsupported")
+    if cohort.get("tool") != expected_tool:
+        raise CapsuleValidationError("optibench counter_profile and tool disagree")
+    _identifier(cohort.get("tool_version"), f"{path}.cohort.tool_version")
+    for field in ("environment", "harness"):
+        _match_evidence_ref(cohort.get(field), evidence, f"{path}.cohort.{field}")
+
+    gate_receipts = _array(value.get("gate_receipts"), f"{path}.gate_receipts", maximum=32)
+    if not gate_receipts:
+        raise CapsuleValidationError("optibench requires at least one gate receipt")
+    gate_order: list[tuple[str, str]] = []
+    for index, receipt in enumerate(gate_receipts):
+        descriptor = _match_evidence_ref(
+            receipt, evidence, f"{path}.gate_receipts[{index}]"
+        )
+        gate_order.append((descriptor["name"], descriptor["sha256"]))
+    _sorted_unique(gate_order, f"{path}.gate_receipts")
+
+    names = value.get("objective_metrics")
+    expected_names = [name for name, _unit in expected_objectives]
+    if names != expected_names:
+        raise CapsuleValidationError(
+            "optibench objective_metrics must exactly match its counter cohort"
+        )
+    metrics = body.get("metrics")
+    if type(metrics) is not list:
+        raise CapsuleValidationError("optibench requires body.metrics")
+    actual_metrics: list[tuple[str, str]] = []
+    for metric in metrics:
+        actual_metrics.append((metric["name"], metric["unit"]))
+        if (
+            len(metric["value"]) > MAX_OBJECTIVE_DIGITS
+            or not _NONNEGATIVE_INTEGER_RE.fullmatch(metric["value"])
+        ):
+            raise CapsuleValidationError(
+                "optibench objective values must be nonnegative integer strings"
+            )
+    if tuple(actual_metrics) != expected_objectives:
+        raise CapsuleValidationError(
+            "optibench body.metrics must exactly match its counter cohort"
+        )
+
+    if value.get("aggregation") != "median":
+        raise CapsuleValidationError("optibench aggregation must be median")
+    repetitions = _positive_safe_int(value.get("repetitions"), f"{path}.repetitions")
+    if repetitions % 2 == 0:
+        raise CapsuleValidationError("optibench repetitions must be odd for an integer median")
+    baseline_relation = value.get("baseline_relation")
+    if type(baseline_relation) is not str or baseline_relation not in {
+        "dominated_by_baseline",
+        "dominates_baseline",
+        "equal_baseline",
+        "incomparable_to_baseline",
+    }:
+        raise CapsuleValidationError("optibench baseline_relation is unsupported")
+
+    nsga2 = _object(value.get("nsga2"), f"{path}.nsga2")
+    _exact_keys(nsga2, {"algorithm", "crowding", "pareto_rank"}, f"{path}.nsga2")
+    if nsga2.get("algorithm") != "nsga2_exact_v1":
+        raise CapsuleValidationError("optibench nsga2 algorithm must be nsga2_exact_v1")
+    _nonnegative_safe_int(nsga2.get("pareto_rank"), f"{path}.nsga2.pareto_rank")
+    _crowding(nsga2.get("crowding"), f"{path}.nsga2.crowding")
+
+
+def _crowding(raw: Any, path: str) -> None:
+    value = _object(raw, path)
+    kind = value.get("kind")
+    if kind == "boundary":
+        _exact_keys(value, {"kind"}, path)
+        return
+    if kind != "finite":
+        raise CapsuleValidationError(f"{path}.kind must be boundary or finite")
+    _exact_keys(value, {"denominator", "kind", "numerator"}, path)
+    numerator = value.get("numerator")
+    denominator = value.get("denominator")
+    if (
+        type(numerator) is not str
+        or len(numerator) > MAX_RATIONAL_DIGITS
+        or not _NONNEGATIVE_INTEGER_RE.fullmatch(numerator)
+    ):
+        raise CapsuleValidationError(f"{path}.numerator must be a nonnegative integer string")
+    if (
+        type(denominator) is not str
+        or len(denominator) > MAX_RATIONAL_DIGITS
+        or not _POSITIVE_INTEGER_RE.fullmatch(denominator)
+    ):
+        raise CapsuleValidationError(f"{path}.denominator must be a positive integer string")
+    if math.gcd(int(numerator), int(denominator)) != 1:
+        raise CapsuleValidationError(f"{path} finite rational must be reduced")
+
+
+def _validate_dpo(
+    body: Mapping[str, Any], data: Any, evidence: Mapping[str, Mapping[str, Any]]
+) -> None:
+    path = "$.body.payload.data"
+    value = _object(data, path)
+    _exact_keys(
+        value,
+        {
+            "chosen",
+            "cohort_proof_manifest",
+            "export_profile",
+            "population_manifest",
+            "preference",
+            "prompt",
+            "rejected",
+            "task_capsule",
+        },
+        path,
+    )
+    if body.get("kind") != "evaluation":
+        raise CapsuleValidationError("agentic DPO pair requires body.kind evaluation")
+    if body.get("metrics"):
+        raise CapsuleValidationError("agentic DPO pair does not duplicate benchmark metrics")
+    task = _capsule_id(value.get("task_capsule"), f"{path}.task_capsule")
+    _match_evidence_ref(
+        value.get("cohort_proof_manifest"),
+        evidence,
+        f"{path}.cohort_proof_manifest",
+    )
+    _match_evidence_ref(value.get("population_manifest"), evidence, f"{path}.population_manifest")
+    _match_evidence_ref(value.get("prompt"), evidence, f"{path}.prompt")
+
+    sides: dict[str, Mapping[str, Any]] = {}
+    expected_parents = {task}
+    for side in ("chosen", "rejected"):
+        item_path = f"{path}.{side}"
+        item = _object(value.get(side), item_path)
+        _exact_keys(item, {"artifact", "benchmark_capsule", "candidate_capsule"}, item_path)
+        candidate = _capsule_id(item.get("candidate_capsule"), f"{item_path}.candidate_capsule")
+        benchmark = _capsule_id(item.get("benchmark_capsule"), f"{item_path}.benchmark_capsule")
+        _match_evidence_ref(item.get("artifact"), evidence, f"{item_path}.artifact")
+        expected_parents.update((candidate, benchmark))
+        sides[side] = item
+    if len(expected_parents) != 5 or body.get("parents") != sorted(expected_parents):
+        raise CapsuleValidationError(
+            "agentic DPO parents must be the task and distinct chosen/rejected candidate and benchmark capsules"
+        )
+    if sides["chosen"]["artifact"]["sha256"] == sides["rejected"]["artifact"]["sha256"]:
+        raise CapsuleValidationError("agentic DPO chosen and rejected artifacts must differ")
+
+    preference = _object(value.get("preference"), f"{path}.preference")
+    _exact_keys(
+        preference,
+        {"basis", "dominance_receipt", "policy"},
+        f"{path}.preference",
+    )
+    if preference.get("basis") != "pareto_dominance":
+        raise CapsuleValidationError("agentic DPO v1 only supports direct Pareto dominance")
+    if preference.get("policy") != "nsga2_direct_dominance_v1":
+        raise CapsuleValidationError("agentic DPO preference policy is unsupported")
+    _match_evidence_ref(
+        preference.get("dominance_receipt"), evidence, f"{path}.preference.dominance_receipt"
+    )
+    if value.get("export_profile") != "preference_jsonl_v1":
+        raise CapsuleValidationError("agentic DPO export_profile is unsupported")
+
+
+def _evidence_index(raw: Any) -> dict[str, Mapping[str, Any]]:
+    if type(raw) is not list:
+        raise CapsuleValidationError("$.body.evidence must be an array")
+    result: dict[str, Mapping[str, Any]] = {}
+    for index, item in enumerate(raw):
+        if type(item) is not dict or type(item.get("name")) is not str:
+            raise CapsuleValidationError(f"$.body.evidence[{index}] is malformed")
+        name = _identifier(item["name"], f"$.body.evidence[{index}].name")
+        if name in result:
+            raise CapsuleValidationError(
+                "known payload profiles require unique evidence names"
+            )
+        result[name] = item
+    return result
+
+
+def _artifact_refs(
+    raw: Any,
+    evidence: Mapping[str, Mapping[str, Any]],
+    path: str,
+    *,
+    allowed_roles: set[str],
+) -> list[Mapping[str, Any]]:
+    values = _array(raw, path, maximum=64)
+    if not values:
+        raise CapsuleValidationError(f"{path} must not be empty")
+    order: list[tuple[str, str, str]] = []
+    result: list[Mapping[str, Any]] = []
+    for index, raw_item in enumerate(values):
+        item_path = f"{path}[{index}]"
+        item = _object(raw_item, item_path)
+        _exact_keys(item, {"evidence_name", "role", "sha256"}, item_path)
+        role = item.get("role")
+        if type(role) is not str or role not in allowed_roles:
+            raise CapsuleValidationError(f"{item_path}.role is unsupported")
+        descriptor = _match_evidence_ref(item, evidence, item_path, allow_role=True)
+        order.append((item["role"], descriptor["name"], descriptor["sha256"]))
+        result.append(item)
+    _sorted_unique(order, path)
+    return result
+
+
+def _match_evidence_ref(
+    raw: Any,
+    evidence: Mapping[str, Mapping[str, Any]],
+    path: str,
+    *,
+    allow_role: bool = False,
+) -> Mapping[str, Any]:
+    ref = _object(raw, path)
+    expected = {"evidence_name", "sha256"} | ({"role"} if allow_role else set())
+    _exact_keys(ref, expected, path)
+    name = _identifier(ref.get("evidence_name"), f"{path}.evidence_name")
+    digest = ref.get("sha256")
+    if type(digest) is not str or not _DIGEST_RE.fullmatch(digest):
+        raise CapsuleValidationError(f"{path}.sha256 is invalid")
+    descriptor = evidence.get(name)
+    if descriptor is None or descriptor.get("sha256") != digest:
+        raise CapsuleValidationError(f"{path} does not match a body.evidence descriptor")
+    return descriptor
+
+
+def _verified_evidence_bytes(
+    ref: Any,
+    evidence: Mapping[str, Mapping[str, Any]],
+    blobs: Mapping[str, bytes],
+    path: str,
+    *,
+    allow_role: bool = False,
+) -> bytes:
+    descriptor = _match_evidence_ref(
+        ref, evidence, path, allow_role=allow_role
+    )
+    name = descriptor["name"]
+    raw = blobs.get(name)
+    if type(raw) is not bytes:
+        raise CapsuleValidationError(f"{path} is missing evidence bytes")
+    if len(raw) != descriptor["bytes"]:
+        raise CapsuleValidationError(f"{path} evidence byte count does not match")
+    if hashlib.sha256(raw).hexdigest() != descriptor["sha256"]:
+        raise CapsuleValidationError(f"{path} evidence SHA-256 does not match")
+    return raw
+
+
+def _dominates(left: Sequence[int], right: Sequence[int]) -> bool:
+    return all(a <= b for a, b in zip(left, right)) and any(
+        a < b for a, b in zip(left, right)
+    )
+
+
+def _validate_closed_graph(bodies: Mapping[str, Mapping[str, Any]]) -> None:
+    state: dict[str, int] = {}
+
+    def visit(identifier: str, depth: int) -> None:
+        if depth > MAX_GRAPH_BODIES:
+            raise CapsuleValidationError("preference graph exceeds the v1 depth limit")
+        current = state.get(identifier, 0)
+        if current == 1:
+            raise CapsuleValidationError("preference graph contains a parent cycle")
+        if current == 2:
+            return
+        state[identifier] = 1
+        for parent_id in bodies[identifier]["parents"]:
+            if parent_id not in bodies:
+                raise CapsuleValidationError(
+                    "preference graph is not closed over every parent"
+                )
+            visit(parent_id, depth + 1)
+        state[identifier] = 2
+
+    for identifier in sorted(bodies):
+        visit(identifier, 1)
+
+
+def _nondominated_ranks(points: Mapping[str, tuple[int, ...]]) -> dict[str, int]:
+    remaining = set(points)
+    ranks: dict[str, int] = {}
+    rank = 0
+    while remaining:
+        front = sorted(
+            candidate
+            for candidate in remaining
+            if not any(
+                other != candidate
+                and _dominates(points[other], points[candidate])
+                for other in remaining
+            )
+        )
+        if not front:
+            raise CapsuleValidationError("closed cohort has no nondominated front")
+        for candidate in front:
+            ranks[candidate] = rank
+            remaining.remove(candidate)
+        rank += 1
+    return ranks
+
+
+def _exact_crowding(
+    points: Mapping[str, tuple[int, ...]], ranks: Mapping[str, int]
+) -> dict[str, dict[str, str]]:
+    """Return deterministic value-symmetric NSGA-II crowding receipts."""
+
+    result: dict[str, dict[str, str]] = {}
+    for rank in sorted(set(ranks.values())):
+        front = sorted(candidate for candidate, value in ranks.items() if value == rank)
+        if not front:
+            raise CapsuleValidationError("closed cohort has an empty Pareto front")
+        if len(front) == 1:
+            result[front[0]] = {"kind": "boundary"}
+            continue
+
+        distances = {candidate: Fraction(0, 1) for candidate in front}
+        boundary: set[str] = set()
+        objective_count = len(points[front[0]])
+        for objective in range(objective_count):
+            groups: dict[int, list[str]] = {}
+            for candidate in front:
+                groups.setdefault(points[candidate][objective], []).append(candidate)
+            ordered_values = sorted(groups)
+            low = ordered_values[0]
+            high = ordered_values[-1]
+            if low == high:
+                continue
+            boundary.update(groups[low])
+            boundary.update(groups[high])
+            span = high - low
+            for index, value in enumerate(ordered_values[1:-1], start=1):
+                contribution = Fraction(
+                    ordered_values[index + 1] - ordered_values[index - 1], span
+                )
+                for candidate in groups[value]:
+                    distances[candidate] += contribution
+
+        for candidate in front:
+            if candidate in boundary:
+                result[candidate] = {"kind": "boundary"}
+                continue
+            distance = distances[candidate]
+            numerator = str(distance.numerator)
+            denominator = str(distance.denominator)
+            if (
+                len(numerator) > MAX_RATIONAL_DIGITS
+                or len(denominator) > MAX_RATIONAL_DIGITS
+            ):
+                raise CapsuleValidationError(
+                    "computed crowding exceeds the v1 rational digit bound"
+                )
+            result[candidate] = {
+                "denominator": denominator,
+                "kind": "finite",
+                "numerator": numerator,
+            }
+    return result
+
+
+def _contains_secret_like(text: str) -> bool:
+    return any(pattern.search(text) is not None for pattern in _SHARED_SECRET_PATTERNS)
+
+
+def _reject_secret_strings(raw: Any, path: str) -> None:
+    if type(raw) is str:
+        if _contains_secret_like(raw):
+            raise CapsuleValidationError(f"{path} contains secret-like content")
+        return
+    if type(raw) is dict:
+        for key, value in raw.items():
+            _reject_secret_strings(key, f"{path}.<key>")
+            _reject_secret_strings(value, f"{path}.{key}")
+        return
+    if type(raw) is list:
+        for index, value in enumerate(raw):
+            _reject_secret_strings(value, f"{path}[{index}]")
+
+
+def _object(raw: Any, path: str) -> Mapping[str, Any]:
+    if type(raw) is not dict:
+        raise CapsuleValidationError(f"{path} must be an object")
+    return raw
+
+
+def _array(raw: Any, path: str, *, maximum: int) -> list[Any]:
+    if type(raw) is not list:
+        raise CapsuleValidationError(f"{path} must be an array")
+    if len(raw) > maximum:
+        raise CapsuleValidationError(f"{path} exceeds its maximum of {maximum} items")
+    return raw
+
+
+def _exact_keys(value: Mapping[str, Any], expected: set[str], path: str) -> None:
+    keys = set(value)
+    if keys != expected:
+        missing = sorted(expected - keys)
+        extra = sorted(keys - expected)
+        raise CapsuleValidationError(
+            f"{path} fields do not match profile; missing={missing}, extra={extra}"
+        )
+
+
+def _identifier(raw: Any, path: str) -> str:
+    if type(raw) is not str or not _IDENTIFIER_RE.fullmatch(raw):
+        raise CapsuleValidationError(f"{path} is not a valid identifier")
+    if _contains_secret_like(raw):
+        raise CapsuleValidationError(f"{path} contains secret-like content")
+    return raw
+
+
+def _capsule_id(raw: Any, path: str) -> str:
+    if type(raw) is not str or not _CAPSULE_ID_RE.fullmatch(raw):
+        raise CapsuleValidationError(f"{path} is not a valid capsule id")
+    return raw
+
+
+def _positive_safe_int(raw: Any, path: str) -> int:
+    if type(raw) is not int or not 1 <= raw <= MAX_SAFE_INTEGER:
+        raise CapsuleValidationError(f"{path} must be a positive safe integer")
+    return raw
+
+
+def _nonnegative_safe_int(raw: Any, path: str) -> int:
+    if type(raw) is not int or not 0 <= raw <= MAX_SAFE_INTEGER:
+        raise CapsuleValidationError(f"{path} must be a nonnegative safe integer")
+    return raw
+
+
+def _sorted_unique(values: list[Any], path: str) -> None:
+    if values != sorted(values) or len(values) != len(set(values)):
+        raise CapsuleValidationError(f"{path} must be unique and canonically sorted")

--- a/tests/test_intelligence_payloads.py
+++ b/tests/test_intelligence_payloads.py
@@ -1,0 +1,1278 @@
+import copy
+import hashlib
+import inspect
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from src import intelligence_capsule as capsule
+from src import intelligence_payloads as payloads
+
+
+ROOT = Path(__file__).parents[1]
+FIXTURE = ROOT / "tests" / "fixtures" / "intelligence_capsule" / "v1" / "golden-envelope.json"
+CONFORMANCE = ROOT / "docs" / "okf" / "intelligence-payload-conformance-v1.json"
+
+
+def _capsule_id(digit: str) -> str:
+    return f"ucap1:sha256:{digit * 64}"
+
+
+def _evidence(name: str, raw: bytes, media_type: str = "text/plain") -> dict:
+    return {
+        "bytes": len(raw),
+        "media_type": media_type,
+        "name": name,
+        "sha256": hashlib.sha256(raw).hexdigest(),
+    }
+
+
+def _ref(descriptor: dict) -> dict:
+    return {
+        "evidence_name": descriptor["name"],
+        "sha256": descriptor["sha256"],
+    }
+
+
+def _body(
+    *,
+    kind: str,
+    schema: str,
+    data: dict,
+    evidence: list[dict],
+    parents: list[str],
+    metrics: list[dict] | None = None,
+) -> dict:
+    base = json.loads(FIXTURE.read_text(encoding="utf-8"))["body"]
+    base["kind"] = kind
+    base["parents"] = sorted(parents)
+    base["evidence"] = sorted(evidence, key=lambda item: (item["name"], item["sha256"]))
+    base["payload"] = {"data": data, "schema": schema}
+    if schema == payloads.GNO_ENVELOPE_SCHEMA and data.get("phase") == "result":
+        base.pop("execution", None)
+    if metrics is None:
+        base.pop("metrics", None)
+    else:
+        base["metrics"] = metrics
+    return base
+
+
+def _validate_known_body(body: dict) -> None:
+    capsule.validate_body(body)
+    assert payloads.validate_known_payload_profile(body) is True
+
+
+def _gno_dispatch_with_blobs() -> tuple[dict, dict[str, bytes]]:
+    task_spec = _evidence("task-spec", b"optimize foo without ambient reads")
+    routing = {
+        "algorithm": "discounted_ucb_v1",
+        "arm": "hot_loop",
+        "arm_pull": 7,
+        "parameters": [
+            {"name": "decay", "value": "0.95"},
+            {"name": "exploration", "value": "1"},
+        ],
+        "reason": "discounted_ucb",
+        "seed": 42,
+        "step": 25,
+    }
+    execution = json.loads(FIXTURE.read_text(encoding="utf-8"))["body"]["execution"]
+    declared = [{"role": "task_spec", **_ref(task_spec)}]
+    input_manifest_raw = capsule.canonicalize(
+        {
+            "declared_artifacts": declared,
+            "execution": execution,
+            "routing": routing,
+        }
+    )
+    input_manifest = _evidence(
+        "input-manifest", input_manifest_raw, "application/json"
+    )
+    data = {
+        "artifacts": [
+            {"role": "input_manifest", **_ref(input_manifest)},
+            *declared,
+        ],
+        "generation": 1,
+        "mutator": {"origin": "agent", "profile": "hot_loop"},
+        "node_id": "node-01",
+        "phase": "dispatch",
+        "routing": routing,
+        "slot": 2,
+    }
+    body = _body(
+        kind="task",
+        schema=payloads.GNO_ENVELOPE_SCHEMA,
+        data=data,
+        evidence=[input_manifest, task_spec],
+        parents=[_capsule_id("1")],
+    )
+    return body, {
+        "input-manifest": input_manifest_raw,
+        "task-spec": b"optimize foo without ambient reads",
+    }
+
+
+def _gno_dispatch() -> dict:
+    return _gno_dispatch_with_blobs()[0]
+
+
+def _optibench() -> dict:
+    candidate = _capsule_id("2")
+    blobs = {
+        "counter-output": b"1,234 instructions",
+        "environment": b'{"runner":"linux-x86_64"}',
+        "harness": b'{"tokenizer":"pinned-v1"}',
+        "population": b'{"closed":true}',
+        "tests": b'{"passed":true}',
+    }
+    evidence = {name: _evidence(name, raw) for name, raw in blobs.items()}
+    data = {
+        "aggregation": "median",
+        "baseline_relation": "dominates_baseline",
+        "candidate_capsule": candidate,
+        "cohort": {
+            "counter_profile": "perf_stat_instructions_v1",
+            "environment": _ref(evidence["environment"]),
+            "harness": _ref(evidence["harness"]),
+            "tool": "perf",
+            "tool_version": "6.8.0",
+        },
+        "counter_output": _ref(evidence["counter-output"]),
+        "gate_receipts": [_ref(evidence["tests"])],
+        "nsga2": {
+            "algorithm": "nsga2_exact_v1",
+            "crowding": {"kind": "boundary"},
+            "pareto_rank": 0,
+        },
+        "objective_metrics": [
+            "cpu_instructions_retired",
+            "diff_tokens",
+            "peak_memory_bytes",
+        ],
+        "population_closed": True,
+        "population_manifest": _ref(evidence["population"]),
+        "repetitions": 5,
+    }
+    metrics = [
+        {"name": "cpu_instructions_retired", "unit": "instruction", "value": "1234"},
+        {"name": "diff_tokens", "unit": "token", "value": "18"},
+        {"name": "peak_memory_bytes", "unit": "byte", "value": "29300"},
+    ]
+    return _body(
+        kind="benchmark",
+        schema=payloads.OPTIBENCH_RESULT_SCHEMA,
+        data=data,
+        evidence=list(evidence.values()),
+        parents=[candidate],
+        metrics=metrics,
+    )
+
+
+def _dpo() -> tuple[dict, dict[str, bytes]]:
+    blobs = {
+        "chosen-output": b"optimized implementation",
+        "cohort-proof": b'{"benchmarks":[]}',
+        "dominance": b'{"chosen":[10,20,3],"rejected":[12,25,4]}',
+        "population": b'{"closed":true,"cohort":"abc"}',
+        "prompt": b"Optimize the focus function.",
+        "rejected-output": b"slower implementation",
+    }
+    evidence = {name: _evidence(name, raw) for name, raw in blobs.items()}
+    task = _capsule_id("1")
+    chosen_candidate = _capsule_id("2")
+    chosen_benchmark = _capsule_id("3")
+    rejected_candidate = _capsule_id("4")
+    rejected_benchmark = _capsule_id("5")
+    data = {
+        "chosen": {
+            "artifact": _ref(evidence["chosen-output"]),
+            "benchmark_capsule": chosen_benchmark,
+            "candidate_capsule": chosen_candidate,
+        },
+        "cohort_proof_manifest": _ref(evidence["cohort-proof"]),
+        "export_profile": "preference_jsonl_v1",
+        "population_manifest": _ref(evidence["population"]),
+        "preference": {
+            "basis": "pareto_dominance",
+            "dominance_receipt": _ref(evidence["dominance"]),
+            "policy": "nsga2_direct_dominance_v1",
+        },
+        "prompt": _ref(evidence["prompt"]),
+        "rejected": {
+            "artifact": _ref(evidence["rejected-output"]),
+            "benchmark_capsule": rejected_benchmark,
+            "candidate_capsule": rejected_candidate,
+        },
+        "task_capsule": task,
+    }
+    body = _body(
+        kind="evaluation",
+        schema=payloads.AGENTIC_DPO_PAIR_SCHEMA,
+        data=data,
+        evidence=list(evidence.values()),
+        parents=[
+            task,
+            chosen_candidate,
+            chosen_benchmark,
+            rejected_candidate,
+            rejected_benchmark,
+        ],
+    )
+    return body, blobs
+
+
+def _trusted_preference_graph(
+    *,
+    chosen_test_raw: bytes | None = None,
+    task_parents: list[str] | None = None,
+):
+    task_raw = b"Optimize the focus function."
+    task_evidence = _evidence("prompt", task_raw)
+    routing = {
+        "algorithm": "deterministic_v1",
+        "arm": "preference-fixture",
+        "arm_pull": 1,
+        "parameters": [],
+        "reason": "test-fixture",
+        "seed": 7,
+        "step": 1,
+    }
+    execution = json.loads(FIXTURE.read_text(encoding="utf-8"))["body"]["execution"]
+    declared = [{"role": "task_spec", **_ref(task_evidence)}]
+    task_manifest_raw = capsule.canonicalize(
+        {
+            "declared_artifacts": declared,
+            "execution": execution,
+            "routing": routing,
+        }
+    )
+    task_manifest = _evidence(
+        "input-manifest", task_manifest_raw, "application/json"
+    )
+    task = _body(
+        kind="task",
+        schema=payloads.GNO_ENVELOPE_SCHEMA,
+        data={
+            "artifacts": [
+                {"role": "input_manifest", **_ref(task_manifest)},
+                *declared,
+            ],
+            "generation": 1,
+            "mutator": {"origin": "agent", "profile": "preference-fixture"},
+            "node_id": "preference-node",
+            "phase": "dispatch",
+            "routing": routing,
+            "slot": 1,
+        },
+        evidence=[task_manifest, task_evidence],
+        parents=task_parents or [],
+    )
+    task_id = capsule.capsule_id(task)
+    task_blobs = {
+        "input-manifest": task_manifest_raw,
+        "prompt": task_raw,
+    }
+
+    chosen_raw = b"optimized implementation"
+    rejected_raw = b"slower implementation"
+
+    def candidate(
+        name: str, raw: bytes, test_raw: bytes | None = None
+    ) -> tuple[dict, dict[str, bytes]]:
+        descriptor = _evidence(name, raw)
+        artifacts = [{"role": "output_diff", **_ref(descriptor)}]
+        evidence_items = [descriptor]
+        blobs = {name: raw}
+        if test_raw is not None:
+            test_descriptor = _evidence("chosen-tests", test_raw, "application/json")
+            artifacts.append({"role": "test_receipt", **_ref(test_descriptor)})
+            evidence_items.append(test_descriptor)
+            blobs["chosen-tests"] = test_raw
+        result = _body(
+            kind="candidate",
+            schema=payloads.GNO_ENVELOPE_SCHEMA,
+            data={
+                "artifacts": sorted(
+                    artifacts,
+                    key=lambda item: (
+                        item["role"],
+                        item["evidence_name"],
+                        item["sha256"],
+                    ),
+                ),
+                "dispatch_capsule": task_id,
+                "generation": 1,
+                "node_id": "preference-node",
+                "outcome": "candidate",
+                "phase": "result",
+                "slot": 1,
+            },
+            evidence=evidence_items,
+            parents=[task_id],
+        )
+        return result, blobs
+
+    chosen_candidate, chosen_candidate_blobs = candidate(
+        "chosen-output", chosen_raw, chosen_test_raw
+    )
+    rejected_candidate, rejected_candidate_blobs = candidate(
+        "rejected-output", rejected_raw
+    )
+    chosen_candidate_id = capsule.capsule_id(chosen_candidate)
+    rejected_candidate_id = capsule.capsule_id(rejected_candidate)
+    population = sorted([chosen_candidate_id, rejected_candidate_id])
+
+    environment_raw = capsule.canonicalize(
+        {
+            "architecture": "x86_64",
+            "cpu_model": "zen4",
+            "kernel": "linux-6.8.0",
+            "operating_system": "ubuntu-24.04",
+            "runner": "linux-x86_64",
+        }
+    )
+    harness_raw = capsule.canonicalize(
+        {
+            "diff_metric": "token_count",
+            "peak_memory_method": "max_rss",
+            "source_commit": "aa1daa2de2a2bc1d1dab6c2e053022287aa63157",
+            "tokenizer": "pinned-v1",
+            "version": "1.0.0",
+        }
+    )
+    tests_raw = capsule.canonicalize({"gate": "tests", "passed": True})
+    environment = _evidence("environment", environment_raw, "application/json")
+    harness = _evidence("harness", harness_raw, "application/json")
+    tests = _evidence("tests", tests_raw, "application/json")
+    cohort = {
+        "counter_profile": "perf_stat_instructions_v1",
+        "environment": _ref(environment),
+        "harness": _ref(harness),
+        "tool": "perf",
+        "tool_version": "6.8.0",
+    }
+    population_raw = capsule.canonicalize(
+        {
+            "candidate_capsules": population,
+            "closed": True,
+            "cohort_sha256": hashlib.sha256(capsule.canonicalize(cohort)).hexdigest(),
+        }
+    )
+    population_evidence = _evidence("population", population_raw, "application/json")
+
+    objective_names = [
+        "cpu_instructions_retired",
+        "diff_tokens",
+        "peak_memory_bytes",
+    ]
+
+    def benchmark(
+        candidate_capsule: str,
+        point: tuple[int, int, int],
+        rank: int,
+        baseline_relation: str,
+    ) -> tuple[dict, dict[str, bytes]]:
+        samples = [
+            {name: str(value) for name, value in zip(objective_names, point)}
+            for _ in range(5)
+        ]
+        counter_raw = capsule.canonicalize(
+            {
+                "baseline": {
+                    name: str(value)
+                    for name, value in zip(objective_names, (1100, 11, 105))
+                },
+                "counter_profile": "perf_stat_instructions_v1",
+                "samples": samples,
+            }
+        )
+        counter = _evidence("counter-output", counter_raw, "application/json")
+        data = {
+            "aggregation": "median",
+            "baseline_relation": baseline_relation,
+            "candidate_capsule": candidate_capsule,
+            "cohort": cohort,
+            "counter_output": _ref(counter),
+            "gate_receipts": [_ref(tests)],
+            "nsga2": {
+                "algorithm": "nsga2_exact_v1",
+                "crowding": {"kind": "boundary"},
+                "pareto_rank": rank,
+            },
+            "objective_metrics": objective_names,
+            "population_closed": True,
+            "population_manifest": _ref(population_evidence),
+            "repetitions": 5,
+        }
+        metrics = [
+            {"name": name, "unit": unit, "value": str(value)}
+            for (name, unit), value in zip(payloads.PERF_OBJECTIVES, point)
+        ]
+        result = _body(
+            kind="benchmark",
+            schema=payloads.OPTIBENCH_RESULT_SCHEMA,
+            data=data,
+            evidence=[counter, environment, harness, population_evidence, tests],
+            parents=population,
+            metrics=metrics,
+        )
+        return result, {
+            "counter-output": counter_raw,
+            "environment": environment_raw,
+            "harness": harness_raw,
+            "population": population_raw,
+            "tests": tests_raw,
+        }
+
+    chosen_benchmark, chosen_benchmark_blobs = benchmark(
+        chosen_candidate_id, (1000, 10, 100), 0, "dominates_baseline"
+    )
+    rejected_benchmark, rejected_benchmark_blobs = benchmark(
+        rejected_candidate_id, (1200, 12, 110), 1, "dominated_by_baseline"
+    )
+    chosen_benchmark_id = capsule.capsule_id(chosen_benchmark)
+    rejected_benchmark_id = capsule.capsule_id(rejected_benchmark)
+    benchmark_ids = {
+        chosen_candidate_id: chosen_benchmark_id,
+        rejected_candidate_id: rejected_benchmark_id,
+    }
+    cohort_proof_raw = capsule.canonicalize(
+        {
+            "benchmarks": [
+                {
+                    "benchmark_capsule": benchmark_ids[candidate_id],
+                    "candidate_capsule": candidate_id,
+                }
+                for candidate_id in population
+            ],
+            "cohort_sha256": hashlib.sha256(capsule.canonicalize(cohort)).hexdigest(),
+            "population_manifest_sha256": population_evidence["sha256"],
+        }
+    )
+
+    dominance_raw = capsule.canonicalize(
+        {
+            "chosen_benchmark": chosen_benchmark_id,
+            "metrics": [
+                {
+                    "chosen": str(chosen),
+                    "name": name,
+                    "rejected": str(rejected),
+                    "unit": unit,
+                }
+                for (name, unit), chosen, rejected in zip(
+                    payloads.PERF_OBJECTIVES,
+                    (1000, 10, 100),
+                    (1200, 12, 110),
+                )
+            ],
+            "rejected_benchmark": rejected_benchmark_id,
+            "relation": "dominates",
+        }
+    )
+    prompt_raw = b"Optimize the focus function."
+    dpo_blobs = {
+        "chosen-output": chosen_raw,
+        "cohort-proof": cohort_proof_raw,
+        "dominance": dominance_raw,
+        "population": population_raw,
+        "prompt": prompt_raw,
+        "rejected-output": rejected_raw,
+    }
+    dpo_evidence = {
+        name: _evidence(
+            name,
+            raw,
+            "application/json"
+            if name in {"cohort-proof", "dominance", "population"}
+            else "text/plain",
+        )
+        for name, raw in dpo_blobs.items()
+    }
+    dpo_data = {
+        "chosen": {
+            "artifact": _ref(dpo_evidence["chosen-output"]),
+            "benchmark_capsule": chosen_benchmark_id,
+            "candidate_capsule": chosen_candidate_id,
+        },
+        "cohort_proof_manifest": _ref(dpo_evidence["cohort-proof"]),
+        "export_profile": "preference_jsonl_v1",
+        "population_manifest": _ref(dpo_evidence["population"]),
+        "preference": {
+            "basis": "pareto_dominance",
+            "dominance_receipt": _ref(dpo_evidence["dominance"]),
+            "policy": "nsga2_direct_dominance_v1",
+        },
+        "prompt": _ref(dpo_evidence["prompt"]),
+        "rejected": {
+            "artifact": _ref(dpo_evidence["rejected-output"]),
+            "benchmark_capsule": rejected_benchmark_id,
+            "candidate_capsule": rejected_candidate_id,
+        },
+        "task_capsule": task_id,
+    }
+    dpo = _body(
+        kind="evaluation",
+        schema=payloads.AGENTIC_DPO_PAIR_SCHEMA,
+        data=dpo_data,
+        evidence=list(dpo_evidence.values()),
+        parents=[
+            task_id,
+            chosen_candidate_id,
+            rejected_candidate_id,
+            chosen_benchmark_id,
+            rejected_benchmark_id,
+        ],
+    )
+    graph = {
+        task_id: task,
+        chosen_candidate_id: chosen_candidate,
+        rejected_candidate_id: rejected_candidate,
+        chosen_benchmark_id: chosen_benchmark,
+        rejected_benchmark_id: rejected_benchmark,
+    }
+    graph_blobs = {
+        task_id: task_blobs,
+        chosen_candidate_id: chosen_candidate_blobs,
+        rejected_candidate_id: rejected_candidate_blobs,
+        chosen_benchmark_id: chosen_benchmark_blobs,
+        rejected_benchmark_id: rejected_benchmark_blobs,
+    }
+    return dpo, dpo_blobs, graph, graph_blobs
+
+
+def test_capsule_v1_schema_remains_pinned_while_profiles_evolve_separately():
+    capsule_schema = ROOT / "docs" / "okf" / "intelligence-capsule-v1.schema.json"
+    assert hashlib.sha256(capsule_schema.read_bytes()).hexdigest() == (
+        "10c2ec4638bd6c4e303b3e2c4c7d91ae582554f48aaa01fac2d9370062b98d4c"
+    )
+    for schema, file_name in payloads.PROFILE_SCHEMA_FILES.items():
+        path = ROOT / "docs" / "okf" / file_name
+        document = json.loads(path.read_text(encoding="utf-8"))
+        assert document["$id"] == f"https://grokmcp.org/docs/okf/{file_name}"
+        assert hashlib.sha256(path.read_bytes()).hexdigest() == (
+            payloads.payload_profile_schema_sha256(schema)
+        )
+    for schema, file_name in payloads.PROJECTION_SCHEMA_FILES.items():
+        path = ROOT / "docs" / "okf" / file_name
+        assert hashlib.sha256(path.read_bytes()).hexdigest() == (
+            payloads.PROJECTION_SCHEMA_SHA256[schema]
+        )
+    semantic_spec = ROOT / "docs" / "okf" / payloads.SEMANTIC_SPEC_FILE
+    assert hashlib.sha256(semantic_spec.read_bytes()).hexdigest() == (
+        payloads.SEMANTIC_SPEC_SHA256
+    )
+    assert hashlib.sha256(CONFORMANCE.read_bytes()).hexdigest() == (
+        payloads.CONFORMANCE_SHA256
+    )
+    semantic_document = json.loads(semantic_spec.read_text(encoding="utf-8"))
+    assert semantic_document["conformance"] == {
+        "file": payloads.CONFORMANCE_FILE,
+        "sha256": payloads.CONFORMANCE_SHA256,
+    }
+    assert [
+        {
+            "expression": pattern.pattern,
+            "ignore_case": bool(pattern.flags & re.IGNORECASE),
+        }
+        for pattern in payloads._SHARED_SECRET_PATTERNS
+    ] == semantic_document["secret_rejection"]["patterns"]
+
+
+def test_unknown_profile_stays_structural_but_is_not_registered():
+    body = json.loads(FIXTURE.read_text(encoding="utf-8"))["body"]
+    capsule.validate_body(body)
+    assert payloads.validate_known_payload_profile(body) is False
+
+    invalid_known = _gno_dispatch()
+    invalid_known["payload"]["data"]["artifacts"] = [
+        item
+        for item in invalid_known["payload"]["data"]["artifacts"]
+        if item["role"] != "task_spec"
+    ]
+    capsule.validate_body(invalid_known)
+    with pytest.raises(capsule.CapsuleValidationError, match="task_spec"):
+        payloads.validate_known_payload_profile(invalid_known)
+
+
+def test_python_matches_shared_profile_identity_vectors():
+    vectors = json.loads(CONFORMANCE.read_text(encoding="utf-8"))
+    bodies = (_gno_dispatch(), _optibench(), _dpo()[0])
+    for body in bodies:
+        schema = body["payload"]["schema"]
+        assert capsule.digest_body(body) == vectors["accepted_body_sha256"][schema]
+
+
+def test_gno_dispatch_and_result_are_input_closed_and_parent_bound():
+    dispatch, dispatch_blobs = _gno_dispatch_with_blobs()
+    _validate_known_body(dispatch)
+    payloads.validate_gno_dispatch_evidence(dispatch, dispatch_blobs)
+
+    output_raw = b"diff --git a/a.py b/a.py\n"
+    output = _evidence("candidate-patch", output_raw)
+    dispatch_id = capsule.capsule_id(dispatch)
+    result = _body(
+        kind="candidate",
+        schema=payloads.GNO_ENVELOPE_SCHEMA,
+        data={
+            "artifacts": [{"role": "output_diff", **_ref(output)}],
+            "dispatch_capsule": dispatch_id,
+            "generation": 1,
+            "node_id": "node-01",
+            "outcome": "candidate",
+            "phase": "result",
+            "slot": 2,
+        },
+        evidence=[output],
+        parents=[dispatch_id],
+    )
+    _validate_known_body(result)
+    payloads.validate_gno_result_graph(
+        result,
+        dispatch,
+        result_evidence_blobs={"candidate-patch": output_raw},
+        dispatch_evidence_blobs=dispatch_blobs,
+    )
+
+    invalid = copy.deepcopy(result)
+    invalid["parents"] = [_capsule_id("f")]
+    with pytest.raises(capsule.CapsuleValidationError, match="sole parent"):
+        _validate_known_body(invalid)
+
+    opposite = copy.deepcopy(result)
+    failure_raw = b'{"error":"failed"}'
+    failure = _evidence("failure", failure_raw, "application/json")
+    opposite["evidence"].append(failure)
+    opposite["evidence"].sort(key=lambda item: (item["name"], item["sha256"]))
+    opposite["payload"]["data"]["artifacts"].append(
+        {"role": "failure_receipt", **_ref(failure)}
+    )
+    opposite["payload"]["data"]["artifacts"].sort(
+        key=lambda item: (item["role"], item["evidence_name"], item["sha256"])
+    )
+    with pytest.raises(capsule.CapsuleValidationError, match="forbids failure_receipt"):
+        _validate_known_body(opposite)
+
+    contradictory_execution = copy.deepcopy(result)
+    contradictory_execution["execution"] = {
+        "model": "grok-build-0.1",
+        "plane": "api",
+        "runtime": "cloud",
+        "target": "cloud_api",
+    }
+    with pytest.raises(capsule.CapsuleValidationError, match="inherits execution"):
+        _validate_known_body(contradictory_execution)
+
+
+def test_gno_rejects_dishonest_or_noncanonical_receipts():
+    body = _gno_dispatch()
+    body["payload"]["data"]["routing"]["parameters"][0]["value"] = 0.95
+    with pytest.raises(capsule.CapsuleValidationError, match="decimal string"):
+        _validate_known_body(body)
+
+    body = _gno_dispatch()
+    body["payload"]["data"]["routing"]["parameters"].reverse()
+    with pytest.raises(capsule.CapsuleValidationError, match="canonically sorted"):
+        _validate_known_body(body)
+
+    body = _gno_dispatch()
+    body["payload"]["data"]["artifacts"][0]["sha256"] = "f" * 64
+    with pytest.raises(capsule.CapsuleValidationError, match="does not match"):
+        _validate_known_body(body)
+
+    body = _gno_dispatch()
+    duplicate = copy.deepcopy(body["evidence"][0])
+    duplicate["name"] = "input-manifest-2"
+    body["evidence"].append(duplicate)
+    body["evidence"].sort(key=lambda item: (item["name"], item["sha256"]))
+    body["payload"]["data"]["artifacts"].append(
+        {"role": "input_manifest", **_ref(duplicate)}
+    )
+    body["payload"]["data"]["artifacts"].sort(
+        key=lambda item: (item["role"], item["evidence_name"], item["sha256"])
+    )
+    with pytest.raises(capsule.CapsuleValidationError, match="exactly one input_manifest"):
+        _validate_known_body(body)
+
+
+def test_known_profiles_forbid_ambiguous_duplicate_evidence_names():
+    body = _gno_dispatch()
+    duplicate = copy.deepcopy(body["evidence"][0])
+    duplicate["sha256"] = "f" * 64
+    body["evidence"].append(duplicate)
+    body["evidence"].sort(key=lambda item: (item["name"], item["sha256"]))
+    with pytest.raises(capsule.CapsuleValidationError, match="unique evidence names"):
+        _validate_known_body(body)
+
+    vector = next(
+        item
+        for item in json.loads(CONFORMANCE.read_text(encoding="utf-8"))["reject_vectors"]
+        if item["mutation"] == "secret_identifier"
+    )
+    secret_value = "".join(vector["value_parts"])
+    secret_name = _gno_dispatch()
+    secret_name["evidence"].append(
+        _evidence(secret_value, b"unused non-secret evidence")
+    )
+    secret_name["evidence"].sort(key=lambda item: (item["name"], item["sha256"]))
+    with pytest.raises(capsule.CapsuleValidationError, match=vector["error"]):
+        _validate_known_body(secret_name)
+
+    secret_actor = _gno_dispatch()
+    secret_actor["actor"]["agent_id"] = secret_value
+    capsule.validate_body(secret_actor)
+    with pytest.raises(capsule.CapsuleValidationError, match=vector["error"]):
+        payloads.validate_known_payload_profile(secret_actor)
+
+    enum_vector = next(
+        item
+        for item in json.loads(CONFORMANCE.read_text(encoding="utf-8"))["reject_vectors"]
+        if item["mutation"] == "enum_type_confusion"
+    )
+    confused = _gno_dispatch()
+    confused["payload"]["data"]["mutator"]["origin"] = enum_vector["value"]
+    capsule.validate_body(confused)
+    with pytest.raises(capsule.CapsuleValidationError, match=enum_vector["error"]):
+        payloads.validate_known_payload_profile(confused)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "XAI_API_KEY: notproviderformattedsecret123",
+        '"XAI_API_KEY":"notproviderformattedsecret123"',
+        "password: correcthorsebatterystaple",
+        "client_secret: verysecretvalue123",
+        '"password":"correct horse battery staple"',
+        'password: "p@ssw0rd!"',
+        'CLIENT_SECRET: "!very-secret-value!"',
+        '"clientSecret":"verysecretvalue123"',
+        '"apiKey":"verysecretvalue123"',
+        "accessToken: verysecretvalue123",
+        "privateKey: verysecretvalue123",
+        "Authorization: Basic dXNlcjpwYXNzd29yZA==",
+    ],
+)
+def test_pinned_secret_detector_rejects_mapping_and_auth_forms(text: str):
+    assert payloads._contains_secret_like(text)
+    assert not payloads._contains_secret_like('"XAI_API_KEY":"${XAI_API_KEY}"')
+
+
+def test_optibench_requires_closed_evidenced_hardware_cohort():
+    body = _optibench()
+    _validate_known_body(body)
+
+    mixed = copy.deepcopy(body)
+    mixed["payload"]["data"]["cohort"]["counter_profile"] = "callgrind_ir_v1"
+    with pytest.raises(capsule.CapsuleValidationError, match="profile and tool disagree"):
+        _validate_known_body(mixed)
+
+    provisional = copy.deepcopy(body)
+    provisional["payload"]["data"]["population_closed"] = False
+    with pytest.raises(capsule.CapsuleValidationError, match="population must be closed"):
+        _validate_known_body(provisional)
+
+    fabricated = copy.deepcopy(body)
+    fabricated["payload"]["data"]["counter_output"]["sha256"] = "f" * 64
+    with pytest.raises(capsule.CapsuleValidationError, match="does not match"):
+        _validate_known_body(fabricated)
+
+
+def test_optibench_uses_exact_integer_metrics_and_rational_crowding():
+    body = _optibench()
+    body["payload"]["data"]["nsga2"]["crowding"] = {
+        "denominator": "6",
+        "kind": "finite",
+        "numerator": "17",
+    }
+    _validate_known_body(body)
+
+    non_reduced = copy.deepcopy(body)
+    non_reduced["payload"]["data"]["nsga2"]["crowding"] = {
+        "denominator": "6",
+        "kind": "finite",
+        "numerator": "18",
+    }
+    with pytest.raises(capsule.CapsuleValidationError, match="must be reduced"):
+        _validate_known_body(non_reduced)
+
+    float_value = copy.deepcopy(body)
+    float_value["metrics"][0]["value"] = "1234.5"
+    with pytest.raises(capsule.CapsuleValidationError, match="nonnegative integer"):
+        _validate_known_body(float_value)
+
+
+def test_optibench_evidence_recomputes_population_gates_and_medians():
+    _dpo_body, _dpo_blobs, graph, graph_blobs = _trusted_preference_graph()
+    benchmarks = [
+        (identifier, body)
+        for identifier, body in graph.items()
+        if body["kind"] == "benchmark"
+    ]
+    for identifier, body in benchmarks:
+        payloads.validate_optibench_evidence(body, graph_blobs[identifier])
+
+    identifier, tampered = benchmarks[0]
+    tampered = copy.deepcopy(tampered)
+    tampered["metrics"][0]["value"] = "999"
+    with pytest.raises(capsule.CapsuleValidationError, match="median counter samples"):
+        payloads.validate_optibench_evidence(tampered, graph_blobs[identifier])
+
+    secret_environment = copy.deepcopy(benchmarks[0][1])
+    secret_blobs = dict(graph_blobs[benchmarks[0][0]])
+    environment = capsule.parse_canonical(secret_blobs["environment"])
+    environment["runner"] = "github_pat_0123456789abcdefghij"
+    environment_raw = capsule.canonicalize(environment)
+    environment_descriptor = _evidence(
+        "environment", environment_raw, "application/json"
+    )
+    for descriptor in secret_environment["evidence"]:
+        if descriptor["name"] == "environment":
+            descriptor.update(environment_descriptor)
+    secret_environment["payload"]["data"]["cohort"]["environment"] = _ref(
+        environment_descriptor
+    )
+    secret_blobs["environment"] = environment_raw
+    with pytest.raises(capsule.CapsuleValidationError, match="secret-like"):
+        payloads.validate_optibench_evidence(secret_environment, secret_blobs)
+
+    secret_gate = copy.deepcopy(benchmarks[0][1])
+    gate_blobs = dict(graph_blobs[benchmarks[0][0]])
+    gate_raw = capsule.canonicalize(
+        {"gate": "ghp_abcdefghijklmnopqrstuvwxyz123456", "passed": True}
+    )
+    gate_descriptor = _evidence("tests", gate_raw, "application/json")
+    for descriptor in secret_gate["evidence"]:
+        if descriptor["name"] == "tests":
+            descriptor.update(gate_descriptor)
+    secret_gate["payload"]["data"]["gate_receipts"] = [_ref(gate_descriptor)]
+    gate_blobs["tests"] = gate_raw
+    with pytest.raises(capsule.CapsuleValidationError, match="secret-like"):
+        payloads.validate_optibench_evidence(secret_gate, gate_blobs)
+
+
+def test_optibench_population_recomputes_rank_and_exact_crowding():
+    _dpo_body, _dpo_blobs, graph, graph_blobs = _trusted_preference_graph()
+    benchmarks = {
+        identifier: body
+        for identifier, body in graph.items()
+        if body["kind"] == "benchmark"
+    }
+    summaries = payloads.validate_optibench_population(benchmarks, graph_blobs)
+    assert {summary["pareto_rank"] for summary in summaries.values()} == {0, 1}
+    assert all(
+        summary["crowding"] == {"kind": "boundary"}
+        for summary in summaries.values()
+    )
+
+    original_id, original = next(iter(benchmarks.items()))
+    fake_rank = copy.deepcopy(original)
+    fake_rank["payload"]["data"]["nsga2"]["pareto_rank"] = 42
+    fake_rank_id = capsule.capsule_id(fake_rank)
+    fake_rank_population = {
+        **{key: value for key, value in benchmarks.items() if key != original_id},
+        fake_rank_id: fake_rank,
+    }
+    fake_rank_blobs = {
+        **{key: value for key, value in graph_blobs.items() if key != original_id},
+        fake_rank_id: graph_blobs[original_id],
+    }
+    with pytest.raises(capsule.CapsuleValidationError, match="Pareto rank"):
+        payloads.validate_optibench_population(
+            fake_rank_population, fake_rank_blobs
+        )
+
+    fake_crowding = copy.deepcopy(original)
+    fake_crowding["payload"]["data"]["nsga2"]["crowding"] = {
+        "denominator": "1",
+        "kind": "finite",
+        "numerator": "0",
+    }
+    fake_crowding_id = capsule.capsule_id(fake_crowding)
+    fake_crowding_population = {
+        **{key: value for key, value in benchmarks.items() if key != original_id},
+        fake_crowding_id: fake_crowding,
+    }
+    fake_crowding_blobs = {
+        **{key: value for key, value in graph_blobs.items() if key != original_id},
+        fake_crowding_id: graph_blobs[original_id],
+    }
+    with pytest.raises(capsule.CapsuleValidationError, match="crowding"):
+        payloads.validate_optibench_population(
+            fake_crowding_population, fake_crowding_blobs
+        )
+
+    malformed = copy.deepcopy(original)
+    malformed["payload"]["data"].pop("cohort")
+    malformed_id = capsule.capsule_id(malformed)
+    with pytest.raises(capsule.CapsuleValidationError, match="fields do not match"):
+        payloads.validate_optibench_population(
+            {malformed_id: malformed},
+            {malformed_id: graph_blobs[original_id]},
+        )
+
+
+def test_exact_nsga2_crowding_is_tie_symmetric_and_order_independent():
+    vector = json.loads(CONFORMANCE.read_text(encoding="utf-8"))["semantic_vectors"][
+        "nsga2_exact_v1"
+    ]
+    points = {
+        item["candidate_capsule"]: tuple(int(value) for value in item["values"])
+        for item in vector["points"]
+    }
+    ranks = payloads._nondominated_ranks(points)
+    expected_ranks = {
+        item["candidate_capsule"]: item["pareto_rank"]
+        for item in vector["expected"]
+    }
+    expected_crowding = {
+        item["candidate_capsule"]: item["crowding"]
+        for item in vector["expected"]
+    }
+    assert ranks == expected_ranks
+    assert payloads._exact_crowding(points, ranks) == expected_crowding
+    assert (
+        payloads._exact_crowding(dict(reversed(list(points.items()))), ranks)
+        == expected_crowding
+    )
+
+    identical = {"a": (1, 1), "b": (1, 1), "c": (1, 1)}
+    identical_ranks = payloads._nondominated_ranks(identical)
+    assert payloads._exact_crowding(identical, identical_ranks) == {
+        candidate: {"denominator": "1", "kind": "finite", "numerator": "0"}
+        for candidate in identical
+    }
+
+
+def test_public_dpo_cohort_proof_vector_has_one_canonical_identity():
+    vector = json.loads(CONFORMANCE.read_text(encoding="utf-8"))["semantic_vectors"][
+        "dpo_cohort_proof_v1"
+    ]
+    assert hashlib.sha256(capsule.canonicalize(vector["manifest"])).hexdigest() == (
+        vector["expected_sha256"]
+    )
+
+
+def test_crowding_digit_bound_is_fail_closed_and_cross_runtime_safe():
+    body = _optibench()
+    body["payload"]["data"]["nsga2"]["crowding"] = {
+        "denominator": "1",
+        "kind": "finite",
+        "numerator": "9" * (payloads.MAX_RATIONAL_DIGITS + 1),
+    }
+    with pytest.raises(capsule.CapsuleValidationError, match="numerator"):
+        _validate_known_body(body)
+
+
+def test_dpo_pair_is_graph_proven_before_verified_jsonl_export():
+    body, blobs, graph, graph_blobs = _trusted_preference_graph()
+    _validate_known_body(body)
+    payloads.validate_dpo_preference_graph(body, graph, blobs, graph_blobs)
+    example = payloads.build_preference_example(
+        body,
+        blobs,
+        graph_bodies=graph,
+        graph_evidence_blobs=graph_blobs,
+    )
+    rendered = payloads.render_preference_jsonl(
+        body,
+        blobs,
+        graph_bodies=graph,
+        graph_evidence_blobs=graph_blobs,
+    )
+    assert rendered.endswith(b"\n") and not rendered.endswith(b"\n\n")
+    record = json.loads(rendered)
+    assert record == example == {
+        "chosen": "optimized implementation",
+        "prompt": "Optimize the focus function.",
+        "rejected": "slower implementation",
+        "source_capsule": capsule.capsule_id(body),
+    }
+    assert rendered == capsule.canonicalize(record) + b"\n"
+
+
+def test_dpo_pair_fails_closed_on_bad_provenance_or_blob_bytes():
+    body, blobs, graph, graph_blobs = _trusted_preference_graph()
+    arbitrary = copy.deepcopy(body)
+    arbitrary["parents"] = arbitrary["parents"][:-1]
+    with pytest.raises(capsule.CapsuleValidationError, match="parents must be"):
+        _validate_known_body(arbitrary)
+
+    same_artifact = copy.deepcopy(body)
+    same_artifact["payload"]["data"]["rejected"]["artifact"] = copy.deepcopy(
+        same_artifact["payload"]["data"]["chosen"]["artifact"]
+    )
+    with pytest.raises(capsule.CapsuleValidationError, match="artifacts must differ"):
+        _validate_known_body(same_artifact)
+
+    substituted = dict(blobs)
+    substituted["chosen-output"] = b"tampered"
+    with pytest.raises(capsule.CapsuleValidationError, match="byte count|digest"):
+        payloads.render_preference_jsonl(
+            body,
+            substituted,
+            graph_bodies=graph,
+            graph_evidence_blobs=graph_blobs,
+        )
+
+    missing_proof = dict(blobs)
+    missing_proof.pop("dominance")
+    with pytest.raises(capsule.CapsuleValidationError, match="missing evidence bytes"):
+        payloads.render_preference_jsonl(
+            body,
+            missing_proof,
+            graph_bodies=graph,
+            graph_evidence_blobs=graph_blobs,
+        )
+
+    incomplete_cohort = copy.deepcopy(body)
+    cohort_proof = capsule.parse_canonical(blobs["cohort-proof"])
+    cohort_proof["benchmarks"].pop()
+    cohort_proof_raw = capsule.canonicalize(cohort_proof)
+    cohort_proof_descriptor = _evidence(
+        "cohort-proof", cohort_proof_raw, "application/json"
+    )
+    for descriptor in incomplete_cohort["evidence"]:
+        if descriptor["name"] == "cohort-proof":
+            descriptor.update(cohort_proof_descriptor)
+    incomplete_cohort["payload"]["data"]["cohort_proof_manifest"] = _ref(
+        cohort_proof_descriptor
+    )
+    with pytest.raises(capsule.CapsuleValidationError, match="complete benchmark"):
+        payloads.validate_dpo_preference_graph(
+            incomplete_cohort,
+            graph,
+            {**blobs, "cohort-proof": cohort_proof_raw},
+            graph_blobs,
+        )
+
+
+def test_dpo_text_must_bind_exact_gno_semantic_roles():
+    body, blobs, graph, graph_blobs = _trusted_preference_graph()
+    task_id = body["payload"]["data"]["task_capsule"]
+    manifest_raw = graph_blobs[task_id]["input-manifest"]
+    manifest = _evidence("input-manifest", manifest_raw, "application/json")
+    wrong_prompt = copy.deepcopy(body)
+    wrong_prompt["evidence"].append(manifest)
+    wrong_prompt["evidence"].sort(
+        key=lambda item: (item["name"], item["sha256"])
+    )
+    wrong_prompt["payload"]["data"]["prompt"] = _ref(manifest)
+    with pytest.raises(capsule.CapsuleValidationError, match="GNO task_spec"):
+        payloads.validate_dpo_preference_graph(
+            wrong_prompt,
+            graph,
+            {**blobs, "input-manifest": manifest_raw},
+            graph_blobs,
+        )
+
+    test_raw = b'{"passed":true}'
+    body, blobs, graph, graph_blobs = _trusted_preference_graph(
+        chosen_test_raw=test_raw
+    )
+    test_descriptor = _evidence("chosen-tests", test_raw, "application/json")
+    wrong_chosen = copy.deepcopy(body)
+    wrong_chosen["evidence"].append(test_descriptor)
+    wrong_chosen["evidence"].sort(
+        key=lambda item: (item["name"], item["sha256"])
+    )
+    wrong_chosen["payload"]["data"]["chosen"]["artifact"] = _ref(
+        test_descriptor
+    )
+    with pytest.raises(capsule.CapsuleValidationError, match="GNO output_diff"):
+        payloads.validate_dpo_preference_graph(
+            wrong_chosen,
+            graph,
+            {**blobs, "chosen-tests": test_raw},
+            graph_blobs,
+        )
+
+
+def test_dpo_graph_rejects_unrelated_task_and_mixed_baselines():
+    body, blobs, graph, graph_blobs = _trusted_preference_graph()
+    data = body["payload"]["data"]
+
+    original_task_id = data["task_capsule"]
+    unrelated_task = copy.deepcopy(graph[original_task_id])
+    unrelated_task["payload"]["data"]["mutator"]["profile"] = "unrelated-task"
+    unrelated_task_id = capsule.capsule_id(unrelated_task)
+    unrelated_body = copy.deepcopy(body)
+    unrelated_body["payload"]["data"]["task_capsule"] = unrelated_task_id
+    unrelated_body["parents"] = sorted(
+        unrelated_task_id if item == original_task_id else item
+        for item in unrelated_body["parents"]
+    )
+    unrelated_graph = {**graph, unrelated_task_id: unrelated_task}
+    with pytest.raises(capsule.CapsuleValidationError, match="linked to the declared task"):
+        payloads.validate_dpo_preference_graph(
+            unrelated_body, unrelated_graph, blobs, graph_blobs
+        )
+
+    rejected_benchmark_id = data["rejected"]["benchmark_capsule"]
+    rejected_benchmark = copy.deepcopy(graph[rejected_benchmark_id])
+    rejected_blobs = dict(graph_blobs[rejected_benchmark_id])
+    counter = capsule.parse_canonical(rejected_blobs["counter-output"])
+    counter["baseline"] = {
+        "cpu_instructions_retired": "1300",
+        "diff_tokens": "13",
+        "peak_memory_bytes": "115",
+    }
+    counter_raw = capsule.canonicalize(counter)
+    counter_descriptor = _evidence(
+        "counter-output", counter_raw, "application/json"
+    )
+    for descriptor in rejected_benchmark["evidence"]:
+        if descriptor["name"] == "counter-output":
+            descriptor.update(counter_descriptor)
+    rejected_benchmark["payload"]["data"]["counter_output"] = _ref(
+        counter_descriptor
+    )
+    rejected_benchmark["payload"]["data"][
+        "baseline_relation"
+    ] = "dominates_baseline"
+    new_benchmark_id = capsule.capsule_id(rejected_benchmark)
+    mixed_graph = dict(graph)
+    mixed_graph.pop(rejected_benchmark_id)
+    mixed_graph[new_benchmark_id] = rejected_benchmark
+    mixed_graph_blobs = dict(graph_blobs)
+    mixed_graph_blobs.pop(rejected_benchmark_id)
+    rejected_blobs["counter-output"] = counter_raw
+    mixed_graph_blobs[new_benchmark_id] = rejected_blobs
+
+    mixed_body = copy.deepcopy(body)
+    mixed_body["payload"]["data"]["rejected"][
+        "benchmark_capsule"
+    ] = new_benchmark_id
+    mixed_body["parents"] = sorted(
+        new_benchmark_id if item == rejected_benchmark_id else item
+        for item in mixed_body["parents"]
+    )
+    dominance = capsule.parse_canonical(blobs["dominance"])
+    dominance["rejected_benchmark"] = new_benchmark_id
+    dominance_raw = capsule.canonicalize(dominance)
+    dominance_descriptor = _evidence(
+        "dominance", dominance_raw, "application/json"
+    )
+    for descriptor in mixed_body["evidence"]:
+        if descriptor["name"] == "dominance":
+            descriptor.update(dominance_descriptor)
+    mixed_body["payload"]["data"]["preference"]["dominance_receipt"] = _ref(
+        dominance_descriptor
+    )
+    mixed_blobs = {**blobs, "dominance": dominance_raw}
+    with pytest.raises(capsule.CapsuleValidationError, match="different baselines"):
+        payloads.validate_dpo_preference_graph(
+            mixed_body, mixed_graph, mixed_blobs, mixed_graph_blobs
+        )
+
+
+def test_dpo_graph_must_close_every_transitive_parent():
+    body, blobs, graph, graph_blobs = _trusted_preference_graph(
+        task_parents=[_capsule_id("f")]
+    )
+    with pytest.raises(capsule.CapsuleValidationError, match="not closed"):
+        payloads.validate_dpo_preference_graph(body, graph, blobs, graph_blobs)
+
+
+def test_needle_projection_is_a_bounded_valid_tools_array_not_jsonl():
+    body, blobs, graph, graph_blobs = _trusted_preference_graph()
+    example = payloads.build_preference_example(
+        body,
+        blobs,
+        graph_bodies=graph,
+        graph_evidence_blobs=graph_blobs,
+    )
+    projection = payloads.build_needle_tools_context(
+        "Find relevant optimization context",
+        [example],
+        tokenizer="needle-v0.1.0-pinned",
+        token_counter=lambda text: len(text.encode("utf-8")),
+        max_encoder_tokens=1024,
+    )
+    assert projection["profile"] == payloads.NEEDLE_CONTEXT_PROFILE
+    assert projection["used_source_capsules"] == [example["source_capsule"]]
+    assert projection["encoder_tokens"] <= projection["max_encoder_tokens"]
+    tool = projection["tools"][0]
+    assert tool["name"] == "select_unigrok_context"
+    assert tool["parameters"]["capsule_id"]["required"] is True
+    assert tool["examples"] == [example]
+
+    too_small = payloads.build_needle_tools_context(
+        "q",
+        [example],
+        tokenizer="needle-v0.1.0-pinned",
+        token_counter=lambda text: (
+            1 if text == "q" else 10 if '"examples":[]' in text else 2000
+        ),
+    )
+    assert too_small["used_source_capsules"] == []
+
+    with pytest.raises(capsule.CapsuleValidationError, match="non-empty"):
+        payloads.build_needle_tools_context(
+            "\u00a0\u3000",
+            [],
+            tokenizer="needle-v0.1.0-pinned",
+            token_counter=lambda _text: 0,
+        )
+    with pytest.raises(capsule.CapsuleValidationError, match="strict UTF-8"):
+        payloads.build_needle_tools_context(
+            "\ud800",
+            [],
+            tokenizer="needle-v0.1.0-pinned",
+            token_counter=lambda _text: 0,
+        )
+    with pytest.raises(capsule.CapsuleValidationError, match="strict UTF-8"):
+        payloads.build_needle_tools_context(
+            "q",
+            [{**example, "chosen": "\ud800"}],
+            tokenizer="needle-v0.1.0-pinned",
+            token_counter=lambda _text: 0,
+        )
+    with pytest.raises(capsule.CapsuleValidationError, match="input count"):
+        payloads.build_needle_tools_context(
+            "q",
+            [example] * (payloads.MAX_NEEDLE_INPUT_EXAMPLES + 1),
+            tokenizer="needle-v0.1.0-pinned",
+            token_counter=lambda _text: 0,
+        )
+    with pytest.raises(capsule.CapsuleValidationError, match="secret-like"):
+        payloads.build_needle_tools_context(
+            "q",
+            [
+                {
+                    **example,
+                    "chosen": "github_pat_0123456789abcdefghij",
+                }
+            ],
+            tokenizer="needle-v0.1.0-pinned",
+            token_counter=lambda _text: 0,
+        )
+
+    vector = json.loads(CONFORMANCE.read_text(encoding="utf-8"))["semantic_vectors"][
+        "needle_tools_context_v1"
+    ]
+    vector_projection = payloads.build_needle_tools_context(
+        vector["query"],
+        vector["examples"],
+        tokenizer=vector["tokenizer"],
+        token_counter=lambda text: len(text.encode("utf-8")),
+        max_encoder_tokens=vector["max_encoder_tokens"],
+    )
+    assert vector_projection["encoder_tokens"] == vector["expected_encoder_tokens"]
+    assert (
+        vector_projection["used_source_capsules"]
+        == vector["expected_used_source_capsules"]
+    )
+    assert hashlib.sha256(capsule.canonicalize(vector_projection)).hexdigest() == (
+        vector["expected_projection_sha256"]
+    )
+
+
+def test_payload_protocol_layer_does_not_touch_consumer_sqlite():
+    source = inspect.getsource(payloads)
+    assert "aiosqlite" not in source
+    assert "GrokSessionStore" not in source
+    assert "grok_sessions.db" not in source

--- a/tests/test_release_hygiene.py
+++ b/tests/test_release_hygiene.py
@@ -45,6 +45,17 @@ def test_wheel_configuration_includes_runtime_assets():
     assert included["example.env"] == "example.env"
 
 
+def test_sdist_configuration_excludes_generated_dependency_trees():
+    metadata = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    excluded = set(metadata["tool"]["hatch"]["build"]["targets"]["sdist"]["exclude"])
+
+    assert "/sites/**/node_modules" in excluded
+    assert "/sites/**/.sites-runtime" in excluded
+    assert "/sites/**/.next" in excluded
+    assert "/sites/**/.wrangler" in excluded
+    assert "/**/__pycache__" in excluded
+
+
 def test_public_setup_surfaces_use_the_grok_phoneword_endpoint():
     paths = [
         ROOT / "README.md",


### PR DESCRIPTION
## What changed

- Added immutable v1 payload contracts for manifest-closed GNO dispatch/results, evidence-verified closed-population OptiBench results, and direct-Pareto Agentic DPO pairs.
- Added a separate bounded `org.grokmcp.needle_tools_context.v1` projection that uses Needle's real nested tools-JSON context path without claiming parameter training or chosen/rejected decoder semantics.
- Published digest-pinned JSON Schemas, a machine-explicit semantic contract, public conformance vectors, generated OKF documentation, and matching Python/TypeScript structural validators.
- Added complete GNO/OptiBench parent closure, exact task/output role binding, all-population benchmark proof binding, deterministic exact-rational NSGA-II rank/crowding verification, strict evidence receipts, and fail-closed shared-text secret checks.
- Kept generic IntelligenceCapsule v1 byte and validator behavior unchanged; profile validation remains a separate trust gate.
- Added source-distribution exclusions and a CI bound so local `node_modules`, `.sites-runtime`, build caches, and IDE residue cannot enter release artifacts.

## Why

This is the canonical Insider/Contributor protocol layer for sharing optimization evidence through the Git DAG without tunnels or a shared runtime database. Public MCP consumers remain headless in their IDE and retain private local SQLite; this PR does not change their runtime or credential path.

## Current product impact

This freezes contracts and verifiers. The current local Swarm still uses contributor SQLite, wall-clock/`tracemalloc` metrics, and discounted UCB; it does not yet publish these capsules. The browser TypeScript implementation is structural only. Python evidence and graph verification is the current promotion authority.

## Validation

- `uv run pytest -q` — 1,151 passed
- `npm audit --audit-level=moderate` — 0 vulnerabilities
- `npm run lint` — 0 errors, 4 pre-existing Swarm warnings
- `npm run test:deployment` — build plus 54 tests passed
- `uv run python -m evals run --check-baseline` — 12/12 passed
- `uvx bandit -r src -ll -q` — passed
- OKF generation/pin/public-mirror checks — passed
- Draft 2020-12 schema validation and cross-runtime mutation checks — passed
- Fresh sdist: ~4.07 MB / 315 entries, no local dependency/cache trees; wheel includes every payload asset
- Independent adversarial reviews found no remaining protocol or packaging blocker. The required Grok MCP review call returned only a zero-token planning stub, so no Grok approval is claimed.

## Exact head and scope

- Commit: `a966ef8c138c6864242c862793aa35c714608339`
- Main paths: `src/intelligence_payloads.py`, `docs/okf/*payload*`, `sites/unigrok-control-center/app/lib/intelligence-payloads.ts`, mirrored public OKF assets, payload/release tests, `pyproject.toml`, and `.github/workflows/ci.yml`
- Risk: new protocol code is intentionally strict and not wired into current Swarm publication yet. Any v1 semantic edit requires a new version rather than changing these pinned bytes in place.

Human-Sponsor: djtelicloud

Agent-Assisted-By: Codex
