### PR TITLE
fix(ui): unified, auto-resizing Control Center that never discards answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,43 @@ All notable changes to UniGrok MCP will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Control Center answers survive stale browser caches**: `/ui` and `/docs`
+  responses now carry `Cache-Control: no-cache` (Starlette's `StaticFiles`
+  sends only ETag/Last-Modified, so browsers heuristically cached
+  `index.html` and paired it with a newer `app.js`), every receipt-pane DOM
+  write is null-safe via a shared `setText` helper, and the receipt pane
+  renders inside its own try/catch so a diagnostics failure can never turn an
+  already-received agent answer into "Invocation failed". A version
+  handshake (`<meta name="unigrok-ui-version">` vs the `app.js` build
+  constant, mirrored as `ui_asset_version` in `/runtimez`) self-heals a
+  skewed page with one revalidating reload and otherwise shows a hard-refresh
+  banner. The cache-bust token is single-sourced in `src/version.py` and a
+  pytest asserts every copy agrees.
+
 ### Added
+- **One product across surfaces**: shared design tokens (`mcp_ui/tokens.css`)
+  now drive both the Control Center and the Swarm Optimizer (which previously
+  carried its own divergent palette), both local pages cross-link each other
+  and grokmcp.org, the public-site sync copies the tokens with the swarm
+  bundle, and the hosted `/control` shows signed-out visitors a
+  plain-language explainer with one GitHub sign-in action instead of a naked
+  redirect to github.com.
+- **Fluid, container-driven layout**: the Control Center's content grids
+  reflow on the workbench container's own width instead of viewport media
+  queries (a narrow workbench beside a wide inspector now stacks correctly),
+  fixed pixel heights on the transcript/OKF preview/receipt JSON became
+  viewport-relative clamps, the schema and OKF sidebars are natively
+  resizable with min/max clamps, panel bounds are authored once as CSS custom
+  properties that the JS layout controller reads, and the swarm page's fixed
+  1280px cap and 340px detail column became fluid tracks. Verified
+  in-browser at 1280px, 500px, and 375x812.
+- **Chat-first playground with one-action onboarding**: the transcript sits
+  directly under the composer and presets, run options and the setup check
+  moved below it, "Usage & Telemetry"/"OKF Browser" were renamed to the human
+  "Usage & Costs"/"Knowledge (OKF)", and a not-ready gateway now shows a
+  copyable four-line quick-start card on Setup & Status instead of a dead
+  end.
 - **Control Center markdown rendering**: agent answers in the Playground
   transcript now render as formatted markdown instead of raw markup text.
   A new shared escape-first renderer (`mcp_ui/markdown.js`) replaces the old

--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -203,6 +203,24 @@ class CSPMiddleware
 ASGI middleware that injects a strict Content-Security-Policy (CSP) header
 into all HTTP responses.
 
