### PR TITLE
Stage 0.5: secure Vertex and UniGrok provider wiring

### DIFF
--- a/.agents/campaigns/gemma-needle-2000-v1/provider_profile.example.json
+++ b/.agents/campaigns/gemma-needle-2000-v1/provider_profile.example.json
@@ -1,0 +1,28 @@
+{
+  "version": 1,
+  "campaign_id": "gemma-needle-2000-v1",
+  "max_live_calls": 2,
+  "orchestrator_retry_limit": 0,
+  "vertex_max_output_tokens": 64,
+  "bindings": [
+    {
+      "provider": "vertex",
+      "credential_binding_id": "google-adc-default",
+      "auth_kind": "google_adc",
+      "project": "your-google-cloud-project",
+      "location": "global",
+      "model": "gemini-2.5-flash",
+      "role": "mutation-adjudication-smoke"
+    },
+    {
+      "provider": "unigrok",
+      "credential_binding_id": "unigrok-mcp-local",
+      "auth_kind": "server_managed",
+      "endpoint": "http://127.0.0.1:4765/mcp",
+      "model": "grok-4.5",
+      "plane": "cli",
+      "fallback_policy": "same_plane",
+      "role": "seed-critic-smoke"
+    }
+  ]
+}

--- a/.agents/campaigns/gemma-needle-2000-v1/stage0_5_manifest.json
+++ b/.agents/campaigns/gemma-needle-2000-v1/stage0_5_manifest.json
@@ -1,0 +1,33 @@
+{
+  "stage": "0_5_provider_wiring",
+  "objective": "Prove credential-safe Vertex ADC and loopback UniGrok connectivity before any dataset generation.",
+  "dataset_writes": 0,
+  "max_live_calls": 2,
+  "orchestrator_retry_limit": 0,
+  "providers": [
+    {
+      "provider": "vertex",
+      "auth_kind": "google_adc",
+      "call_limit": 1
+    },
+    {
+      "provider": "unigrok",
+      "auth_kind": "server_managed",
+      "plane": "cli",
+      "fallback_policy": "same_plane",
+      "call_limit": 1
+    }
+  ],
+  "required_gates": [
+    "Explicit --confirm-live opt-in",
+    "One pure JSON object accepted against an exact schema",
+    "No promise-only or prose-wrapped completion accepted",
+    "Private external cache and receipt permissions",
+    "No raw credential copied, logged, cached, or committed",
+    "Offline replay succeeds with zero provider calls"
+  ],
+  "known_limitations": [
+    "The public UniGrok agent contract does not expose a hard output-token cap; this smoke bounds live call count, uses fast mode, and accepts only the tiny exact schema.",
+    "The owner-private replay cache is identity- and digest-bound for integrity, not authenticated against a malicious process already running as the same OS user."
+  ]
+}

--- a/.agents/campaigns/gemma-needle-2000-v1/stage1_manifest.json
+++ b/.agents/campaigns/gemma-needle-2000-v1/stage1_manifest.json
@@ -11,5 +11,5 @@
     "Blinded Grok 4.5 critic execution",
     "Gemini adjudicator execution"
   ],
-  "pre_requisite": "Complete Stage 0 pass."
+  "pre_requisite": "Complete Stage 0 and the bounded Stage 0.5 live/replay provider wiring gate."
 }

--- a/.agents/campaigns/gemma-needle-2000-v1/ticket.json
+++ b/.agents/campaigns/gemma-needle-2000-v1/ticket.json
@@ -2,8 +2,17 @@
   "campaign_id": "gemma-needle-2000-v1",
   "status": "proposal",
   "stage": "research_dev",
-  "codex_status": "pending_codex_acceptance",
+  "codex_status": "stage0_5_passed_pending_git_integration",
   "issue_number": 65,
