### PR TITLE
fix(gateway): distinguish result dashes from hyphens

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -5069,7 +5069,7 @@ _IMMEDIATE_DELIVERY_RE = re.compile(
     rf"(?:i(?:['’]ll|\s+will)|let\s+me)\s+{_PROMISE_ADVERB}"
     r"(?:explain|clarify|answer|summarize|report|review|check|analy[sz]e|audit|inspect)"
     r"\b[^:\n.]{0,80}"
-    r"(?::|[—–-]|\.\s+|\n+)\s*(?P<value>\S[\s\S]*)"
+    r"(?::|[—–]|\s+-\s+|\.\s+|\n+)\s*(?P<value>\S[\s\S]*)"
 )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1913,6 +1913,8 @@ class TestCompletionContentContract:
         "Pulling PR #64 now — I'll report concrete findings shortly.",
         "I'll inspect the completion guard, then return concrete findings. "
         "I found the relevant helper in src/utils.py; next I'll read its tests.",
+        "I'll inspect the completion-contract guard and its tests now and return "
+        "concrete findings plus a verdict.",
         "I'll inspect the completion-contract guard and related tests directly, "
         "then return concrete findings and the smallest deterministic fix.I found "
         "the guard in `utils.py`; next I'll read the full promise/nonanswer logic "
@@ -1980,7 +1982,11 @@ class TestCompletionContentContract:
             "Let me explain: TTL belongs in every prediction input.",
             "Let me explain. TTL belongs in every prediction input.",
             "Let me explain—TTL belongs in every prediction input.",
+            "Let me explain – TTL belongs in every prediction input.",
+            "Let me explain - TTL belongs in every prediction input.",
             "I'll summarize — TTL belongs in every prediction input.",
+            "I'll review the completion-contract result: the guard fails because "
+            "it accepts an expired lease.",
             "I'll explain\nTTL belongs in every prediction input.",
             "I'll fix this:\n```python\nprint('fixed')\n```",
             "I'll review this now. Verdict: the TTL guard fails because it "


### PR DESCRIPTION
## Summary

Fix the remaining promise-as-`final_answer` bypass exposed by the live Grok CLI smoke after PR #69. The immediate-delivery parser treated any ASCII hyphen as a result delimiter, so the hyphen inside `completion-contract` made a future-work promise look like a delivered answer.

The ASCII delimiter now requires surrounding whitespace. Colons, periods, newlines, em dashes, and en dashes remain valid result delimiters.

## Exact handoff

- Commit: `80842ac2369b1699c14c4cbb7718e262f7bdeeb8`
- Changed paths: `src/utils.py`, `tests/test_utils.py`
- Focused tests: 106 passed
- Full suite: 1,518 passed in 69.14s
- `git diff --check`: clean
- Attribution checker: passed
- Risk: narrow completion-grammar change; positive controls cover real result separators and hyphenated prose
- Human sponsor: David Johnston

Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=implementation

Agent-Assisted-By: xAI Grok | model=grok-4.5 | model-source=runtime-receipt | surface=UniGrok CLI | role=testing | evidence=runtime-row:238