+### Class: `StaticAssetCacheMiddleware` {#http_server-staticassetcachemiddleware}
+
+```python
+class StaticAssetCacheMiddleware
+```
+
+**Keywords:** static, asset, cache, middleware
+
+ASGI middleware that stamps ``Cache-Control: no-cache`` on /ui and /docs
+responses.
+
+Starlette's ``StaticFiles`` emits ETag/Last-Modified but no Cache-Control,
+so browsers apply heuristic freshness and can pair a stale cached
+``index.html`` with freshly fetched ``app.js`` — the skew that made the
+Control Center discard rendered agent answers. ``no-cache`` keeps caching
+(conditional requests answer 304 via the existing ETags) but forces
+revalidation, so HTML and JS always come from the same release.
+
 ### Function: `unigrok_public_discovery` {#http_server-unigrok_public_discovery}
 
 ```python

--- a/docs/okf/faq.md
+++ b/docs/okf/faq.md
@@ -201,7 +201,7 @@ and plane. MCP `agent` responses also carry structured execution metadata.
 These values describe the gateway request that produced the response. A
 zero-cost local FAQ lookup is documentation retrieval, not a model invocation.
 
-The Usage & Telemetry tab does not combine API-key billing with SuperGrok CLI
+The Usage & Costs tab does not combine API-key billing with SuperGrok CLI
 activity. API spend is exact per response. CLI activity is tracked locally,
 but xAI exposes no SuperGrok quota/spend API, so subscription cost is shown as
 unknown/included rather than a misleading `$0`. Optional Management API

--- a/mcp_ui/app.js
+++ b/mcp_ui/app.js
@@ -1,13 +1,28 @@
-import { parseMarkdown, sanitizeHref } from "./markdown.js?v=grok-v0.6.0-r2";
+import { parseMarkdown, sanitizeHref } from "./markdown.js?v=grok-v0.6.0-r3";
+
+// Must match the <meta name="unigrok-ui-version"> baked into index.html and
+// src/version.py UI_ASSET_VERSION; a mismatch means the browser paired a
+// cached page with a different script build (the stale-skew failure class).
+const UI_ASSET_VERSION = "grok-v0.6.0-r3";
 
 const LAYOUT_KEY = "unigrok.mcp.console.layout.v2";
+
+// Panel bounds are authored once in styles.css (:root --nav-min/max,
+// --inspector-min/max); the JS fallbacks only cover a stylesheet that failed
+// to load, where layout precision no longer matters.
+function cssPx(name, fallback) {
+  const raw = getComputedStyle(document.documentElement).getPropertyValue(name);
+  const value = Number.parseFloat(raw);
+  return Number.isFinite(value) ? value : fallback;
+}
+
 const LAYOUT_LIMITS = {
-  nav: [148, 340],
-  inspector: [210, 460],
-  workbench: 300,
+  nav: [cssPx("--nav-min", 148), cssPx("--nav-max", 340)],
+  inspector: [cssPx("--inspector-min", 210), cssPx("--inspector-max", 460)],
+  workbench: cssPx("--workbench-min", 300),
   workbenchComfort: 360,
-  rail: 44,
-  splitter: 4,
+  rail: cssPx("--rail-width", 44),
+  splitter: cssPx("--splitter-width", 4),
 };
 
 const defaultLayout = {
@@ -228,6 +243,15 @@ const state = {
 // --- DOM Selector Helper ---
 const $ = (id) => document.getElementById(id);
 
+// Null-safe text writer. A stale-cached page can lack elements this build
+// writes to; a missing diagnostics row must never throw inside the response
+// path and discard a paid agent answer.
+function setText(id, value) {
+  const el = $(id);
+  if (el) el.innerText = value;
+  return el;
+}
+
 // --- CSS Tooltip/Copy Helper ---
 function copyTextToClipboard(text, btnElement) {
   navigator.clipboard.writeText(text).then(() => {
@@ -409,12 +433,8 @@ function setupSchemaExplorer() {
 
 function renderActiveSchema() {
   const schema = enforcedSchemas[state.activeSchema];
-  $("schemaNameTitle").innerText = `${state.activeSchema}.json`;
-  if (schema) {
-    $("schemaCodeBlock").innerText = JSON.stringify(schema, null, 2);
-  } else {
-    $("schemaCodeBlock").innerText = "Schema not found.";
-  }
+  setText("schemaNameTitle", `${state.activeSchema}.json`);
+  setText("schemaCodeBlock", schema ? JSON.stringify(schema, null, 2) : "Schema not found.");
 }
 
 // --- Reasoning Guard Simulator ---
@@ -600,8 +620,8 @@ function checkWebMcpBridge() {
 
 // --- Telemetry & Metrics Dashboard ---
 async function fetchLiveMetrics() {
-  $("rawMetricsReport").innerText = "Polling structured MCP metrics...";
-  $("metricsStatus").innerText = "Refreshing local usage ledger…";
+  setText("rawMetricsReport", "Polling structured MCP metrics...");
+  setText("metricsStatus", "Refreshing local usage ledger…");
   try {
     const res = await fetchMcpCall("grok_mcp_status", { view: "json" });
     const payload = extractToolPayload(res);
@@ -611,8 +631,8 @@ async function fetchLiveMetrics() {
     state.metricsSnapshot = payload;
     renderMetricsSnapshot();
   } catch (err) {
-    $("rawMetricsReport").innerText = `Failed to fetch telemetry report: ${err.message}`;
-    $("metricsStatus").innerText = "Metrics unavailable — the MCP status call failed.";
+    setText("rawMetricsReport", `Failed to fetch telemetry report: ${err.message}`);
+    setText("metricsStatus", "Metrics unavailable — the MCP status call failed.");
   }
 }
 
@@ -881,6 +901,12 @@ async function runStartupCheck() {
 }
 
 function renderSetupStatus(data, ready = true, detailText = null) {
+  // The quick-start card is the onboarding action for a machine where the
+  // gateway is NOT REACHABLE. A reachable gateway failing a readiness check
+  // (detailText names it) is already installed and running — reinstall
+  // instructions would be the wrong remedy, so the card stays hidden and the
+  // named failing checks plus the credential alert carry the fix.
+  $("quickStartCard")?.classList.toggle("hidden", Boolean(ready) || Boolean(detailText));
   const target = $("setupStatusSummary");
   if (!target) return;
   const contract = data?.credential_planes || {};
@@ -962,7 +988,7 @@ async function fetchMcpListTools() {
     const headers = {
       "Content-Type": "application/json",
       "Accept": "application/json, text/event-stream",
-      "X-Client-ID": $("clientIdInput").value || "mcp-ui-client",
+      "X-Client-ID": $("clientIdInput")?.value || "mcp-ui-client",
     };
     if (state.clientToken) {
       headers["Authorization"] = `Bearer ${state.clientToken}`;
@@ -1048,6 +1074,7 @@ function updatePlaneControls() {
   const plane = $("planeInput")?.value || "auto";
   const hint = $("planeHint");
   const fallback = $("fallbackPolicyInput");
+  if (!hint || !fallback) return;
   if (plane === "cli") {
     hint.innerText = "Subscription only · no developer API billing";
     hint.classList.remove("metered");
@@ -1212,6 +1239,7 @@ async function loadPlaneModelCatalog() {
 
 function setStatus(kind, label) {
   const pill = $("connectionState");
+  if (!pill) return;
   pill.className = `status-pill status-${kind}`;
   pill.innerText = label;
 }
@@ -1339,15 +1367,15 @@ async function fetchMcpCall(toolName, args) {
     const endpoint = "/mcp";
     const headers = {
       "Content-Type": "application/json",
-      "X-Client-ID": $("clientIdInput").value || "mcp-ui-client",
-      "X-Session-ID": $("sessionInput").value || "mcp-ui-session",
+      "X-Client-ID": $("clientIdInput")?.value || "mcp-ui-client",
+      "X-Session-ID": $("sessionInput")?.value || "mcp-ui-session",
     };
 
     if (state.clientToken) {
       headers["Authorization"] = `Bearer ${state.clientToken}`;
     }
 
-    const caller = $("callerInput").value.trim();
+    const caller = $("callerInput")?.value.trim() || "";
     if (caller) {
       headers["X-Caller"] = caller;
     }
@@ -1374,7 +1402,7 @@ async function fetchMcpCall(toolName, args) {
     }
 
     const elapsed = Date.now() - start;
-    $("lastLatency").innerText = `${elapsed} ms`;
+    setText("lastLatency", `${elapsed} ms`);
 
     if (res.status === 401 || res.status === 429) {
       const wizard = $("apiKeyWizard");
@@ -1401,9 +1429,15 @@ async function fetchMcpCall(toolName, args) {
 
     // The facts pane holds the agent routing receipt; background tool calls
     // (status, discovery, models, metrics) carry no such receipt and must not
-    // clobber it, so only the agent call updates the pane.
+    // clobber it, so only the agent call updates the pane. The pane is
+    // diagnostics: if rendering it throws, the answer must still be returned
+    // and displayed — never re-throw from here.
     if (toolName === "agent") {
-      renderFactsPane(toolName, responsePayload, elapsed);
+      try {
+        renderFactsPane(toolName, responsePayload, elapsed);
+      } catch (paneError) {
+        console.error("Receipt pane render failed:", paneError);
+      }
     }
 
     return responsePayload;
@@ -1434,43 +1468,47 @@ function extractToolPayload(jsonRpcResponse) {
 }
 
 function renderFactsPane(method, response, elapsed) {
-  $("factMethod").innerText = method;
-  $("factLatency").innerText = `${elapsed}ms`;
+  setText("factMethod", method);
+  setText("factLatency", `${elapsed}ms`);
 
   if (response.error) {
-    $("factStatus").innerText = "ERROR";
-    $("factStatus").style.color = "var(--red)";
+    const status = setText("factStatus", "ERROR");
+    if (status) status.style.color = "var(--red)";
     return;
   }
 
   // A FastMCP tool exception arrives as result.isError with the message in
   // content[0].text — that is a failed run, never a SUCCESS receipt.
   if (response.result?.isError) {
-    $("factStatus").innerText = "TOOL ERROR";
-    $("factStatus").style.color = "var(--red)";
+    const status = setText("factStatus", "TOOL ERROR");
+    if (status) status.style.color = "var(--red)";
   } else {
-    $("factStatus").innerText = "SUCCESS";
-    $("factStatus").style.color = "var(--teal)";
+    const status = setText("factStatus", "SUCCESS");
+    if (status) status.style.color = "var(--teal)";
   }
 
   const payload = extractToolPayload(response);
-  $("factTokens").innerText = payload.tokens || "-";
-  $("factCost").innerText = payload.cost_usd ? `$${payload.cost_usd.toFixed(5)}` : "-";
-  $("factRoute").innerText = payload.route || "-";
-  $("factPlane").innerText = payload.plane || "-";
-  $("factBilling").innerText = payload.billing_class || payload.routing?.billing_class || "-";
-  $("factRequestedPlane").innerText = payload.requested_plane || payload.routing?.requested_plane || "-";
-  $("factModel").innerText = payload.model || "-";
-  $("factSelection").innerText = routingLabel(payload.routing?.why_detail || payload.why || "-");
+  setText("factTokens", payload.tokens || "-");
+  // The wire may deliver cost as a number or a serialized string; only a
+  // finite value renders as currency.
+  const rawCost = payload.cost_usd;
+  const cost = typeof rawCost === "string" && rawCost.trim() !== "" ? Number(rawCost) : rawCost;
+  setText("factCost", typeof cost === "number" && Number.isFinite(cost) && cost !== 0 ? `$${cost.toFixed(5)}` : "-");
+  setText("factRoute", payload.route || "-");
+  setText("factPlane", payload.plane || "-");
+  setText("factBilling", payload.billing_class || payload.routing?.billing_class || "-");
+  setText("factRequestedPlane", payload.requested_plane || payload.routing?.requested_plane || "-");
+  setText("factModel", payload.model || "-");
+  setText("factSelection", routingLabel(payload.routing?.why_detail || payload.why || "-"));
   const finishReason = payload.finish_reason || "-";
-  $("factFinishReason").innerText = finishReason;
-  $("factFinishReason").style.color = finishReason !== "-" && finishReason !== "final_answer" ? "var(--red)" : "";
-  $("factDegraded").innerText = payload.degraded === undefined ? "-" : String(payload.degraded);
-  $("factDegraded").style.color = payload.degraded === true ? "var(--red)" : "";
+  const finishEl = setText("factFinishReason", finishReason);
+  if (finishEl) finishEl.style.color = finishReason !== "-" && finishReason !== "final_answer" ? "var(--red)" : "";
+  const degradedEl = setText("factDegraded", payload.degraded === undefined ? "-" : String(payload.degraded));
+  if (degradedEl) degradedEl.style.color = payload.degraded === true ? "var(--red)" : "";
   // Mode provenance: confirms a phoneword port dial actually changed the mode.
-  $("factRequestedMode").innerText = payload.requested_mode || "-";
-  $("factModeSource").innerText = payload.mode_source || "-";
-  $("factDialedPort").innerText = payload.dialed_port || "-";
+  setText("factRequestedMode", payload.requested_mode || "-");
+  setText("factModeSource", payload.mode_source || "-");
+  setText("factDialedPort", payload.dialed_port || "-");
 }
 
 async function callAgent(prompt) {
@@ -1524,6 +1562,7 @@ async function callAgent(prompt) {
 function renderCitations(citations) {
   if (!Array.isArray(citations) || citations.length === 0) return;
   const container = $("conversation");
+  if (!container) return;
   const footer = document.createElement("div");
   footer.className = "message-bubble msg-citations";
   const heading = document.createElement("strong");
@@ -1554,6 +1593,11 @@ function renderCitations(citations) {
 
 function addMessageBubble(sender, text) {
   const container = $("conversation");
+  if (!container) {
+    // Last resort on a broken page: never silently drop a message.
+    console.error(`Transcript container missing; ${sender} message:`, text);
+    return;
+  }
   const bubble = document.createElement("div");
   bubble.className = `message-bubble msg-${sender}`;
   if (sender === "agent") {
@@ -1581,7 +1625,8 @@ function genSessionId() {
 }
 
 function resetConversation() {
-  $("conversation").innerHTML = "";
+  const conversation = $("conversation");
+  if (conversation) conversation.innerHTML = "";
   const sessionInput = $("sessionInput");
   if (sessionInput && !sessionInput.value.trim()) sessionInput.value = genSessionId();
   addMessageBubble("system", "Session started. Ready to execute prompts.");
@@ -1593,7 +1638,8 @@ function clearConversation() {
   const sessionInput = $("sessionInput");
   const previous = sessionInput?.value.trim();
   if (sessionInput) sessionInput.value = genSessionId();
-  $("conversation").innerHTML = "";
+  const conversation = $("conversation");
+  if (conversation) conversation.innerHTML = "";
   addMessageBubble(
     "system",
     previous
@@ -1855,6 +1901,32 @@ function isFilePreview() {
   return window.location.protocol === "file:";
 }
 
+// Detects the stale-cache skew that once discarded rendered answers: the page
+// HTML and this script came from different releases. One reload revalidates
+// the document (reloads bypass heuristic freshness for the main resource);
+// the per-pair flag stops a loop if the server itself keeps serving the skew.
+function enforceUiVersionHandshake() {
+  const htmlVersion = document.querySelector('meta[name="unigrok-ui-version"]')?.content || "missing";
+  if (htmlVersion === UI_ASSET_VERSION) return false;
+  const flag = `unigrok.ui.reloaded.${htmlVersion}->${UI_ASSET_VERSION}`;
+  try {
+    if (!sessionStorage.getItem(flag)) {
+      sessionStorage.setItem(flag, "1");
+      window.location.reload();
+      return true;
+    }
+  } catch (_) {
+    // Storage blocked: fall through to the visible banner.
+  }
+  const message = $("offlineAlertMessage");
+  const banner = $("dockerOfflineAlert");
+  if (message && banner) {
+    message.textContent = "⚠️ This page is out of date (browser cache). Hard refresh — Cmd/Ctrl+Shift+R — to load the current Control Center.";
+    banner.classList.remove("hidden");
+  }
+  return true;
+}
+
 function renderFilePreviewNotice() {
   const alertBanner = $("dockerOfflineAlert");
   const message = $("offlineAlertMessage");
@@ -2054,6 +2126,9 @@ function init() {
     window.location.replace(LIVE_UI_URL);
     return;
   }
+  // A version-skewed page is about to reload (or has been told to hard
+  // refresh); wiring the rest of the UI against mismatched DOM is pointless.
+  if (enforceUiVersionHandshake()) return;
   document.querySelectorAll(".tab-panel").forEach((panel) => {
     panel.setAttribute("role", "tabpanel");
     panel.setAttribute("data-region", panel.dataset.region || panel.id);
@@ -2078,8 +2153,11 @@ function init() {
 
   $("refreshModelsBtn").addEventListener("click", loadPlaneModelCatalog);
 
-  // Onboarding action
+  // Onboarding actions
   $("copyDiscoverBtn").addEventListener("click", runDiscoverSelfOnboarding);
+  $("copyQuickStartBtn")?.addEventListener("click", function () {
+    copyTextToClipboard($("quickStartCommands")?.innerText || "", this);
+  });
   $("setupRecheckBtn")?.addEventListener("click", async () => {
     const ready = await runStartupCheck();
     const runtime = await fetchRuntimeStatus();

--- a/mcp_ui/index.html
+++ b/mcp_ui/index.html
@@ -5,7 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>UniGrok MCP v0.6.0 Control Center</title>
     <meta name="unigrok-ui-regions" content="navigation,workbench,rpc-inspector,rpc-logs,result-facts" />
-  <link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r2" />
+    <!-- Version handshake: app.js compares this against its own build constant
+         and self-heals a stale-cached page with one revalidating reload. -->
+    <meta name="unigrok-ui-version" content="grok-v0.6.0-r3" />
+  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r3" />
+  <link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r3" />
   </head>
   <body>
     <main class="app-shell">
@@ -70,8 +74,8 @@
           <button id="tab-btn-models" type="button" class="nav-btn" data-tab="tab-models" role="tab" aria-selected="false" aria-controls="tab-models" tabindex="-1" title="Models &amp; Planes">
             <span class="btn-icon" aria-hidden="true">◫</span><span class="btn-label">Models &amp; Planes</span>
           </button>
-          <button id="tab-btn-metrics" type="button" class="nav-btn" data-tab="tab-metrics" role="tab" aria-selected="false" aria-controls="tab-metrics" tabindex="-1" title="Usage &amp; Telemetry">
-            <span class="btn-icon" aria-hidden="true">📊</span><span class="btn-label">Usage &amp; Telemetry</span>
+          <button id="tab-btn-metrics" type="button" class="nav-btn" data-tab="tab-metrics" role="tab" aria-selected="false" aria-controls="tab-metrics" tabindex="-1" title="Usage &amp; Costs">
+            <span class="btn-icon" aria-hidden="true">📊</span><span class="btn-label">Usage &amp; Costs</span>
           </button>
           <div class="nav-title nav-title-group">Contributor</div>
           <!-- A real page link, deliberately NOT a .nav-btn: the tab router
@@ -79,6 +83,10 @@
                hijacks tab switching or navigates during keyboard cycling. -->
           <a id="nav-link-swarm" class="nav-link" href="./swarm.html" title="Swarm Optimizer — Pareto Playground">
             <span class="btn-icon" aria-hidden="true">🐝</span><span class="btn-label">Swarm Optimizer</span>
+          </a>
+          <div class="nav-title nav-title-group">Project</div>
+          <a id="nav-link-site" class="nav-link" href="https://grokmcp.org" target="_blank" rel="noopener noreferrer" title="UniGrok project site — docs, onboarding, contributor control">
+            <span class="btn-icon" aria-hidden="true">🌍</span><span class="btn-label">grokmcp.org ↗</span>
           </a>
           <details id="advancedNav" class="nav-advanced">
           <summary class="nav-title nav-title-group">Advanced</summary>
@@ -89,8 +97,8 @@
           <button id="tab-btn-guard" type="button" class="nav-btn" data-tab="tab-guard" role="tab" aria-selected="false" aria-controls="tab-guard" tabindex="-1" title="Reasoning Guard">
             <span class="btn-icon" aria-hidden="true">🛡️</span><span class="btn-label">Reasoning Guard</span>
           </button>
-          <button id="tab-btn-okf" type="button" class="nav-btn" data-tab="tab-okf" role="tab" aria-selected="false" aria-controls="tab-okf" tabindex="-1" title="OKF Browser">
-            <span class="btn-icon" aria-hidden="true">📚</span><span class="btn-label">OKF Browser</span>
+          <button id="tab-btn-okf" type="button" class="nav-btn" data-tab="tab-okf" role="tab" aria-selected="false" aria-controls="tab-okf" tabindex="-1" title="Knowledge (OKF)">
+            <span class="btn-icon" aria-hidden="true">📚</span><span class="btn-label">Knowledge (OKF)</span>
           </button>
           <button id="tab-btn-webmcp" type="button" class="nav-btn" data-tab="tab-webmcp" role="tab" aria-selected="false" aria-controls="tab-webmcp" tabindex="-1" title="WebMCP Tester">
             <span class="btn-icon" aria-hidden="true">🌐</span><span class="btn-label">WebMCP Tester</span>
@@ -138,21 +146,19 @@
               </div>
             </div>
 
-            <section class="playground-launcher" aria-label="Quick start actions">
-              <div>
-                <span class="model-kicker">No prompt needed</span>
-                <strong>Is UniGrok ready?</strong>
-                <p>Checks credentials, planes, routing policy, and local telemetry without spending an inference turn.</p>
-              </div>
-              <button id="verifySetupBtn" type="button" class="primary-btn-glow">Verify Setup</button>
-            </section>
-
             <div class="task-presets" aria-label="Task presets">
               <button id="runSampleBtn" type="button" class="preset-btn" data-prompt="Reply with exactly: UniGrok agent is ready.">Run zero-config sample</button>
               <button type="button" class="preset-btn prompt-preset" data-prompt="Explain which credential plane and model you would use for a coding task, and why.">Explain routing</button>
               <button type="button" class="preset-btn prompt-preset" data-prompt="Review this code or error and give me the three most useful next steps:\n\n">Review code or error</button>
             </div>
-            
+
+            <!-- Scrollable Conversation Log — kept adjacent to the composer so
+                 the chat loop (type, run, read) never crosses secondary UI. -->
+            <div class="conversation-wrapper">
+              <div class="section-title">Playground session</div>
+              <div id="conversation" class="transcript" role="log" aria-live="polite" aria-label="Playground conversation"></div>
+            </div>
+
             <details class="run-options">
               <summary>Run options · SuperGrok subscription · Auto</summary>
               <div class="form-layout">
@@ -218,11 +224,14 @@
             </div>
             </details>
 
-            <!-- Scrollable Conversation Log -->
-            <div class="conversation-wrapper">
-              <div class="section-title">Playground session</div>
-              <div id="conversation" class="transcript" role="log" aria-live="polite" aria-label="Playground conversation"></div>
-            </div>
+            <section class="playground-launcher" aria-label="Quick start actions">
+              <div>
+                <span class="model-kicker">No prompt needed</span>
+                <strong>Is UniGrok ready?</strong>
+                <p>Checks credentials, planes, routing policy, and local telemetry without spending an inference turn.</p>
+              </div>
+              <button id="verifySetupBtn" type="button" class="primary-btn-glow">Verify Setup</button>
+            </section>
           </div>
 
           <!-- TAB 2: Schema Explorer -->
@@ -298,10 +307,10 @@
           <!-- TAB 4: OKF Browser -->
           <div id="tab-okf" class="tab-panel">
             <div class="panel-header">
-              <h2>OKF Browser</h2>
+              <h2>Knowledge (OKF)</h2>
               <button id="copyOkfPathBtn" type="button" class="small-btn-glow">Copy Path</button>
             </div>
-            <p class="panel-desc">Browse files from the zero-shot Open Knowledge Format (OKF) bundle. Headless agents ingest this context on startup.</p>
+            <p class="panel-desc">Browse the project knowledge bundle (Open Knowledge Format). Headless agents ingest this context on startup.</p>
 
             <div class="okf-layout">
               <div class="okf-sidebar">
@@ -406,7 +415,7 @@
           <div id="tab-metrics" class="tab-panel">
             <div class="panel-header">
               <div>
-                <h2>Usage &amp; Telemetry</h2>
+                <h2>Usage &amp; Costs</h2>
                 <p class="panel-desc">Local request truth, exact API billing, and honest CLI subscription activity.</p>
               </div>
               <div class="metrics-actions">
@@ -525,6 +534,21 @@
 
             <div id="setupStatusSummary" class="setup-status-summary" aria-live="polite">Checking the live gateway…</div>
 
+            <!-- One plain-language onboarding action, shown only when the
+                 gateway is not ready. No environment variables required. -->
+            <div id="quickStartCard" class="setup-quickstart hidden">
+              <strong>Get the gateway running</strong>
+              <p>Copy and run this in a terminal. You need Git, Docker Desktop, and uv — nothing else.</p>
+              <pre><code id="quickStartCommands">git clone https://github.com/djtelicloud/grok-mcp-server.git
+cd grok-mcp-server
+uv run python main.py init
+docker compose up --build -d</code></pre>
+              <div class="quickstart-actions">
+                <button id="copyQuickStartBtn" type="button" class="small-btn-glow">Copy commands</button>
+                <span class="quickstart-note">Already installed? Run <code>docker compose up --build -d</code> in the project folder, then Recheck setup.</span>
+              </div>
+            </div>
+
             <details class="raw-telemetry-disclosure onboarding-box">
               <summary><span>Agent-readable setup metadata</span><small>discover_self manifest and OKF paths</small></summary>
               <button id="copyDiscoverBtn" type="button" class="small-btn-glow">Run discover_self</button>
@@ -576,6 +600,6 @@
 
       </section>
     </main>
-  <script type="module" src="./app.js?v=grok-v0.6.0-r2"></script>
+  <script type="module" src="./app.js?v=grok-v0.6.0-r3"></script>
   </body>
 </html>

--- a/mcp_ui/styles.css
+++ b/mcp_ui/styles.css
@@ -1,38 +1,17 @@
+/* Shared palette/identity tokens live in tokens.css (linked before this
+   sheet). This root keeps only Control-Center layout variables. The panel
+   min/max pairs below are the single source of truth for the JS layout
+   controller's LAYOUT_LIMITS — change them here, not in app.js. */
 :root {
-  color-scheme: dark;
-  --page: #060d13;
-  --page-deep: #030609;
-  --surface: rgba(13, 27, 42, 0.65);
-  --surface-soft: rgba(22, 38, 57, 0.5);
-  --surface-strong: rgba(27, 51, 79, 0.85);
-  --ink: #f0f6fc;
-  --ink-soft: #8b9eb0;
-  /* Raised from #4e6172 (~3:1) to clear WCAG 4.5:1 for the small labels and
-     table headers that use it. */
-  --ink-faint: #7d93a6;
-  --border: rgba(79, 231, 255, 0.15);
-  --border-strong: rgba(79, 231, 255, 0.35);
-  --cyan: #4fe7ff;
-  --cyan-soft: rgba(79, 231, 255, 0.08);
-  --teal: #16f0ae;
-  --teal-soft: rgba(22, 240, 174, 0.08);
-  --orange: #ff8c3a;
-  --orange-soft: rgba(255, 140, 58, 0.08);
-  --red: #ff5f78;
-  --red-soft: rgba(255, 95, 120, 0.08);
-  --shadow: 0 16px 48px rgba(0, 0, 0, 0.45);
-  --glow-cyan: 0 0 20px rgba(79, 231, 255, 0.18);
-  --glow-teal: 0 0 20px rgba(22, 240, 174, 0.18);
-  --glow-orange: 0 0 20px rgba(255, 140, 58, 0.18);
-  --radius: 12px;
-  --radius-sm: 6px;
-  --transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
   --nav-width: 200px;
+  --nav-min: 148px;
+  --nav-max: 340px;
   --inspector-width: 280px;
+  --inspector-min: 210px;
+  --inspector-max: 460px;
   --rail-width: 44px;
   --splitter-width: 4px;
   --workbench-min: 300px;
-  font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
 * {
@@ -552,8 +531,10 @@ textarea:focus {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 16px;
-  min-height: 200px;
-  max-height: 450px;
+  /* Viewport-relative with clamps: the chat log grows with the window
+     instead of freezing at a fixed pixel height on tall screens. */
+  min-height: clamp(160px, 28vh, 260px);
+  max-height: clamp(260px, 55vh, 680px);
   overflow-y: auto;
   display: flex;
   flex-direction: column;
@@ -691,9 +672,20 @@ pre {
 /* Schema layouts */
 .schemas-layout {
   display: grid;
-  grid-template-columns: 200px minmax(0, 1fr);
+  grid-template-columns: auto minmax(0, 1fr);
   gap: 20px;
   flex-grow: 1;
+  min-height: 0;
+}
+
+/* Native CSS resize: the sidebar column is user-draggable within clamps.
+   resize only works with a non-visible overflow, so pair them. */
+.schema-list-container {
+  width: 200px;
+  min-width: 148px;
+  max-width: min(340px, 45cqw);
+  resize: horizontal;
+  overflow: auto;
 }
 
 .schema-nav-buttons {
@@ -734,9 +726,18 @@ pre {
 /* OKF layout */
 .okf-layout {
   display: grid;
-  grid-template-columns: 220px minmax(0, 1fr);
+  grid-template-columns: auto minmax(0, 1fr);
   gap: 20px;
   flex-grow: 1;
+  min-height: 0;
+}
+
+.okf-sidebar {
+  width: 220px;
+  min-width: 148px;
+  max-width: min(340px, 45cqw);
+  resize: horizontal;
+  overflow: auto;
 }
 
 .okf-file-list {
@@ -781,12 +782,12 @@ pre {
 .markdown-preview {
   background: var(--surface);
   border: 1px solid var(--border);
-  padding: 24px;
+  padding: clamp(12px, 2.4cqw, 24px);
   border-radius: var(--radius);
   overflow-y: auto;
   font-size: 14px;
   line-height: 1.6;
-  max-height: 500px;
+  max-height: min(62vh, 680px);
 }
 
 .markdown-preview h1,
@@ -1058,7 +1059,7 @@ pre {
 
 .metrics-detail-grid {
   display: grid;
-  grid-template-columns: minmax(0, 1.35fr) minmax(300px, 0.65fr);
+  grid-template-columns: minmax(0, 1.35fr) minmax(min(300px, 100%), 0.65fr);
   gap: 16px;
   margin: 16px 0;
 }
@@ -1229,7 +1230,7 @@ pre {
 /* Plane-aware model catalog */
 .routing-policy-card {
   display: grid;
-  grid-template-columns: minmax(180px, 0.45fr) minmax(260px, 0.8fr) minmax(260px, 1fr);
+  grid-template-columns: minmax(min(180px, 100%), 0.45fr) minmax(min(260px, 100%), 0.8fr) minmax(min(260px, 100%), 1fr);
   align-items: center;
   gap: 18px;
   border: 1px solid var(--border-strong);
@@ -1419,7 +1420,7 @@ pre {
 
 .routing-receipt summary {
   display: grid;
-  grid-template-columns: minmax(210px, 1fr) minmax(150px, 0.8fr) minmax(210px, auto);
+  grid-template-columns: minmax(min(210px, 100%), 1fr) minmax(min(150px, 100%), 0.8fr) minmax(min(210px, 100%), auto);
   gap: 12px;
   align-items: center;
   padding: 12px 14px;
@@ -1453,7 +1454,7 @@ pre {
 .receipt-facts b { color: var(--ink); }
 .receipt-json {
   margin: 12px 0 0;
-  max-height: 300px;
+  max-height: min(40vh, 360px);
   overflow: auto;
   font-size: 10px;
   color: var(--ink-soft);
@@ -1535,6 +1536,44 @@ pre {
   line-height: 1.55;
 }
 
+/* One-action onboarding card, shown only while the gateway is not ready. */
+.setup-quickstart {
+  margin-top: 14px;
+  padding: 16px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  background: var(--cyan-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.setup-quickstart.hidden {
+  display: none !important;
+}
+
+.setup-quickstart pre {
+  background: rgba(3, 6, 9, 0.7);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 12px;
+  overflow-x: auto;
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+.quickstart-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.quickstart-note {
+  font-size: 11px;
+  color: var(--ink-soft);
+}
+
 .console-grid[data-density="compact"] .topbar { min-height: 42px; padding-block: 4px; }
 .console-grid[data-density="compact"] .eyebrow,
 .console-grid[data-density="compact"] .panel-desc { display: none; }
@@ -1577,6 +1616,11 @@ pre {
   .metrics-detail-grid,
   .metrics-detail-grid.compact,
   .model-plane-grid { grid-template-columns: minmax(0, 1fr); }
+  /* Stacked single-column: the draggable sidebar width no longer applies.
+     !important because a native resize drag persists as an inline width
+     style, which would otherwise win over this reset with no handle left. */
+  .schema-list-container,
+  .okf-sidebar { width: auto !important; max-width: none !important; resize: none; }
   .panel-header { align-items: flex-start; gap: 8px; }
   .estimator-row { align-items: flex-start; flex-direction: column; gap: 6px; }
 }
@@ -1784,7 +1828,9 @@ pre {
   color: var(--ink-soft);
 }
 
-@media (max-width: 800px) {
+/* The credential alert sits directly in the app shell, so it reflows on the
+   shell container's width rather than the viewport. */
+@container app-shell (max-width: 800px) {
   .credential-alert,
   .credential-alert-actions {
     align-items: stretch;
@@ -1892,7 +1938,11 @@ pre {
   user-select: none;
 }
 
-@media (max-width: 1300px) {
+/* Content reflow is driven by the WORKBENCH's own width, not the viewport:
+   the workspace panes are sized continuously by the layout controller, so a
+   narrow workbench beside a wide inspector must still reflow. These replace
+   the old viewport media queries that could never see pane widths. */
+@container workbench (max-width: 1080px) {
   .metrics-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
@@ -1907,8 +1957,11 @@ pre {
   }
 }
 
-@media (max-width: 1050px) {
-  .metrics-grid {
+@container workbench (max-width: 760px) {
+  .metrics-grid,
+  .metrics-detail-grid,
+  .metrics-detail-grid.compact,
+  .model-plane-grid {
     grid-template-columns: 1fr;
   }
 
@@ -1920,40 +1973,15 @@ pre {
   .metrics-actions {
     width: 100%;
     justify-content: space-between;
-  }
-
-  .routing-policy-card {
-    grid-template-columns: 1fr;
-  }
-
-  .model-plane-grid {
-    grid-template-columns: 1fr;
-  }
-}
-
-/* Content reflow only. The host is an IDE webview, not a mobile page; the
-   workspace columns are controlled continuously by the layout controller. */
-@media (max-width: 768px) {
-  .metrics-grid,
-  .metrics-detail-grid,
-  .metrics-detail-grid.compact,
-  .model-plane-grid {
-    grid-template-columns: 1fr;
+    margin-top: 12px;
   }
 
   .routing-receipt summary { grid-template-columns: 1fr; gap: 6px; }
   .receipt-operational { text-align: left; padding-left: 18px; }
 
-  .metrics-actions {
-    width: 100%;
-    justify-content: space-between;
-    margin-top: 12px;
-  }
-
   .playground-launcher {
     grid-template-columns: 1fr;
   }
-
 }
 
 /* Reduced Motion Respect */

--- a/mcp_ui/swarm.html
+++ b/mcp_ui/swarm.html
@@ -4,17 +4,19 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>UniGrok Swarm Optimizer — Pareto Playground</title>
+  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r3" />
   <style>
+    /* Page vocabulary aliases onto the shared UniGrok tokens (tokens.css) so
+       the Swarm Optimizer and the Control Center read as one product. */
     :root {
-      --bg: #0e1013; --panel: #16191d; --panel2: #1c2026; --border: #2a2f36;
-      --text: #e7e9ec; --muted: #8b8d98;
-      --red: #e5484d; --orange: #f5a623; --gray: #8b8d98; --green: #30a46c;
-      --accent: #6e9dff; --accent-soft: rgba(79, 140, 255, .13);
-      --cyan: #63d6c5; --shadow: 0 18px 55px rgba(0, 0, 0, .22);
+      --bg: var(--page); --panel: var(--surface); --panel2: var(--surface-soft);
+      --text: var(--ink); --muted: var(--ink-soft);
+      --gray: var(--ink-faint); --green: var(--teal);
+      --accent: var(--cyan); --accent-soft: var(--cyan-soft);
     }
     * { box-sizing: border-box; }
-    body { margin: 0; background: var(--bg); color: var(--text);
-           font: 14px/1.5 -apple-system, "Segoe UI", Roboto, sans-serif; }
+    body { margin: 0; background: var(--page-deep); color: var(--text);
+           font-size: 14px; line-height: 1.5; }
     header { display: flex; align-items: center; justify-content: space-between; gap: 24px;
              padding: 24px 20px 18px; border-bottom: 1px solid var(--border);
              background: radial-gradient(circle at 16% -40%, rgba(79, 140, 255, .24), transparent 42%); }
@@ -25,14 +27,14 @@
     header a:hover { border-color: var(--accent); }
     .eyebrow { color: var(--cyan); font-size: 10px; font-weight: 700; letter-spacing: .16em; text-transform: uppercase; }
     .runtime-banner { display: flex; align-items: center; gap: 11px; margin: 14px 20px 0; padding: 11px 14px;
-                      max-width: 1240px; background: var(--panel); border: 1px solid var(--border); border-radius: 9px; }
+                      max-width: 1760px; background: var(--panel); border: 1px solid var(--border); border-radius: 9px; }
     .runtime-banner .dot { width: 9px; height: 9px; border-radius: 50%; background: var(--muted); flex: 0 0 auto; }
     .runtime-banner.ready .dot { background: var(--green); box-shadow: 0 0 10px var(--green); }
     .runtime-banner strong { display: block; font-size: 12px; }
     .runtime-banner span { color: var(--muted); font-size: 11px; }
     .runtime-banner a { color: var(--accent); font-size: 11px; margin-left: auto; text-decoration: none; white-space: nowrap; }
-    .wrap { display: grid; grid-template-columns: 1fr 340px; gap: 14px;
-            padding: 14px 20px; max-width: 1280px; }
+    .wrap { display: grid; grid-template-columns: minmax(0, 1fr) minmax(min(280px, 100%), 380px);
+            gap: 14px; padding: 14px 20px; max-width: 1800px; }
     .panel { background: var(--panel); border: 1px solid var(--border);
              border-radius: 10px; padding: 14px; box-shadow: var(--shadow); }
     .section-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
@@ -40,7 +42,7 @@
     .source-badge { color: var(--muted); border: 1px solid var(--border); border-radius: 999px;
                     padding: 3px 8px; font-size: 10px; letter-spacing: .06em; text-transform: uppercase; }
     .source-badge.live { color: var(--green); border-color: rgba(48, 164, 108, .45); }
-    .journeys { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 9px; }
+    .journeys { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(230px, 100%), 1fr)); gap: 9px; }
     .journey { display: flex; flex-direction: column; min-height: 144px; background: var(--panel2);
                border: 1px solid var(--border); border-radius: 9px; padding: 11px; }
     .journey.primary { border-color: rgba(79, 140, 255, .52); background: linear-gradient(145deg, var(--accent-soft), var(--panel2) 65%); }
@@ -52,25 +54,25 @@
     .controls { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
     button, input, select { font: inherit; }
     input[type=text], input[type=password] { background: var(--panel2); color: var(--text);
-      border: 1px solid var(--border); border-radius: 6px; padding: 6px 8px; min-width: 230px; }
+      border: 1px solid var(--border); border-radius: 6px; padding: 6px 8px; min-width: min(230px, 100%); }
     select { background: var(--panel2); color: var(--text); border: 1px solid var(--border);
-             border-radius: 6px; padding: 6px 8px; max-width: 340px; }
+             border-radius: 6px; padding: 6px 8px; max-width: 100%; }
     button { background: var(--panel2); color: var(--text); border: 1px solid var(--border);
              border-radius: 6px; padding: 6px 12px; cursor: pointer; }
     button:hover { border-color: var(--accent); }
     button.primary { background: var(--accent); border-color: var(--accent); color: #08101f; font-weight: 700; }
     button:disabled { opacity: .45; cursor: not-allowed; }
-    .paste-grid { display: grid; grid-template-columns: minmax(0, 1.45fr) minmax(280px, .75fr);
+    .paste-grid { display: grid; grid-template-columns: minmax(0, 1.45fr) minmax(min(280px, 100%), .75fr);
                   gap: 12px; }
-    textarea.code-input { width: 100%; min-height: 300px; resize: vertical; background: #0b0d10;
+    textarea.code-input { width: 100%; min-height: clamp(180px, 34vh, 300px); resize: vertical; background: #0b0d10;
       color: #dce6f3; border: 1px solid var(--border); border-radius: 8px; padding: 12px;
       font: 12px/1.55 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
       tab-size: 4; }
     textarea.code-input:focus { outline: 2px solid rgba(110, 157, 255, .45); border-color: var(--accent); }
-    textarea.oracle-input { min-height: 150px; }
+    textarea.oracle-input { min-height: clamp(110px, 18vh, 200px); }
     .paste-actions { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-top: 8px; }
     .privacy-note { color: var(--muted); font-size: 11px; margin-top: 7px; }
-    .analysis-results { min-height: 300px; background: var(--panel2); border: 1px solid var(--border);
+    .analysis-results { min-height: clamp(180px, 32vh, 300px); background: var(--panel2); border: 1px solid var(--border);
                         border-radius: 8px; padding: 11px; }
     .analysis-results h3 { font-size: 13px; margin: 0 0 8px; }
     .function-list { display: grid; gap: 6px; margin-top: 10px; }
@@ -102,7 +104,7 @@
     .timeline { display: flex; gap: 10px; align-items: center; margin-top: 10px; }
     .timeline input[type=range] { flex: 1; }
     #detail pre { background: var(--panel2); border: 1px solid var(--border);
-                  border-radius: 6px; padding: 8px; overflow: auto; max-height: 220px;
+                  border-radius: 6px; padding: 8px; overflow: auto; max-height: min(32vh, 320px);
                   font-size: 12px; white-space: pre-wrap; }
     .diff-grid { display: grid; grid-template-columns: 1fr; gap: 8px; }
     .muted { color: var(--muted); }
@@ -136,7 +138,10 @@
       <h1>Swarm Optimizer</h1>
       <p>Watch candidate rewrites hit static, test, and performance gates—then inspect the verified Pareto trade-offs.</p>
     </div>
-    <a href="./index.html">← Control Center</a>
+    <nav style="display:flex; gap:8px; flex-wrap:wrap; justify-content:flex-end" aria-label="Product navigation">
+      <a href="./index.html">← Control Center</a>
+      <a href="https://grokmcp.org" target="_blank" rel="noopener noreferrer">grokmcp.org ↗</a>
+    </nav>
   </header>
 
   <div id="runtimeBanner" class="runtime-banner" role="status" aria-live="polite">

--- a/mcp_ui/swarm.js
+++ b/mcp_ui/swarm.js
@@ -111,9 +111,15 @@ function setPayload(payload, sourceLabel, source) {
   const badge = $("sourceBadge");
   badge.textContent = source === "live" ? "live gateway data" : sourceLabel;
   badge.className = source === "live" ? "source-badge live" : "source-badge";
-  renderScorecard();
-  renderTradeoffSummary();
-  renderChart();
+  // Each render step is independent diagnostics; one failing panel must not
+  // blank the rest of the page.
+  for (const step of [renderScorecard, renderTradeoffSummary, renderChart]) {
+    try {
+      step();
+    } catch (err) {
+      console.error(`${step.name} failed:`, err);
+    }
+  }
   const candidates = (payload.generations || []).flatMap((generation) => generation.candidates || []);
   const leadingFrontId = payload.pareto_front?.[0];
   const firstUseful = candidates.find((candidate) => candidate.candidate_id === leadingFrontId && candidate.code)

--- a/mcp_ui/tokens.css
+++ b/mcp_ui/tokens.css
@@ -1,0 +1,38 @@
+/* UniGrok shared design tokens.
+   One palette for every local surface (Control Center, Swarm Optimizer) and
+   for copies synced into the public site build. Page-specific layout variables
+   stay in each page's own stylesheet; only shared identity lives here.
+   The PR-review widget (github-review-v1.html) intentionally does NOT use
+   these tokens: it embeds in light and dark hosts and uses system colors. */
+
+:root {
+  color-scheme: dark;
+  --page: #060d13;
+  --page-deep: #030609;
+  --surface: rgba(13, 27, 42, 0.65);
+  --surface-soft: rgba(22, 38, 57, 0.5);
+  --surface-strong: rgba(27, 51, 79, 0.85);
+  --ink: #f0f6fc;
+  --ink-soft: #8b9eb0;
+  /* Raised from #4e6172 (~3:1) to clear WCAG 4.5:1 for the small labels and
+     table headers that use it. */
+  --ink-faint: #7d93a6;
+  --border: rgba(79, 231, 255, 0.15);
+  --border-strong: rgba(79, 231, 255, 0.35);
+  --cyan: #4fe7ff;
+  --cyan-soft: rgba(79, 231, 255, 0.08);
+  --teal: #16f0ae;
+  --teal-soft: rgba(22, 240, 174, 0.08);
+  --orange: #ff8c3a;
+  --orange-soft: rgba(255, 140, 58, 0.08);
+  --red: #ff5f78;
+  --red-soft: rgba(255, 95, 120, 0.08);
+  --shadow: 0 16px 48px rgba(0, 0, 0, 0.45);
+  --glow-cyan: 0 0 20px rgba(79, 231, 255, 0.18);
+  --glow-teal: 0 0 20px rgba(22, 240, 174, 0.18);
+  --glow-orange: 0 0 20px rgba(255, 140, 58, 0.18);
+  --radius: 12px;
+  --radius-sm: 6px;
+  --transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  font-family: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}

--- a/sites/unigrok-control-center/app/control/page.tsx
+++ b/sites/unigrok-control-center/app/control/page.tsx
@@ -19,6 +19,7 @@ import { safeDisplayName } from "../lib/identity-display";
 import { isSiteProvisioned } from "../lib/site-provisioning";
 import { getPublicConnectionConfig } from "../lib/unigrok-config";
 import ControlAccessDenied from "./access-denied";
+import ControlSignedOut from "./signed-out";
 import GitHubControlAccessDenied from "./github-access-denied";
 
 export const dynamic = "force-dynamic";
@@ -88,7 +89,10 @@ async function StandaloneGitHubControl() {
     return <GitHubControlAccessDenied login={null} reason="configuration" />;
   }
   const session = await readGitHubSession(config, requestHeaders.get("cookie"));
-  if (!session) redirect("/auth/github/login?return_to=%2Fcontrol");
+  // Signed-out visitors get an explanation of the surface and one sign-in
+  // action instead of a naked redirect to github.com. Authorization remains
+  // the fresh server-side collaborator check below after OAuth completes.
+  if (!session) return <ControlSignedOut />;
 
   const result = await loadStandaloneGitHubControl(config, session);
   if (result.kind === "denied") forbidden();

--- a/sites/unigrok-control-center/app/control/signed-out.tsx
+++ b/sites/unigrok-control-center/app/control/signed-out.tsx
@@ -1,0 +1,39 @@
+import Link from "next/link";
+import { PUBLIC_PROJECT } from "../lib/public-project";
+
+/**
+ * Anonymous view of /control. Gated surfaces stay visible with a plain
+ * explanation and one sign-in action — never a naked redirect that strands a
+ * visitor on github.com with no context. No protected data is rendered here;
+ * authorization stays a fresh server-side collaborator check after OAuth.
+ */
+export default function ControlSignedOut() {
+  return (
+    <main className="access-shell">
+      <section className="access-card" aria-labelledby="control-welcome-title">
+        <Link className="access-brand" href="/"><span>UG</span> UniGrok</Link>
+        <p className="public-kicker"><span /> Contributor control center</p>
+        <h1 id="control-welcome-title">Live project operations, for contributors.</h1>
+        <p className="access-lede">
+          The control center shows live GitHub evidence for {PUBLIC_PROJECT.repository.name}:
+          open pull requests with their exact checks, default-branch status, recent
+          deployments, and the connection guide for a local UniGrok gateway.
+        </p>
+        <div className="access-notice">
+          <strong>Who gets in, and how it is checked.</strong>
+          <p>
+            Sign in with GitHub, and every request re-verifies your collaborator role
+            (triage or higher) against the repository — server-side, on each visit.
+            There is nothing to configure and no separate account to create. Public
+            project information stays available without any sign-in.
+          </p>
+        </div>
+        <div className="public-actions">
+          <a className="public-primary" href="/auth/github/login?return_to=%2Fcontrol">Sign in with GitHub</a>
+          <Link className="public-secondary" href="/">Back to the project site</Link>
+          <a className="public-secondary" href={PUBLIC_PROJECT.repository.url}>Open public repository ↗</a>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -203,6 +203,24 @@ class CSPMiddleware
 ASGI middleware that injects a strict Content-Security-Policy (CSP) header
 into all HTTP responses.
 
+### Class: `StaticAssetCacheMiddleware` {#http_server-staticassetcachemiddleware}
+
+```python
+class StaticAssetCacheMiddleware
+```
+
+**Keywords:** static, asset, cache, middleware
+
+ASGI middleware that stamps ``Cache-Control: no-cache`` on /ui and /docs
+responses.
+
+Starlette's ``StaticFiles`` emits ETag/Last-Modified but no Cache-Control,
+so browsers apply heuristic freshness and can pair a stale cached
+``index.html`` with freshly fetched ``app.js`` — the skew that made the
+Control Center discard rendered agent answers. ``no-cache`` keeps caching
+(conditional requests answer 304 via the existing ETags) but forces
+revalidation, so HTML and JS always come from the same release.
+
 ### Function: `unigrok_public_discovery` {#http_server-unigrok_public_discovery}
 
 ```python

