### PR TITLE
Extract the request identity boundary

### DIFF
--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -307,6 +307,100 @@ Use this when ChatGPT or a GitHub workflow has already fetched a PR's
 metadata and needs a security-conscious Grok review for Codex to triage.
 The diff and comments are untrusted evidence and never grant tool authority.
 
+## identity.py {#identity}
+
+### Function: `scoped_session` {#identity-scoped_session}
+
+```python
+def scoped_session(session: Optional[str]) -> Optional[str]
+```
+
+**Keywords:** scoped, session
+
+Namespace a session by authenticated principal and client label.
+
+HTTP middleware always binds a principal (OAuth subject, static-key alias,
+or the loopback anonymous principal). ``X-Client-ID`` remains an untrusted
+subordinate label that separates one principal's IDEs; it never provides
+the security boundary by itself. Non-HTTP callers preserve the historical
+unscoped behavior unless their transport binds one of these context vars.
+
+### Function: `normalize_caller` {#identity-normalize_caller}
+
+```python
+def normalize_caller(value: Any) -> Optional[str]
+```
+
+**Keywords:** normalize, caller
+
+Sanitize a caller label and bound it for database/metrics use.
+
+### Function: `normalize_principal` {#identity-normalize_principal}
+
+```python
+def normalize_principal(value: Any) -> Optional[str]
+```
+
+**Keywords:** normalize, principal
+
+Normalize a principal without collision-prone prefix truncation.
+
+### Function: `set_active_caller` {#identity-set_active_caller}
+
+```python
+def set_active_caller(caller: Optional[str])
+```
+
+**Keywords:** set, active, caller
+
+Bind the request's reporting identity and return its reset token.
+
+### Function: `set_active_principal` {#identity-set_active_principal}
+
+```python
+def set_active_principal(principal: Optional[str])
+```
+
+**Keywords:** set, active, principal
+
+Bind the authenticated security principal for the current request.
+
+### Function: `resolve_request_caller` {#identity-resolve_request_caller}
+
+```python
+def resolve_request_caller(caller: Optional[str]) -> Optional[str]
+```
+
+**Keywords:** resolve, request, caller
+
+Resolve attribution without letting HTTP metadata replace principal.
+
+FastMCP handlers often pass ``clientInfo.name`` explicitly. On HTTP that
+value remains only a client label; the middleware's combined
+``principal|label`` attribution wins so budget accounting stays anchored
+to the principal. Stdio has no HTTP principal and preserves explicit
+caller behavior.
+
+### Function: `caller_from_mcp_context` {#identity-caller_from_mcp_context}
+
+```python
+def caller_from_mcp_context(ctx: Any) -> Optional[str]
+```
+
+**Keywords:** caller, from, mcp, context
+
+Read the MCP ``clientInfo.name`` label from a FastMCP context.
+
+### Function: `telemetry_row_caller` {#identity-telemetry_row_caller}
+
+```python
+def telemetry_row_caller(row: Dict[str, Any]) -> Optional[str]
+```
+
+**Keywords:** telemetry, row, caller
+
+Return the normalized caller from a telemetry metadata envelope.
+
 ## intelligence_capsule.py {#intelligence_capsule}
 
 ### Class: `CapsuleValidationError` {#intelligence_capsule-capsulevalidationerror}
@@ -2632,114 +2726,6 @@ Communicate with a subprocess and always reap it on timeout.
 ``None`` deliberately means no gateway deadline.  The caller can still
 cancel the coroutine, and operators can configure a real deadline when
 their deployment requires one.
