### PR TITLE
Fix promise-only completion recovery

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -23,7 +23,7 @@ import functools
 import concurrent.futures
 import aiosqlite
 from datetime import datetime, timedelta
-from typing import Optional, List, Dict, Any, Literal, Callable
+from typing import Optional, List, Dict, Any, Literal, Callable, Awaitable
 from dotenv import load_dotenv
 from pydantic import BaseModel, Field as PydanticField
 from .routing import (
@@ -4953,7 +4953,9 @@ class GitContextCache:
 ModelPlane = Literal["reasoning", "composer", "cli-fallback"]
 
 _PROMISE_ACTION = (
-    r"(?:run|review|audit|check|inspect|investigate|analy[sz]e|start|begin|"
+    r"(?:run|(?:peer[-\s]?)?review|audit|check|inspect|investigate|analy[sz]e|"
+    r"pull|fetch|load|read|retrieve|gather|collect|open|examine|evaluate|assess|"
+    r"test|validate|verify|compare|trace|query|start|begin|"
     r"perform|conduct|try|recover|fix|work\s+on|get\s+(?:started|right\s+on)|"
     r"look\s+into|take\s+a\s+look|explain|summarize|report|answer|proceed|"
     r"handle(?:\s+(?:it|this|that))?|do\s+(?:it|this|that)|get\s+back)"
@@ -4961,9 +4963,13 @@ _PROMISE_ACTION = (
 _PROMISE_WRAPPER = (
     r"(?:(?:(?:sure\s+thing|no\s+problem|all\s+right|sure|okay|ok|understood|"
     r"absolutely|certainly|got\s+it|on\s+it|thanks|of\s+course)\b"
-    r"[\s,.:;!—–-]*|update\s*:\s*))*"
+    r"[\s,.:;!—–-]*|update\s*:\s*|before\s+i\s+(?:answer|respond)\b"
+    r"[\s,.:;!—–-]*))*"
 )
-_PROMISE_ADVERB = r"(?:(?:first|quickly|now|next|briefly|immediately)\s+)?"
+_PROMISE_ADVERB = (
+    r"(?:(?:first|quickly|now|next|briefly|immediately|carefully|thoroughly|"
+    r"directly|independently)\s+)?"
+)
 _PROMISE_ONLY_PREFIX_RE = re.compile(
     rf"""(?ix)^\s*(?:[>*#-]+\s*)?
         {_PROMISE_WRAPPER}(?:
@@ -4973,7 +4979,10 @@ _PROMISE_ONLY_PREFIX_RE = re.compile(
           | let\s+me\s+{_PROMISE_ADVERB}{_PROMISE_ACTION}\b
           | (?:i(?:['’]m|\s+am)\s+)?{_PROMISE_ADVERB}
             (?:performing|running|starting|beginning|conducting|checking|reviewing|
-               auditing|investigating|analyzing|working\s+on)\b
+               peer[-\s]?reviewing|auditing|investigating|analyzing|pulling|
+               fetching|loading|reading|retrieving|gathering|collecting|opening|
+               examining|evaluating|assessing|testing|validating|verifying|
+               comparing|tracing|querying|working\s+on)\b
         )"""
 )
 _PLAN_ONLY_HEADING_RE = re.compile(
@@ -5031,6 +5040,7 @@ _OBSERVATION_RESULT_RE = re.compile(
 _PLACEHOLDER_RESULT_RE = re.compile(
     r"(?is)^\s*(?:(?:still\s+)?pending|tbd|todo|forthcoming|coming\b|later\b|"
     r"unknown\b|to\s+follow\b|(?:i\s+)?will\s+(?:follow\s+up|report|return)\b|"
+    r"(?:i\s+)?will\s+(?:provide|deliver|share)\b|"
     r"(?:i\s+)?need\s+more\s+time\b|going\s+to\s+follow\b|not\s+yet\b|"
     r"not\s+(?:checked|run|verified|done|available)\b|no\s+(?:result|answer)\s+yet\b)"
 )
@@ -5044,6 +5054,15 @@ _UNFINISHED_EVIDENCE_RE = re.compile(
     r"|\b0\s+(?:tests?|checks?)\s+(?:passed|completed)\b.{0,120}"
     r"\bnot\s+(?:run|started|begun)\b"
     r")"
+)
+_TERMINAL_FUTURE_WORK_RE = re.compile(
+    rf"(?is)(?:"
+    rf"\b(?:next|then|after\s+that|afterwards?)\s*,?\s*"
+    rf"(?:i|we)(?:['’]ll|\s+will)\s+{_PROMISE_ADVERB}{_PROMISE_ACTION}\b"
+    rf"|\b(?:i|we)(?:['’]ll|\s+will)\s+(?:next|then)\s+{_PROMISE_ACTION}\b"
+    rf"|\b(?:i|we)\s+(?:still\s+)?(?:need|plan|intend)\s+to\s+"
+    rf"{_PROMISE_ADVERB}{_PROMISE_ACTION}\b"
+    rf")"
 )
 _IMMEDIATE_DELIVERY_RE = re.compile(
     rf"(?is)^\s*(?:[>*#-]+\s*)?{_PROMISE_WRAPPER}"
@@ -5084,7 +5103,10 @@ def _has_completion_evidence(text: str) -> bool:
 
 
 def _contains_unfinished_result(text: str) -> bool:
-    if _UNFINISHED_EVIDENCE_RE.search(text):
+    if (
+        _UNFINISHED_EVIDENCE_RE.search(text)
+        or _TERMINAL_FUTURE_WORK_RE.search(text)
+    ):
         return True
     for pattern in (_RESULT_MARKER_RE, _OBSERVATION_RESULT_RE):
         for match in pattern.finditer(text):
@@ -5123,9 +5145,15 @@ def _is_nonanswer_completion(content: Any, *, prompt: str = "") -> bool:
         # Wrapper words and the promise verb itself are not evidence. Only
         # inspect content delivered after the matched promise lead.
         promise_payload = text[promise.end():]
+        deferred_matches = list(_TERMINAL_FUTURE_WORK_RE.finditer(promise_payload))
+        evidence_payload = (
+            promise_payload[deferred_matches[-1].end():]
+            if deferred_matches
+            else promise_payload
+        )
         promise_evidence = (
-            not _contains_unfinished_result(promise_payload)
-            and _has_completion_evidence(promise_payload)
+            not _contains_unfinished_result(evidence_payload)
+            and _has_completion_evidence(evidence_payload)
         )
         requested_plan = plan_requested and _looks_like_plan(text)
         return not (delivered or promise_evidence or requested_plan)
@@ -5145,6 +5173,40 @@ def _completion_finish_reason(content: Any, intended: str, *, prompt: str = "") 
     ):
         return "error"
     return intended
+
+
+def _completion_recovery_prompt(original_prompt: str) -> str:
+    """Ask once for the result after a transport-level non-answer."""
+
+    return (
+        "Your previous response described future work but did not deliver a "
+        "result. Complete the original request now. Return the actual answer, "
+        "findings, or a concrete verified blocker. Do not narrate setup, promise "
+        "future work, or defer the result.\n\n"
+        f"# Original request\n{original_prompt}"
+    )
+
+
+async def _recover_nonanswer_once(
+    invoke: Callable[[str], Awaitable[tuple[str, int, float, bool]]],
+    original_prompt: str,
+    initial: tuple[str, int, float, bool],
+) -> tuple[tuple[str, int, float, bool], bool]:
+    """Retry one non-answer on the same caller-supplied execution plane."""
+
+    text, tokens, cost, is_cli = initial
+    if not _is_nonanswer_completion(text, prompt=original_prompt):
+        return initial, False
+
+    retry_text, retry_tokens, retry_cost, retry_is_cli = await invoke(
+        _completion_recovery_prompt(original_prompt)
+    )
+    return (
+        retry_text,
+        tokens + retry_tokens,
+        cost + retry_cost,
+        retry_is_cli,
+    ), True
 
 
 def _verified_outcome_label(finish_reason: str) -> Optional[int]:
@@ -8597,20 +8659,36 @@ async def orchestrate(
 
     layer = MetaLayer(routing_receipt=routing_receipt)
     try:
-        gen_res, g_tok, g_cost, is_cli = await _call_plane(
-            actual_mode, prompt, session, store, dynamic_sys_prompt,
-            requested_model=actual_model,
-            agent_count=agent_count,
-            input_messages=input_messages,
-            profile=active_profile,
-            on_event=on_event,
-            include=include,
-            max_turns=cli_max_turns,
-            cli_no_plan=cli_no_plan,
-            cli_verbatim=cli_verbatim,
-            cli_allowed_tools=cli_allowed_tools,
-            cli_isolated=cli_isolated,
+        async def _invoke_fast_plane(
+            call_prompt: str,
+        ) -> tuple[str, int, float, bool]:
+            call_messages = input_messages
+            if input_messages is not None and call_prompt != prompt:
+                call_messages = [
+                    *input_messages,
+                    {"role": "user", "content": call_prompt},
+                ]
+            return await _call_plane(
+                actual_mode, call_prompt, session, store, dynamic_sys_prompt,
+                requested_model=actual_model,
+                agent_count=agent_count,
+                input_messages=call_messages,
+                profile=active_profile,
+                on_event=on_event,
+                include=include,
+                max_turns=cli_max_turns,
+                cli_no_plan=cli_no_plan,
+                cli_verbatim=cli_verbatim,
+                cli_allowed_tools=cli_allowed_tools,
+                cli_isolated=cli_isolated,
+            )
+
+        fast_result, completion_recovery_attempted = await _recover_nonanswer_once(
+            _invoke_fast_plane,
+            prompt,
+            await _invoke_fast_plane(prompt),
         )
+        gen_res, g_tok, g_cost, is_cli = fast_result
         layer.generation = gen_res
         layer.tokens = g_tok
         layer.cost_usd = g_cost
@@ -8634,6 +8712,22 @@ async def orchestrate(
                 "why_detail": "agentic_to_fast",
                 "fallback": {"from_route": "agentic", "to_route": "fast"},
             }
+        if completion_recovery_attempted:
+            recovery_succeeded = layer.finish_reason != "error"
+            layer.routing_receipt = {
+                **layer.routing_receipt,
+                "completion_recovery": {
+                    "attempted": True,
+                    "reason": "nonanswer_completion",
+                    "succeeded": recovery_succeeded,
+                    "attempts": 1,
+                },
+            }
+            if not recovery_succeeded:
+                layer.generation = (
+                    "Grok returned a non-answer completion twice; UniGrok "
+                    "rejected both responses and produced no result."
+                )
         if store:
             await store.save_telemetry(
                 prompt[:100], layer.plane,
@@ -8728,16 +8822,28 @@ async def orchestrate(
         layer.plane = "CLI-Fallback"
         try:
             fallback_profile = load_grok_profile("grok-composer-2.5-fast")
-            gen_res, g_tok, g_cost, _ = await _call_plane(
-                "cli-fallback", prompt, session, store, dynamic_sys_prompt,
-                requested_model="grok-composer-2.5-fast",
-                profile=fallback_profile,
-                max_turns=cli_max_turns,
-                cli_no_plan=cli_no_plan,
-                cli_verbatim=cli_verbatim,
-                cli_allowed_tools=cli_allowed_tools,
-                cli_isolated=cli_isolated,
+            async def _invoke_cli_fallback(
+                call_prompt: str,
+            ) -> tuple[str, int, float, bool]:
+                return await _call_plane(
+                    "cli-fallback", call_prompt, session, store, dynamic_sys_prompt,
+                    requested_model="grok-composer-2.5-fast",
+                    profile=fallback_profile,
+                    max_turns=cli_max_turns,
+                    cli_no_plan=cli_no_plan,
+                    cli_verbatim=cli_verbatim,
+                    cli_allowed_tools=cli_allowed_tools,
+                    cli_isolated=cli_isolated,
+                )
+
+            fallback_result, completion_recovery_attempted = (
+                await _recover_nonanswer_once(
+                    _invoke_cli_fallback,
+                    prompt,
+                    await _invoke_cli_fallback(prompt),
+                )
             )
+            gen_res, g_tok, g_cost, _ = fallback_result
             layer.generation = gen_res
             layer.tokens = g_tok
             layer.cost_usd = g_cost
@@ -8761,6 +8867,22 @@ async def orchestrate(
                 "fallback_occurred": True,
                 "billing_class": "subscription",
             }
+            if completion_recovery_attempted:
+                recovery_succeeded = layer.finish_reason != "error"
+                layer.routing_receipt = {
+                    **layer.routing_receipt,
+                    "completion_recovery": {
+                        "attempted": True,
+                        "reason": "nonanswer_completion",
+                        "succeeded": recovery_succeeded,
+                        "attempts": 1,
+                    },
+                }
+                if not recovery_succeeded:
+                    layer.generation = (
+                        "Grok returned a non-answer completion twice; UniGrok "
+                        "rejected both responses and produced no result."
+                    )
             if store:
                 await store.save_telemetry(
                     prompt[:100], layer.plane,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1909,6 +1909,16 @@ class TestCompletionContentContract:
         "evidence and saving findings for the later consolidated verdict.",
         "Performing the chunk-1 audit from the supplied Stage-1 harness/manifest "
         "material now — concrete findings only, no deferred work.",
+        "I'll peer-review PR #64 now and return a concrete verdict.",
+        "Pulling PR #64 now — I'll report concrete findings shortly.",
+        "I'll inspect the completion guard, then return concrete findings. "
+        "I found the relevant helper in src/utils.py; next I'll read its tests.",
+        "I'll inspect the completion-contract guard and related tests directly, "
+        "then return concrete findings and the smallest deterministic fix.I found "
+        "the guard in `utils.py`; next I'll read the full promise/nonanswer logic "
+        "and the tests that cover it.",
+        "Before I answer, I'll inspect the repository and report back.",
+        "I'll carefully peer-review the patch and return a verdict.",
     )
     wrapped_promises = (
         "Sure — I'll run the audit now and report back.",
@@ -1933,6 +1943,7 @@ class TestCompletionContentContract:
         "I'll audit now. I found that I need more time.",
         "I'll audit now. I verified nothing because I have not started.",
         "I'll audit now. 0 tests passed because I have not run them.",
+        "I'll audit now. Verdict: I will provide the result after I inspect it.",
     )
 
     @pytest.mark.parametrize(
@@ -1972,6 +1983,8 @@ class TestCompletionContentContract:
             "I'll summarize — TTL belongs in every prediction input.",
             "I'll explain\nTTL belongs in every prediction input.",
             "I'll fix this:\n```python\nprint('fixed')\n```",
+            "I'll review this now. Verdict: the TTL guard fails because it "
+            "accepts an expired lease.",
         ),
     )
     def test_accepts_substantive_answers_and_discussion_of_promises(self, content):
@@ -2104,11 +2117,16 @@ class TestHonestOutcomes:
         "promise",
         (
             TestCompletionContentContract.reproduced_promises[1],
+            TestCompletionContentContract.reproduced_promises[2],
+            TestCompletionContentContract.reproduced_promises[3],
+            TestCompletionContentContract.reproduced_promises[5],
             TestCompletionContentContract.wrapped_promises[0],
             TestCompletionContentContract.wrapped_promises[6],
         ),
     )
-    async def test_fast_promise_only_completion_is_error(self, monkeypatch, promise):
+    async def test_fast_repeated_promise_only_completion_is_error(
+        self, monkeypatch, promise
+    ):
         from src.utils import orchestrate
 
         mock_store = self._mock_store()
@@ -2123,10 +2141,60 @@ class TestHonestOutcomes:
                 enable_agentic=False,
             )
 
-        assert layer.generation == promise
+        assert layer.generation == (
+            "Grok returned a non-answer completion twice; UniGrok "
+            "rejected both responses and produced no result."
+        )
         assert layer.finish_reason == "error"
+        assert mock_call.await_count == 2
+        assert "# Original request\nAudit the repository" in (
+            mock_call.await_args_list[1].args[1]
+        )
+        assert layer.routing_receipt["completion_recovery"] == {
+            "attempted": True,
+            "reason": "nonanswer_completion",
+            "succeeded": False,
+            "attempts": 1,
+        }
         assert mock_store.save_telemetry.await_args.args[2] == 0
         assert mock_store.save_task_memory.await_args.kwargs["success"] == 0
+
+    @pytest.mark.asyncio
+    async def test_fast_promise_only_completion_recovers_once(self, monkeypatch):
+        from src.utils import orchestrate
+
+        mock_store = self._mock_store()
+        promise = "I'll peer-review PR #64 now and return a concrete verdict."
+
+        with patch("src.utils._call_plane", new_callable=AsyncMock) as mock_call:
+            mock_call.side_effect = (
+                (promise, 10, 0.001, True),
+                ("Findings: the PR needs a current-main rebase.", 12, 0.002, True),
+            )
+            layer = await orchestrate(
+                prompt="Audit the repository",
+                mode="auto",
+                store=mock_store,
+                dynamic_sys_prompt="sys",
+                enable_agentic=False,
+            )
+
+        assert layer.generation == "Findings: the PR needs a current-main rebase."
+        assert layer.finish_reason == "final_answer"
+        assert layer.tokens == 22
+        assert layer.cost_usd == pytest.approx(0.003)
+        assert mock_call.await_count == 2
+        assert mock_call.await_args_list[0].kwargs["requested_model"] == (
+            mock_call.await_args_list[1].kwargs["requested_model"]
+        )
+        assert layer.routing_receipt["completion_recovery"] == {
+            "attempted": True,
+            "reason": "nonanswer_completion",
+            "succeeded": True,
+            "attempts": 1,
+        }
+        assert mock_store.save_telemetry.await_args.args[2] is None
+        assert mock_store.save_task_memory.await_args.kwargs["success"] is None
 
     @pytest.mark.asyncio
     async def test_fast_final_answer_remains_unverified(self, monkeypatch):
@@ -2421,6 +2489,7 @@ class TestThinkingLoop:
         "promise",
         (
             TestCompletionContentContract.reproduced_promises[0],
+            TestCompletionContentContract.reproduced_promises[5],
             TestCompletionContentContract.wrapped_promises[6],
         ),
     )


### PR DESCRIPTION
## Summary

Fixes the Grok CLI completion-contract bug where progress promises such as `I'll peer-review...`, `Pulling PR...`, or a partial `I found...` followed by `next I'll read...` were labeled `final_answer`.

## Changes

- Detects the three exact live failure shapes plus deferred continuations.
- Performs one bounded retry on the same model and credential plane.
- Rejects a second non-answer with an honest gateway error instead of returning the promise as a result.
- Records a completion-recovery receipt without claiming semantic correctness.
- Adds direct, agentic, and thinking regression coverage plus positive controls.

## Head and handoff evidence

- Exact head SHA: `4b043b925e940952cb9b2e8adab6380450f4f17d`
- Accountable GitHub contributor: `@djtelicloud`
- Branch: `codex/grok-completion-recovery`
- Changed paths: `src/utils.py`, `tests/test_utils.py`
- Verification after current-main rebase: `./scripts/land` — `LANDED TO MAIN: 4b043b925e940952cb9b2e8adab6380450f4f17d`; 1,513 tests passed; attribution check and runtime smoke passed.
- Known risk: streamed clients may already have observed first-attempt deltas before bounded recovery; the terminal result and receipt remain fail-closed.

### Agent and model provenance

| Role | Provider product | Model | Model source | Surface | Evidence |
| --- | --- | --- | --- | --- | --- |
| implementation | OpenAI Codex | GPT-5 | provider-session | Codex Desktop | commit trailer |
| live regression testing | xAI Grok | grok-4.5 | runtime-receipt | UniGrok CLI | runtime row 237 |

## Security

No credentials, provider tokens, or machine-specific paths are included. Recovery stays on the original plane and is capped at one attempt.