### PR TITLE
fix(cli): restore native session continuity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,9 +40,10 @@ plane requests should use `fallback_policy=same_plane` when crossing credential
 planes is forbidden; `cross_plane` permits bounded failover. The CLI execution
 adapter does not expose the full API ReAct local-tool loop. `_call_plane`
 invokes the headless CLI with
-`--output-format json` or `streaming-json`, deterministic `-s` native session
-ids, optional `--json-schema`, `--effort`, and `--max-turns`, plus `grok
---check` for plane readiness. Native CLI sessions are the continuity mechanism;
+`--output-format json` or `streaming-json`, deterministic `--session-id`
+creation and `--resume` continuation, optional `--json-schema`, `--effort`,
+and `--max-turns`, plus `grok --check` for plane readiness. Native CLI sessions
+are the continuity mechanism;
 the old `grok sessions list` scrape and fragile regex session sync are gone.
 Still-unintegrated CLI surfaces include `grok agent stdio|serve|leader` and
 `--best-of-n`. Treat the CLI as ground truth when unifying the two planes.

--- a/architecture.md
+++ b/architecture.md
@@ -341,11 +341,14 @@ with a bounded, cached, API-key-stripped `grok models` call that must report a
 grok.com login; calls use `--output-format json` or `streaming-json`, and
 forward structured-output and reasoning controls through `--json-schema`,
 `--effort`, and `--max-turns` when those are present on the internal request.
