### PR TITLE
fix(site): reject stale public deployment assets

### DIFF
--- a/sites/unigrok-control-center/scripts/validate-artifact.sh
+++ b/sites/unigrok-control-center/scripts/validate-artifact.sh
@@ -34,4 +34,8 @@ if (!worker.default || typeof worker.default.fetch !== "function") {
 }
 NODE
 
-echo "Validated Sites artifact: ESM Worker default.fetch and hosting manifest are present."
+node "${script_dir}/validate-static-assets.mjs" \
+  "${SITES_PROJECT_ROOT}/public" \
+  "${SITES_PROJECT_ROOT}/dist/client"
+
+echo "Validated Sites artifact: Worker, hosting manifest, and public assets are current."

--- a/sites/unigrok-control-center/scripts/validate-static-assets.mjs
+++ b/sites/unigrok-control-center/scripts/validate-static-assets.mjs
@@ -1,0 +1,64 @@
+import { readFile, readdir } from "node:fs/promises";
+import { relative, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+async function listFiles(root, directory = root) {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const path = resolve(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listFiles(root, path)));
+      continue;
+    }
+    if (!entry.isFile()) {
+      throw new Error(`Unsupported public asset type: ${relative(root, path)}`);
+    }
+    files.push(relative(root, path));
+  }
+
+  return files.sort();
+}
+
+export async function validateStaticAssets(publicDirectory, clientDirectory) {
+  const publicRoot = resolve(publicDirectory);
+  const clientRoot = resolve(clientDirectory);
+  const files = await listFiles(publicRoot);
+
+  for (const file of files) {
+    const source = await readFile(resolve(publicRoot, file));
+    let built;
+    try {
+      built = await readFile(resolve(clientRoot, file));
+    } catch (error) {
+      if (error?.code === "ENOENT") {
+        throw new Error(`Missing built static asset: ${file}`);
+      }
+      throw error;
+    }
+    if (!source.equals(built)) {
+      throw new Error(`Stale built static asset: ${file}`);
+    }
+  }
+
+  return files.length;
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : null;
+if (invokedPath === import.meta.url) {
+  const [publicDirectory, clientDirectory] = process.argv.slice(2);
+  if (!publicDirectory || !clientDirectory) {
+    console.error("Usage: node validate-static-assets.mjs PUBLIC_DIR CLIENT_DIR");
+    process.exitCode = 64;
+  } else {
+    try {
+      const count = await validateStaticAssets(publicDirectory, clientDirectory);
+      console.log(`Validated ${count} public assets against dist/client.`);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`Static asset validation failed: ${message}`);
+      process.exitCode = 1;
+    }
+  }
+}

--- a/sites/unigrok-control-center/tests/static-asset-validation.test.mjs
+++ b/sites/unigrok-control-center/tests/static-asset-validation.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, mkdir, rm, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { validateStaticAssets } from "../scripts/validate-static-assets.mjs";
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), "unigrok-static-assets-"));
+  const publicDirectory = join(root, "public");
+  const clientDirectory = join(root, "dist", "client");
+  const relativeAsset = join("docs", "okf", "intelligence-payload-semantics-v1.json");
+  await mkdir(join(publicDirectory, "docs", "okf"), { recursive: true });
+  await mkdir(join(clientDirectory, "docs", "okf"), { recursive: true });
+  await writeFile(join(publicDirectory, relativeAsset), '{"version":1}\n');
+  await writeFile(join(clientDirectory, relativeAsset), '{"version":1}\n');
+  return { root, publicDirectory, clientDirectory, relativeAsset };
+}
+
+test("accepts byte-identical public assets", async (t) => {
+  const current = await fixture();
+  t.after(() => rm(current.root, { recursive: true, force: true }));
+
+  assert.equal(
+    await validateStaticAssets(current.publicDirectory, current.clientDirectory),
+    1,
+  );
+});
+
+test("rejects a stale built public asset", async (t) => {
+  const current = await fixture();
+  t.after(() => rm(current.root, { recursive: true, force: true }));
+  await writeFile(join(current.clientDirectory, current.relativeAsset), '{"version":0}\n');
+
+  await assert.rejects(
+    validateStaticAssets(current.publicDirectory, current.clientDirectory),
+    /Stale built static asset: docs\/okf\/intelligence-payload-semantics-v1\.json/,
+  );
+});
+
+test("rejects a missing built public asset", async (t) => {
+  const current = await fixture();
+  t.after(() => rm(current.root, { recursive: true, force: true }));
+  await unlink(join(current.clientDirectory, current.relativeAsset));
+
+  await assert.rejects(
+    validateStaticAssets(current.publicDirectory, current.clientDirectory),
+    /Missing built static asset: docs\/okf\/intelligence-payload-semantics-v1\.json/,
+  );
+});
+
+test("CLI reports validation failures without a stack trace", async (t) => {
+  const current = await fixture();
+  t.after(() => rm(current.root, { recursive: true, force: true }));
+  await writeFile(join(current.clientDirectory, current.relativeAsset), '{"version":0}\n');
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      fileURLToPath(new URL("../scripts/validate-static-assets.mjs", import.meta.url)),
+      current.publicDirectory,
+      current.clientDirectory,
+    ],
+    { encoding: "utf8" },
+  );
+
+  assert.equal(result.status, 1);
+  assert.equal(result.stdout, "");
+  assert.match(
+    result.stderr,
+    /^Static asset validation failed: Stale built static asset: docs\/okf\/intelligence-payload-semantics-v1\.json\n$/,
+  );
+});


### PR DESCRIPTION
## Summary
- fail Sites artifact validation when a public asset is missing or stale in dist/client
- verify byte parity recursively for every public file
- emit concise CLI errors for expected validation failures
- cover matching, stale, missing, and CLI failure cases

## Exact head
5c03076a7d20ff7b7fd60d89060c1cbd9eba7abb

## Changed paths
- sites/unigrok-control-center/scripts/validate-artifact.sh
- sites/unigrok-control-center/scripts/validate-static-assets.mjs
- sites/unigrok-control-center/tests/static-asset-validation.test.mjs

## Verification
- npm test: 58 passed
- npm run lint: 0 errors, 4 pre-existing Swarm warnings
- git diff --check

## Risk
Low. This tightens the existing build gate and makes stale ignored dist output fail closed; it does not alter runtime routes or credentials.

Human-Sponsor: djtelicloud

Agent-Assisted-By: Codex