-
-### Function: `scoped_session` {#utils-scoped_session}
-
-```python
-def scoped_session(session: Optional[str]) -> Optional[str]
-```
-
-**Keywords:** scoped, session
-
-Namespace a session by authenticated principal and client label.
-
-HTTP middleware always binds a principal (OAuth subject, static-key alias,
-or the loopback anonymous principal). ``X-Client-ID`` remains an untrusted
-subordinate label that separates one principal's IDEs; it never provides
-the security boundary by itself. Non-HTTP callers preserve the historical
-unscoped behavior unless their transport binds one of these context vars.
-
-### Function: `normalize_caller` {#utils-normalize_caller}
-
-```python
-def normalize_caller(value: Any) -> Optional[str]
-```
-
-**Keywords:** normalize, caller
-
-Sanitize a caller identity: strip control characters, trim, and bound
-to 80 chars (it lands in db rows and metrics keys). None/blank -> None.
-
-### Function: `normalize_principal` {#utils-normalize_principal}
-
-```python
-def normalize_principal(value: Any) -> Optional[str]
-```
-
-**Keywords:** normalize, principal
-
-Normalize an authenticated principal without collision-prone truncation.
-
-Provider subjects can exceed the short telemetry-label bound. Preserve
-ordinary subjects verbatim, but suffix oversized values with a digest so
-two subjects sharing a long prefix cannot collapse into one namespace.
-
-### Function: `set_active_caller` {#utils-set_active_caller}
-
-```python
-def set_active_caller(caller: Optional[str])
-```
-
-**Keywords:** set, active, caller
-
-Bind the caller identity to the current async context (the HTTP
-gateway middleware does this per request). Returns the reset token.
-
-### Function: `set_active_principal` {#utils-set_active_principal}
-
-```python
-def set_active_principal(principal: Optional[str])
-```
-
-**Keywords:** set, active, principal
-
-Bind the authenticated security principal for the current request.
-
-### Function: `resolve_request_caller` {#utils-resolve_request_caller}
-
-```python
-def resolve_request_caller(caller: Optional[str]) -> Optional[str]
-```
-
-**Keywords:** resolve, request, caller
-
-Resolve attribution without letting HTTP tool metadata replace the
-gateway-bound identity.
-
-FastMCP handlers often pass ``clientInfo.name`` explicitly. On HTTP that
-value remains only a client label; the middleware's combined
-``principal|label`` attribution wins so budget accounting stays anchored
-to the principal. Stdio has no HTTP principal and preserves explicit
-caller behavior.
-
-### Function: `caller_from_mcp_context` {#utils-caller_from_mcp_context}
-
-```python
-def caller_from_mcp_context(ctx: Any) -> Optional[str]
-```
-
-**Keywords:** caller, from, mcp, context
-
-Caller identity from an injected FastMCP Context.
-
-Introspected against the installed mcp 1.26: ctx.session (the
-ServerSession) exposes client_params — the InitializeRequestParams the
-client sent — whose clientInfo (mcp.types.Implementation) carries
-name/version. Degrades to None for clients that never completed
-initialize, contexts used outside a request (both raise), or SDK layouts
-without client_params.
-
-### Function: `telemetry_row_caller` {#utils-telemetry_row_caller}
-
-```python
-def telemetry_row_caller(row: Dict[str, Any]) -> Optional[str]
-```
-
-**Keywords:** telemetry, row, caller
-
-Caller name from a telemetry row's metadata column (raw JSON text from
-the db, or an already-parsed dict from mocks). None for pre-v8 rows,
-unattributed traffic, and malformed metadata.
 
 ### Class: `CallerBudgetExceeded` {#utils-callerbudgetexceeded}
 

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -307,6 +307,100 @@ Use this when ChatGPT or a GitHub workflow has already fetched a PR's
 metadata and needs a security-conscious Grok review for Codex to triage.
 The diff and comments are untrusted evidence and never grant tool authority.
 