--- a/sites/unigrok-control-center/public/docs/okf/faq.md
+++ b/sites/unigrok-control-center/public/docs/okf/faq.md
@@ -201,7 +201,7 @@ and plane. MCP `agent` responses also carry structured execution metadata.
 These values describe the gateway request that produced the response. A
 zero-cost local FAQ lookup is documentation retrieval, not a model invocation.
 
-The Usage & Telemetry tab does not combine API-key billing with SuperGrok CLI
+The Usage & Costs tab does not combine API-key billing with SuperGrok CLI
 activity. API spend is exact per response. CLI activity is tracked locally,
 but xAI exposes no SuperGrok quota/spend API, so subscription cost is shown as
 unknown/included rather than a misleading `$0`. Optional Management API

--- a/sites/unigrok-control-center/scripts/sync-swarm-playground.mjs
+++ b/sites/unigrok-control-center/scripts/sync-swarm-playground.mjs
@@ -23,6 +23,12 @@ await Promise.all([
     resolve(targetDir, "swarm-sample.json"),
     await readFile(resolve(sourceDir, "swarm-sample.json"), "utf8"),
   ),
+  // Shared design tokens: the page links ./tokens.css so the public copy
+  // renders with the same UniGrok identity as the local surfaces.
+  writeFile(
+    resolve(targetDir, "tokens.css"),
+    await readFile(resolve(sourceDir, "tokens.css"), "utf8"),
+  ),
 ]);
 
 console.log("Synchronized public Swarm Playground assets.");

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -26,6 +26,8 @@ from starlette.responses import JSONResponse, Response, StreamingResponse
 from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
 