+  "stage0_5_provider_wiring": {
+    "status": "passed",
+    "dataset_writes": 0,
+    "vertex_auth": "google_adc_reference_only",
+    "grok_auth": "unigrok_server_managed_reference_only",
+    "live_receipt_digest": "sha256:d784e49ab87d891c44985f326072191cb51fce87b9edc10c013b21a236568a54",
+    "replay_status": "mechanical_pass_origin_unverified",
+    "replay_receipt_digest": "sha256:b9c34b95aeea2bbd1c9df62c040528af52b763779b3ce0ead4ea6fefe2833a34"
+  },
   "objective": "Create a high-quality candidate dataset for Gemma planner and Needle specialist experiments",
   "target_accepted_roots": 2000,
   "variants_per_root": {

--- a/.codex/memory/active-work.md
+++ b/.codex/memory/active-work.md
@@ -2,7 +2,7 @@
 
 Last updated: 2026-07-13
 Owner: Codex
-Status: Stage 0.5 provider wiring is in stacked draft PR #67; CI and integration remain
+Status: Stage 0.5 wiring is in stacked draft PR #67; parent CI and integration remain
 
 This is the project-scoped handoff for new Codex chats. Verify drift-prone Git,
 CI, runtime, DNS, cloud, and benchmark state live before acting. Never record
@@ -32,12 +32,16 @@ credentials, OAuth codes, tokens, or private keys here.
   focused campaign/release tests on Python 3.12; Ruff and `git diff --check`
   green; Docker build green with only `.grok/prompts` and `.grok/hyperparams`
   present in the image.
+- GitHub reports PR #67 clean and mergeable. It has no check rollout because
+  `.github/workflows/ci.yml` runs pull-request CI only when the base is `main`;
+  the integrated parent PR #66 head must therefore carry the GitHub CI gate.
 
 ## Remaining gates
 
-- Review the current head of draft PR #67 after GitHub CI completes, then
-  integrate it into `gemini/campaign-gemma-needle-2000-v1` through the normal
-  Codex gate if the exact head remains green.
+- Review the current head of draft PR #67, then integrate it into
+  `gemini/campaign-gemma-needle-2000-v1` through the normal Codex gate. Require
+  the resulting exact parent PR #66 head to pass the GitHub CI checks against
+  `main` before any training campaign proceeds.
 - Do not start Stage 1 generation until the stacked repair is integrated into
   the Gemini campaign branch and its exact head passes CI/Codex review.
 - Do not represent the replay cache as authenticated against a malicious

--- a/.codex/memory/active-work.md
+++ b/.codex/memory/active-work.md
@@ -2,7 +2,7 @@
 
 Last updated: 2026-07-13
 Owner: Codex
-Status: Stage 0.5 provider wiring passed; Git integration and CI remain
+Status: Stage 0.5 provider wiring is in stacked draft PR #67; CI and integration remain
 
 This is the project-scoped handoff for new Codex chats. Verify drift-prone Git,
 CI, runtime, DNS, cloud, and benchmark state live before acting. Never record
@@ -10,10 +10,10 @@ credentials, OAuth codes, tokens, or private keys here.
 
 ## Exact verified state
 
-- Campaign Issue #65 and Gemini draft PR #66 remain the parent proposal. The
-  Codex repair branch starts from Gemini head
-  `8d99427d2719da286cb24245adbdedf656464070` and must be published as a
-  stacked draft PR; it is not landed on `main`.
+- Campaign Issue #65 and Gemini draft PR #66 remain the parent proposal. Codex
+  published stacked draft PR #67 from functional code commit
+  `634ffd75d1a1488262139740563330ce1d34cb44`, based directly on Gemini head
+  `8d99427d2719da286cb24245adbdedf656464070`. It is not landed on `main`.
 - Stage 0.5 securely binds Vertex through standard Google ADC and Grok through
   the loopback UniGrok MCP. No ADC file, API key, OAuth file, CLI auth, `.env`,
   Gemini config, Claude auth, or Codex auth was copied into a worktree.
@@ -35,9 +35,9 @@ credentials, OAuth codes, tokens, or private keys here.
 
 ## Remaining gates
 
-- Commit and push `codex/campaign-provider-runtime`, open a stacked draft PR
-  against `gemini/campaign-gemma-needle-2000-v1`, and link it to Issue #65 and
-  PR #66 with the exact head and test/receipt evidence.
+- Review the current head of draft PR #67 after GitHub CI completes, then
+  integrate it into `gemini/campaign-gemma-needle-2000-v1` through the normal
+  Codex gate if the exact head remains green.
 - Do not start Stage 1 generation until the stacked repair is integrated into
   the Gemini campaign branch and its exact head passes CI/Codex review.
 - Do not represent the replay cache as authenticated against a malicious

--- a/.codex/memory/active-work.md
+++ b/.codex/memory/active-work.md
@@ -2,44 +2,47 @@
 
 Last updated: 2026-07-13
 Owner: Codex
-Status: Session-continuity integration complete; no active landing or runtime gate
+Status: Stage 0.5 provider wiring passed; Git integration and CI remain
 
 This is the project-scoped handoff for new Codex chats. Verify drift-prone Git,
 CI, runtime, DNS, cloud, and benchmark state live before acting. Never record
 credentials, OAuth codes, tokens, or private keys here.
 
-## Completed state
+## Exact verified state
 
-- Gemini handed off `459c741b729cad4f821472ab49edcbda545079eb` as a
-  session/telemetry repair. Exact review rejected its promise-string heuristic
-  and blanket `success=0` changes because they mislabeled unverified results as
-  failures and would poison routing/task-memory readers.
-- The salvageable continuity work was corrected at reviewed head
-  `d0eedcc316880c5fa6d89031d2d0389aa80874bc`: Grok CLI 0.2.93 now creates
-  sessions with `--session-id`, resumes with `--resume`, forks genuinely busy
-  sessions, rebuilds missing mappings from bounded SQLite history, and keeps
-  explicit message arrays authoritative.
-- PR #62 passed 1,233 local tests, all required CI and CodeQL checks, Grok 4.5
-  exact-diff review, exact-head Codex Approval, and `./scripts/land`. The
-  landing receipt printed `LANDED TO MAIN: d0eedcc316880c5fa6d89031d2d0389aa80874bc`.
-- PR #62 merged to protected `origin/main` as
-  `741460316cc95083ff43b82d333976303a13fb0f`; visible local `main`, cached
-  `origin/main`, and live remote `main` were synchronized to that merge.
-- Stable `:4765` was rebuilt from synchronized main. Its in-container
-  `src/utils.py` hash matched the source tree, health and CLI OAuth readiness
-  were green, and a live public-MCP three-turn CLI replay returned
-  `SAVED`, `NEEDLE-LIVE-7414`, then `NEEDLE-LIVE-7414-THIRD` on one persisted
-  native session without busy/missing/error logs.
-- Existing contributor worktrees and the primary checkout's untracked
-  `scratch_swarm/` directory were preserved.
+- Campaign Issue #65 and Gemini draft PR #66 remain the parent proposal. The
+  Codex repair branch starts from Gemini head
+  `8d99427d2719da286cb24245adbdedf656464070` and must be published as a
+  stacked draft PR; it is not landed on `main`.
+- Stage 0.5 securely binds Vertex through standard Google ADC and Grok through
+  the loopback UniGrok MCP. No ADC file, API key, OAuth file, CLI auth, `.env`,
+  Gemini config, Claude auth, or Codex auth was copied into a worktree.
+- The owner-only non-secret provider profile lives under
+  `~/Library/Application Support/UniGrok/campaigns/gemma-needle-2000-v1/`.
+  Provider caches and receipts are external, mode `0700`/`0600`, schema- and
+  provenance-validated, and digest-bound for integrity.
+- Final live smoke passed with exactly two transport attempts, two verified
+  provider responses, and zero dataset writes. Receipt digest:
+  `sha256:d784e49ab87d891c44985f326072191cb51fce87b9edc10c013b21a236568a54`.
+- Disconnected replay passed with dead ADC/network settings, two cache hits,
+  zero transport attempts, zero provider responses, and zero dataset writes.
+  Receipt digest:
+  `sha256:b9c34b95aeea2bbd1c9df62c040528af52b763779b3ce0ead4ea6fefe2833a34`.
+- Exact final local verification: 1,287 full-suite tests on Python 3.11; 65
+  focused campaign/release tests on Python 3.12; Ruff and `git diff --check`
+  green; Docker build green with only `.grok/prompts` and `.grok/hyperparams`
+  present in the image.
 
-## Follow-up boundary
+## Remaining gates
 
-- Truthful outcome telemetry is separate product work, not an unfinished gate
-  on PR #62. Follow `docs/design/authority-inversion.md`: preserve
-  `finish_reason`, add a three-valued verified-success/verified-failure/
-  unverified verdict, keep semantic judges advisory, and quarantine unverified
-  or legacy binary rows from training, task memory, RAG, and routing.
-- Do not feed the current binary `success` field into Needle training. A Swarm
-  optimizer can generate adversarial candidates and mechanically verified code
-  episodes, but it must not act as its own semantic judge.
+- Commit and push `codex/campaign-provider-runtime`, open a stacked draft PR
+  against `gemini/campaign-gemma-needle-2000-v1`, and link it to Issue #65 and
+  PR #66 with the exact head and test/receipt evidence.
+- Do not start Stage 1 generation until the stacked repair is integrated into
+  the Gemini campaign branch and its exact head passes CI/Codex review.
+- Do not represent the replay cache as authenticated against a malicious
+  process already running as the same OS user. It is owner-private and
+  digest-bound; stronger same-user resistance would require a Keychain-backed
+  signing key.
+- Local Gemma weights were not downloaded. Model acquisition remains a
+  separately authorized, digest-pinned experiment.

--- a/.dockerignore
+++ b/.dockerignore
@@ -25,6 +25,17 @@ venv/
 .venv
 env/
 .env
+.env.*
+secrets/
+.agents/
+.claude/
+.codex/
+.gemini/
+.gcloud/
+.google/
+.vertex/
+.openai/
+.anthropic/
 
 # IDE
 .vscode/
@@ -48,9 +59,12 @@ docs/
 !docs/okf/
 !docs/okf/**
 
-# Runtime adapter configuration is required by the bare image.
-!.grok/
-!.grok/**
+# Runtime adapter configuration is required by the bare image, but OAuth is not.
+.grok/**
+!.grok/hyperparams/
+!.grok/hyperparams/**
+!.grok/prompts/
+!.grok/prompts/**
 
 # Test files
 test_*.py

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -11,6 +11,7 @@ Welcome, Gemini Agent! You are operating inside the local environment of the **G
 * **Telemetry Sanitization**: Never write raw `XAI_API_KEY`s or authorization bearer tokens to logs or telemetry rows. Sanitize them using regex patterns before persisting them to the database.
 * **CLI Command Validation**: Ensure inputs processed by command lines are escaped to prevent command injection.
 * **Secret Scan Validation**: Before saving any edits or committing configuration files, scan the changes to ensure no sensitive variables (such as `XAI_API_KEY`, `sk-` live Stripe keys, or `ghp-` GitHub PATs) are hardcoded.
+* **Credential References Only**: Never copy `~/.gemini/config/config.json`, Google ADC, Grok OAuth, Claude auth, Codex auth, or a repository `.env` into this checkout. In particular, `.gemini/config.json` is tracked public project configuration and must never be replaced with the similarly named host file. Campaigns use the external owner-only provider profile, standard ADC discovery, and the loopback UniGrok MCP.
 
 ## 3. Grok MCP Tool Routing
 Select modular tools based on the nature of the request:

--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,8 @@ celerybeat.pid
 
 # Environments
 .env
+.env.*
+!.env.example
 .venv
 env/
 venv/
@@ -137,6 +139,23 @@ chats/
 logs/
 .unigrok-state/
 artifacts/
+.agents/data_shards/
+
+# Local provider credentials and private agent overrides. Runtime code resolves
+# credentials in place (ADC, Keychain, or UniGrok); these files are never copied.
+.codex/auth.json
+.codex/config.toml
+.gemini/config/
+.gemini/settings.local.json
+.claude/.credentials.json
+.claude/settings.local.json
+.grok/auth.json
+.google/
+.gcloud/
+.vertex/
+.openai/
+.anthropic/
+secrets/
 
 # Spyder project settings
 .spyderproject

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,8 @@ COPY main.py ./
 COPY src/ ./src/
 COPY mcp_ui/ ./mcp_ui/
 COPY docs/okf/ ./docs/okf/
-COPY .grok/ ./.grok/
+COPY .grok/hyperparams/ ./.grok/hyperparams/
+COPY .grok/prompts/ ./.grok/prompts/
 
 # Run as an unprivileged user. Stable mutable data lives under /state, never
 # in the application bundle or an IDE project.

--- a/evals/campaigns/gemma_needle_2000_v1/provider_adapters.py
+++ b/evals/campaigns/gemma_needle_2000_v1/provider_adapters.py
@@ -1,31 +1,271 @@
-import os
-import json
+"""Credential-blind provider execution and cache isolation for the campaign.
+
+This module deliberately knows only an opaque ``credential_binding_id``.  A
+transport resolves the real credential through its provider-owned mechanism
+(for example Google ADC or the local UniGrok service) and returns model output.
+Secret material must never enter adapter settings, cache keys, or receipts.
+"""
+
+from __future__ import annotations
+
 import hashlib
+import json
+import os
+import re
+import stat
 import tempfile
-import shutil
 from enum import Enum
-from .schemas import BaseRootEnvelope
+from pathlib import Path
+from typing import Any, Callable
+
+from pydantic import BaseModel, ValidationError
+
+
+CAMPAIGN_ID = "gemma-needle-2000-v1"
+_SECRET_SETTING_NAMES = (
+    "api_key",
+    "access_token",
+    "auth_token",
+    "authorization",
+    "bearer",
+    "client_secret",
+    "cookie",
+    "credential",
+    "password",
+    "private_key",
+    "refresh_token",
+    "secret",
+)
+_SAFE_IDENTITY = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,95}$")
+_MAX_CACHE_BYTES = 8 * 1024 * 1024
+_CACHE_FORMAT_VERSION = 1
+_SECRET_VALUE_PATTERNS = (
+    re.compile(r"github_pat_[A-Za-z0-9_]{10,}|gh[pousr]_[A-Za-z0-9]{10,}"),
+    re.compile(r"glpat-[A-Za-z0-9_-]{10,}"),
+    re.compile(r"\bsk-(?:proj-|svcacct-)?[A-Za-z0-9_-]{12,}"),
+    re.compile(r"\bxai-[A-Za-z0-9_-]{12,}", re.IGNORECASE),
+    re.compile(r"\bAIza[A-Za-z0-9_-]{25,}"),
+    re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b"),
+    re.compile(r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----"),
+    re.compile(
+        r"\bBearer\s+(?!<|\$\{|\[)[A-Za-z0-9._~+/=-]{8,}",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r'''(?:^|[^A-Za-z0-9_])["']?[A-Z0-9_-]*(?:API[_-]?KEY|SESSION[_-]?TOKEN|ACCESS[_-]?TOKEN|AUTH[_-]?TOKEN|PASSWORD|PRIVATE[_-]?KEY|CLIENT[_-]?SECRET)["']?\s*[:=]\s*(?!["']?(?:<|\$\{|\[))(?:"[^"\r\n]{8,}"|'[^'\r\n]{8,}'|[A-Za-z0-9._~+/=@!#$%^&*()-]{8,})''',
+        re.IGNORECASE,
+    ),
+)
+
 
 class RunMode(str, Enum):
     MOCK = "mock"
     REPLAY = "replay"
     LIVE = "live"
 
+
+class ProviderContractError(ValueError):
+    """A transport returned, but its artifact/provenance contract failed."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.transport_response_observed = True
+
+
+ProviderTransport = Callable[[str, dict[str, Any]], dict[str, Any]]
+ResponseSchema = type[BaseModel]
+
+
+def default_cache_root() -> Path:
+    """Return a user-private cache root outside every repository worktree."""
+
+    if os.name == "posix" and Path.home().joinpath("Library").is_dir():
+        return Path.home() / "Library" / "Caches" / "UniGrok" / "campaigns" / CAMPAIGN_ID
+    return Path.home() / ".cache" / "unigrok" / "campaigns" / CAMPAIGN_ID
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def _is_in_git_workspace(path: Path) -> bool:
+    absolute = Path(os.path.abspath(path))
+    return any((candidate / ".git").exists() for candidate in (absolute, *absolute.parents))
+
+
+def _reject_symlink_components(path: Path) -> None:
+    absolute = Path(os.path.abspath(path))
+    for candidate in (absolute, *absolute.parents):
+        try:
+            if stat.S_ISLNK(candidate.lstat().st_mode):
+                raise ValueError("Campaign cache paths cannot traverse symbolic links.")
+        except FileNotFoundError:
+            continue
+
+
+def _is_owner_private_directory(path: Path) -> bool:
+    try:
+        metadata = path.stat(follow_symlinks=False)
+    except OSError:
+        return False
+    return (
+        stat.S_ISDIR(metadata.st_mode)
+        and not stat.S_ISLNK(metadata.st_mode)
+        and stat.S_IMODE(metadata.st_mode) == 0o700
+        and (not hasattr(os, "geteuid") or metadata.st_uid == os.geteuid())
+    )
+
+
+def _private_directory(path: Path) -> None:
+    """Create missing leaves privately; never chmod a caller-owned directory."""
+
+    _reject_symlink_components(path)
+    if path.exists():
+        if not _is_owner_private_directory(path):
+            raise ValueError("Existing campaign cache directories must be owner-only (0700).")
+        return
+
+    missing: list[Path] = []
+    cursor = path
+    while not cursor.exists():
+        missing.append(cursor)
+        cursor = cursor.parent
+    _reject_symlink_components(cursor)
+    for candidate in reversed(missing):
+        candidate.mkdir(mode=0o700)
+        if not _is_owner_private_directory(candidate):
+            raise ValueError("Campaign cache directory creation was not owner-only.")
+
+
+def _segment(value: str) -> str:
+    cleaned = value.strip()
+    if not _SAFE_IDENTITY.fullmatch(cleaned):
+        raise ValueError("Provider cache identity fields must be safe opaque identifiers.")
+    _reject_secret_like_payload(cleaned)
+    return cleaned
+
+
+def _reject_secret_setting_names(value: Any, *, path: str = "settings") -> None:
+    """Fail closed when caller settings try to carry credential material."""
+
+    if isinstance(value, dict):
+        for raw_key, child in value.items():
+            key = str(raw_key).casefold().replace("-", "_")
+            if any(name in key for name in _SECRET_SETTING_NAMES):
+                raise ValueError(f"Secret or credential setting is forbidden at {path}.{raw_key}.")
+            _reject_secret_setting_names(child, path=f"{path}.{raw_key}")
+    elif isinstance(value, (list, tuple)):
+        for index, child in enumerate(value):
+            _reject_secret_setting_names(child, path=f"{path}[{index}]")
+
+
+def _reject_secret_like_payload(value: Any) -> None:
+    """Reject provider output containing recognizable credential material."""
+
+    try:
+        serialized = json.dumps(value, ensure_ascii=False, sort_keys=True)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Provider response must contain deterministic JSON values.") from exc
+    if any(pattern.search(serialized) for pattern in _SECRET_VALUE_PATTERNS):
+        raise ValueError("Provider response contains secret-like content and was not cached.")
+
+
+def _canonical_json_bytes(value: Any) -> bytes:
+    try:
+        return json.dumps(
+            value,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Provider data must contain deterministic JSON values.") from exc
+
+
+def _sha256_json(value: Any) -> str:
+    return hashlib.sha256(_canonical_json_bytes(value)).hexdigest()
+
+
 class ProviderAdapter:
-    def __init__(self, provider: str, model: str, plane: str, role: str, mode: RunMode):
-        self.provider = provider
-        self.model = model
-        self.plane = plane
-        self.role = role
-        self.mode = mode
-        
-        # Safe cache location outside of tracked source. Segregated by mode.
-        self.cache_dir = os.path.expanduser(f"~/.gemini/antigravity/cache/campaigns/gemma-needle-2000-v1/{mode.value}")
-        os.makedirs(self.cache_dir, exist_ok=True)
-        
-    def _compute_cache_key(self, schema_version: str, template_digest: str, settings: dict, request: str) -> str:
-        # Do not lowercase request, case matters for JSON artifacts
+    """Validate provider output and persist only isolated, schema-valid cache rows."""
+
+    def __init__(
+        self,
+        provider: str,
+        model: str,
+        plane: str,
+        role: str,
+        mode: RunMode,
+        *,
+        cache_root: Path | str | None = None,
+        credential_binding_id: str = "unbound",
+        transport: ProviderTransport | None = None,
+    ) -> None:
+        self.provider = provider.strip()
+        self.model = model.strip()
+        self.plane = plane.strip()
+        self.role = role.strip()
+        self.mode = RunMode(mode)
+        self.credential_binding_id = credential_binding_id.strip()
+        self.transport = transport
+
+        for label, value in (
+            ("provider", self.provider),
+            ("model", self.model),
+            ("plane", self.plane),
+            ("role", self.role),
+            ("credential_binding_id", self.credential_binding_id),
+        ):
+            try:
+                _segment(value)
+            except ValueError as exc:
+                raise ValueError(f"{label} must be a safe opaque identifier.") from exc
+
+        root = Path(cache_root).expanduser() if cache_root is not None else default_cache_root()
+        _reject_symlink_components(root)
+        resolved = root.resolve(strict=False)
+        if _is_within(resolved, _repo_root()) or _is_in_git_workspace(resolved):
+            raise ValueError("Campaign cache root must remain outside the repository workspace.")
+        self.cache_root = resolved
+        _private_directory(self.cache_root)
+
+    def _source_mode(self) -> RunMode:
+        return RunMode.LIVE if self.mode == RunMode.REPLAY else self.mode
+
+    def _namespace_dir(self) -> Path:
+        path = self.cache_root / self._source_mode().value
+        for value in (
+            self.credential_binding_id,
+            self.provider,
+            self.model,
+            self.plane,
+            self.role,
+        ):
+            path /= _segment(value)
+        current = self.cache_root
+        for part in path.relative_to(self.cache_root).parts:
+            current /= part
+            _private_directory(current)
+        return path
+
+    def _compute_cache_key(
+        self,
+        schema_version: str,
+        template_digest: str,
+        settings: dict[str, Any],
+        request: str,
+    ) -> str:
+        _reject_secret_setting_names(settings)
         key_data = {
+            "credential_binding_id": self.credential_binding_id,
             "provider": self.provider,
             "model": self.model,
             "plane": self.plane,
@@ -33,73 +273,258 @@ class ProviderAdapter:
             "schema_version": schema_version,
             "template_digest": template_digest,
             "settings": settings,
-            "request": request
+            "request": request,
         }
-        key_str = json.dumps(key_data, sort_keys=True)
-        return hashlib.sha256(key_str.encode()).hexdigest()
-        
-    def _atomic_write_cache(self, key: str, response: dict):
-        path = os.path.join(self.cache_dir, f"{key}.json")
-        fd, temp_path = tempfile.mkstemp(dir=self.cache_dir)
-        with os.fdopen(fd, 'w') as f:
-            json.dump(response, f)
-        shutil.move(temp_path, path)
+        _reject_secret_like_payload(key_data)
+        key_bytes = _canonical_json_bytes(key_data)
+        return hashlib.sha256(key_bytes).hexdigest()
 
-    def _read_cache(self, key: str) -> Optional[dict]:
-        path = os.path.join(self.cache_dir, f"{key}.json")
-        if os.path.exists(path):
-            with open(path, 'r') as f:
-                return json.load(f)
-        return None
+    def _cache_provenance(
+        self,
+        schema_version: str,
+        template_digest: str,
+        settings: dict[str, Any],
+        request: str,
+    ) -> dict[str, str]:
+        return {
+            "request_digest": hashlib.sha256(request.encode("utf-8")).hexdigest(),
+            "schema_version": schema_version,
+            "settings_digest": _sha256_json(settings),
+            "template_digest": template_digest,
+        }
 
-    def extract_json_artifact(self, content: str) -> Optional[dict]:
-        """Strict JSON parsing from content, handling promise preface."""
+    def _cache_path(self, key: str) -> Path:
+        return self._namespace_dir() / f"{key}.json"
+
+    def _cache_identity(self) -> dict[str, str]:
+        return {
+            "credential_binding_id": self.credential_binding_id,
+            "model": self.model,
+            "plane": self.plane,
+            "provider": self.provider,
+            "role": self.role,
+        }
+
+    def _atomic_write_cache(
+        self,
+        key: str,
+        response: dict[str, Any],
+        provenance: dict[str, str],
+    ) -> None:
+        path = self._cache_path(key)
+        envelope = {
+            "cache_key": key,
+            "format_version": _CACHE_FORMAT_VERSION,
+            "identity": self._cache_identity(),
+            "provenance": provenance,
+            "response": response,
+            "response_digest": _sha256_json(response),
+        }
+        payload = _canonical_json_bytes(envelope)
+        if len(payload) > _MAX_CACHE_BYTES:
+            raise ValueError("Provider response exceeds the campaign cache size limit.")
+
+        fd, temp_name = tempfile.mkstemp(prefix=f".{key}.", dir=path.parent)
+        temp_path = Path(temp_name)
         try:
-            start_idx = content.find('{')
-            end_idx = content.rfind('}')
-            if start_idx != -1 and end_idx != -1 and end_idx > start_idx:
-                json_str = content[start_idx:end_idx+1]
-                return json.loads(json_str)
-            return None
-        except Exception:
-            return None
+            os.fchmod(fd, 0o600)
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temp_path, path)
+            path.chmod(0o600)
+        finally:
+            if temp_path.exists():
+                temp_path.unlink()
 
-    def validate_response(self, response: dict) -> bool:
-        """Fail-closed response-schema validation, artifact-presence, promise-only rejection."""
+    def _read_cache(
+        self,
+        key: str,
+        provenance: dict[str, str],
+    ) -> dict[str, Any] | None:
+        path = self._cache_path(key)
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        descriptor = -1
+        try:
+            descriptor = os.open(path, flags)
+            metadata = os.fstat(descriptor)
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or stat.S_IMODE(metadata.st_mode) != 0o600
+                or (hasattr(os, "geteuid") and metadata.st_uid != os.geteuid())
+                or metadata.st_size > _MAX_CACHE_BYTES
+            ):
+                return None
+            handle = os.fdopen(descriptor, "r", encoding="utf-8")
+            descriptor = -1
+            with handle:
+                payload = json.load(handle)
+        except (OSError, json.JSONDecodeError):
+            return None
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+        if not isinstance(payload, dict) or set(payload) != {
+            "cache_key",
+            "format_version",
+            "identity",
+            "provenance",
+            "response",
+            "response_digest",
+        }:
+            return None
+        response = payload.get("response")
+        if (
+            payload.get("format_version") != _CACHE_FORMAT_VERSION
+            or payload.get("cache_key") != key
+            or payload.get("identity") != self._cache_identity()
+            or payload.get("provenance") != provenance
+            or not isinstance(response, dict)
+            or payload.get("response_digest") != _sha256_json(response)
+        ):
+            return None
+        return response
+
+    def extract_json_artifact(self, content: str) -> dict[str, Any] | None:
+        """Accept exactly one JSON object and reject prose or fence wrappers."""
+
+        if not isinstance(content, str) or not content.strip():
+            return None
+        try:
+            artifact = json.loads(content)
+        except json.JSONDecodeError:
+            return None
+        return artifact if isinstance(artifact, dict) else None
+
+    def _validated_artifact(
+        self,
+        response: dict[str, Any],
+        response_schema: ResponseSchema | None,
+        *,
+        require_transport_receipt: bool = False,
+    ) -> dict[str, Any]:
         if not response or not isinstance(response, dict):
-            return False
-            
-        content = response.get("content", "")
-        if not content.strip():
-            return False
-            
-        # Reject promise-only without artifact
-        artifact = self.extract_json_artifact(content)
-        if not artifact:
-            return False
-            
-        # Ensure it actually decodes to a known schema or dict
-        if not isinstance(artifact, dict):
-            return False
-            
-        return True
+            raise ValueError("Provider response must be an object.")
+        artifact = self.extract_json_artifact(response.get("content", ""))
+        if artifact is None:
+            raise ValueError("Provider response must contain one pure JSON object.")
+        if response_schema is not None:
+            try:
+                validated = response_schema.model_validate(artifact)
+            except ValidationError as exc:
+                raise ValueError("Provider response failed the requested schema.") from exc
+            artifact = validated.model_dump(mode="json")
+        _reject_secret_like_payload(response)
+        if require_transport_receipt:
+            self._validate_transport_receipt(response)
+        return artifact
 
-    def execute(self, request: str, schema_version: str, template_digest: str, settings: dict) -> dict:
+    def _validate_transport_receipt(self, response: dict[str, Any]) -> None:
+        receipt = response.get("transport_receipt")
+        if not isinstance(receipt, dict):
+            raise ValueError("Provider response is missing its transport receipt.")
+        required = {
+            "configured_model",
+            "provider",
+            "resolved_model",
+            "resolved_plane",
+        }
+        if not required.issubset(receipt):
+            raise ValueError("Provider transport receipt is incomplete.")
+        if receipt.get("provider") != self.provider:
+            raise ValueError("Provider transport receipt has the wrong provider.")
+        if receipt.get("configured_model") != self.model:
+            raise ValueError("Provider transport receipt has the wrong configured model.")
+        if not str(receipt.get("resolved_model") or "").strip():
+            raise ValueError("Provider transport receipt has no resolved model.")
+        if str(receipt.get("resolved_plane") or "").casefold() != self.plane.casefold():
+            raise ValueError("Provider transport receipt has the wrong credential plane.")
+        if self.provider == "vertex" and (
+            receipt.get("auth_kind") != "google_adc"
+            or receipt.get("total_attempt_limit") != 1
+            or str(receipt.get("resolved_plane") or "").casefold() != "api"
+        ):
+            raise ValueError("Vertex transport receipt violates the ADC attempt contract.")
+        if self.provider == "unigrok" and (
+            receipt.get("auth_kind") != "server_managed"
+            or receipt.get("fallback_policy") != "same_plane"
+            or receipt.get("finish_reason") != "final_answer"
+            or receipt.get("resolved_model") != self.model
+            or str(receipt.get("resolved_plane") or "").casefold() != "cli"
+        ):
+            raise ValueError("UniGrok transport receipt violates the pinned-plane contract.")
+
+    def validate_response(
+        self,
+        response: dict[str, Any],
+        response_schema: ResponseSchema | None = None,
+        *,
+        require_transport_receipt: bool = False,
+    ) -> bool:
+        try:
+            self._validated_artifact(
+                response,
+                response_schema,
+                require_transport_receipt=require_transport_receipt,
+            )
+            return True
+        except ValueError:
+            return False
+
+    def execute(
+        self,
+        request: str,
+        schema_version: str,
+        template_digest: str,
+        settings: dict[str, Any],
+        response_schema: ResponseSchema | None = None,
+    ) -> dict[str, Any]:
         key = self._compute_cache_key(schema_version, template_digest, settings, request)
-        
-        # Never allow mock replay in live, isolated namespaces guarantee this.
-        if self.mode in (RunMode.MOCK, RunMode.REPLAY):
-            cached = self._read_cache(key)
-            if cached and self.validate_response(cached):
-                return cached
-            if self.mode == RunMode.REPLAY:
-                raise ValueError("Replay mode: Cache miss or invalid cache for deterministic execution.")
-        
+        provenance = self._cache_provenance(
+            schema_version,
+            template_digest,
+            settings,
+            request,
+        )
+
+        if self.mode == RunMode.REPLAY:
+            cached = self._read_cache(key, provenance)
+            if cached is None or not self.validate_response(
+                cached,
+                response_schema,
+                require_transport_receipt=response_schema is not None,
+            ):
+                raise ValueError("Replay cache miss or invalid cached provider response.")
+            return {**cached, "_cache_hit": True}
+
         if self.mode == RunMode.MOCK:
-            # Generate a valid mock response
-            response = {"content": "I'll do that right away.\n{\"mocked_artifact\": true}"}
-            if self.validate_response(response):
-                self._atomic_write_cache(key, response)
-            return response
-            
-        raise NotImplementedError("Live mode not implemented for Stage 0.")
+            cached = self._read_cache(key, provenance)
+            if cached is not None and self.validate_response(cached, response_schema):
+                return {**cached, "_cache_hit": True}
+            response: dict[str, Any] = {"content": '{"mocked_artifact":true}'}
+            self._validated_artifact(response, response_schema)
+            self._atomic_write_cache(key, response, provenance)
+            return {**response, "_cache_hit": False}
+
+        if self.transport is None:
+            raise RuntimeError("Live provider execution requires an injected transport.")
+        if response_schema is None:
+            raise ValueError("Live provider execution requires an explicit response schema.")
+
+        # LIVE deliberately does not read a previous cache row.  Every live call
+        # produces fresh transport evidence; REPLAY is the only zero-call reuse.
+        try:
+            response = self.transport(request, dict(settings))
+        except Exception as exc:
+            raise RuntimeError("Live provider transport failed.") from exc
+        try:
+            self._validated_artifact(
+                response,
+                response_schema,
+                require_transport_receipt=True,
+            )
+            self._atomic_write_cache(key, response, provenance)
+        except (OSError, ValueError) as exc:
+            raise ProviderContractError(str(exc)) from exc
+        return {**response, "_cache_hit": False}

--- a/evals/campaigns/gemma_needle_2000_v1/provider_smoke.py
+++ b/evals/campaigns/gemma_needle_2000_v1/provider_smoke.py
@@ -1,0 +1,491 @@
+"""Bounded Stage 0.5 provider wiring smoke for Vertex and UniGrok.
+
+This command performs no dataset generation. A live run is limited to one
+synthetic probe per configured provider, with zero retries, and requires an
+explicit command-line confirmation. Replay re-validates only the private live
+cache and never constructs a provider transport.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import stat
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Annotated, Any, Literal
+from urllib.parse import urlparse
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+from .provider_adapters import (
+    CAMPAIGN_ID,
+    ProviderAdapter,
+    RunMode,
+    _reject_secret_like_payload,
+)
+from .provider_transports import UniGrokMCPTransport, VertexADCTransport
+
+
+PROBE_SCHEMA_VERSION = "provider-contract-v1"
+PROBE_TEMPLATE = (
+    "Return exactly this one-line JSON object and nothing else: "
+    '{"probe":"provider-contract-v1","nonce":"<NONCE>"}. '
+    "Do not use markdown, commentary, promises, or additional fields."
+)
+PROBE_TEMPLATE_DIGEST = "sha256:" + hashlib.sha256(
+    PROBE_TEMPLATE.encode("utf-8")
+).hexdigest()
+_MAX_PROFILE_BYTES = 64 * 1024
+_SAFE_BINDING_ID = r"^[A-Za-z0-9][A-Za-z0-9_.-]{2,95}$"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _is_within(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+        return True
+    except ValueError:
+        return False
+
+
+def _is_in_git_workspace(path: Path) -> bool:
+    absolute = Path(os.path.abspath(path))
+    return any((candidate / ".git").exists() for candidate in (absolute, *absolute.parents))
+
+
+def _reject_symlink_components(path: Path) -> None:
+    absolute = Path(os.path.abspath(path))
+    for candidate in (absolute, *absolute.parents):
+        try:
+            if stat.S_ISLNK(candidate.lstat().st_mode):
+                raise ValueError("Provider paths cannot traverse symbolic links.")
+        except FileNotFoundError:
+            continue
+
+
+def default_profile_path() -> Path:
+    return (
+        Path.home()
+        / "Library"
+        / "Application Support"
+        / "UniGrok"
+        / "campaigns"
+        / CAMPAIGN_ID
+        / "providers.json"
+    )
+
+
+def default_receipts_root() -> Path:
+    return (
+        Path.home()
+        / "Library"
+        / "Application Support"
+        / "UniGrok"
+        / "campaigns"
+        / CAMPAIGN_ID
+        / "receipts"
+    )
+
+
+class ProbeArtifact(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    probe: Literal["provider-contract-v1"]
+    nonce: str = Field(min_length=8, max_length=96, pattern=r"^[A-Za-z0-9_.-]+$")
+
+
+class VertexBinding(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    provider: Literal["vertex"]
+    credential_binding_id: str = Field(pattern=_SAFE_BINDING_ID)
+    auth_kind: Literal["google_adc"]
+    project: str = Field(min_length=4, max_length=128, pattern=r"^[a-z][a-z0-9-]+$")
+    location: str = Field(min_length=2, max_length=64, pattern=r"^[a-z0-9-]+$")
+    model: str = Field(min_length=3, max_length=128, pattern=r"^[A-Za-z0-9._-]+$")
+    role: Literal["mutation-adjudication-smoke"]
+
+
+class UniGrokBinding(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    provider: Literal["unigrok"]
+    credential_binding_id: str = Field(pattern=_SAFE_BINDING_ID)
+    auth_kind: Literal["server_managed"]
+    endpoint: str
+    model: str = Field(min_length=3, max_length=128, pattern=r"^[A-Za-z0-9._-]+$")
+    plane: Literal["cli"]
+    fallback_policy: Literal["same_plane"]
+    role: Literal["seed-critic-smoke"]
+
+    @field_validator("endpoint")
+    @classmethod
+    def require_loopback_mcp(cls, value: str) -> str:
+        parsed = urlparse(value)
+        if (
+            parsed.scheme != "http"
+            or parsed.hostname != "127.0.0.1"
+            or parsed.port != 4765
+            or parsed.path.rstrip("/") != "/mcp"
+            or parsed.username
+            or parsed.password
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ValueError(
+                "UniGrok endpoint must be the uncredentialed loopback :4765/mcp URL."
+            )
+        return value
+
+
+ProviderBinding = Annotated[
+    VertexBinding | UniGrokBinding,
+    Field(discriminator="provider"),
+]
+
+
+class ProviderSmokeProfile(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    version: Literal[1]
+    campaign_id: Literal["gemma-needle-2000-v1"]
+    max_live_calls: Literal[2]
+    orchestrator_retry_limit: Literal[0]
+    vertex_max_output_tokens: int = Field(ge=16, le=128)
+    bindings: list[ProviderBinding] = Field(min_length=2, max_length=2)
+
+    @field_validator("bindings")
+    @classmethod
+    def require_one_binding_per_provider(
+        cls,
+        value: list[ProviderBinding],
+    ) -> list[ProviderBinding]:
+        if {binding.provider for binding in value} != {"vertex", "unigrok"}:
+            raise ValueError("Profile must contain exactly one Vertex and one UniGrok binding.")
+        return value
+
+
+def _owner_private_file(path: Path) -> None:
+    metadata = path.stat(follow_symlinks=False)
+    if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISREG(metadata.st_mode):
+        raise ValueError("Provider profile must be a regular file.")
+    if (
+        stat.S_IMODE(metadata.st_mode) != 0o600
+        or (hasattr(os, "geteuid") and metadata.st_uid != os.geteuid())
+    ):
+        raise ValueError("Provider profile must be owner-owned and mode 0600.")
+    parent = path.parent.stat(follow_symlinks=False)
+    if (
+        not stat.S_ISDIR(parent.st_mode)
+        or stat.S_IMODE(parent.st_mode) != 0o700
+        or (hasattr(os, "geteuid") and parent.st_uid != os.geteuid())
+    ):
+        raise ValueError("Provider profile parent must be owner-owned and mode 0700.")
+
+
+def load_profile(path: Path) -> ProviderSmokeProfile:
+    expanded = path.expanduser()
+    _reject_symlink_components(expanded)
+    resolved = expanded.resolve(strict=True)
+    if _is_within(resolved, _repo_root()) or _is_in_git_workspace(resolved):
+        raise ValueError("Live provider profiles must remain outside the repository.")
+    _owner_private_file(resolved)
+    if resolved.stat().st_size > _MAX_PROFILE_BYTES:
+        raise ValueError("Provider profile exceeds the size limit.")
+    try:
+        raw = json.loads(resolved.read_text(encoding="utf-8"))
+        profile = ProviderSmokeProfile.model_validate(raw)
+        _reject_secret_like_payload(profile.model_dump(mode="json"))
+        return profile
+    except (json.JSONDecodeError, OSError, ValidationError) as exc:
+        raise ValueError("Provider profile failed strict validation.") from exc
+
+
+def _private_directory(path: Path) -> None:
+    _reject_symlink_components(path)
+    if path.exists():
+        metadata = path.stat(follow_symlinks=False)
+        if (
+            not stat.S_ISDIR(metadata.st_mode)
+            or stat.S_IMODE(metadata.st_mode) != 0o700
+            or (hasattr(os, "geteuid") and metadata.st_uid != os.geteuid())
+        ):
+            raise ValueError("Existing receipt directories must be owner-only (0700).")
+        return
+
+    missing: list[Path] = []
+    cursor = path
+    while not cursor.exists():
+        missing.append(cursor)
+        cursor = cursor.parent
+    _reject_symlink_components(cursor)
+    for candidate in reversed(missing):
+        candidate.mkdir(mode=0o700)
+        metadata = candidate.stat(follow_symlinks=False)
+        if stat.S_IMODE(metadata.st_mode) != 0o700:
+            raise ValueError("Receipt directory creation was not owner-only.")
+
+
+def _write_receipt(path: Path, payload: dict[str, Any]) -> None:
+    _private_directory(path.parent)
+    encoded = json.dumps(
+        payload,
+        ensure_ascii=True,
+        indent=2,
+        sort_keys=True,
+    ).encode("utf-8")
+    fd, temp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    temp_path = Path(temp_name)
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(encoded)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.link(temp_path, path, follow_symlinks=False)
+    finally:
+        if temp_path.exists():
+            temp_path.unlink()
+
+
+def _sha256_json(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def _transport(binding: ProviderBinding):
+    if isinstance(binding, VertexBinding):
+        return VertexADCTransport(
+            project=binding.project,
+            location=binding.location,
+            model=binding.model,
+        )
+    return UniGrokMCPTransport(
+        endpoint=binding.endpoint,
+        model=binding.model,
+        plane=binding.plane,
+        fallback_policy=binding.fallback_policy,
+    )
+
+
+def _safe_error_code(exc: Exception) -> str:
+    message = str(exc).casefold()
+    if "pure json" in message:
+        return "invalid_json_artifact"
+    if "requested schema" in message or "different probe nonce" in message:
+        return "schema_contract_failed"
+    if "transport receipt" in message or "credential plane" in message:
+        return "provenance_contract_failed"
+    if "transport failed" in message:
+        return "transport_failed"
+    return "provider_contract_failed"
+
+
+def run_smoke(
+    *,
+    profile: ProviderSmokeProfile,
+    mode: RunMode,
+    nonce: str,
+    receipts_root: Path,
+) -> tuple[dict[str, Any], bool]:
+    if mode not in {RunMode.LIVE, RunMode.REPLAY}:
+        raise ValueError("Stage 0.5 supports only live or replay mode.")
+    expanded_receipts = receipts_root.expanduser()
+    _reject_symlink_components(expanded_receipts)
+    resolved_receipts = expanded_receipts.resolve(strict=False)
+    if _is_within(resolved_receipts, _repo_root()) or _is_in_git_workspace(
+        resolved_receipts
+    ):
+        raise ValueError("Provider receipts must remain outside the repository.")
+    _private_directory(resolved_receipts)
+
+    expected = ProbeArtifact(probe=PROBE_SCHEMA_VERSION, nonce=nonce)
+    request = PROBE_TEMPLATE.replace("<NONCE>", nonce)
+    provider_receipts: list[dict[str, Any]] = []
+
+    for binding in profile.bindings:
+        response_observed = False
+        settings = (
+            {
+                "max_output_tokens": profile.vertex_max_output_tokens,
+                "temperature": 0,
+                "total_attempt_limit": 1,
+            }
+            if isinstance(binding, VertexBinding)
+            else {"accepted_artifact": PROBE_SCHEMA_VERSION, "mode": "fast"}
+        )
+        adapter = ProviderAdapter(
+            provider=binding.provider,
+            model=binding.model,
+            plane=getattr(binding, "plane", "api"),
+            role=binding.role,
+            mode=mode,
+            credential_binding_id=binding.credential_binding_id,
+            transport=_transport(binding) if mode == RunMode.LIVE else None,
+        )
+        try:
+            response = adapter.execute(
+                request=request,
+                schema_version=PROBE_SCHEMA_VERSION,
+                template_digest=PROBE_TEMPLATE_DIGEST,
+                settings=settings,
+                response_schema=ProbeArtifact,
+            )
+            response_observed = mode == RunMode.LIVE
+            artifact = ProbeArtifact.model_validate_json(response["content"])
+            if artifact != expected:
+                raise ValueError("Provider returned a different probe nonce.")
+            provider_receipts.append(
+                {
+                    "artifact_digest": _sha256_json(artifact.model_dump(mode="json")),
+                    "artifact_source": (
+                        "live_cache" if mode == RunMode.REPLAY else "live_transport"
+                    ),
+                    "evidence_class": (
+                        "cache_integrity_checked_origin_unverified"
+                        if mode == RunMode.REPLAY
+                        else "live_transport_contract_passed"
+                    ),
+                    "cache_hit": response.get("_cache_hit") is True,
+                    "credential_binding_id": binding.credential_binding_id,
+                    "model": binding.model,
+                    "provider": binding.provider,
+                    "request_digest": _sha256_json(request),
+                    "source_transport_receipt": response.get("transport_receipt"),
+                    "source_transport_receipt_digest": _sha256_json(
+                        response.get("transport_receipt")
+                    ),
+                    "status": "passed",
+                    "transport_invoked_current_run": mode == RunMode.LIVE,
+                    "transport_invocation_attempts_current_run": (
+                        1 if mode == RunMode.LIVE else 0
+                    ),
+                    "transport_response_observed_current_run": mode == RunMode.LIVE,
+                }
+            )
+        except (RuntimeError, ValueError, ValidationError) as exc:
+            provider_receipts.append(
+                {
+                    "credential_binding_id": binding.credential_binding_id,
+                    "evidence_class": (
+                        "cache_replay_contract_failed"
+                        if mode == RunMode.REPLAY
+                        else "live_transport_contract_failed"
+                    ),
+                    "error_class": type(exc).__name__,
+                    "error_code": _safe_error_code(exc),
+                    "model": binding.model,
+                    "provider": binding.provider,
+                    "request_digest": _sha256_json(request),
+                    "status": "failed",
+                    "transport_invoked_current_run": mode == RunMode.LIVE,
+                    "transport_invocation_attempts_current_run": (
+                        1 if mode == RunMode.LIVE else 0
+                    ),
+                    "transport_response_observed_current_run": bool(
+                        response_observed
+                        or getattr(exc, "transport_response_observed", False)
+                    ),
+                }
+            )
+
+    passed = all(item["status"] == "passed" for item in provider_receipts)
+    recorded_at = datetime.now(timezone.utc)
+    receipt = {
+        "campaign_id": profile.campaign_id,
+        "dataset_write_operations_current_run": 0,
+        "evidence_class": (
+            (
+                "cache_integrity_checked_origin_unverified"
+                if passed
+                else "cache_replay_contract_failed"
+            )
+            if mode == RunMode.REPLAY
+            else (
+                "live_transport_contract_passed"
+                if passed
+                else "live_transport_contract_failed"
+            )
+        ),
+        "live_call_limit": profile.max_live_calls if mode == RunMode.LIVE else 0,
+        "mode": mode.value,
+        "orchestrator_retry_limit": profile.orchestrator_retry_limit,
+        "passed": passed,
+        "transport_responses_observed_current_run": sum(
+            int(item["transport_response_observed_current_run"])
+            for item in provider_receipts
+        ),
+        "providers": provider_receipts,
+        "recorded_at": recorded_at.isoformat(),
+        "schema_version": PROBE_SCHEMA_VERSION,
+        "template_digest": PROBE_TEMPLATE_DIGEST,
+        "transport_invocation_attempts_current_run": sum(
+            item["transport_invocation_attempts_current_run"]
+            for item in provider_receipts
+        ),
+    }
+    receipt_digest = _sha256_json(receipt)
+    stamp = recorded_at.strftime("%Y%m%dT%H%M%S.%fZ")
+    receipt_path = resolved_receipts / (
+        f"stage0-5-{mode.value}-{stamp}-{receipt_digest[7:19]}.json"
+    )
+    _write_receipt(receipt_path, receipt)
+    summary = {
+        "passed": passed,
+        "provider_statuses": {
+            item["provider"]: item["status"] for item in provider_receipts
+        },
+        "receipt_path": str(receipt_path),
+        "receipt_digest": receipt_digest,
+    }
+    return summary, passed
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--mode",
+        choices=(RunMode.LIVE.value, RunMode.REPLAY.value),
+        required=True,
+    )
+    parser.add_argument("--profile", type=Path, default=default_profile_path())
+    parser.add_argument("--receipts-root", type=Path, default=default_receipts_root())
+    parser.add_argument("--nonce", default="stage0-5-wiring-v1")
+    parser.add_argument(
+        "--confirm-live",
+        action="store_true",
+        help="Required confirmation for the two-call live mode.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    mode = RunMode(args.mode)
+    if mode == RunMode.LIVE and not args.confirm_live:
+        raise SystemExit("Live mode requires --confirm-live.")
+    profile = load_profile(args.profile)
+    summary, passed = run_smoke(
+        profile=profile,
+        mode=mode,
+        nonce=args.nonce,
+        receipts_root=args.receipts_root,
+    )
+    print(json.dumps(summary, ensure_ascii=True, sort_keys=True))
+    return 0 if passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/campaigns/gemma_needle_2000_v1/provider_transports.py
+++ b/evals/campaigns/gemma_needle_2000_v1/provider_transports.py
@@ -1,0 +1,273 @@
+"""Credential-reference transports for the campaign provider smoke gate.
+
+The transports intentionally never accept raw credential values. Vertex uses
+Google Application Default Credentials in place, while Grok is reached through
+the loopback UniGrok MCP so its API key and CLI OAuth session remain server-side.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+from mcp import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+
+
+PROVIDER_PROBE_JSON_SCHEMA = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "probe": {"type": "string", "enum": ["provider-contract-v1"]},
+        "nonce": {
+            "type": "string",
+            "minLength": 8,
+            "maxLength": 96,
+            "pattern": "^[A-Za-z0-9_.-]+$",
+        },
+    },
+    "required": ["probe", "nonce"],
+}
+
+
+def _integer_setting(
+    settings: dict[str, Any],
+    name: str,
+    *,
+    default: int,
+    minimum: int,
+    maximum: int,
+) -> int:
+    raw = settings.get(name, default)
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        raise ValueError(f"{name} must be an integer.")
+    if not minimum <= raw <= maximum:
+        raise ValueError(f"{name} must be between {minimum} and {maximum}.")
+    return raw
+
+
+def _temperature(settings: dict[str, Any]) -> float:
+    raw = settings.get("temperature", 0)
+    if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+        raise ValueError("temperature must be numeric.")
+    value = float(raw)
+    if not 0 <= value <= 1:
+        raise ValueError("temperature must be between 0 and 1.")
+    return value
+
+
+@dataclass(frozen=True)
+class VertexADCTransport:
+    """Call Gemini on Vertex through standard host ADC discovery."""
+
+    project: str
+    location: str
+    model: str
+    total_attempt_limit: int = field(default=1, init=False)
+    thinking_budget: int = field(default=0, init=False)
+
+    def build_http_options(self, types_module):
+        """Build the SDK options separately so the one-attempt wire is testable."""
+
+        return types_module.HttpOptions(
+            api_version="v1",
+            retry_options=types_module.HttpRetryOptions(
+                attempts=self.total_attempt_limit
+            ),
+        )
+
+    def __call__(self, request: str, settings: dict[str, Any]) -> dict[str, Any]:
+        try:
+            from google import genai
+            from google.genai import types
+        except ImportError as exc:
+            raise RuntimeError(
+                "Vertex transport requires the optional campaign dependency."
+            ) from exc
+
+        max_output_tokens = _integer_setting(
+            settings,
+            "max_output_tokens",
+            default=64,
+            minimum=16,
+            maximum=512,
+        )
+        config = types.GenerateContentConfig(
+            temperature=_temperature(settings),
+            max_output_tokens=max_output_tokens,
+            response_mime_type="application/json",
+            response_json_schema=PROVIDER_PROBE_JSON_SCHEMA,
+            thinking_config=types.ThinkingConfig(
+                include_thoughts=False,
+                thinking_budget=self.thinking_budget,
+            ),
+        )
+        client = genai.Client(
+            vertexai=True,
+            project=self.project,
+            location=self.location,
+            http_options=self.build_http_options(types),
+        )
+        try:
+            response = client.models.generate_content(
+                model=self.model,
+                contents=request,
+                config=config,
+            )
+        finally:
+            client.close()
+
+        content = getattr(response, "text", None)
+        if not isinstance(content, str) or not content.strip():
+            raise RuntimeError("Vertex returned no text artifact.")
+
+        usage = getattr(response, "usage_metadata", None)
+        receipt: dict[str, Any] = {
+            "auth_kind": "google_adc",
+            "configured_model": self.model,
+            "location": self.location,
+            "project": self.project,
+            "provider": "vertex",
+            "resolved_model": str(
+                getattr(response, "model_version", None) or self.model
+            ),
+            "resolved_plane": "api",
+            "thinking_budget": self.thinking_budget,
+            "total_attempt_limit": self.total_attempt_limit,
+        }
+        if usage is not None:
+            for source, target in (
+                ("prompt_token_count", "input_tokens"),
+                ("candidates_token_count", "output_tokens"),
+                ("total_token_count", "total_tokens"),
+            ):
+                value = getattr(usage, source, None)
+                if isinstance(value, int):
+                    receipt[target] = value
+
+        return {"content": content, "transport_receipt": receipt}
+
+
+@dataclass(frozen=True)
+class UniGrokMCPTransport:
+    """Call a pinned Grok model without transferring its credentials."""
+
+    endpoint: str
+    model: str
+    plane: str = "cli"
+    fallback_policy: str = "same_plane"
+    client_id: str = "antigravity-campaign-gemma-needle-2000-v1"
+    timeout_seconds: int = 180
+
+    def __post_init__(self) -> None:
+        parsed = urlparse(self.endpoint)
+        if (
+            parsed.scheme != "http"
+            or parsed.hostname != "127.0.0.1"
+            or parsed.port != 4765
+            or parsed.path.rstrip("/") != "/mcp"
+            or parsed.username
+            or parsed.password
+            or parsed.query
+            or parsed.fragment
+        ):
+            raise ValueError("UniGrok transport requires the canonical loopback MCP endpoint.")
+
+    def agent_arguments(self, request: str) -> dict[str, Any]:
+        """Build the public UniGrok MCP contract, not the internal tool signature."""
+
+        return {
+            "prompt": request,
+            "mode": "fast",
+            "model": self.model,
+            "plane": self.plane,
+            "fallback_policy": self.fallback_policy,
+        }
+
+    def http_client_options(self, headers: dict[str, str]) -> dict[str, Any]:
+        return {
+            "headers": headers,
+            "timeout": float(self.timeout_seconds),
+            "trust_env": False,
+        }
+
+    def __call__(self, request: str, settings: dict[str, Any]) -> dict[str, Any]:
+        # The public UniGrok agent contract does not expose a hard output-token
+        # cap. Stage 0.5 therefore bounds calls and accepted schema size, and its
+        # receipts state this limitation instead of pretending the Vertex cap
+        # also applies to Grok.
+        if settings != {"accepted_artifact": "provider-contract-v1", "mode": "fast"}:
+            raise ValueError("UniGrok smoke settings do not match the bounded contract.")
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self._call(request))
+        raise RuntimeError("UniGrok sync transport cannot run inside an event loop.")
+
+    async def _call(self, request: str) -> dict[str, Any]:
+        headers = {"X-Client-ID": self.client_id}
+        gateway_token = os.environ.get("UNIGROK_CLIENT_TOKEN", "").strip()
+        if gateway_token:
+            headers["Authorization"] = f"Bearer {gateway_token}"
+
+        timeout = float(self.timeout_seconds)
+        async with httpx.AsyncClient(**self.http_client_options(headers)) as client:
+            async with streamable_http_client(
+                self.endpoint,
+                http_client=client,
+            ) as (read, write, _):
+                async with ClientSession(
+                    read,
+                    write,
+                    read_timeout_seconds=timedelta(seconds=timeout),
+                ) as session:
+                    await session.initialize()
+                    result = await session.call_tool(
+                        "agent",
+                        self.agent_arguments(request),
+                    )
+
+        if result.isError:
+            raise RuntimeError("UniGrok agent tool reported an error.")
+        payload = result.structuredContent
+        if not isinstance(payload, dict):
+            raise RuntimeError("UniGrok returned no structured agent result.")
+
+        content = payload.get("response")
+        resolved_model = str(payload.get("model") or "")
+        resolved_plane = str(
+            payload.get("resolved_plane") or payload.get("plane") or ""
+        ).upper()
+        finish_reason = str(payload.get("finish_reason") or "unknown")
+        if not isinstance(content, str) or not content.strip():
+            raise RuntimeError("UniGrok returned no text artifact.")
+        if resolved_model != self.model:
+            raise RuntimeError("UniGrok did not execute the pinned model.")
+        if resolved_plane != self.plane.upper():
+            raise RuntimeError("UniGrok crossed the requested credential plane.")
+        if payload.get("degraded") is True:
+            raise RuntimeError("UniGrok reported degraded execution.")
+        if finish_reason != "final_answer":
+            raise RuntimeError("UniGrok did not report a final answer.")
+
+        receipt = {
+            "auth_kind": "server_managed",
+            "billing_class": payload.get("billing_class"),
+            "configured_model": self.model,
+            "fallback_policy": self.fallback_policy,
+            "finish_reason": finish_reason,
+            "provider": "unigrok",
+            "provider_output_token_limit": "not_exposed_by_public_agent",
+            "resolved_model": resolved_model,
+            "resolved_plane": resolved_plane,
+            "route": payload.get("route"),
+        }
+        cost = payload.get("cost_usd")
+        if isinstance(cost, (int, float)) and not isinstance(cost, bool):
+            receipt["cost_usd"] = float(cost)
+        return {"content": content, "transport_receipt": receipt}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,12 @@ forge = [
     "pytest>=9.1.1",
     "ruff>=0.9",
 ]
+# Source-checkout synthetic-data campaign runners use Vertex through standard
+# Google ADC. The eval runner is intentionally not shipped in the wheel; keep
+# this SDK outside the stable UniGrok runtime dependency set.
+campaign = [
+    "google-genai>=1.25,<2",
+]
 
 [project.scripts]
 unigrok-mcp = "src.cli:main"
@@ -60,12 +66,14 @@ packages = ["src"]
 # package. Keep the wheel behavior aligned with source and Docker checkouts.
 "mcp_ui" = "mcp_ui"
 "docs/okf" = "docs/okf"
-".grok" = ".grok"
+".grok/hyperparams" = ".grok/hyperparams"
+".grok/prompts" = ".grok/prompts"
 "example.env" = "example.env"
 
 [tool.hatch.build.targets.sdist]
 exclude = [
     "/.codex",
+    "/.grok/auth.json",
     "/.pytest_cache",
     "/.ruff_cache",
     "/.venv",

--- a/tests/campaigns/gemma_needle_2000_v1/test_provider_contract.py
+++ b/tests/campaigns/gemma_needle_2000_v1/test_provider_contract.py
@@ -1,0 +1,509 @@
+import json
+import stat
+from pathlib import Path
+from typing import Literal
+
+import pytest
+from pydantic import BaseModel, ConfigDict
+
+from evals.campaigns.gemma_needle_2000_v1.provider_adapters import (
+    ProviderAdapter,
+    RunMode,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+REQUEST = "Return the provider wiring probe as JSON."
+SCHEMA_VERSION = "provider-probe-v1"
+TEMPLATE_DIGEST = "sha256:provider-probe-template"
+SAFE_SETTINGS = {"temperature": 0, "max_output_tokens": 48}
+
+
+class ProbeArtifact(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    probe: Literal["provider-contract-v1"]
+    nonce: str
+
+
+def _adapter(tmp_path: Path, **overrides) -> ProviderAdapter:
+    params = {
+        "provider": "provider-a",
+        "model": "model-a",
+        "plane": "api",
+        "role": "seed-author",
+        "mode": RunMode.MOCK,
+        "cache_root": tmp_path / "provider-cache",
+        "credential_binding_id": "binding-a",
+    }
+    params.update(overrides)
+    return ProviderAdapter(**params)
+
+
+def _execute(
+    adapter: ProviderAdapter,
+    *,
+    settings: dict | None = None,
+    response_schema: type[BaseModel] | None = ProbeArtifact,
+) -> dict:
+    return adapter.execute(
+        request=REQUEST,
+        schema_version=SCHEMA_VERSION,
+        template_digest=TEMPLATE_DIGEST,
+        settings=SAFE_SETTINGS if settings is None else settings,
+        response_schema=response_schema,
+    )
+
+
+def _content(response: dict) -> dict:
+    return json.loads(response["content"])
+
+
+def _transport_receipt(
+    *,
+    provider: str = "provider-a",
+    model: str = "model-a",
+    plane: str = "api",
+) -> dict:
+    return {
+        "configured_model": model,
+        "provider": provider,
+        "resolved_model": model,
+        "resolved_plane": plane,
+    }
+
+
+def test_json_artifact_parser_accepts_only_one_pure_json_object(tmp_path: Path):
+    adapter = _adapter(tmp_path)
+    expected = {"probe": "provider-contract-v1", "nonce": "n-1"}
+
+    assert adapter.extract_json_artifact(json.dumps(expected)) == expected
+    assert adapter.extract_json_artifact(f"  {json.dumps(expected)}\n") == expected
+
+    rejected = [
+        f"I will do that.\n{json.dumps(expected)}",
+        f"```json\n{json.dumps(expected)}\n```",
+        f"{json.dumps(expected)}\nFinished.",
+        json.dumps([expected]),
+        "{not-json}",
+        "",
+    ]
+    for content in rejected:
+        assert adapter.extract_json_artifact(content) is None
+
+
+def test_live_refuses_to_run_without_an_injected_transport(tmp_path: Path):
+    adapter = _adapter(tmp_path, mode=RunMode.LIVE)
+
+    with pytest.raises((RuntimeError, ValueError), match="(?i)transport"):
+        _execute(adapter)
+
+
+def test_live_refuses_to_call_transport_without_a_response_schema(tmp_path: Path):
+    calls = 0
+
+    def transport(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return {
+            "content": '{"probe":"provider-contract-v1","nonce":"live"}',
+            "transport_receipt": _transport_receipt(),
+        }
+
+    adapter = _adapter(tmp_path, mode=RunMode.LIVE, transport=transport)
+
+    with pytest.raises((RuntimeError, ValueError), match="(?i)schema"):
+        _execute(adapter, response_schema=None)
+    assert calls == 0
+
+
+def test_live_rejects_prose_wrapped_or_wrong_schema_responses_before_caching(
+    tmp_path: Path,
+):
+    responses = iter(
+        [
+            {
+                "content": (
+                    "Here it is:\n"
+                    '{"probe":"provider-contract-v1","nonce":"wrapped"}'
+                ),
+                "transport_receipt": _transport_receipt(),
+            },
+            {
+                "content": (
+                    '{"probe":"provider-contract-v1","nonce":"extra",'
+                    '"unexpected":true}'
+                ),
+                "transport_receipt": _transport_receipt(),
+            },
+        ]
+    )
+
+    def transport(*args, **kwargs):
+        return next(responses)
+
+    adapter = _adapter(tmp_path, mode=RunMode.LIVE, transport=transport)
+
+    with pytest.raises((RuntimeError, ValueError), match="(?i)(json|schema|response)"):
+        _execute(adapter)
+    with pytest.raises((RuntimeError, ValueError), match="(?i)(json|schema|response)"):
+        _execute(adapter)
+
+    assert not list((tmp_path / "provider-cache" / "live").rglob("*.json"))
+
+
+def test_mock_live_and_replay_namespaces_cannot_cross_contaminate(tmp_path: Path):
+    cache_root = tmp_path / "provider-cache"
+
+    mock = _adapter(tmp_path, mode=RunMode.MOCK, cache_root=cache_root)
+    _execute(mock, response_schema=None)
+
+    replay_before_live = _adapter(tmp_path, mode=RunMode.REPLAY, cache_root=cache_root)
+    with pytest.raises((RuntimeError, ValueError), match="(?i)(cache|replay|miss)"):
+        _execute(replay_before_live)
+
+    calls = 0
+
+    def transport(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return {
+            "content": json.dumps(
+                {
+                    "probe": "provider-contract-v1",
+                    "nonce": f"live-{calls}",
+                }
+            ),
+            "transport_receipt": _transport_receipt(),
+        }
+
+    live = _adapter(
+        tmp_path,
+        mode=RunMode.LIVE,
+        cache_root=cache_root,
+        transport=transport,
+    )
+    assert _content(_execute(live))["nonce"] == "live-1"
+
+    # LIVE must execute its transport even when a matching LIVE cache exists.
+    assert _content(_execute(live))["nonce"] == "live-2"
+    assert calls == 2
+
+    replay = _adapter(tmp_path, mode=RunMode.REPLAY, cache_root=cache_root)
+    replayed = _execute(replay)
+    assert _content(replayed)["nonce"] == "live-2"
+    assert replayed.get("_cache_hit") is True
+    assert calls == 2
+
+    assert list((cache_root / "mock").rglob("*.json"))
+    assert list((cache_root / "live").rglob("*.json"))
+    assert not (cache_root / "replay").exists()
+
+
+def test_cache_is_partitioned_by_binding_provider_model_role_and_plane(tmp_path: Path):
+    cache_root = tmp_path / "provider-cache"
+    dimensions = [
+        {},
+        {"credential_binding_id": "binding-b"},
+        {"provider": "provider-b"},
+        {"model": "model-b"},
+        {"role": "critic"},
+        {"plane": "cli"},
+    ]
+
+    for changed_dimension in dimensions:
+        adapter = _adapter(
+            tmp_path,
+            cache_root=cache_root,
+            mode=RunMode.MOCK,
+            **changed_dimension,
+        )
+        _execute(adapter, response_schema=None)
+
+    assert len(list((cache_root / "mock").rglob("*.json"))) == len(dimensions)
+
+
+def test_cache_directories_and_files_are_owner_only(tmp_path: Path):
+    cache_root = tmp_path / "provider-cache"
+    adapter = _adapter(tmp_path, cache_root=cache_root, mode=RunMode.MOCK)
+    _execute(adapter, response_schema=None)
+
+    directories = [cache_root, *(p for p in cache_root.rglob("*") if p.is_dir())]
+    files = [p for p in cache_root.rglob("*") if p.is_file()]
+
+    assert directories
+    assert files
+    assert all(stat.S_IMODE(path.stat().st_mode) == 0o700 for path in directories)
+    assert all(stat.S_IMODE(path.stat().st_mode) == 0o600 for path in files)
+
+
+@pytest.mark.parametrize(
+    "settings",
+    [
+        {"api_key": "redacted-test-value"},
+        {"authorization": "Bearer redacted-test-value"},
+        {"provider": {"access_token": "redacted-test-value"}},
+        {"provider": {"client_secret": "redacted-test-value"}},
+        {"note": "xai-this-is-a-secret-shaped-settings-value"},
+    ],
+)
+def test_secret_like_settings_are_rejected_before_cache_write(
+    tmp_path: Path, settings: dict
+):
+    cache_root = tmp_path / "provider-cache"
+    adapter = _adapter(tmp_path, cache_root=cache_root, mode=RunMode.MOCK)
+
+    with pytest.raises((RuntimeError, ValueError), match="(?i)(secret|credential|setting)"):
+        _execute(adapter, settings=settings, response_schema=None)
+
+    assert not list(cache_root.rglob("*.json"))
+
+
+def test_nonsecret_token_budget_setting_remains_allowed(tmp_path: Path):
+    adapter = _adapter(tmp_path, mode=RunMode.MOCK)
+
+    result = _execute(
+        adapter,
+        settings={"temperature": 0, "max_output_tokens": 48},
+        response_schema=None,
+    )
+
+    assert isinstance(result, dict)
+
+
+def test_secret_like_provider_output_is_rejected_before_cache_write(tmp_path: Path):
+    cache_root = tmp_path / "provider-cache"
+
+    def transport(*args, **kwargs):
+        return {
+            "content": json.dumps(
+                {
+                    "probe": "provider-contract-v1",
+                    "nonce": "xai-this-is-a-fake-but-secret-shaped-value",
+                }
+            ),
+            "transport_receipt": _transport_receipt(),
+        }
+
+    adapter = _adapter(
+        tmp_path,
+        cache_root=cache_root,
+        mode=RunMode.LIVE,
+        transport=transport,
+    )
+
+    with pytest.raises(ValueError, match="(?i)secret"):
+        _execute(adapter)
+
+    assert not list(cache_root.rglob("*.json"))
+
+
+@pytest.mark.parametrize(
+    "receipt",
+    [
+        None,
+        _transport_receipt(provider="provider-b"),
+        _transport_receipt(model="model-b"),
+        _transport_receipt(plane="cli"),
+    ],
+)
+def test_live_requires_matching_provider_provenance_before_caching(
+    tmp_path: Path,
+    receipt: dict | None,
+):
+    cache_root = tmp_path / "provider-cache"
+
+    def transport(*args, **kwargs):
+        response = {
+            "content": '{"probe":"provider-contract-v1","nonce":"live"}'
+        }
+        if receipt is not None:
+            response["transport_receipt"] = receipt
+        return response
+
+    adapter = _adapter(
+        tmp_path,
+        cache_root=cache_root,
+        mode=RunMode.LIVE,
+        transport=transport,
+    )
+
+    with pytest.raises(ValueError, match="(?i)(receipt|provider|model|plane)"):
+        _execute(adapter)
+
+    assert not list(cache_root.rglob("*.json"))
+
+
+def test_replay_rejects_insecure_or_integrity_mismatched_cache(tmp_path: Path):
+    cache_root = tmp_path / "provider-cache"
+
+    def transport(*args, **kwargs):
+        return {
+            "content": '{"probe":"provider-contract-v1","nonce":"live"}',
+            "transport_receipt": _transport_receipt(),
+        }
+
+    live = _adapter(
+        tmp_path,
+        cache_root=cache_root,
+        mode=RunMode.LIVE,
+        transport=transport,
+    )
+    _execute(live)
+    cache_file = next((cache_root / "live").rglob("*.json"))
+    cache_file.chmod(0o644)
+
+    replay = _adapter(tmp_path, cache_root=cache_root, mode=RunMode.REPLAY)
+    with pytest.raises(ValueError, match="(?i)(cache|replay)"):
+        _execute(replay)
+
+    cache_file.chmod(0o600)
+    envelope = json.loads(cache_file.read_text(encoding="utf-8"))
+    envelope["response"]["content"] = (
+        '{"probe":"provider-contract-v1","nonce":"tampered"}'
+    )
+    cache_file.write_text(json.dumps(envelope), encoding="utf-8")
+    cache_file.chmod(0o600)
+    with pytest.raises(ValueError, match="(?i)(cache|replay)"):
+        _execute(replay)
+
+
+def test_cache_root_inside_repository_is_rejected_without_creating_it():
+    cache_root = REPO_ROOT / ".provider-cache-contract-test"
+    assert not cache_root.exists()
+
+    with pytest.raises((RuntimeError, ValueError), match="(?i)(cache|repository|workspace)"):
+        ProviderAdapter(
+            provider="provider-a",
+            model="model-a",
+            plane="api",
+            role="seed-author",
+            mode=RunMode.MOCK,
+            cache_root=cache_root,
+            credential_binding_id="binding-a",
+        )
+
+    assert not cache_root.exists()
+
+
+def test_existing_insecure_cache_root_is_rejected_without_chmod(tmp_path: Path):
+    cache_root = tmp_path / "shared-cache"
+    cache_root.mkdir(mode=0o755)
+    cache_root.chmod(0o755)
+
+    with pytest.raises(ValueError, match="(?i)(owner|0700)"):
+        _adapter(tmp_path, cache_root=cache_root)
+
+    assert stat.S_IMODE(cache_root.stat().st_mode) == 0o755
+
+
+def test_symlink_cache_root_is_rejected(tmp_path: Path):
+    target = tmp_path / "target"
+    target.mkdir(mode=0o700)
+    link = tmp_path / "cache-link"
+    link.symlink_to(target, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="(?i)symbolic"):
+        _adapter(tmp_path, cache_root=link)
+
+
+def test_secret_shaped_request_or_binding_id_is_rejected(tmp_path: Path):
+    adapter = _adapter(tmp_path)
+    with pytest.raises(ValueError, match="(?i)secret"):
+        adapter.execute(
+            request="xai-this-is-a-secret-shaped-request-value",
+            schema_version=SCHEMA_VERSION,
+            template_digest=TEMPLATE_DIGEST,
+            settings=SAFE_SETTINGS,
+        )
+
+    with pytest.raises(ValueError, match="(?i)(safe|opaque|binding)"):
+        _adapter(
+            tmp_path,
+            credential_binding_id="xai-secret-shaped-binding-value",
+        )
+
+
+def test_provider_specific_transport_receipt_contracts(tmp_path: Path):
+    content = '{"probe":"provider-contract-v1","nonce":"live"}'
+    vertex = ProviderAdapter(
+        provider="vertex",
+        model="gemini-2.5-flash",
+        plane="api",
+        role="mutation-smoke",
+        mode=RunMode.LIVE,
+        cache_root=tmp_path / "vertex-cache",
+        credential_binding_id="google-adc-default",
+    )
+    vertex_receipt = {
+        "auth_kind": "google_adc",
+        "configured_model": "gemini-2.5-flash",
+        "provider": "vertex",
+        "resolved_model": "gemini-2.5-flash",
+        "resolved_plane": "api",
+        "total_attempt_limit": 1,
+    }
+    assert vertex.validate_response(
+        {"content": content, "transport_receipt": vertex_receipt},
+        ProbeArtifact,
+        require_transport_receipt=True,
+    )
+    for field, wrong in (
+        ("auth_kind", "api_key"),
+        ("total_attempt_limit", 2),
+        ("resolved_plane", "cli"),
+    ):
+        invalid = {**vertex_receipt, field: wrong}
+        assert not vertex.validate_response(
+            {"content": content, "transport_receipt": invalid},
+            ProbeArtifact,
+            require_transport_receipt=True,
+        )
+
+    unigrok = ProviderAdapter(
+        provider="unigrok",
+        model="grok-4.5",
+        plane="cli",
+        role="critic-smoke",
+        mode=RunMode.LIVE,
+        cache_root=tmp_path / "unigrok-cache",
+        credential_binding_id="unigrok-mcp-local",
+    )
+    unigrok_receipt = {
+        "auth_kind": "server_managed",
+        "configured_model": "grok-4.5",
+        "fallback_policy": "same_plane",
+        "finish_reason": "final_answer",
+        "provider": "unigrok",
+        "resolved_model": "grok-4.5",
+        "resolved_plane": "CLI",
+    }
+    assert unigrok.validate_response(
+        {"content": content, "transport_receipt": unigrok_receipt},
+        ProbeArtifact,
+        require_transport_receipt=True,
+    )
+    for field, wrong in (
+        ("auth_kind", "copied_oauth"),
+        ("fallback_policy", "cross_plane"),
+        ("finish_reason", "fallback"),
+        ("resolved_model", "other-model"),
+    ):
+        invalid = {**unigrok_receipt, field: wrong}
+        assert not unigrok.validate_response(
+            {"content": content, "transport_receipt": invalid},
+            ProbeArtifact,
+            require_transport_receipt=True,
+        )
+
+
+def test_cache_rejects_a_sibling_git_workspace(tmp_path: Path):
+    other_repo = tmp_path / "other-repo"
+    other_repo.mkdir(mode=0o700)
+    (other_repo / ".git").mkdir(mode=0o700)
+    cache_root = other_repo / "campaign-cache"
+
+    with pytest.raises(ValueError, match="(?i)(cache|repository)"):
+        _adapter(tmp_path, cache_root=cache_root)
+
+    assert not cache_root.exists()

--- a/tests/campaigns/gemma_needle_2000_v1/test_provider_smoke.py
+++ b/tests/campaigns/gemma_needle_2000_v1/test_provider_smoke.py
@@ -1,0 +1,407 @@
+import json
+import stat
+from pathlib import Path
+
+import pytest
+
+from evals.campaigns.gemma_needle_2000_v1 import provider_smoke
+from evals.campaigns.gemma_needle_2000_v1.provider_adapters import RunMode
+from evals.campaigns.gemma_needle_2000_v1.provider_transports import (
+    PROVIDER_PROBE_JSON_SCHEMA,
+    UniGrokMCPTransport,
+    VertexADCTransport,
+)
+
+
+def _profile_payload() -> dict:
+    return {
+        "version": 1,
+        "campaign_id": "gemma-needle-2000-v1",
+        "max_live_calls": 2,
+        "orchestrator_retry_limit": 0,
+        "vertex_max_output_tokens": 64,
+        "bindings": [
+            {
+                "provider": "vertex",
+                "credential_binding_id": "google-adc-default",
+                "auth_kind": "google_adc",
+                "project": "example-project",
+                "location": "global",
+                "model": "gemini-2.5-flash",
+                "role": "mutation-adjudication-smoke",
+            },
+            {
+                "provider": "unigrok",
+                "credential_binding_id": "unigrok-mcp-local",
+                "auth_kind": "server_managed",
+                "endpoint": "http://127.0.0.1:4765/mcp",
+                "model": "grok-4.5",
+                "plane": "cli",
+                "fallback_policy": "same_plane",
+                "role": "seed-critic-smoke",
+            },
+        ],
+    }
+
+
+def _private_profile(tmp_path: Path) -> Path:
+    tmp_path.chmod(0o700)
+    path = tmp_path / "providers.json"
+    path.write_text(json.dumps(_profile_payload()), encoding="utf-8")
+    path.chmod(0o600)
+    return path
+
+
+def _provider_receipt(binding) -> dict:
+    receipt = {
+        "configured_model": binding.model,
+        "provider": binding.provider,
+        "resolved_model": binding.model,
+        "resolved_plane": getattr(binding, "plane", "api"),
+    }
+    if binding.provider == "vertex":
+        receipt.update(
+            {
+                "auth_kind": "google_adc",
+                "total_attempt_limit": 1,
+            }
+        )
+    else:
+        receipt.update(
+            {
+                "auth_kind": "server_managed",
+                "fallback_policy": "same_plane",
+                "finish_reason": "final_answer",
+            }
+        )
+    return receipt
+
+
+def test_profile_requires_owner_private_permissions(tmp_path: Path):
+    path = _private_profile(tmp_path)
+    assert provider_smoke.load_profile(path).max_live_calls == 2
+
+    path.chmod(0o644)
+    with pytest.raises(ValueError, match="(?i)(owner|0600)"):
+        provider_smoke.load_profile(path)
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "https://127.0.0.1:4765/mcp",
+        "http://example.com/mcp",
+        "http://user:password@127.0.0.1:4765/mcp",
+        "http://127.0.0.1:4765/not-mcp",
+        "http://127.0.0.1:9999/mcp",
+        "http://localhost:4765/mcp",
+    ],
+)
+def test_profile_rejects_nonloopback_or_credentialed_mcp_urls(
+    tmp_path: Path,
+    endpoint: str,
+):
+    payload = _profile_payload()
+    payload["bindings"][1]["endpoint"] = endpoint
+    path = tmp_path / "providers.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    path.chmod(0o600)
+
+    with pytest.raises(ValueError, match="(?i)validation"):
+        provider_smoke.load_profile(path)
+
+
+def test_live_then_replay_uses_two_calls_then_zero_calls(
+    monkeypatch,
+    tmp_path: Path,
+):
+    profile = provider_smoke.load_profile(_private_profile(tmp_path))
+    cache_root = tmp_path / "cache"
+    calls = []
+
+    def fake_transport(binding):
+        def call(request, settings):
+            calls.append(binding.provider)
+            nonce = request.split('"nonce":"', 1)[1].split('"', 1)[0]
+            return {
+                "content": json.dumps(
+                    {"probe": "provider-contract-v1", "nonce": nonce}
+                ),
+                "transport_receipt": _provider_receipt(binding),
+            }
+
+        return call
+
+    monkeypatch.setattr(provider_smoke, "_transport", fake_transport)
+    monkeypatch.setattr(
+        "evals.campaigns.gemma_needle_2000_v1.provider_adapters.default_cache_root",
+        lambda: cache_root,
+    )
+    receipts_root = tmp_path / "receipts"
+
+    live, live_passed = provider_smoke.run_smoke(
+        profile=profile,
+        mode=RunMode.LIVE,
+        nonce="stage0-5-test-nonce",
+        receipts_root=receipts_root,
+    )
+    assert live_passed is True
+    assert calls == ["vertex", "unigrok"]
+
+    def transport_must_not_be_built(binding):
+        raise AssertionError("replay constructed a provider transport")
+
+    monkeypatch.setattr(provider_smoke, "_transport", transport_must_not_be_built)
+    replay, replay_passed = provider_smoke.run_smoke(
+        profile=profile,
+        mode=RunMode.REPLAY,
+        nonce="stage0-5-test-nonce",
+        receipts_root=receipts_root,
+    )
+    assert replay_passed is True
+    assert calls == ["vertex", "unigrok"]
+    assert live["provider_statuses"] == {"vertex": "passed", "unigrok": "passed"}
+    assert replay["provider_statuses"] == live["provider_statuses"]
+
+    live_receipt = json.loads(Path(live["receipt_path"]).read_text(encoding="utf-8"))
+    assert live_receipt["evidence_class"] == "live_transport_contract_passed"
+    replay_receipt = json.loads(Path(replay["receipt_path"]).read_text(encoding="utf-8"))
+    assert replay_receipt["transport_responses_observed_current_run"] == 0
+    assert replay_receipt["transport_invocation_attempts_current_run"] == 0
+    assert replay_receipt["evidence_class"] == (
+        "cache_integrity_checked_origin_unverified"
+    )
+    assert all(
+        provider["transport_invoked_current_run"] is False
+        and provider["artifact_source"] == "live_cache"
+        and provider["evidence_class"] == "cache_integrity_checked_origin_unverified"
+        and provider["source_transport_receipt_digest"].startswith("sha256:")
+        for provider in replay_receipt["providers"]
+    )
+
+    for path in cache_root.rglob("*"):
+        mode = stat.S_IMODE(path.stat().st_mode)
+        assert mode == (0o700 if path.is_dir() else 0o600)
+    for path in receipts_root.rglob("*"):
+        mode = stat.S_IMODE(path.stat().st_mode)
+        assert mode == (0o700 if path.is_dir() else 0o600)
+
+
+def test_unigrok_transport_uses_the_public_agent_prompt_contract():
+    transport = UniGrokMCPTransport(
+        endpoint="http://127.0.0.1:4765/mcp",
+        model="grok-4.5",
+    )
+
+    arguments = transport.agent_arguments("probe")
+
+    assert arguments["prompt"] == "probe"
+    assert "task" not in arguments
+    assert arguments["plane"] == "cli"
+    assert arguments["fallback_policy"] == "same_plane"
+    http_options = transport.http_client_options({"X-Client-ID": "test"})
+    assert http_options["trust_env"] is False
+
+    with pytest.raises(ValueError, match="(?i)canonical"):
+        UniGrokMCPTransport(
+            endpoint="http://localhost:4765/mcp",
+            model="grok-4.5",
+        )
+
+
+def test_vertex_transport_has_one_total_sdk_attempt():
+    transport = VertexADCTransport(
+        project="example-project",
+        location="global",
+        model="gemini-2.5-flash",
+    )
+
+    assert transport.total_attempt_limit == 1
+    assert transport.thinking_budget == 0
+    assert PROVIDER_PROBE_JSON_SCHEMA["additionalProperties"] is False
+    assert set(PROVIDER_PROBE_JSON_SCHEMA["required"]) == {"probe", "nonce"}
+
+    class FakeRetryOptions:
+        def __init__(self, *, attempts):
+            self.attempts = attempts
+
+    class FakeHttpOptions:
+        def __init__(self, *, api_version, retry_options):
+            self.api_version = api_version
+            self.retry_options = retry_options
+
+    class FakeTypes:
+        HttpRetryOptions = FakeRetryOptions
+        HttpOptions = FakeHttpOptions
+
+    options = transport.build_http_options(FakeTypes)
+    assert options.api_version == "v1"
+    assert options.retry_options.attempts == 1
+
+
+def test_profile_symlink_and_insecure_parent_are_rejected(tmp_path: Path):
+    path = _private_profile(tmp_path)
+    link = tmp_path / "profile-link.json"
+    link.symlink_to(path)
+    with pytest.raises(ValueError, match="(?i)symbolic"):
+        provider_smoke.load_profile(link)
+
+    tmp_path.chmod(0o755)
+    with pytest.raises(ValueError, match="(?i)(parent|0700)"):
+        provider_smoke.load_profile(path)
+    assert stat.S_IMODE(tmp_path.stat().st_mode) == 0o755
+
+
+def test_profile_rejects_secret_shaped_binding_identifiers(tmp_path: Path):
+    tmp_path.chmod(0o700)
+    payload = _profile_payload()
+    payload["bindings"][0]["credential_binding_id"] = (
+        "xai-secret-shaped-binding-identifier"
+    )
+    path = tmp_path / "providers.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    path.chmod(0o600)
+
+    with pytest.raises(ValueError, match="(?i)secret"):
+        provider_smoke.load_profile(path)
+
+
+def test_receipt_root_inside_repository_is_rejected(tmp_path: Path):
+    profile = provider_smoke.load_profile(_private_profile(tmp_path))
+    repo_receipts = Path(__file__).resolve().parents[3] / ".provider-receipts-test"
+    assert not repo_receipts.exists()
+
+    with pytest.raises(ValueError, match="(?i)(receipt|repository)"):
+        provider_smoke.run_smoke(
+            profile=profile,
+            mode=RunMode.REPLAY,
+            nonce="stage0-5-test-nonce",
+            receipts_root=repo_receipts,
+        )
+
+    assert not repo_receipts.exists()
+
+
+def test_existing_insecure_receipt_root_is_rejected_before_live_calls(
+    monkeypatch,
+    tmp_path: Path,
+):
+    profile = provider_smoke.load_profile(_private_profile(tmp_path))
+    receipts_root = tmp_path / "shared-receipts"
+    receipts_root.mkdir(mode=0o755)
+    receipts_root.chmod(0o755)
+    calls = []
+
+    def transport_must_not_be_built(binding):
+        calls.append(binding.provider)
+        raise AssertionError("transport built before receipt preflight")
+
+    monkeypatch.setattr(provider_smoke, "_transport", transport_must_not_be_built)
+
+    with pytest.raises(ValueError, match="(?i)(owner|0700)"):
+        provider_smoke.run_smoke(
+            profile=profile,
+            mode=RunMode.LIVE,
+            nonce="stage0-5-test-nonce",
+            receipts_root=receipts_root,
+        )
+
+    assert calls == []
+    assert stat.S_IMODE(receipts_root.stat().st_mode) == 0o755
+
+
+@pytest.mark.parametrize(
+    ("failure_kind", "response_observed"),
+    [
+        ("transport_error", False),
+        ("invalid_json", True),
+        ("invalid_provenance", True),
+        ("wrong_nonce", True),
+    ],
+)
+def test_failure_receipts_distinguish_transport_attempt_from_response(
+    monkeypatch,
+    tmp_path: Path,
+    failure_kind: str,
+    response_observed: bool,
+):
+    profile = provider_smoke.load_profile(_private_profile(tmp_path))
+    cache_root = tmp_path / "cache"
+    monkeypatch.setattr(
+        "evals.campaigns.gemma_needle_2000_v1.provider_adapters.default_cache_root",
+        lambda: cache_root,
+    )
+
+    def fake_transport(binding):
+        def call(request, settings):
+            if binding.provider == "vertex":
+                if failure_kind == "transport_error":
+                    raise RuntimeError("synthetic transport failure")
+                if failure_kind == "invalid_json":
+                    return {
+                        "content": "not-json",
+                        "transport_receipt": _provider_receipt(binding),
+                    }
+                if failure_kind == "wrong_nonce":
+                    return {
+                        "content": (
+                            '{"probe":"provider-contract-v1",'
+                            '"nonce":"different-live-nonce"}'
+                        ),
+                        "transport_receipt": _provider_receipt(binding),
+                    }
+                receipt = _provider_receipt(binding)
+                receipt["auth_kind"] = "wrong"
+                return {
+                    "content": (
+                        '{"probe":"provider-contract-v1",'
+                        '"nonce":"stage0-5-test-nonce"}'
+                    ),
+                    "transport_receipt": receipt,
+                }
+            return {
+                "content": (
+                    '{"probe":"provider-contract-v1",'
+                    '"nonce":"stage0-5-test-nonce"}'
+                ),
+                "transport_receipt": _provider_receipt(binding),
+            }
+
+        return call
+
+    monkeypatch.setattr(provider_smoke, "_transport", fake_transport)
+    summary, passed = provider_smoke.run_smoke(
+        profile=profile,
+        mode=RunMode.LIVE,
+        nonce="stage0-5-test-nonce",
+        receipts_root=tmp_path / "receipts",
+    )
+    assert passed is False
+    receipt = json.loads(Path(summary["receipt_path"]).read_text(encoding="utf-8"))
+    assert receipt["evidence_class"] == "live_transport_contract_failed"
+    vertex = next(item for item in receipt["providers"] if item["provider"] == "vertex")
+    assert vertex["transport_invocation_attempts_current_run"] == 1
+    assert vertex["transport_response_observed_current_run"] is response_observed
+    assert vertex["evidence_class"] == "live_transport_contract_failed"
+
+
+def test_profile_and_receipts_reject_a_sibling_git_workspace(tmp_path: Path):
+    profile = provider_smoke.load_profile(_private_profile(tmp_path))
+    other_repo = tmp_path / "other-repo"
+    other_repo.mkdir(mode=0o700)
+    (other_repo / ".git").mkdir(mode=0o700)
+    private = other_repo / "private"
+    private.mkdir(mode=0o700)
+    profile_path = private / "providers.json"
+    profile_path.write_text(json.dumps(_profile_payload()), encoding="utf-8")
+    profile_path.chmod(0o600)
+
+    with pytest.raises(ValueError, match="(?i)(profile|repository)"):
+        provider_smoke.load_profile(profile_path)
+    with pytest.raises(ValueError, match="(?i)(receipt|repository)"):
+        provider_smoke.run_smoke(
+            profile=profile,
+            mode=RunMode.REPLAY,
+            nonce="stage0-5-test-nonce",
+            receipts_root=other_repo / "receipts",
+        )

--- a/tests/campaigns/gemma_needle_2000_v1/test_stage0_mechanical.py
+++ b/tests/campaigns/gemma_needle_2000_v1/test_stage0_mechanical.py
@@ -1,12 +1,12 @@
 import pytest
 from datetime import datetime, timezone, timedelta
-import json
 from pydantic import ValidationError
 
 from evals.campaigns.gemma_needle_2000_v1.schemas import (
-    ToolSelectionPack, GemmaPlanStatePack, BaseRootEnvelope, EpisodeOutcome, 
-    ProposalVerdict, TTLState, OracleRegistryContract, ActionProposal, 
-    AbstentionProposal, RequestVerificationProposal, Receipt
+    EpisodeOutcome,
+    GemmaPlanStatePack,
+    ToolSelectionPack,
+    TTLState,
 )
 from evals.campaigns.gemma_needle_2000_v1.validators import MechanicalValidators
 from evals.campaigns.gemma_needle_2000_v1.mechanical_mutators import MechanicalMutators
@@ -110,11 +110,11 @@ def test_secret_pii_unsafe_path():
     
     # Legit vocabulary (should pass)
     env.objective = "Parse the user password and security token."
-    assert MechanicalValidators.scan_unsafe_credentials(env) == True
+    assert MechanicalValidators.scan_unsafe_credentials(env)
     
     # Real credentials (should fail)
     env.objective = "My secret is AIzaSyB_mockKey123456789012345678901234"
-    assert MechanicalValidators.scan_unsafe_credentials(env) == False
+    assert not MechanicalValidators.scan_unsafe_credentials(env)
 
 def test_ttl_validation_timezone_aware():
     data = get_valid_base_fixture()
@@ -135,17 +135,30 @@ def test_evaluate_episode_outcome():
     env.observed_receipts = []
     assert MechanicalValidators.evaluate_episode_outcome(env, now) == EpisodeOutcome.VERIFIED_FAILURE
 
-def test_provider_adapter_strict_validation():
-    adapter = ProviderAdapter("test", "test", "test", "test", RunMode.MOCK)
+def test_provider_adapter_strict_validation(tmp_path):
+    adapter = ProviderAdapter(
+        "test",
+        "test",
+        "test",
+        "test",
+        RunMode.MOCK,
+        cache_root=tmp_path / "provider-cache",
+    )
     
     # Reject empty
-    assert adapter.validate_response({"content": ""}) == False
+    assert not adapter.validate_response({"content": ""})
     # Reject promise-only
-    assert adapter.validate_response({"content": "I'll do that."}) == False
-    # Accept promise-preface with valid JSON artifact
-    assert adapter.validate_response({"content": "I'll do that.\n{ \"test\": \"valid\" }"}) == True
+    assert not adapter.validate_response({"content": "I'll do that."})
+    # Reject promise-preface even when it includes a JSON artifact
+    assert not adapter.validate_response(
+        {"content": "I'll do that.\n{ \"test\": \"valid\" }"}
+    )
+    # Accept exactly one pure JSON artifact
+    assert adapter.validate_response({"content": "{ \"test\": \"valid\" }"})
     # Reject malformed
-    assert adapter.validate_response({"content": "I'll do that.\n{ \"test\": \"valid\" "}) == False
+    assert not adapter.validate_response(
+        {"content": "I'll do that.\n{ \"test\": \"valid\" "}
+    )
 
 def test_mechanical_mutator_lineage():
     data = get_valid_base_fixture()

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -222,9 +222,11 @@ def test_docker_image_copies_mcp_ui_assets():
 
     assert "COPY mcp_ui/ ./mcp_ui/" in dockerfile
     assert "COPY docs/okf/ ./docs/okf/" in dockerfile
-    assert "COPY .grok/ ./.grok/" in dockerfile
+    assert "COPY .grok/prompts/ ./.grok/prompts/" in dockerfile
+    assert "COPY .grok/hyperparams/ ./.grok/hyperparams/" in dockerfile
     assert "!docs/okf/**" in dockerignore
-    assert "!.grok/**" in dockerignore
+    assert "!.grok/prompts/**" in dockerignore
+    assert "!.grok/hyperparams/**" in dockerignore
 
 
 def test_cloudrun_requires_api_keys(monkeypatch):

--- a/tests/test_release_hygiene.py
+++ b/tests/test_release_hygiene.py
@@ -46,8 +46,47 @@ def test_wheel_configuration_includes_runtime_assets():
 
     assert included["mcp_ui"] == "mcp_ui"
     assert included["docs/okf"] == "docs/okf"
-    assert included[".grok"] == ".grok"
+    assert included[".grok/hyperparams"] == ".grok/hyperparams"
+    assert included[".grok/prompts"] == ".grok/prompts"
+    assert ".grok" not in included
     assert included["example.env"] == "example.env"
+
+
+def test_local_provider_credentials_are_ignored_and_not_force_included():
+    gitignore = (ROOT / ".gitignore").read_text(encoding="utf-8")
+    dockerignore = (ROOT / ".dockerignore").read_text(encoding="utf-8")
+    dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+
+    for path in (
+        ".codex/auth.json",
+        ".gemini/config/",
+        ".gemini/settings.local.json",
+        ".claude/.credentials.json",
+        ".grok/auth.json",
+        ".gcloud/",
+        ".google/",
+        "secrets/",
+    ):
+        assert path in gitignore
+
+    assert ".grok/**" in dockerignore
+    assert "!.grok/prompts/**" in dockerignore
+    assert "!.grok/hyperparams/**" in dockerignore
+    assert "COPY .grok/ ./.grok/" not in dockerfile
+    assert "COPY .grok/prompts/ ./.grok/prompts/" in dockerfile
+    assert "COPY .grok/hyperparams/ ./.grok/hyperparams/" in dockerfile
+
+    gemini_config = json.loads((ROOT / ".gemini" / "config.json").read_text())
+    assert gemini_config == {
+        "userSettings": {
+            "browserJsExecutionPolicy": "BROWSER_JS_EXECUTION_POLICY_TURBO",
+            "useAiCredits": True,
+            "verboseAgentChat": True,
+        }
+    }
+    gemini_guidance = (ROOT / ".gemini" / "GEMINI.md").read_text(encoding="utf-8")
+    assert "must never be replaced" in gemini_guidance
+    assert "standard ADC discovery" in gemini_guidance
 
 
 def test_forge_execution_tools_are_not_core_runtime_dependencies():

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -496,6 +500,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "frozenlist"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -598,6 +611,45 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
     { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
     { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.56.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/66/b4ba60005743e01933e22b4f62313e063f7460458b7d8a358427b4930013/google_auth-2.56.0.tar.gz", hash = "sha256:f90fa030b569a92654b9d690665a073841df33d57487be53db583a9a0867a553", size = 364629, upload-time = "2026-07-13T19:09:57.143Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/7d/cd3e187f14ce832e419e70709bfcc40cb0dc11517d5d03c9d3919bcc3101/google_auth-2.56.0-py3-none-any.whl", hash = "sha256:6e88c10217e07a92bfd01cac8ee99e32ccfb08414c3102e6c5b8d58f37a0d1e0", size = 257976, upload-time = "2026-07-13T19:09:42.685Z" },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
+]
+
+[[package]]
+name = "google-genai"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/59/3ed61240ef20b3ae6ed54e82c6f8b6d1f194947bc6679679dd6cdb037594/google_genai-1.75.0.tar.gz", hash = "sha256:56bac3991b311c93f980c0a2abcd287b672146905df1fbd71c92ed633d5a07cf", size = 539039, upload-time = "2026-05-04T22:48:54.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/b6/552d40e96da22921eb1fead7c14b00b5b5473a20e45959488660fab35ee2/google_genai-1.75.0-py3-none-any.whl", hash = "sha256:8dc4c096e7d6288c3087f6893f582fe52468932464781edb8193bd92b9fefb2c", size = 793726, upload-time = "2026-05-04T22:48:53.033Z" },
 ]
 
 [[package]]
@@ -858,6 +910,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+campaign = [
+    { name = "google-genai" },
+]
 forge = [
     { name = "coverage" },
     { name = "pytest" },
@@ -877,6 +932,7 @@ dev = [
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "coverage", marker = "extra == 'forge'", specifier = ">=7.6" },
+    { name = "google-genai", marker = "extra == 'campaign'", specifier = ">=1.25,<2" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.13.1" },
     { name = "pydantic", specifier = ">=2.9.0" },
@@ -891,7 +947,7 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.40.0" },
     { name = "xai-sdk", specifier = ">=1.17.0" },
 ]
-provides-extras = ["forge"]
+provides-extras = ["forge", "campaign"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1198,6 +1254,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411, upload-time = "2026-01-29T21:51:27.446Z" },
     { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465, upload-time = "2026-01-29T21:51:28.925Z" },
     { url = "https://files.pythonhosted.org/packages/57/bf/2086963c69bdac3d7cff1cc7ff79b8ce5ea0bec6797a017e1be338a46248/protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02", size = 170687, upload-time = "2026-01-29T21:51:32.557Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -1713,6 +1790,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1736,6 +1822,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]
@@ -1909,6 +2004,105 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl", hash = "sha256:c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee", size = 68502, upload-time = "2025-12-21T14:16:21.041Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/02/b9a097e1e16fee4e2fd1ec8c39f6a9c5d6257bae8fa12640caf869f54436/websockets-16.1.tar.gz", hash = "sha256:299468cbe42e2b9981134c7c51d99387d8a7bf562b00183b3eec53f882846dad", size = 182530, upload-time = "2026-07-10T06:32:57.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/13/d47429afcc2c28616c32640009c84ea3f95660dab805766345b9682468e0/websockets-16.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a9b1d7a63cba8e6b9b77e499a81eab29d31100298d090ad4507d1048c0b9cae0", size = 179770, upload-time = "2026-07-10T06:30:46.308Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c7/2f0a722039a1e0107be73ed672ba604449b4956e48733e8e6b8a005aea42/websockets-16.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:bedbc5efeb96621aa2921d2d92608246691399418cac22acba427eb11877ea1f", size = 177455, upload-time = "2026-07-10T06:30:47.601Z" },
+    { url = "https://files.pythonhosted.org/packages/43/6a/c26b0ae449e93d256ce5cdd50d5fe97b575a63e8dcd311a1faa972fd6bc6/websockets-16.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fd847ab82133015afe65d778e7966ab42dba16bd7ad2e5b8a7918db6539f3f94", size = 177731, upload-time = "2026-07-10T06:30:49.102Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/3f/381550b344a02f0d2f84cda25e79b54575291bc7022128a41163fe8ba5b0/websockets-16.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e2fb33ccb16ee40a95cc676d7b0ff451a9a2632f11a0dbc2e666326892b2e1de", size = 187066, upload-time = "2026-07-10T06:30:50.505Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/87/5ab1ec2086910f23cfb9ec0c1c29fbcc24a9d190b5198b1557c00ce4a47e/websockets-16.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f15b6d9ea9c2eaf6ccab964a082b09bfa6634a495bb0c2e9e7ee6943f58976", size = 188301, upload-time = "2026-07-10T06:30:51.835Z" },
+    { url = "https://files.pythonhosted.org/packages/75/4b/bbbb8e6fac4cfc53d7aaa69a3d531bf10799354b0021f4b58914aced8c1a/websockets-16.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:638cf57c48b4ad8ac1ff1e453f4f97db2426b690ddc111e6da96b27b4a340bc3", size = 191594, upload-time = "2026-07-10T06:30:53.229Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/da/6c0c349443d6e999f481e3d9a0e57e7ac2956d75d6391bec24b92af3fe13/websockets-16.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2c1c85f61bc9d5eac57ce705d848dc2d2ce3680638300bf4e1da7d749e2cf4ce", size = 188862, upload-time = "2026-07-10T06:30:54.744Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ea/a368d37c010425a5451f42052fe804e754e23333e8448aef5d55c8a8d64f/websockets-16.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:eeab6d27f51c7e579023c971f5e6dff200deadf01faf6831beaecd32052dfaef", size = 187633, upload-time = "2026-07-10T06:30:56.055Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/4e/2ecd59add10d0855ec03dbdedfcdacdbd1aaabcd44b7dcbeda27538662e9/websockets-16.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2ed64e5a97b0b97a0b66e18bfe281317a75fbbd5afe692f939ea8d14a4292f2c", size = 185089, upload-time = "2026-07-10T06:30:57.444Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/eb/c6c3dcd7a01097bb0d42f4e9ef21a2c2a491d36b77cd0870ab59f9e8e77f/websockets-16.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9b3b021d0ed4bc16eea9775f62c9fa71acdacba0fc790b38581754dedf29ca60", size = 187790, upload-time = "2026-07-10T06:30:58.731Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3e/775d36885d5e48ab8020aaf377de0ff5fbeb8bc2682a7e46419e4a14521c/websockets-16.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:6eb604a4167f0a0d53c2243dfc667a29f0b43c3436057184e070bb82a1000fa2", size = 186381, upload-time = "2026-07-10T06:31:00.355Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/90/6305c00812a92e47d0582604c02bd759db0118bbafc13f707d712dbcf898/websockets-16.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:9a3f125e44c3e34d61d111652e608e0f5b85ce08c225c8d56ad0eb822fa40030", size = 188193, upload-time = "2026-07-10T06:31:01.677Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/32/96bf8302c81d961585b4d34a2ddd3f229782f9b8c57bc78bbf98f1b1a4ac/websockets-16.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:8fdf0b00d0d1f30d1f06a92cab46fe542eec3eb302a7aee7163f142d0780f216", size = 185771, upload-time = "2026-07-10T06:31:03.062Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/1f/e8fe44b1d2dc417d740d9959d28fd2a846f268e7df38a686c04ac7dfe947/websockets-16.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:67b56828712f5fa7852de4c0265c28827311a657a4d275b7312ed0d1a918bee4", size = 186803, upload-time = "2026-07-10T06:31:04.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/29/b07d3a4e1eb2ab03e94e7f53f0c7a628e85fde6ad86011f7afd08f27b985/websockets-16.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:39c7e7730be33b8f0cd6f0aa8e8c82f9cdd1813f159765e073b2ece65f4824b5", size = 187041, upload-time = "2026-07-10T06:31:05.567Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/fd/e0abb8acc435642ac4a671490f6cf781c882f3fe682cdced9080ea455ab5/websockets-16.1-cp311-cp311-win32.whl", hash = "sha256:c54fe94fb2f11e11b48920c5f971e298cec73ac35db56efe57a49db63dfc95d4", size = 180158, upload-time = "2026-07-10T06:31:06.929Z" },
+    { url = "https://files.pythonhosted.org/packages/81/06/85574d9458d3b913090087b817df0cc47b68e9a01dd0ab6ac04b77f49b0a/websockets-16.1-cp311-cp311-win_amd64.whl", hash = "sha256:f9f4fb9ae8b802e55609685db98382d48fd3feb1397804e1e774968dea0f28c7", size = 180456, upload-time = "2026-07-10T06:31:08.247Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/52/748c014f07f4e0e170c8932de7e647a1511d5ab3049cd978797136aee577/websockets-16.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b6aa3f7ad345cf3862c21f4fbf2ef5e14d911348476c2845e137c091fe3a3f0b", size = 179798, upload-time = "2026-07-10T06:31:09.664Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/5e/2a2e64d977d084e49d37c187c26c056daaff41965be7300cd5dbde6f8b07/websockets-16.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b43fcfb521ac2f34ba80b7b8ea16303e4ad82dd8af667bf40839ad3a5d37b164", size = 177478, upload-time = "2026-07-10T06:31:11.072Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/12/5b85b4e75d697e548a94962ce5c036b05dd21cb9545759d555c5586422fc/websockets-16.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2bd3e12cd9afbe2baedae0b1eeade8ba64329b60fe2f9abdc966bd10fd2c2ef5", size = 177746, upload-time = "2026-07-10T06:31:12.386Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/62/79b1c8f0cee0da648b4899e1c5b0dbd3aa59846985136a54854db6827ab4/websockets-16.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:35f41979c8623df9bd30d949d82010a8fda5c56ff12cd8508a5b7272b6d4b53a", size = 187345, upload-time = "2026-07-10T06:31:13.754Z" },
+    { url = "https://files.pythonhosted.org/packages/25/34/b7c5c52c2f24280e1c017acb7ad491a566750a5cceca7f3cf999373bba21/websockets-16.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a24d1f35aef07d794a16c853c688e74956c50239bec37b4f2de080056046419b", size = 188581, upload-time = "2026-07-10T06:31:15.075Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/37/604193bebcbeffe96fdf795960b83a15d600880c64dc17ec9c31c5b3427d/websockets-16.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0c64c024ddf7a35331b21fcddb562a039c275d2c82e8c2d12939e7da23997270", size = 191362, upload-time = "2026-07-10T06:31:16.395Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/b4/5ee27575b367d7110d4d13945e2a9de067ec84dc71e54b87f01e38550d9a/websockets-16.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c3e99757f5baafe20fc598e202ea6f5b0b265186ad38d0a17bd8beca16296955", size = 189216, upload-time = "2026-07-10T06:31:17.776Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/3e2dcc78d85fc5d9d814895ce6d07d0dfacc0f6aaa1d151f2b8c8d772299/websockets-16.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:353f3bc6e058ac1ccab4b3588e8598837a8c04cfc8351233e6d523be675d844c", size = 187971, upload-time = "2026-07-10T06:31:19.152Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2f/cd271717b93d5ee19626cb5e38a85baab745c86e33db7c31a3ac729b31b8/websockets-16.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0352f5b38b40e857b6428d468fa21dbb4dd4a567d933c26d9831b4efe1b92f43", size = 185381, upload-time = "2026-07-10T06:31:20.665Z" },
+    { url = "https://files.pythonhosted.org/packages/78/91/6ad6f2f1426317b5001bd490534208c7360636b35bac1dec2e0c22bfc40e/websockets-16.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:70bd789afab579602968c39f21cb925466505f3edff22f0ae852bca54978a4f9", size = 188015, upload-time = "2026-07-10T06:31:22.024Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/6d/533733132ab4c07540efd4a8f0b9a435d3a5059b2f26cc476ace1abf7f45/websockets-16.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:d0fb4b46f121eccd539353baebd1083a8767a9a351109453d1d1caecd1ba40c2", size = 186619, upload-time = "2026-07-10T06:31:23.376Z" },
+    { url = "https://files.pythonhosted.org/packages/08/73/16c059f3d73b3331eba10793704afa4faa9939234fb08ef7dca35794e8f0/websockets-16.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c14b6634af01541e4efe2954fd8f263386f7aa6d37c01e55dd8109fd17661452", size = 188497, upload-time = "2026-07-10T06:31:25.024Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/89/9a8fae7dd2acdcfb1a8844c29fe42b518a04b64fce38a0923b6290e452f1/websockets-16.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:a58532c49a851bcb481e58c1be23b315c17fe2fbbed509d75aeea12f543d2c15", size = 186051, upload-time = "2026-07-10T06:31:26.291Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/40/b240c7dd6a0e0c59c1f68377cc3015263521080c327c15f5e753c1f6d378/websockets-16.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:4e969170c3b08e1d8dabd990fef1fa702c4233aeaabec33f871806e444f6a0e4", size = 187029, upload-time = "2026-07-10T06:31:27.605Z" },
+    { url = "https://files.pythonhosted.org/packages/50/35/524e3fac40e47d6fdcf6c4b2c95ef1bc8a97e01593c90eff86621df7b716/websockets-16.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ff9b000064b88787ba9f7a3cb2af2b68a658ca5aad76458a46469e7124b678a0", size = 187308, upload-time = "2026-07-10T06:31:28.927Z" },
+    { url = "https://files.pythonhosted.org/packages/00/13/56840cf62c8859af6ba22b9529da937332468c80f32b598753e8a66d3990/websockets-16.1-cp312-cp312-win32.whl", hash = "sha256:b9f5d83f80f4d7c4bba6d97f3755ac05850c784dce0fd2ab371c4e41172f53ff", size = 180161, upload-time = "2026-07-10T06:31:30.316Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ff/87eb9eb44cb62424a8d729834f2b0515a47e2669fabec29820268f4d50a1/websockets-16.1-cp312-cp312-win_amd64.whl", hash = "sha256:6852c9f653966c16109d3b6f31181fd734f7914927e3f0fa1117af7a18c9aa21", size = 180462, upload-time = "2026-07-10T06:31:31.708Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/63/df158b155420b566f025e75613424ad9649a24bcb0e9f259321ab3d58bea/websockets-16.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b0232ed141cec3df2af5a3959a071c51f40036336b0d37e17faf9ef52fc73e47", size = 179791, upload-time = "2026-07-10T06:31:33.108Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cf/00fe9414dfeafa6fe54eae9f5716c8c8e9ac59d192be3b893c096d395846/websockets-16.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a71b73d143991714144e159f767b698f03c4a70b8a65ae1733b650cff488045b", size = 177472, upload-time = "2026-07-10T06:31:34.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/76/b10633424d40681b4e892ffd08ca5226322b2426e62d4ab71eae484c3a32/websockets-16.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:187323204c3b2fc465e8fc2609e60437c521790cb9c1acb49c4c452a33e57f37", size = 177737, upload-time = "2026-07-10T06:31:35.964Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/d3bb03b2229bb1afd72008742d586cf1ea240dce64dd48c71c8c7fd3294c/websockets-16.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9dba74233c8c3ce368850818c98354dad2570f57231b3fd3bd00d7aa57628881", size = 187403, upload-time = "2026-07-10T06:31:37.496Z" },
+    { url = "https://files.pythonhosted.org/packages/26/16/cc2e80478f688fc3c39c67dc1fac6a0783858058914ebc2489917462cb42/websockets-16.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:63339bc8c63c86a463177775cb7c677691f5bcfac7b3b2f01b286d42acd41600", size = 188639, upload-time = "2026-07-10T06:31:38.86Z" },
+    { url = "https://files.pythonhosted.org/packages/15/d6/ad87b2507e57de1cbf897a56c963f2925962ed5e85fbe06aaa83ced27acd/websockets-16.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:23e545ea8ae4263e37cdfd4e22a217f519e48e432728bc461185bbf585f38a83", size = 190078, upload-time = "2026-07-10T06:31:40.218Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1a/5b37b3fd335d5811f29fc829f2646a3e6d1463a4bf09c3100708684c766e/websockets-16.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2237081454846fb40403a80ba86d82e2038b9c45865ab96af0abe7d002a91045", size = 189267, upload-time = "2026-07-10T06:31:41.523Z" },
+    { url = "https://files.pythonhosted.org/packages/42/98/06afc33e9450d4230f94c664db78875d90f5f6a5fb77f0bc6ec15ae74e1c/websockets-16.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5f5218de1ed047385ca53744caba9435d65f75d008364970a3fae95a05812cf9", size = 188022, upload-time = "2026-07-10T06:31:42.838Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/42fef5d5887c18cf2d148b02debf56cecb9cfbffc68027cde9b12c8f432c/websockets-16.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:75c98e3920039d0edff03b74478ada504b7ce3a1bc406db2cabfca84320f7baf", size = 185435, upload-time = "2026-07-10T06:31:44.219Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/9b/8021c133add5fe40ed40312553a6cd1408c069d7efe3444ad483d4973ed3/websockets-16.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1facd189d8190af30487a55b4c3688484dd50801628a3b5b2ccd26db08e67057", size = 188080, upload-time = "2026-07-10T06:31:45.986Z" },
+    { url = "https://files.pythonhosted.org/packages/69/54/1e37384f395eaa127383aab15c1c45e200890a7d7b99db5c312233d193e0/websockets-16.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:cc0c6a6eef613c7da32d4fb068f82ef834b58134f6a16b54e6c1e5bf9529ab3d", size = 186678, upload-time = "2026-07-10T06:31:47.449Z" },
+    { url = "https://files.pythonhosted.org/packages/68/79/1caeacab5bc2081e4519288d248bc8bd2de30652e6eaa94be6be09a1fe5b/websockets-16.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:ad9411eded8988b879be6038206698bf7106c85a78f642c004485bcb95be17eb", size = 188554, upload-time = "2026-07-10T06:31:48.886Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/83/b3dca5fad71487b726e31cb0acf56f226792c1cc34e6ab18cbf146bd2d74/websockets-16.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:cd68f0914f3b64694895bc5e9b14e8b447e41d7bf5ffaf989bb8dcb5e2dfdce7", size = 186109, upload-time = "2026-07-10T06:31:50.508Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/0b/8f246c3712f07f207b52ea5fb47f3b2b66fafec7303162644c74aed51c6a/websockets-16.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fef2debfe7f7ebdda12176f26166f95b7af17af05ba06150fcf889032e0213e9", size = 187061, upload-time = "2026-07-10T06:31:51.861Z" },
+    { url = "https://files.pythonhosted.org/packages/47/eb/27d6c92a01696b6495386af4fc941d7d0a13f2eab2bf9c336111d7321491/websockets-16.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a3cd6c9b798218798f4bb7b2e71c38f0e744bb94ca537b13376f88019d46384d", size = 187347, upload-time = "2026-07-10T06:31:53.246Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/d5/eeee439921f55d5eaeabcea18d0f7ce32cdc39cb8fc1e185431a094c5c7b/websockets-16.1-cp313-cp313-win32.whl", hash = "sha256:84c170c6869633536921e4474b1cce7254c0c9b0053ef5725f966cee47e718e4", size = 180149, upload-time = "2026-07-10T06:31:55.058Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/03/971e98d4a4864cf263f9e94c5b2b7c9a9b7682d77bfbba4e732c55ee85a9/websockets-16.1-cp313-cp313-win_amd64.whl", hash = "sha256:bef52d327d70fa75dad93ee61ea2cb1d1489aca9f35c188833563f5a3b4df0a5", size = 180458, upload-time = "2026-07-10T06:31:56.767Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/e6/da1dc11507f8118145a81c751fe0c77e5e1c11b8554496addb39389e2dc2/websockets-16.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:f881fca0a45dd6789939bd6637cd98169b92f1c3fdc78262f2cb9ec2cb1f324e", size = 179833, upload-time = "2026-07-10T06:31:58.19Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ac/c0d46f62e31e232487b2c123bc3cfd9a4e45684ca7dc0c37f0987f29baae/websockets-16.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:30c379d5b207d3a7f0ba4c2e4602a895b0bcc63fb5f5371a4ae7fbddb03b672b", size = 177524, upload-time = "2026-07-10T06:31:59.563Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/33/abd966074b34a51e4f134e0aaed80f5a4a0a35163ea5ac58a1bc5a076d23/websockets-16.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:98ab58a4faa72b46da0127ccc1931dcbfc0985b0778892300a092185910c4cbe", size = 177743, upload-time = "2026-07-10T06:32:00.959Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/30/646e47b8a8dff04e227bdab512e6dde60663a647eeac7bbd6edddd92bbc5/websockets-16.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8e9c4e369fc181b2d41a99e01477215cecdc8546a39f7d41a59cc0a7065a0b09", size = 187474, upload-time = "2026-07-10T06:32:02.54Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/72/890ab9d77494af93ea65268230bfbc0a90ba789401ed7a44356a44785644/websockets-16.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0704df094b2d5fa7f6f410925a594c2a5c9a09167731a76292e5410934208209", size = 188717, upload-time = "2026-07-10T06:32:04.156Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/aa/baedbbaa6bf9ed6029617ed5e8976535bd805f483ca9b3484e7ad9ee08bf/websockets-16.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b22b1f4950f6ab7126623329c3b47b3b90a14c05db517f2db2a026ad6c928352", size = 190090, upload-time = "2026-07-10T06:32:05.822Z" },
+    { url = "https://files.pythonhosted.org/packages/52/4f/d813ec94e18002571ef4959d87a630eff6e01b72a51bcb0832b75ae8c51a/websockets-16.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1ae4a686a662964a6671069f84f7f908cc3475e782227726b0c622c715962105", size = 189320, upload-time = "2026-07-10T06:32:07.223Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/3c/8ec52a6662f3df64090fba28cd521d405d54759268d8e820477037e8c80d/websockets-16.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:856bdd638f8277f86465057bfdd4da097c73058fb0f9d2bd5baea29e2bf2d367", size = 188068, upload-time = "2026-07-10T06:32:08.586Z" },
+    { url = "https://files.pythonhosted.org/packages/96/7f/f0ae6042b14f86fa5f996c6563ea4cf107adc036ccbedc9d4f418d0095f9/websockets-16.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9003a1fde1c21a322a3ca3fa0c4bda8c639da81dbc925162766086643b05ba87", size = 185493, upload-time = "2026-07-10T06:32:09.968Z" },
+    { url = "https://files.pythonhosted.org/packages/89/ad/5ffc53af9939c49fd653d147fa5b8f78ced1f6bce6c49a7446860945b0ce/websockets-16.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:39e947b1f5fdab045174306e3916785bf3ed537648acc1549827c08c33b10953", size = 188141, upload-time = "2026-07-10T06:32:11.434Z" },
+    { url = "https://files.pythonhosted.org/packages/67/62/729206c0ee577a4db8eae6dd06e0eef725a1287c6df11b2ef831d003df31/websockets-16.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:5dd0e666b5931c0509cf65714686a1c5126771e663a79ac5d40da4f58b1f9502", size = 186653, upload-time = "2026-07-10T06:32:12.845Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/86/e8806a99ec4589914f255e6b658853fe537bf359c05e6ba5762ad9c27917/websockets-16.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a0285df7925657ad65a65fb8dc330808bce082827538fd50ef45fa12d1fc5bca", size = 188614, upload-time = "2026-07-10T06:32:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/89/38/ac554e2fc6ff0b8deeff9798b92e7abd8f99e2bd9731532e7033de208220/websockets-16.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:82d1c2cab3c133e9d059b3a5420bed9376bd30e21c185c63dda4ddadf6ddda47", size = 186165, upload-time = "2026-07-10T06:32:15.626Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c5/4ef4d8e53342f94f3c49e1ae089b32c1e8b3878e15e0022c7708c647f351/websockets-16.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:c39907f1eaf11f6277def65aa02d68f30576b693d0c1ca332aafa3caa723ac6d", size = 187119, upload-time = "2026-07-10T06:32:17.114Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/33/4788b1dd417bd97eeb2698af3b9df6775ac656f96e9987da0419a067602f/websockets-16.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:45c5ea55446171949eb99fd34b771ceddd511ca21958d40d0197ced33159e5ee", size = 187411, upload-time = "2026-07-10T06:32:18.629Z" },
+    { url = "https://files.pythonhosted.org/packages/30/38/00d37aad6dc3244ce349e2864815362e50b3cfc00cac28d216db20efe40f/websockets-16.1-cp314-cp314-win32.whl", hash = "sha256:b8ef8b1c8d6bd029a475ac432e730fba2dfd456715d26c473e2a82291024b99c", size = 179822, upload-time = "2026-07-10T06:32:20.233Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/37/2a8cb0eaddee5eaebda47a90a3ba0898d1ce3d866b02a4857fea17d82e5b/websockets-16.1-cp314-cp314-win_amd64.whl", hash = "sha256:7358ff21632b5d062707f73e859c824f1c3807e73d8ca25e71caca7c4cdcf145", size = 180167, upload-time = "2026-07-10T06:32:21.749Z" },
+    { url = "https://files.pythonhosted.org/packages/07/5a/262ad5fcaef4198997b165060f09a63f861e76939b1786ab546ccc3f8120/websockets-16.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d0f38f4c3e9b359e257c339c2cc1967ccaeedb102e57c1c986bdce4bf4f32268", size = 180166, upload-time = "2026-07-10T06:32:23.278Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/36377db690f4292826e4501a6dec2801dc55fd1cf0405923b04937e478df/websockets-16.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:3c3d2cbd1602593bad49bd86fa3fbb25407d87a3b4bf8857c0ac5ac4914e1901", size = 177697, upload-time = "2026-07-10T06:32:25.164Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c7/07171abce1e39799a76f473608580fe98bd43a1230f5146159622c02bccf/websockets-16.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:36069b74671e7e667f48a7484249f84c45a825a134c8b1bdc01875d0daa10d79", size = 177902, upload-time = "2026-07-10T06:32:26.564Z" },
+    { url = "https://files.pythonhosted.org/packages/14/17/c831f48e250bc4749f57c00dcce73337c41cd32f6d59a64567b84e782601/websockets-16.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:587f83c2ce8a5d628e166384d77fa7f0ac69b9007d515ab442123e6615aa8da3", size = 187766, upload-time = "2026-07-10T06:32:27.981Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/2e/4dfe63e245b0ecfaf470cf082d25c6ce35808159135fd88c82653a6b11ab/websockets-16.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6db7972d52bc1b66cefe2246902e256cbaebc9ba8a45eac09343d7eb6671b2", size = 188939, upload-time = "2026-07-10T06:32:29.365Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/e5/5faf65aebd9562f6b4bc473d24ce38cc56f84eb5f5bee66ed9b86733f93c/websockets-16.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e7d6014888a0632e1ed7a4095248bb3095232999447f2d83bfb1900987dd9ed9", size = 191081, upload-time = "2026-07-10T06:32:30.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/cd/2634f2f2c0556c1aae6501ed6840019cc569dd6fdbcac6494378daea4dc0/websockets-16.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9cb074d150e4ad2a77aa8a332c2be85f3f64f2681519d2570c1225c12c9821ff", size = 189513, upload-time = "2026-07-10T06:32:32.399Z" },
+    { url = "https://files.pythonhosted.org/packages/59/bb/2c700b51196104f09715b326b1f092ed25326bdf79a03e00a4842e503743/websockets-16.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d19c9067e1fe9490f974bffbc0e443b80a7674c5efb4980c429cc00771f07c5a", size = 188240, upload-time = "2026-07-10T06:32:33.897Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/20/86283636e499a1a357fa9441f690ba34f255e731f2fea174132b3b762b57/websockets-16.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d440ff0c6c7469ad59c0a412c383c235935b43635e89425e3f6a0c36de90c31b", size = 185955, upload-time = "2026-07-10T06:32:35.279Z" },
+    { url = "https://files.pythonhosted.org/packages/91/23/d7fb734b0095d43bc7f1c9f68afd50adb4176e7e513403e8c70ad7daa4fa/websockets-16.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8613129a2533f08de24505e69a3e403cedaadae49abdb043c4d170ca71b7e4bd", size = 188491, upload-time = "2026-07-10T06:32:36.673Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5e/168a192689db468405ecf3b8e4a2c18811936b0724d017ad7e6d252734f0/websockets-16.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:a5bf9c23f197b4ec88290fd5463f33db67362a1bb10f85fc2e8e7627f0ddab97", size = 186983, upload-time = "2026-07-10T06:32:38.207Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/9b/66795fa91ebe49019ebe4fa910282172252e37046b80e08fc52e0c365150/websockets-16.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:520b0fd0395f075febb283c76755af724ab9fd19dffa4f3bfd18cb4e622790a3", size = 188890, upload-time = "2026-07-10T06:32:39.545Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/32/126bbc844be5afb3613fd43211dac10a9645f4cf39741d04acaa2ec7030c/websockets-16.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:7143aa09a67e1c013be44e81a88dfe90fc6244198ab86c7edd064152cf619805", size = 186583, upload-time = "2026-07-10T06:32:41.038Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b9/0b5db9cbcf6e4970db4496893244a8d92e07f71a8ef27cf34b08aa02fef1/websockets-16.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:7acb811fad08e611755800d1560e395c67e11a6bd563598ea6abb319afb86938", size = 187353, upload-time = "2026-07-10T06:32:42.501Z" },
+    { url = "https://files.pythonhosted.org/packages/99/2e/254b2131a10d831b76e2c18dfe7add9729c6292c674a8085bf8de01ad151/websockets-16.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:c5cf88e3faa2f7931bc6baeee7599c97656a3f6ac7f831f4fccba233e141783a", size = 187784, upload-time = "2026-07-10T06:32:43.929Z" },
+    { url = "https://files.pythonhosted.org/packages/21/dc/e7288aa8e3ac5a88a0924619984d663c1abf2a87d0ea98290c66fdaee0ec/websockets-16.1-cp314-cp314t-win32.whl", hash = "sha256:589f8842521c8307684ce0b40ce4ad70c5e0aa46484c6f1225a94ef4b8970341", size = 179947, upload-time = "2026-07-10T06:32:45.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/de/37edf1260ff0fbbd2f82433489c4cfbe799ac2ff21355331609879329fe6/websockets-16.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c0e0857c30bbbc2bb5c30687508f0b7ec19aa026cd9f2ff8424d0fee42dcc07", size = 180291, upload-time = "2026-07-10T06:32:47.119Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f4/84ef884775bbe77c46cce79bc7d705ea3bc6574cc00acf81af89754c077d/websockets-16.1-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7289d899c79e763e6221c8dcb8959361cb43274418538d7c7ad16a43b01d12f9", size = 177387, upload-time = "2026-07-10T06:32:48.574Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/d9/6831ec6f65e1eeac770375f4f4b604f23df9bafaa1b47004bc5f9488d513/websockets-16.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:e22e9e3719f5131bd62da4db63c8da63eb8c91cc99e16c1cbd122f130e1ae07a", size = 177663, upload-time = "2026-07-10T06:32:50.043Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/d4/21d4922fa7fe855813a8b38f181a0ecf02a586e16c1f095fd05471f78cc2/websockets-16.1-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:83bdabafef431247e6b11a9aab8a0893fd8e82e1ed95b32e0373625b03ffce4a", size = 178501, upload-time = "2026-07-10T06:32:51.439Z" },
+    { url = "https://files.pythonhosted.org/packages/91/87/7a0320df854dacd09507ca972cb04a4dc5aae279583cc5b80ad5f5819533/websockets-16.1-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b8d13ceabc5c60995f201b5211d76876e17e68706ebf5d3bc666b32eefff1a6", size = 179397, upload-time = "2026-07-10T06:32:52.892Z" },
+    { url = "https://files.pythonhosted.org/packages/31/6a/0da1eb8c8da2ace7b578c8523d32618af85e62a9ebad56051d4a14a38a1c/websockets-16.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:81495f9c0085361c582efbc3207fb877174cfe03370f17d9cd70624404aa526f", size = 180546, upload-time = "2026-07-10T06:32:54.619Z" },
+    { url = "https://files.pythonhosted.org/packages/66/58/bd83247f39ddc26ffc2c24eb05087a3b749e00cb4509fc6d19daa23c8495/websockets-16.1-py3-none-any.whl", hash = "sha256:c5149dfe490ec7e5ee5dbf624c642fb725f93a5575c7f00ab594ca9eddb8dd81", size = 174031, upload-time = "2026-07-10T06:32:56.079Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Scope

Stacked repair for the Gemini synthetic-data campaign. Base head reviewed: 8d99427d2719da286cb24245adbdedf656464070. Exact current PR head: e6ecf6c2260de7baf6420d9a59fdcf08c5e20151. Functional provider-runtime commit: 634ffd75d1a1488262139740563330ce1d34cb44; the two final commits only update the Git-native handoff and clarify the parent CI gate.

This adds a bounded Stage 0.5 provider gate: Vertex through host Google ADC and Grok through the loopback UniGrok MCP. Credential values remain in their existing provider-owned locations. No dataset generation or sealed evaluation occurred.

## Changed paths

- .agents/campaigns/gemma-needle-2000-v1/provider_profile.example.json
- .agents/campaigns/gemma-needle-2000-v1/stage0_5_manifest.json
- .agents/campaigns/gemma-needle-2000-v1/stage1_manifest.json
- .agents/campaigns/gemma-needle-2000-v1/ticket.json
- .codex/memory/active-work.md
- .dockerignore
- .gemini/GEMINI.md
- .gitignore
- Dockerfile
- evals/campaigns/gemma_needle_2000_v1/provider_adapters.py
- evals/campaigns/gemma_needle_2000_v1/provider_smoke.py
- evals/campaigns/gemma_needle_2000_v1/provider_transports.py
- pyproject.toml
- tests/campaigns/gemma_needle_2000_v1/test_provider_contract.py
- tests/campaigns/gemma_needle_2000_v1/test_provider_smoke.py
- tests/campaigns/gemma_needle_2000_v1/test_stage0_mechanical.py
- tests/test_http_server.py
- tests/test_release_hygiene.py
- uv.lock

## Verification

- Python 3.11 full suite: 1,287 passed
- Python 3.12 campaign and release slice: 65 passed
- Targeted provider reviewer suite: 44 passed
- Ruff on provider runtime and tests: passed
- git diff --check: passed
- Docker build: passed
- Image inspection: no .grok/auth.json, .gemini, or .codex; only allowlisted .grok prompts and hyperparameters
- Independent final security and test review: no remaining P0 or P1 findings

## Live evidence

- Exactly one Vertex call and one UniGrok call passed; zero orchestrator retries and zero dataset writes
- Live receipt digest: sha256:d784e49ab87d891c44985f326072191cb51fce87b9edc10c013b21a236568a54
- Offline replay passed with zero transport calls
- Replay receipt digest: sha256:b9c34b95aeea2bbd1c9df62c040528af52b763779b3ce0ead4ea6fefe2833a34

## Safety and remaining risk

- No ADC, API key, OAuth file, CLI auth, .env, Gemini config, Claude auth, or Codex auth was copied or committed.
- External profiles, caches, and receipts enforce owner-only paths and modes.
- Replay proves cache integrity checks, not authenticated provider origin against a malicious same-user process. Keychain-backed signing would be required for that stronger claim.
- Stage 1 remains blocked until this stacked repair is integrated and the exact parent PR #66 head passes CI against main.
- PR #67 itself has no check rollout because repository CI is scoped to pull requests targeting main.
- Local Gemma weights were not downloaded.

Human sponsor: David

Agent-Assisted-By: Codex

Relates to #65. Stacked on draft PR #66.