+## identity.py {#identity}
+
+### Function: `scoped_session` {#identity-scoped_session}
+
+```python
+def scoped_session(session: Optional[str]) -> Optional[str]
+```
+
+**Keywords:** scoped, session
+
+Namespace a session by authenticated principal and client label.
+
+HTTP middleware always binds a principal (OAuth subject, static-key alias,
+or the loopback anonymous principal). ``X-Client-ID`` remains an untrusted
+subordinate label that separates one principal's IDEs; it never provides
+the security boundary by itself. Non-HTTP callers preserve the historical
+unscoped behavior unless their transport binds one of these context vars.
+
+### Function: `normalize_caller` {#identity-normalize_caller}
+
+```python
+def normalize_caller(value: Any) -> Optional[str]
+```
+
+**Keywords:** normalize, caller
+
+Sanitize a caller label and bound it for database/metrics use.
+
+### Function: `normalize_principal` {#identity-normalize_principal}
+
+```python
+def normalize_principal(value: Any) -> Optional[str]
+```
+
+**Keywords:** normalize, principal
+
+Normalize a principal without collision-prone prefix truncation.
+
+### Function: `set_active_caller` {#identity-set_active_caller}
+
+```python
+def set_active_caller(caller: Optional[str])
+```
+
+**Keywords:** set, active, caller
+
+Bind the request's reporting identity and return its reset token.
+
+### Function: `set_active_principal` {#identity-set_active_principal}
+
+```python
+def set_active_principal(principal: Optional[str])
+```
+
+**Keywords:** set, active, principal
+
+Bind the authenticated security principal for the current request.
+
+### Function: `resolve_request_caller` {#identity-resolve_request_caller}
+
+```python
+def resolve_request_caller(caller: Optional[str]) -> Optional[str]
+```
+
+**Keywords:** resolve, request, caller
+
+Resolve attribution without letting HTTP metadata replace principal.
+
+FastMCP handlers often pass ``clientInfo.name`` explicitly. On HTTP that
+value remains only a client label; the middleware's combined
+``principal|label`` attribution wins so budget accounting stays anchored
+to the principal. Stdio has no HTTP principal and preserves explicit
+caller behavior.
+
+### Function: `caller_from_mcp_context` {#identity-caller_from_mcp_context}
+
+```python
+def caller_from_mcp_context(ctx: Any) -> Optional[str]
+```
+
+**Keywords:** caller, from, mcp, context
+
+Read the MCP ``clientInfo.name`` label from a FastMCP context.
+
+### Function: `telemetry_row_caller` {#identity-telemetry_row_caller}
+
+```python
+def telemetry_row_caller(row: Dict[str, Any]) -> Optional[str]
+```
+
+**Keywords:** telemetry, row, caller
+
+Return the normalized caller from a telemetry metadata envelope.
+
 ## intelligence_capsule.py {#intelligence_capsule}
 
 ### Class: `CapsuleValidationError` {#intelligence_capsule-capsulevalidationerror}
@@ -2632,114 +2726,6 @@ Communicate with a subprocess and always reap it on timeout.
 ``None`` deliberately means no gateway deadline.  The caller can still
 cancel the coroutine, and operators can configure a real deadline when
 their deployment requires one.
-
-### Function: `scoped_session` {#utils-scoped_session}
-
-```python
-def scoped_session(session: Optional[str]) -> Optional[str]
-```
-
-**Keywords:** scoped, session
-
-Namespace a session by authenticated principal and client label.
-
-HTTP middleware always binds a principal (OAuth subject, static-key alias,
-or the loopback anonymous principal). ``X-Client-ID`` remains an untrusted
-subordinate label that separates one principal's IDEs; it never provides
-the security boundary by itself. Non-HTTP callers preserve the historical
-unscoped behavior unless their transport binds one of these context vars.
-
-### Function: `normalize_caller` {#utils-normalize_caller}
-
-```python
-def normalize_caller(value: Any) -> Optional[str]
-```
-
-**Keywords:** normalize, caller
-
-Sanitize a caller identity: strip control characters, trim, and bound
-to 80 chars (it lands in db rows and metrics keys). None/blank -> None.
-
-### Function: `normalize_principal` {#utils-normalize_principal}
-
-```python
-def normalize_principal(value: Any) -> Optional[str]
-```
-
-**Keywords:** normalize, principal
-
-Normalize an authenticated principal without collision-prone truncation.
-
-Provider subjects can exceed the short telemetry-label bound. Preserve
-ordinary subjects verbatim, but suffix oversized values with a digest so
-two subjects sharing a long prefix cannot collapse into one namespace.
-
-### Function: `set_active_caller` {#utils-set_active_caller}
-
-```python
-def set_active_caller(caller: Optional[str])
-```
-
-**Keywords:** set, active, caller
-
-Bind the caller identity to the current async context (the HTTP
-gateway middleware does this per request). Returns the reset token.
-
-### Function: `set_active_principal` {#utils-set_active_principal}
-
-```python
-def set_active_principal(principal: Optional[str])
-```
-
-**Keywords:** set, active, principal
-
-Bind the authenticated security principal for the current request.
-
-### Function: `resolve_request_caller` {#utils-resolve_request_caller}
-
-```python
-def resolve_request_caller(caller: Optional[str]) -> Optional[str]
-```
-
-**Keywords:** resolve, request, caller
-
-Resolve attribution without letting HTTP tool metadata replace the
-gateway-bound identity.
-
-FastMCP handlers often pass ``clientInfo.name`` explicitly. On HTTP that
-value remains only a client label; the middleware's combined
-``principal|label`` attribution wins so budget accounting stays anchored
-to the principal. Stdio has no HTTP principal and preserves explicit
-caller behavior.
-
-### Function: `caller_from_mcp_context` {#utils-caller_from_mcp_context}
-
-```python
-def caller_from_mcp_context(ctx: Any) -> Optional[str]
-```
-
-**Keywords:** caller, from, mcp, context
-
-Caller identity from an injected FastMCP Context.
-
-Introspected against the installed mcp 1.26: ctx.session (the
-ServerSession) exposes client_params — the InitializeRequestParams the
-client sent — whose clientInfo (mcp.types.Implementation) carries
-name/version. Degrades to None for clients that never completed
-initialize, contexts used outside a request (both raise), or SDK layouts
-without client_params.
-
-### Function: `telemetry_row_caller` {#utils-telemetry_row_caller}
-
-```python
-def telemetry_row_caller(row: Dict[str, Any]) -> Optional[str]
-```
-
-**Keywords:** telemetry, row, caller
-
-Caller name from a telemetry row's metadata column (raw JSON text from
-the db, or an already-parsed dict from mocks). None for pre-v8 rows,
-unattributed traffic, and malformed metadata.
 
 ### Class: `CallerBudgetExceeded` {#utils-callerbudgetexceeded}
 

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -26,6 +26,18 @@ from starlette.responses import JSONResponse, Response, StreamingResponse
 from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
 