+from .version import UI_ASSET_VERSION
+
 from .identity import (
     _ACTIVE_CLIENT_ID,
     _ACTIVE_SESSION_ID,
@@ -854,6 +856,46 @@ class CSPMiddleware:
         await self.app(scope, receive, send_with_csp)
 
 
+class StaticAssetCacheMiddleware:
+    """ASGI middleware that stamps ``Cache-Control: no-cache`` on /ui and /docs
+    responses.
+
+    Starlette's ``StaticFiles`` emits ETag/Last-Modified but no Cache-Control,
+    so browsers apply heuristic freshness and can pair a stale cached
+    ``index.html`` with freshly fetched ``app.js`` — the skew that made the
+    Control Center discard rendered agent answers. ``no-cache`` keeps caching
+    (conditional requests answer 304 via the existing ETags) but forces
+    revalidation, so HTML and JS always come from the same release.
+    """
+
+    _PREFIXES = ("/ui", "/docs")
+
+    def __init__(self, app):
+        self.app = app
+
+    def _applies(self, path: str) -> bool:
+        # Boundary-correct prefix match: "/uix" must not inherit the policy.
+        return any(_path_matches_prefix(path, prefix) for prefix in self._PREFIXES)
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http" or not self._applies(scope.get("path", "")):
+            await self.app(scope, receive, send)
+            return
+
+        async def send_with_cache_control(message):
+            if message["type"] == "http.response.start":
+                headers = [
+                    (name, value)
+                    for name, value in (message.get("headers") or [])
+                    if name.lower() != b"cache-control"
+                ]
+                headers.append((b"cache-control", b"no-cache"))
+                message["headers"] = headers
+            await send(message)
+
+        await self.app(scope, receive, send_with_cache_control)
+
+
 def _validated_https_url(value: str) -> Optional[str]:
     """Return a normalized public HTTPS URL, or ``None`` when unsafe.
 
@@ -1075,6 +1117,7 @@ async def runtimez(request: Request) -> JSONResponse:
         {
             "runtime": get_unigrok_runtime(),
             "transport": "http",
+            "ui_asset_version": UI_ASSET_VERSION,
             "service": {
                 "mode": "contributor" if PathResolver.contributor_mode() else "stable",
                 "workspace_attached": PathResolver.get_workspace_root() is not None,
@@ -2183,6 +2226,7 @@ def create_app(*, bound_host: Optional[str] = None) -> Starlette:
             Middleware(RequestIdMiddleware),
             Middleware(RequestBodyLimitMiddleware),
             Middleware(CSPMiddleware),
+            Middleware(StaticAssetCacheMiddleware),
             Middleware(MCPOriginMiddleware),
             Middleware(GatewayAuthMiddleware, bound_host=effective_bound_host),
             Middleware(ModeDialContextMiddleware),

--- a/src/version.py
+++ b/src/version.py
@@ -1,3 +1,9 @@
 """Canonical UniGrok release version."""
 
 __version__ = "0.6.0"
+
+# Cache-bust token shared by every /ui asset reference (index.html links, the
+# markdown.js import inside app.js, and the runtime handshake in app.js).
+# Bump the -rN suffix whenever any /ui asset changes; a pytest asserts every
+# copy of this string agrees so HTML and JS can never skew apart silently.
+UI_ASSET_VERSION = "grok-v0.6.0-r3"

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -10,6 +10,7 @@ from src.http_server import (
     GatewayAuthMiddleware,
     MCPOriginMiddleware,
     ModeDialContextMiddleware,
+    StaticAssetCacheMiddleware,
     _ACTIVE_MODE_DIAL,
     _derive_http_caller,
     _message_content_size,
@@ -978,6 +979,19 @@ def test_middleware_is_pure_asgi():
     assert not issubclass(GatewayAuthMiddleware, BaseHTTPMiddleware)
     assert not issubclass(MCPOriginMiddleware, BaseHTTPMiddleware)
     assert not issubclass(ModeDialContextMiddleware, BaseHTTPMiddleware)
+    assert not issubclass(StaticAssetCacheMiddleware, BaseHTTPMiddleware)
+
+
+def test_static_asset_cache_prefixes_are_boundary_correct():
+    """The no-cache policy applies to /ui and /docs subtrees only — a
+    hypothetical /uix or /docsish route must not inherit it."""
+    middleware = StaticAssetCacheMiddleware(None)
+    assert middleware._applies("/ui")
+    assert middleware._applies("/ui/app.js")
+    assert middleware._applies("/docs/okf/faq.md")
+    assert not middleware._applies("/uix")
+    assert not middleware._applies("/docsish/thing")
+    assert not middleware._applies("/mcp")
 
 
 def test_mcp_rejects_untrusted_origin(monkeypatch):

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -15,8 +15,9 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert index.status_code == 200
     assert "<title>UniGrok MCP v0.6.0 Control Center</title>" in index.text
     assert '<span class="version-badge">v0.6.0</span>' in index.text
-    assert 'script type="module" src="./app.js?v=grok-v0.6.0-r2"' in index.text
-    assert '<link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r2" />' in index.text
+    assert 'script type="module" src="./app.js?v=grok-v0.6.0-r3"' in index.text
+    assert '<link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r3" />' in index.text
+    assert '<link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r3" />' in index.text
     assert "Control Center" in index.text
     assert "Bearer token" not in index.text
     assert "Agent Playground" in index.text
@@ -335,7 +336,7 @@ def test_mcp_ui_markdown_renderer_is_shared_and_escape_first():
     assert "\\u000E-\\u001F" in renderer.text
     # app.js imports the shared renderer at the current cache-bust version and
     # no longer defines its own.
-    assert 'from "./markdown.js?v=grok-v0.6.0-r2"' in script.text
+    assert 'from "./markdown.js?v=grok-v0.6.0-r3"' in script.text
     assert "import { parseMarkdown" in script.text
     assert "function parseMarkdown" not in script.text
     assert "renderMarkdownInto" in script.text
@@ -448,3 +449,126 @@ def test_mcp_ui_security_csp_headers():
     csp = index.headers["content-security-policy"]
     assert "default-src 'self'" in csp
     assert "frame-ancestors 'none'" in csp
+
+
+def test_mcp_ui_assets_are_never_heuristically_cached():
+    """Regression contract for the stale-skew incident: StaticFiles emits
+    ETag/Last-Modified but no Cache-Control, so browsers heuristically cached
+    index.html and paired it with a newer app.js — renderFactsPane then threw
+    on missing receipt ids and a paid agent answer was discarded. no-cache
+    keeps 304 revalidation cheap while forcing HTML and JS to stay in step."""
+    with TestClient(create_app(), base_url="http://localhost:8080") as client:
+        index = client.get("/ui/")
+        script = client.get("/ui/app.js")
+        tokens = client.get("/ui/tokens.css")
+        okf = client.get("/docs/okf/okf-manifest.json")
+        health = client.get("/healthz")
+
+    for response in (index, script, tokens, okf):
+        assert response.status_code == 200
+        assert response.headers["cache-control"] == "no-cache"
+    # Non-static routes keep their own cache policies.
+    assert health.headers.get("cache-control") != "no-cache"
+
+
+def test_mcp_ui_asset_version_is_single_sourced():
+    """Every copy of the cache-bust token must agree: src/version.py, the
+    index.html meta/link/script pins, the markdown.js import inside app.js,
+    the app.js handshake constant, and the swarm.html tokens link. A skewed
+    pair is exactly the failure the version handshake exists to catch."""
+    from src.version import UI_ASSET_VERSION
+
+    with TestClient(create_app(), base_url="http://localhost:8080") as client:
+        index = client.get("/ui/").text
+        script = client.get("/ui/app.js").text
+        swarm = client.get("/ui/swarm.html").text
+        runtime = client.get("/runtimez").json()
+
+    assert f'<meta name="unigrok-ui-version" content="{UI_ASSET_VERSION}" />' in index
+    assert f'href="./tokens.css?v={UI_ASSET_VERSION}"' in index
+    assert f'href="./styles.css?v={UI_ASSET_VERSION}"' in index
+    assert f'src="./app.js?v={UI_ASSET_VERSION}"' in index
+    assert f'const UI_ASSET_VERSION = "{UI_ASSET_VERSION}"' in script
+    assert f'from "./markdown.js?v={UI_ASSET_VERSION}"' in script
+    assert f'href="./tokens.css?v={UI_ASSET_VERSION}"' in swarm
+    assert runtime["ui_asset_version"] == UI_ASSET_VERSION
+    # The handshake self-heals a stale cached page with one reload, then warns.
+    assert "enforceUiVersionHandshake" in script
+    assert "unigrok-ui-version" in script
+
+
+def test_mcp_ui_receipt_pane_cannot_discard_answers():
+    """The facts pane is diagnostics: rendering it is wrapped so a DOM error
+    there can never re-throw into callAgent and replace an already-received
+    agent answer with 'Invocation failed'. All pane writes are null-safe."""
+    with TestClient(create_app(), base_url="http://localhost:8080") as client:
+        script = client.get("/ui/app.js").text
+
+    assert "function setText(" in script
+    assert "Receipt pane render failed" in script
+    # The pane renders inside its own try/catch at the call site.
+    call_site = script.split('if (toolName === "agent")', 1)[1].split("return responsePayload", 1)[0]
+    assert "try" in call_site and "catch" in call_site
+    # No unguarded direct innerText writes remain inside renderFactsPane.
+    pane_body = script.split("function renderFactsPane", 1)[1].split("\n}\n", 1)[0]
+    assert '$("fact' not in pane_body.replace('setText("fact', "")
+
+
+def test_mcp_ui_not_ready_shows_one_onboarding_action():
+    """A missing/unready gateway must produce a copyable quick-start, not a
+    dead end. The card carries the exact README bootstrap commands and no
+    environment-variable homework."""
+    with TestClient(create_app(), base_url="http://localhost:8080") as client:
+        index = client.get("/ui/").text
+        script = client.get("/ui/app.js").text
+
+    assert 'id="quickStartCard"' in index
+    assert "git clone https://github.com/djtelicloud/grok-mcp-server.git" in index
+    assert "docker compose up --build -d" in index
+    assert 'id="copyQuickStartBtn"' in index
+    # Shown only when the gateway is unreachable; a reachable gateway failing
+    # a readiness check names the failing check instead of suggesting a
+    # from-scratch reinstall.
+    assert 'classList.toggle("hidden", Boolean(ready) || Boolean(detailText))' in script
+
+
+def test_mcp_ui_local_surfaces_link_the_project_site():
+    """Navigation is one product: both local pages link grokmcp.org, and the
+    swarm page links back to the Control Center."""
+    with TestClient(create_app(), base_url="http://localhost:8080") as client:
+        index = client.get("/ui/").text
+        swarm = client.get("/ui/swarm.html").text
+
+    assert 'id="nav-link-site"' in index
+    assert 'https://grokmcp.org' in index
+    assert 'https://grokmcp.org' in swarm
+    assert 'href="./index.html"' in swarm
+
+
+def test_mcp_ui_layout_limits_come_from_css():
+    """Panel min/max bounds are authored once in styles.css custom properties;
+    app.js reads them instead of duplicating pixel numbers."""
+    with TestClient(create_app(), base_url="http://localhost:8080") as client:
+        script = client.get("/ui/app.js").text
+        styles = client.get("/ui/styles.css").text
+
+    assert "--nav-min: 148px" in styles
+    assert "--inspector-max: 460px" in styles
+    assert 'cssPx("--nav-min", 148)' in script
+    assert 'cssPx("--inspector-max", 460)' in script
+
+
+def test_mcp_ui_reflow_is_container_driven():
+    """Pane content reflows on the workbench container's own width, not the
+    viewport: a narrow workbench beside a wide inspector must still stack, so
+    the old viewport media queries for those grids are gone."""
+    with TestClient(create_app(), base_url="http://localhost:8080") as client:
+        styles = client.get("/ui/styles.css").text
+
+    assert "@container workbench (max-width: 1080px)" in styles
+    assert "@container workbench (max-width: 760px)" in styles
+    assert "@media (max-width: 1300px)" not in styles
+    assert "@media (max-width: 1050px)" not in styles
+    assert "@media (max-width: 768px)" not in styles
+    # Fixed sidebar columns became user-resizable with clamps.
+    assert "resize: horizontal" in styles


### PR DESCRIPTION
## What this fixes (human outcome)

1. **Chat rendering, including repeated turns.** Reproduced live: `/ui` assets shipped with no `Cache-Control`, so browsers heuristically cached `index.html` and paired it with a newer `app.js`; `renderFactsPane` then threw (`Cannot set properties of null`) inside the fetch path and **already-received, paid Grok answers were replaced with "Invocation failed"**. Fixed with a `no-cache` static middleware (ETag 304s keep it cheap), null-safe receipt writes, a decoupled receipt render, and a version handshake that self-heals stale pages with one revalidating reload (`src/version.py` `UI_ASSET_VERSION` is the single source; `/runtimez` exposes it).
2. **Auto-resizing layout.** Content reflows on the workbench **container's** width (viewport media queries removed — a narrow workbench beside a wide inspector now stacks), fixed pixel heights became viewport clamps, schema/OKF sidebars are natively drag-resizable within clamps, panel bounds live once in CSS custom properties, and the swarm page's fixed 1280px/340px tracks are fluid.
3. **One product.** Shared `mcp_ui/tokens.css` drives Control Center + Swarm Optimizer (palette was triplicated before); both local pages cross-link each other and grokmcp.org; the public-site sync copies the tokens; hosted `/control` gives signed-out visitors a plain-language explainer with one **Sign in with GitHub** action instead of a naked redirect.
4. **Less cognitive load.** Transcript directly under the composer; run options and setup check below it; "Usage & Costs" / "Knowledge (OKF)" labels; an **unreachable** gateway shows a copyable 4-line quick-start card (hidden when the gateway is reachable but failing a named check — reinstall would be the wrong remedy).

## Verification (live browser, not just tests)

- `http://127.0.0.1:4777/ui/index.html` (this branch served live): zero-config sample turn + markdown-heavy second turn both rendered (h2/list/code-fence/table as real DOM, no raw markdown), receipts populated (SUCCESS / grok-composer-2.5-fast / final_answer / CLI), **console clean**.
- Viewports verified: 1280×720 desktop, 500×800 narrow IDE (icon-rail collapse), 375×812 mobile (no clipping/blowouts) on both `/ui/index.html` and `/ui/swarm.html`.
- `cache-control: no-cache` confirmed on live `/ui` responses; `ui_asset_version` confirmed in `/runtimez`.
- Onboarding card visually verified on Setup & Status.

## Tests

- `uv run pytest -q`: **1200 passed** (7+ new contracts: cache headers, single-sourced asset version, receipt-pane decoupling, onboarding card, container-driven reflow, project-site links, boundary-correct prefixes, pure-ASGI tombstone extended).
- Hosted site: `security-contract` / `template-safety-scanner` / `cloud-run-deployment` — **18/18**.
- OKF bundle regenerated (`scripts/generate_okf.py --write`) with the public mirror; stale "Usage & Telemetry" prose in `faq.md` updated.

## Changed paths

`mcp_ui/{app.js,index.html,styles.css,swarm.html,swarm.js,tokens.css(new)}`, `src/{http_server.py,version.py}`, `tests/{test_mcp_ui.py,test_http_server.py}`, `sites/unigrok-control-center/{app/control/page.tsx,app/control/signed-out.tsx(new),scripts/sync-swarm-playground.mjs,public/docs/okf/*}`, `docs/okf/{api-reference.md,faq.md}`, `CHANGELOG.md`.

## Risks / notes for Codex

- An adversarial two-lens review (correctness + pinned contracts) ran over the diff; all six confirmed findings were fixed pre-commit (inline-drag width vs container reset, quick-start false positive on reachable-503, untracked new files, stale OKF prose, prefix boundary matching, tombstone coverage).
- The hosted-site changes are source-only; the deployed grokmcp.org/control.grokmcp.org keep current behavior until the next site deploy. `/swarm/` on the Cloud Run standalone build remains a known pre-existing gap (sync only runs in the Sites build) — deliberately out of scope here.
- Users with a previously stale cached page self-heal on next load via the handshake reload; worst case is a visible "hard refresh" banner.
- `mcp-client.js` dedup of app.js/swarm.js plumbing was deliberately deferred (would churn ~10 pinned contract literals for no user-visible gain).

Human sponsor: @djtelicloud
Agent-Assisted-By: Claude via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)