-For native CLI continuity, the server stores a deterministic CLI session id and
-resumes it with `-s`; the old post-hoc `grok sessions list` scrape and regex
-session sync are no longer part of the runtime. In keyless/non-native mode,
-server-side history can still be rendered into the prompt as a compatibility
-fallback, but native CLI sessions do not prompt-stuff stored history.
+For native CLI continuity, the server creates a deterministic id with
+`--session-id` and later continues it with `--resume`. A genuinely busy session
+is branched with `--fork-session`; bounded server-side history replay is the
+last compatibility fallback if both resume and fork are unavailable. The old
+post-hoc `grok sessions list` scrape and regex session sync are no longer part
+of the runtime. Explicit message arrays and keyless/non-native calls are
+rendered into a self-contained prompt instead of being mixed with a native CLI
+transcript.
 
 ---
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -819,6 +819,7 @@ def _build_grok_cli_args(
     dynamic_sys_prompt: str,
     output_format: str,
     cli_session_id: Optional[str] = None,
+    cli_resume_session_id: Optional[str] = None,
     profile: Optional[Dict[str, Any]] = None,
     max_turns: Optional[int] = None,
     json_schema: Any = None,
@@ -828,10 +829,15 @@ def _build_grok_cli_args(
     isolated: bool = False,
 ) -> List[str]:
     args: List[str] = []
-    if cli_session_id:
-        # -s creates-or-resumes the CLI session under OUR id, so the session
-        # mapping is deterministic up front.
-        args.extend(["-s", cli_session_id])
+    if cli_resume_session_id:
+        args.extend(["--resume", cli_resume_session_id])
+        if cli_session_id:
+            # A busy native session can be continued safely by forking its
+            # full CLI transcript under a new deterministic session id.
+            args.extend(["--fork-session", "--session-id", cli_session_id])
+    elif cli_session_id:
+        # --session-id names a new conversation; it never resumes one.
+        args.extend(["--session-id", cli_session_id])
 
     args.extend(["--system-prompt-override", dynamic_sys_prompt])
 
@@ -950,6 +956,14 @@ def _cli_logical_session_lock(session: str) -> asyncio.Lock:
 def _is_cli_session_in_use_error(message: str) -> bool:
     text = str(message or "").lower()
     return "session id" in text and "already in use" in text
+
+
+def _is_cli_session_missing_error(message: str) -> bool:
+    text = str(message or "").lower()
+    return "session" in text and (
+        "not found locally" in text or "failed to restore session from remote" in text
+    )
+
 
 UNIGROK_SAFETY_POLICY = """# UniGrok Safety Policy
 
@@ -7474,21 +7488,56 @@ async def _call_plane(
 
         grok_path = PathResolver.get_grok_cli_path()
         check_circuit_breaker(model_name)
-        use_native_cli_session = bool(session and store and cli_native_session_ids_enabled())
-        cli_prompt = prompt
-        if session and not input_messages and not use_native_cli_session:
-            history_context = _format_cli_history_context(await load_history(session, store))
-            if history_context:
-                cli_prompt = f"{history_context}\n\n# Current User Request\n{prompt}"
+        # Explicit message arrays are authoritative conversation state. They
+        # use a self-contained prompt instead of mixing caller history with a
+        # possibly unrelated native CLI transcript.
+        use_native_cli_session = bool(
+            session
+            and store
+            and not input_messages
+            and cli_native_session_ids_enabled()
+        )
 
-        async def _invoke_cli(cli_session_id: Optional[str]) -> tuple[str, Optional[str]]:
+        async def _prompt_with_server_history() -> str:
+            if input_messages:
+                context_messages = list(input_messages)
+                for index in range(len(context_messages) - 1, -1, -1):
+                    message = context_messages[index]
+                    if (
+                        str(message.get("role") or "").lower() == "user"
+                        and _message_content_to_text(message.get("content", ""))
+                        == prompt.strip()
+                    ):
+                        context_messages.pop(index)
+                        break
+            elif session:
+                context_messages = await load_history(session, store)
+            else:
+                return prompt
+
+            history_context = _format_cli_history_context(context_messages)
+            if not history_context:
+                return prompt
+            return f"{history_context}\n\n# Current User Request\n{prompt}"
+
+        cli_prompt = prompt
+        if input_messages or (session and not use_native_cli_session):
+            cli_prompt = await _prompt_with_server_history()
+
+        async def _invoke_cli(
+            current_prompt: str,
+            *,
+            cli_session_id: Optional[str] = None,
+            cli_resume_session_id: Optional[str] = None,
+        ) -> tuple[str, Optional[str]]:
             output_format = "streaming-json" if on_event is not None else "json"
             args = _build_grok_cli_args(
-                cli_prompt=cli_prompt,
+                cli_prompt=current_prompt,
                 model_name=model_name,
                 dynamic_sys_prompt=dynamic_sys_prompt,
                 output_format=output_format,
                 cli_session_id=cli_session_id,
+                cli_resume_session_id=cli_resume_session_id,
                 profile=profile or load_grok_profile(model_name),
                 max_turns=max_turns,
                 json_schema=json_schema,
@@ -7565,17 +7614,56 @@ async def _call_plane(
                     stored_cli_id = session_data.get("cli_session_id")
                 cli_session_id = stored_cli_id or str(uuid.uuid4())
 
-            try:
-                text, returned_id = await _invoke_cli(cli_session_id)
-            except RuntimeError as exc:
-                if not (use_native_cli_session and _is_cli_session_in_use_error(str(exc))):
-                    raise
-                retry_cli_id = str(uuid.uuid4())
-                logging.getLogger("GrokMCP").warning(
-                    f"Grok CLI session mapping for '{session}' was busy/stale; retrying with a fresh CLI session id."
+            async def _start_fresh_from_server_history() -> tuple[
+                str, Optional[str], str
+            ]:
+                fresh_cli_id = str(uuid.uuid4())
+                retry_prompt = await _prompt_with_server_history()
+                fresh_text, fresh_returned_id = await _invoke_cli(
+                    retry_prompt,
+                    cli_session_id=fresh_cli_id,
                 )
-                text, returned_id = await _invoke_cli(retry_cli_id)
-                cli_session_id = retry_cli_id
+                return fresh_text, fresh_returned_id, fresh_cli_id
+
+            try:
+                text, returned_id = await _invoke_cli(
+                    cli_prompt,
+                    cli_session_id=None if stored_cli_id else cli_session_id,
+                    cli_resume_session_id=stored_cli_id,
+                )
+            except RuntimeError as exc:
+                if not use_native_cli_session:
+                    raise
+                if _is_cli_session_missing_error(str(exc)):
+                    logging.getLogger("GrokMCP").warning(
+                        f"Grok CLI session mapping for '{session}' was missing; retrying from server history."
+                    )
+                    text, returned_id, cli_session_id = (
+                        await _start_fresh_from_server_history()
+                    )
+                elif _is_cli_session_in_use_error(str(exc)):
+                    fork_cli_id = str(uuid.uuid4())
+                    logging.getLogger("GrokMCP").warning(
+                        f"Grok CLI session mapping for '{session}' was busy; retrying with a forked CLI session id."
+                    )
+                    try:
+                        text, returned_id = await _invoke_cli(
+                            prompt,
+                            cli_session_id=fork_cli_id,
+                            cli_resume_session_id=stored_cli_id,
+                        )
+                        cli_session_id = fork_cli_id
+                    except RuntimeError as fork_exc:
+                        if not _is_cli_session_in_use_error(str(fork_exc)):
+                            raise
+                        logging.getLogger("GrokMCP").warning(
+                            f"Grok CLI session fork for '{session}' was also busy; retrying from server history."
+                        )
+                        text, returned_id, cli_session_id = (
+                            await _start_fresh_from_server_history()
+                        )
+                else:
+                    raise
 
             return text, returned_id, cli_session_id if use_native_cli_session else None, stored_cli_id
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3567,7 +3567,7 @@ class TestCliPlaneV2:
         assert (content, is_cli) == ("ok", True)
         assert captured["cmd"] == [
             "/tmp/grok",
-            "-s",
+            "--resume",
             "sid-existing",
             "--system-prompt-override",
             "sys",
@@ -3738,8 +3738,8 @@ class TestCliPlaneV2:
 
         cmd = captured["cmd"]
         assert cmd[cmd.index("--output-format") + 1] == "json"
-        # New sessions get a generated -s id (create-or-resume semantics)...
-        generated = cmd[cmd.index("-s") + 1]
+        # New sessions get a generated --session-id.
+        generated = cmd[cmd.index("--session-id") + 1]
         uuid_module.UUID(generated)
         # ...but the CLI's reported sessionId wins for persistence.
         store.save_session.assert_awaited_once_with(
@@ -3777,11 +3777,74 @@ class TestCliPlaneV2:
 
         assert content == "resumed"
         cmd = captured["cmd"]
-        assert cmd[cmd.index("-s") + 1] == "abc-123"
+        assert cmd[cmd.index("--resume") + 1] == "abc-123"
+        assert "--session-id" not in cmd
         store.save_session.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_cli_retries_stale_session_id_with_fresh_mapping(self, monkeypatch):
+    async def test_cli_replays_server_history_when_stored_session_is_missing(
+        self, monkeypatch
+    ):
+        import json as json_module
+        import uuid as uuid_module
+
+        from src.utils import _call_plane
+
+        monkeypatch.setenv("UNIGROK_RUNTIME", "local")
+        captured = {"cmds": []}
+
+        class FakeProc:
+            def __init__(self, returncode):
+                self.returncode = returncode
+
+        async def fake_exec(*cmd, **kwargs):
+            captured["cmds"].append(list(cmd))
+            return FakeProc(1 if len(captured["cmds"]) == 1 else 0)
+
+        payload = json_module.dumps({
+            "text": "recovered from server history",
+            "sessionId": "fresh-cli-session",
+        }).encode()
+
+        async def fake_communicate(proc, timeout_sec, input_data=None):
+            if proc.returncode:
+                return (
+                    b"",
+                    b"Session abc-123 not found locally. Failed to restore session from remote: 404 Not Found",
+                )
+            return payload, b""
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        monkeypatch.setattr("src.utils.communicate_with_timeout", fake_communicate)
+
+        store = self._fake_store(session_row={"cli_session_id": "abc-123"})
+        store.load_messages.return_value = [
+            {"role": "user", "content": "Remember marker MISSING-SESSION-MARKER"},
+            {"role": "assistant", "content": "Marker stored"},
+        ]
+        content, _, _, is_cli = await _call_plane(
+            "cli-fallback", "What marker did I give you?", "sess", store, "sys"
+        )
+
+        assert (content, is_cli) == ("recovered from server history", True)
+        assert len(captured["cmds"]) == 2
+        assert captured["cmds"][0][captured["cmds"][0].index("--resume") + 1] == "abc-123"
+        fresh_cmd = captured["cmds"][1]
+        assert "--resume" not in fresh_cmd
+        assert "--fork-session" not in fresh_cmd
+        uuid_module.UUID(fresh_cmd[fresh_cmd.index("--session-id") + 1])
+        retry_prompt = fresh_cmd[fresh_cmd.index("-p") + 1]
+        assert "MISSING-SESSION-MARKER" in retry_prompt
+        assert retry_prompt.count("What marker did I give you?") == 1
+        store.load_messages.assert_awaited_once()
+        store.save_session.assert_awaited_once_with(
+            "sess",
+            cli_session_id="fresh-cli-session",
+            model="grok-composer-2.5-fast",
+        )
+
+    @pytest.mark.asyncio
+    async def test_cli_forks_busy_session_with_fresh_mapping(self, monkeypatch):
         import json as json_module
         import uuid as uuid_module
 
@@ -3804,6 +3867,64 @@ class TestCliPlaneV2:
 
         payload = json_module.dumps({
             "text": "recovered",
+            "sessionId": "forked-cli-session",
+        }).encode()
+
+        async def fake_communicate(proc, timeout_sec, input_data=None):
+            if proc.returncode:
+                return b"", b"Error: Session ID abc-123 is already in use."
+            return payload, b""
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        monkeypatch.setattr("src.utils.communicate_with_timeout", fake_communicate)
+
+        store = self._fake_store(session_row={"cli_session_id": "abc-123"})
+        content, _, _, is_cli = await _call_plane(
+            "cli-fallback", "What marker did I give you?", "sess", store, "sys"
+        )
+
+        assert (content, is_cli) == ("recovered", True)
+        assert len(captured["cmds"]) == 2
+        assert captured["cmds"][0][captured["cmds"][0].index("--resume") + 1] == "abc-123"
+        assert "--session-id" not in captured["cmds"][0]
+        first_prompt = captured["cmds"][0][captured["cmds"][0].index("-p") + 1]
+        assert first_prompt == "What marker did I give you?"
+        fork_cmd = captured["cmds"][1]
+        assert fork_cmd[fork_cmd.index("--resume") + 1] == "abc-123"
+        assert "--fork-session" in fork_cmd
+        fork_id = fork_cmd[fork_cmd.index("--session-id") + 1]
+        uuid_module.UUID(fork_id)
+        assert fork_cmd[fork_cmd.index("-p") + 1] == "What marker did I give you?"
+        store.load_messages.assert_not_awaited()
+        store.save_session.assert_awaited_once_with(
+            "sess",
+            cli_session_id="forked-cli-session",
+            model="grok-composer-2.5-fast",
+        )
+        assert "grok-composer-2.5-fast" not in utils._BREAKER_STATE
+
+    @pytest.mark.asyncio
+    async def test_cli_replays_server_history_when_resume_and_fork_are_busy(
+        self, monkeypatch
+    ):
+        import json as json_module
+        import uuid as uuid_module
+
+        from src.utils import _call_plane
+
+        monkeypatch.setenv("UNIGROK_RUNTIME", "local")
+        captured = {"cmds": []}
+
+        class FakeProc:
+            def __init__(self, returncode):
+                self.returncode = returncode
+
+        async def fake_exec(*cmd, **kwargs):
+            captured["cmds"].append(list(cmd))
+            return FakeProc(1 if len(captured["cmds"]) < 3 else 0)
+
+        payload = json_module.dumps({
+            "text": "recovered from server history",
             "sessionId": "fresh-cli-session",
         }).encode()
 
@@ -3816,20 +3937,33 @@ class TestCliPlaneV2:
         monkeypatch.setattr("src.utils.communicate_with_timeout", fake_communicate)
 
         store = self._fake_store(session_row={"cli_session_id": "abc-123"})
-        content, _, _, is_cli = await _call_plane("cli-fallback", "hi", "sess", store, "sys")
+        store.load_messages.return_value = [
+            {"role": "user", "content": "Remember marker STALE-SESSION-MARKER"},
+            {"role": "assistant", "content": "Marker stored"},
+        ]
+        content, _, _, is_cli = await _call_plane(
+            "cli-fallback", "What marker did I give you?", "sess", store, "sys"
+        )
 
-        assert (content, is_cli) == ("recovered", True)
-        assert len(captured["cmds"]) == 2
-        assert captured["cmds"][0][captured["cmds"][0].index("-s") + 1] == "abc-123"
-        retry_id = captured["cmds"][1][captured["cmds"][1].index("-s") + 1]
-        assert retry_id != "abc-123"
-        uuid_module.UUID(retry_id)
+        assert (content, is_cli) == ("recovered from server history", True)
+        assert len(captured["cmds"]) == 3
+        assert captured["cmds"][0][captured["cmds"][0].index("--resume") + 1] == "abc-123"
+        assert "--fork-session" in captured["cmds"][1]
+        fresh_cmd = captured["cmds"][2]
+        assert "--resume" not in fresh_cmd
+        assert "--fork-session" not in fresh_cmd
+        uuid_module.UUID(fresh_cmd[fresh_cmd.index("--session-id") + 1])
+        retry_prompt = fresh_cmd[fresh_cmd.index("-p") + 1]
+        assert "# Server Conversation History" in retry_prompt
+        assert "STALE-SESSION-MARKER" in retry_prompt
+        assert "# Current User Request" in retry_prompt
+        assert retry_prompt.count("What marker did I give you?") == 1
+        store.load_messages.assert_awaited_once()
         store.save_session.assert_awaited_once_with(
             "sess",
             cli_session_id="fresh-cli-session",
             model="grok-composer-2.5-fast",
         )
-        assert "grok-composer-2.5-fast" not in utils._BREAKER_STATE
 
     @pytest.mark.asyncio
     async def test_keyless_cli_uses_server_history_without_native_session_id(self, monkeypatch):
@@ -3874,12 +4008,60 @@ class TestCliPlaneV2:
 
         assert (content, is_cli) == ("MCP-MARKER", True)
         cmd = captured["cmd"]
-        assert "-s" not in cmd
+        assert "--session-id" not in cmd
+        assert "--resume" not in cmd
         prompt_arg = cmd[cmd.index("-p") + 1]
         assert "Server Conversation History" in prompt_arg
         assert "MCP-MARKER" in prompt_arg
         assert "Current User Request" in prompt_arg
         store.get_session.assert_not_awaited()
+        store.save_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cli_explicit_messages_override_native_session_mapping(self, monkeypatch):
+        import json as json_module
+
+        from src.utils import _call_plane
+
+        monkeypatch.setenv("UNIGROK_RUNTIME", "local")
+        captured = {}
+
+        class FakeProc:
+            returncode = 0
+
+        async def fake_exec(*cmd, **kwargs):
+            captured["cmd"] = list(cmd)
+            return FakeProc()
+
+        async def fake_communicate(proc, timeout_sec, input_data=None):
+            return json_module.dumps({"text": "explicit history used"}).encode(), b""
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        monkeypatch.setattr("src.utils.communicate_with_timeout", fake_communicate)
+
+        store = self._fake_store(session_row={"cli_session_id": "native-cli-session"})
+        content, _, _, is_cli = await _call_plane(
+            "cli-fallback",
+            "What marker did I give you?",
+            "sess",
+            store,
+            "sys",
+            input_messages=[
+                {"role": "user", "content": "Remember marker EXPLICIT-MARKER"},
+                {"role": "assistant", "content": "Marker stored"},
+                {"role": "user", "content": "What marker did I give you?"},
+            ],
+        )
+
+        assert (content, is_cli) == ("explicit history used", True)
+        cmd = captured["cmd"]
+        assert "--resume" not in cmd
+        assert "--session-id" not in cmd
+        prompt_arg = cmd[cmd.index("-p") + 1]
+        assert "EXPLICIT-MARKER" in prompt_arg
+        assert prompt_arg.count("What marker did I give you?") == 1
+        store.get_session.assert_not_awaited()
+        store.load_messages.assert_not_awaited()
         store.save_session.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -3928,7 +4110,8 @@ class TestCliPlaneV2:
 
         assert (content, is_cli) == ("context survived via native session", True)
         cmd = captured["cmd"]
-        assert cmd[cmd.index("-s") + 1] == "native-cli-session"
+        assert cmd[cmd.index("--resume") + 1] == "native-cli-session"
+        assert "--session-id" not in cmd
         prompt_arg = cmd[cmd.index("-p") + 1]
         assert prompt_arg == "What marker did I give you?"
         assert "Server Conversation History" not in prompt_arg


### PR DESCRIPTION
## Summary

- Correct the Grok CLI 0.2.93 session contract: create with `--session-id`, continue with `--resume`, and branch a genuinely busy session with `--fork-session`.
- Recover a missing native mapping by rebuilding a fresh CLI session from bounded SQLite conversation history.
- Preserve explicit message arrays as authoritative state and include the current request exactly once.
- Update the architecture and repository guidance to match the live CLI behavior.

Gemini source handoff: `459c741b729cad4f821472ab49edcbda545079eb`.

Exact reviewed integration head: `d0eedcc316880c5fa6d89031d2d0389aa80874bc`.

## Changed paths

- `AGENTS.md`
- `architecture.md`
- `src/utils.py`
- `tests/test_utils.py`

## Verification on the exact head

- `git diff --check HEAD^ HEAD`
- `uv run python scripts/generate_okf.py --check`
- focused CLI/session matrix: 18 passed
- `uv run pytest -q tests/test_utils.py tests/test_swarm_engine.py`: 283 passed
- `uv run pytest -q`: 1,233 passed
- live pinned binary: `grok 0.2.93 (f00f96316d)`
- live create/resume/fork replay preserved token `NEEDLE-7319` across all three commands
- Grok 4.5 API exact-diff peer review: MERGE, no blockers

## Risk and follow-up

- Recovery classifiers intentionally match observed CLI 0.2.93 error text; tests pin those strings.
- Last-resort SQLite replay remains bounded to the existing history window.
- The promise-string heuristic and blanket `success=0` telemetry change from the source handoff were rejected and are not in this PR. Three-valued verified/unverified outcomes will be handled as a separate compatibility-safe change.

Human sponsor: @djtelicloud

Agent-Assisted-By: Codex
Agent-Assisted-By: Gemini 3.1 Pro via Antigravity