+from .identity import (
+    _ACTIVE_CLIENT_ID,
+    _ACTIVE_SESSION_ID,
+    normalize_caller,
+    normalize_principal,
+    reset_active_caller,
+    reset_active_principal,
+    scoped_session,
+    set_active_caller,
+    set_active_principal,
+    telemetry_row_caller,
+)
 from .utils import (
     FALLBACK_XAI_LANGUAGE_MODELS,
     CLI_AUTH_SETUP_COMMAND,
@@ -43,22 +55,12 @@ from .utils import (
     credential_plane_contract,
     is_cloudrun_runtime,
     new_request_id,
-    normalize_caller,
-    normalize_principal,
-    reset_active_caller,
-    reset_active_principal,
     reset_request_id,
     redact_secrets,
     run_blocking,
     run_agent_turn,
-    set_active_caller,
-    set_active_principal,
     set_request_id,
     store,
-    telemetry_row_caller,
-    _ACTIVE_CLIENT_ID,
-    _ACTIVE_SESSION_ID,
-    scoped_session,
 )
 
 

--- a/src/identity.py
+++ b/src/identity.py
@@ -1,0 +1,143 @@
+"""Request identity, principal binding, and session namespace composition.
+
+This module owns the security-sensitive distinction between authenticated HTTP
+principals and caller-controlled client labels. It intentionally has no server,
+storage, or provider dependencies so transports and tools share one contract.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import hashlib
+import json
+import re
+from typing import Any, Dict, Optional
+from urllib.parse import quote
+
+
+_ACTIVE_CALLER: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "unigrok_active_caller", default=None
+)
+
+_ACTIVE_PRINCIPAL: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "unigrok_authenticated_principal", default=None
+)
+
+_ACTIVE_CLIENT_ID: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "unigrok_http_client_id", default=None
+)
+
+_ACTIVE_SESSION_ID: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
+    "unigrok_http_session_id", default=None
+)
+
+
+def scoped_session(session: Optional[str]) -> Optional[str]:
+    """Namespace a session by authenticated principal and client label.
+
+    HTTP middleware always binds a principal (OAuth subject, static-key alias,
+    or the loopback anonymous principal). ``X-Client-ID`` remains an untrusted
+    subordinate label that separates one principal's IDEs; it never provides
+    the security boundary by itself. Non-HTTP callers preserve the historical
+    unscoped behavior unless their transport binds one of these context vars.
+    """
+    principal = _ACTIVE_PRINCIPAL.get()
+    client_id = _ACTIVE_CLIENT_ID.get()
+    if not session:
+        session = _ACTIVE_SESSION_ID.get()
+    # Canonically encode independently owned segments before joining. Without
+    # this, principal ``oauth:a:b`` + client ``c`` could collide with
+    # principal ``oauth:a`` + client ``b:c``.
+    namespace = ":".join(
+        quote(part, safe="-._~") for part in (principal, client_id) if part
+    )
+    if namespace and session and not session.startswith(f"{namespace}:"):
+        return f"{namespace}:{session}"
+    return session
+
+
+def normalize_caller(value: Any) -> Optional[str]:
+    """Sanitize a caller label and bound it for database/metrics use."""
+    if value is None:
+        return None
+    text = re.sub(r"[\x00-\x1f\x7f]", "", str(value)).strip()
+    return text[:80] or None
+
+
+def normalize_principal(value: Any) -> Optional[str]:
+    """Normalize a principal without collision-prone prefix truncation."""
+    if value is None:
+        return None
+    text = re.sub(r"[\x00-\x1f\x7f]", "", str(value)).strip()
+    if not text:
+        return None
+    if len(text) <= 240:
+        return text
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:24]
+    return f"{text[:215]}~{digest}"
+
+
+def set_active_caller(caller: Optional[str]):
+    """Bind the request's reporting identity and return its reset token."""
+    return _ACTIVE_CALLER.set(normalize_caller(caller))
+
+
+def reset_active_caller(token) -> None:
+    with contextlib.suppress(Exception):
+        _ACTIVE_CALLER.reset(token)
+
+
+def get_active_caller() -> Optional[str]:
+    return _ACTIVE_CALLER.get()
+
+
+def set_active_principal(principal: Optional[str]):
+    """Bind the authenticated security principal for the current request."""
+    return _ACTIVE_PRINCIPAL.set(normalize_principal(principal))
+
+
+def reset_active_principal(token) -> None:
+    with contextlib.suppress(Exception):
+        _ACTIVE_PRINCIPAL.reset(token)
+
+
+def get_active_principal() -> Optional[str]:
+    return _ACTIVE_PRINCIPAL.get()
+
+
+def resolve_request_caller(caller: Optional[str]) -> Optional[str]:
+    """Resolve attribution without letting HTTP metadata replace principal.
+
+    FastMCP handlers often pass ``clientInfo.name`` explicitly. On HTTP that
+    value remains only a client label; the middleware's combined
+    ``principal|label`` attribution wins so budget accounting stays anchored
+    to the principal. Stdio has no HTTP principal and preserves explicit
+    caller behavior.
+    """
+    if get_active_principal():
+        return get_active_caller() or get_active_principal()
+    return normalize_caller(caller) or get_active_caller()
+
+
+def caller_from_mcp_context(ctx: Any) -> Optional[str]:
+    """Read the MCP ``clientInfo.name`` label from a FastMCP context."""
+    try:
+        params = getattr(getattr(ctx, "session", None), "client_params", None)
+        info = getattr(params, "clientInfo", None)
+        return normalize_caller(getattr(info, "name", None))
+    except Exception:
+        return None
+
+
+def telemetry_row_caller(row: Dict[str, Any]) -> Optional[str]:
+    """Return the normalized caller from a telemetry metadata envelope."""
+    meta = row.get("metadata")
+    if isinstance(meta, str):
+        try:
+            meta = json.loads(meta)
+        except Exception:
+            return None
+    if not isinstance(meta, dict):
+        return None
+    return normalize_caller(meta.get("caller"))

--- a/src/jobs.py
+++ b/src/jobs.py
@@ -16,6 +16,7 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
+from .identity import get_active_caller, normalize_caller
 from .utils import (
     AGENTIC_TOOLS_SCHEMA,
     _DISTILL_SYS_PROMPT,
@@ -25,9 +26,7 @@ from .utils import (
     _env_timeout,
     _parse_structured,
     check_circuit_breaker,
-    get_active_caller,
     get_xai_client,
-    normalize_caller,
     record_xai_success,
     redact_secrets,
     resolve_model,

--- a/src/tools/chats.py
+++ b/src/tools/chats.py
@@ -9,6 +9,7 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field
 from ..models.results import ChatResult, AgentResult, ReflectionResult
+from ..identity import caller_from_mcp_context, scoped_session
 
 from ..utils import (
     store,
@@ -16,7 +17,6 @@ from ..utils import (
     append_and_save_history,
     MetaLayer,
     GrokInvocationContext,
-    caller_from_mcp_context,
     get_dynamic_context,
     get_xai_client,
     encode_image_to_base64,
@@ -25,7 +25,6 @@ from ..utils import (
     _parse_structured,
     run_agent_turn,
     run_blocking,
-    scoped_session,
     input_limit,
     validate_local_input,
     DEFAULT_PLANNING_MODEL,

--- a/src/tools/knowledge.py
+++ b/src/tools/knowledge.py
@@ -12,10 +12,10 @@ from typing import Any, Dict, Optional
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
 
+from ..identity import caller_from_mcp_context
 from ..jobs import get_job_manager
 from ..utils import (
     _normalize_fact_scope,
-    caller_from_mcp_context,
     search_knowledge_collection,
     store,
     sync_fact_to_collection,

--- a/src/tools/research.py
+++ b/src/tools/research.py
@@ -7,8 +7,8 @@ from typing import Any, Dict, Optional
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
 
+from ..identity import caller_from_mcp_context
 from ..jobs import get_job_manager
-from ..utils import caller_from_mcp_context
 
 logger = logging.getLogger("GrokMCP")
 

--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -39,12 +39,13 @@ from ..utils import (
     get_routing_advisor,
     grok_cli_plane_status,
     credential_plane_contract,
-    scoped_session,
     input_limit,
     validate_local_input,
 )
 from xai_sdk.chat import user
 from xai_sdk.tools import code_execution, web_search as xai_web_search, x_search as xai_x_search
+
+from ..identity import scoped_session
 
 logger = logging.getLogger("GrokMCP")
 

--- a/src/tools/workspace_memory.py
+++ b/src/tools/workspace_memory.py
@@ -7,7 +7,8 @@ from typing import Any, Dict, List, Optional
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
 
-from ..utils import caller_from_mcp_context, register_internal_tool, store
+from ..identity import caller_from_mcp_context
+from ..utils import register_internal_tool, store
 from ..workspace_memory import (
     WorkspaceMemoryError,
     explain_workspace_evidence as _explain,

--- a/src/utils.py
+++ b/src/utils.py
@@ -11,7 +11,6 @@ import re
 import uuid
 import subprocess
 import tempfile
-from urllib.parse import quote
 from dataclasses import asdict, dataclass, field, replace
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
@@ -38,6 +37,24 @@ from .credentials import (
     CLI_AUTH_SETUP_COMMAND,
     build_credential_plane_contract,
     credential_plane_policy,
+)
+from .identity import (
+    _ACTIVE_CALLER,
+    _ACTIVE_CLIENT_ID,
+    _ACTIVE_PRINCIPAL,
+    _ACTIVE_SESSION_ID,
+    caller_from_mcp_context,
+    get_active_caller,
+    get_active_principal,
+    normalize_caller,
+    normalize_principal,
+    reset_active_caller,
+    reset_active_principal,
+    resolve_request_caller,
+    scoped_session,
+    set_active_caller,
+    set_active_principal,
+    telemetry_row_caller,
 )
 
 # Path Resolver for zero-config portability
@@ -502,159 +519,6 @@ async def communicate_with_timeout(
         with contextlib.suppress(Exception):
             await proc.wait()
         raise
-
-# ─── Caller identity (multi-agent workspace) ─────────────────────────────────
-# This MCP is shared by several coding agents (Claude/Codex/Gemini — see
-# .agents/AGENTS.md). The caller identity is a short free-text name derived
-# from the MCP clientInfo sent at initialize (stdio) or from the gateway's
-# X-Caller header / auth-key alias (HTTP). It is attributed to telemetry
-# rows, session message metadata, and research-job rows, and drives the
-# optional per-caller daily budgets. Everything degrades to caller=None.
-
-_ACTIVE_CALLER: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
-    "unigrok_active_caller", default=None
-)
-
-_ACTIVE_PRINCIPAL: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
-    "unigrok_authenticated_principal", default=None
-)
-
-_ACTIVE_CLIENT_ID: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
-    "unigrok_http_client_id", default=None
-)
-
-_ACTIVE_SESSION_ID: contextvars.ContextVar[Optional[str]] = contextvars.ContextVar(
-    "unigrok_http_session_id", default=None
-)
-
-
-def scoped_session(session: Optional[str]) -> Optional[str]:
-    """Namespace a session by authenticated principal and client label.
-
-    HTTP middleware always binds a principal (OAuth subject, static-key alias,
-    or the loopback anonymous principal). ``X-Client-ID`` remains an untrusted
-    subordinate label that separates one principal's IDEs; it never provides
-    the security boundary by itself. Non-HTTP callers preserve the historical
-    unscoped behavior unless their transport binds one of these context vars.
-    """
-    principal = _ACTIVE_PRINCIPAL.get()
-    client_id = _ACTIVE_CLIENT_ID.get()
-    if not session:
-        session = _ACTIVE_SESSION_ID.get()
-    # Canonically encode independently owned segments before joining. Without
-    # this, principal ``oauth:a:b`` + client ``c`` could collide with
-    # principal ``oauth:a`` + client ``b:c``.
-    namespace = ":".join(
-        quote(part, safe="-._~") for part in (principal, client_id) if part
-    )
-    if namespace and session and not session.startswith(f"{namespace}:"):
-        return f"{namespace}:{session}"
-    return session
-
-
-def normalize_caller(value: Any) -> Optional[str]:
-    """Sanitize a caller identity: strip control characters, trim, and bound
-    to 80 chars (it lands in db rows and metrics keys). None/blank -> None."""
-    if value is None:
-        return None
-    text = re.sub(r"[\x00-\x1f\x7f]", "", str(value)).strip()
-    return text[:80] or None
-
-
-def normalize_principal(value: Any) -> Optional[str]:
-    """Normalize an authenticated principal without collision-prone truncation.
-
-    Provider subjects can exceed the short telemetry-label bound. Preserve
-    ordinary subjects verbatim, but suffix oversized values with a digest so
-    two subjects sharing a long prefix cannot collapse into one namespace.
-    """
-    if value is None:
-        return None
-    text = re.sub(r"[\x00-\x1f\x7f]", "", str(value)).strip()
-    if not text:
-        return None
-    if len(text) <= 240:
-        return text
-    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:24]
-    return f"{text[:215]}~{digest}"
-
-
-def set_active_caller(caller: Optional[str]):
-    """Bind the caller identity to the current async context (the HTTP
-    gateway middleware does this per request). Returns the reset token."""
-    return _ACTIVE_CALLER.set(normalize_caller(caller))
-
-
-def reset_active_caller(token) -> None:
-    with contextlib.suppress(Exception):
-        _ACTIVE_CALLER.reset(token)
-
-
-def get_active_caller() -> Optional[str]:
-    return _ACTIVE_CALLER.get()
-
-
-def set_active_principal(principal: Optional[str]):
-    """Bind the authenticated security principal for the current request."""
-    return _ACTIVE_PRINCIPAL.set(normalize_principal(principal))
-
-
-def reset_active_principal(token) -> None:
-    with contextlib.suppress(Exception):
-        _ACTIVE_PRINCIPAL.reset(token)
-
-
-def get_active_principal() -> Optional[str]:
-    return _ACTIVE_PRINCIPAL.get()
-
-
-def resolve_request_caller(caller: Optional[str]) -> Optional[str]:
-    """Resolve attribution without letting HTTP tool metadata replace the
-    gateway-bound identity.
-
-    FastMCP handlers often pass ``clientInfo.name`` explicitly. On HTTP that
-    value remains only a client label; the middleware's combined
-    ``principal|label`` attribution wins so budget accounting stays anchored
-    to the principal. Stdio has no HTTP principal and preserves explicit
-    caller behavior.
-    """
-    if get_active_principal():
-        return get_active_caller() or get_active_principal()
-    return normalize_caller(caller) or get_active_caller()
-
-
-def caller_from_mcp_context(ctx: Any) -> Optional[str]:
-    """Caller identity from an injected FastMCP Context.
-
-    Introspected against the installed mcp 1.26: ctx.session (the
-    ServerSession) exposes client_params — the InitializeRequestParams the
-    client sent — whose clientInfo (mcp.types.Implementation) carries
-    name/version. Degrades to None for clients that never completed
-    initialize, contexts used outside a request (both raise), or SDK layouts
-    without client_params.
-    """
-    try:
-        params = getattr(getattr(ctx, "session", None), "client_params", None)
-        info = getattr(params, "clientInfo", None)
-        return normalize_caller(getattr(info, "name", None))
-    except Exception:
-        return None
-
-
-def telemetry_row_caller(row: Dict[str, Any]) -> Optional[str]:
-    """Caller name from a telemetry row's metadata column (raw JSON text from
-    the db, or an already-parsed dict from mocks). None for pre-v8 rows,
-    unattributed traffic, and malformed metadata."""
-    meta = row.get("metadata")
-    if isinstance(meta, str):
-        try:
-            meta = json.loads(meta)
-        except Exception:
-            return None
-    if not isinstance(meta, dict):
-        return None
-    return normalize_caller(meta.get("caller"))
-
 
 class CallerBudgetExceeded(RuntimeError):
     """A caller's UNIGROK_CALLER_BUDGETS daily spend is at/over its limit.

--- a/src/workspace_memory.py
+++ b/src/workspace_memory.py
@@ -21,11 +21,11 @@ from datetime import datetime
 from pathlib import Path, PurePosixPath
 from typing import Any, Dict, List, Optional, TextIO
 
+from .identity import get_active_caller
 from .utils import (
     PathResolver,
     _bounded_redacted,
     _task_terms,
-    get_active_caller,
     get_unigrok_runtime,
     run_blocking,
 )

--- a/tests/test_multiagent.py
+++ b/tests/test_multiagent.py
@@ -18,23 +18,25 @@ from src.http_server import (
     create_app,
 )
 from src.jobs import JobManager
-from src.utils import (
-    CallerBudgetExceeded,
-    GrokSessionStore,
-    MetaLayer,
+from src.identity import (
     caller_from_mcp_context,
-    enforce_caller_budget,
     get_active_caller,
     get_active_principal,
     normalize_caller,
     normalize_principal,
-    orchestrate,
     reset_active_caller,
     reset_active_principal,
-    run_agent_turn,
     set_active_caller,
     set_active_principal,
     telemetry_row_caller,
+)
+from src.utils import (
+    CallerBudgetExceeded,
+    GrokSessionStore,
+    MetaLayer,
+    enforce_caller_budget,
+    orchestrate,
+    run_agent_turn,
 )
 
 
@@ -100,6 +102,15 @@ class TestCallerFromContext:
 
 
 class TestActiveCallerContext:
+    def test_utils_compatibility_exports_share_identity_contextvars(self):
+        import src.identity as identity_module
+        import src.utils as utils_module
+
+        assert utils_module._ACTIVE_CALLER is identity_module._ACTIVE_CALLER
+        assert utils_module._ACTIVE_PRINCIPAL is identity_module._ACTIVE_PRINCIPAL
+        assert utils_module._ACTIVE_CLIENT_ID is identity_module._ACTIVE_CLIENT_ID
+        assert utils_module._ACTIVE_SESSION_ID is identity_module._ACTIVE_SESSION_ID
+
     def test_set_get_reset_roundtrip(self):
         token = set_active_caller("claude-code")
         try:


### PR DESCRIPTION
## Summary

- extract request identity, authenticated-principal context, session namespace composition, and telemetry caller parsing into dependency-light `src/identity.py`
- migrate HTTP, jobs, workspace-memory, and MCP tool call sites to the bounded identity module
- preserve `src.utils` compatibility exports so existing downstream imports continue to resolve to the exact same context-variable objects
- regenerate the OKF API reference under the new module ownership

## Why

The principal/session security contract landed in PR #48, but its implementation still lived inside the 8,900-line `utils.py`. This behavior-preserving extraction establishes a reviewable security boundary before broader modularization and prevents provider/storage concerns from owning request identity state.

## Exact handoff

- Commit: `18b43c420832dc9b5b8960846a120a4597622287`
- Changed paths: `src/identity.py`, compatibility imports in `src/utils.py`, direct production import sites, identity regression tests, generated OKF API references
- Human sponsor: `djtelicloud`
- Risk: import/re-export wiring and accidental duplicate ContextVar instances; regression tests assert all four `src.utils` compatibility exports are object-identical to `src.identity`
- Grok review: PASS; no actionable import-cycle, singleton-state, or compatibility regressions found

## Verification

- `uv run pytest -q` — 1,162 passed
- focused identity/multi-agent suite — 69 passed after the compatibility identity assertion was added
- `uv run python scripts/generate_okf.py --check`
- Ruff passes for the new identity module and changed clean modules; pre-existing unrelated file-level findings remain excluded
- `git diff --check`

Agent-Assisted-By: Codex (GPT-5)
