### PR TITLE
fix(gateway): reject progress-only completions

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -5071,6 +5071,69 @@ _IMMEDIATE_DELIVERY_RE = re.compile(
     r"\b[^:\n.]{0,80}"
     r"(?::|[—–]|\s+-\s+|\.\s+|\n+)\s*(?P<value>\S[\s\S]*)"
 )
+_PROGRESS_STATUS_PREFIX_RE = re.compile(
+    rf"""(?ix)^\s*(?:[>*#-]+\s*)?{_PROMISE_WRAPPER}
+        (?:continuing|resuming|proceeding)(?:\s+with)?\s+
+        (?:(?:the|my|our)\s+)?
+        (?:inspection|review|audit|analysis|investigation|validation|
+           verification|tests?|checks?|trace|search|work)\b(?:\s+now)?
+    """
+)
+_ONGOING_ACTIVITY_PREFIX_RE = re.compile(
+    rf"""(?ix)^\s*(?:[>*#-]+\s*)?{_PROMISE_WRAPPER}(?:
+        (?:(?:i(?:['’]m|\s+am)|we(?:['’]re|\s+are))\s+)?
+          (?:still|currently)\s+
+          (?:working\s+on|inspecting|reviewing|auditing|analyzing|investigating|
+             validating|verifying|testing|checking|reading|locating|tracing|
+             gathering|collecting|running|exercising|searching)
+        | (?:status|progress)(?:\s+update)?\s*:\s*
+          (?:still\s+|currently\s+)?
+          (?:working\s+on|inspecting|reviewing|auditing|analyzing|investigating|
+             validating|verifying|testing|checking|reading|locating|tracing|
+             gathering|collecting|running|exercising|searching)
+        | (?:continuing|resuming|proceeding)\s+(?:
+            to\s+(?:inspect|review|audit|analy[sz]e|investigate|validate|verify|
+                    test|check|read|locate|trace|gather|collect|run|exercise|search)
+            | (?:work|working)\s+on
+          )
+    )\b"""
+)
+_IN_PROGRESS_PREFIX_RE = re.compile(
+    rf"""(?ix)^\s*(?:[>*#-]+\s*)?{_PROMISE_WRAPPER}
+        (?:inspection|review|audit|analysis|investigation|validation|
+           verification|tests?|checks?)\s+(?:is\s+)?
+        (?:underway|in\s+progress)\b
+    """
+)
+_PROGRESS_ACTIVITY_TAIL_RE = re.compile(
+    r"""(?ix)^(?:
+        locat(?:e|ing)|read(?:ing)?|inspect(?:ing)?|check(?:ing)?|run(?:ning)?|
+        exercis(?:e|ing)|test(?:ing)?|review(?:ing)?|trac(?:e|ing)|gather(?:ing)?|
+        collect(?:ing)?|open(?:ing)?|examin(?:e|ing)|evaluat(?:e|ing)|
+        assess(?:ing)?|validat(?:e|ing)|verif(?:y|ying)|compar(?:e|ing)|
+        query(?:ing)?|search(?:ing)?|analy[sz](?:e|ing)|audit(?:ing)?|
+        investigat(?:e|ing)|work(?:ing)?
+    )\b"""
+)
+_PROGRESS_TAIL_LEAD_RE = re.compile(
+    r"(?ix)^\s*(?:(?::|[.;,—–]|-\s+)\s*)?"
+    r"(?:(?:and|then|while|by|to)\s+)?"
+)
+_PROGRESS_RESULT_RE = re.compile(
+    r"(?ix)\b(?:found|identified|confirmed|verified|completed|finished|fixed|"
+    r"implemented|changed|updated|tested|revealed|showed|"
+    r"demonstrated|indicated)\b|"
+    r"\b(?:findings?|results?|verdict|evidence|answer|cause|fix|issues?|"
+    r"problems?|bugs?)\s*(?::|\b(?:is|are)\b)"
+)
+_STATUS_REQUEST_RE = re.compile(
+    r"(?is)(?:^\s*(?:current\s+)?(?:status|progress)\s*\??\s*$|"
+    r"\bwhat(?:['’]s|\s+is)\b.{0,40}\b(?:status|progress)\b|"
+    r"\b(?:give|provide|report|show|send)\b.{0,40}"
+    r"\b(?:status|progress)(?:\s+update)?\b|"
+    r"\bhow\s+(?:is|are)\b.{0,40}\bgoing\b|"
+    r"\bwhere\s+(?:are|do)\s+we\b)"
+)
 
 
 def _prompt_explicitly_requests_plan(prompt: str) -> bool:
@@ -5080,6 +5143,27 @@ def _prompt_explicitly_requests_plan(prompt: str) -> bool:
     if re.search(r"\b(?:do\s+not|don't)\b.{0,30}\b(?:plan|roadmap)\b", lowered):
         return False
     return bool(_EXPLICIT_PLAN_REQUEST_RE.search(prompt))
+
+
+def _prompt_explicitly_requests_status(prompt: str) -> bool:
+    return isinstance(prompt, str) and bool(_STATUS_REQUEST_RE.search(prompt))
+
+
+def _looks_like_progress_only(text: str) -> bool:
+    """Detect operational narration without rejecting a delivered conclusion."""
+
+    ongoing = _ONGOING_ACTIVITY_PREFIX_RE.search(text)
+    lead = ongoing or _PROGRESS_STATUS_PREFIX_RE.search(text) or _IN_PROGRESS_PREFIX_RE.search(text)
+    if not lead:
+        return False
+    if _contains_unfinished_result(text):
+        return True
+    tail = _PROGRESS_TAIL_LEAD_RE.sub("", text[lead.end():], count=1)
+    if _PROGRESS_RESULT_RE.search(tail):
+        return False
+    if ongoing:
+        return True
+    return not tail.strip() or bool(_PROGRESS_ACTIVITY_TAIL_RE.match(tail))
 
 
 def _is_substantive_result(value: str) -> bool:
@@ -5133,6 +5217,12 @@ def _is_nonanswer_completion(content: Any, *, prompt: str = "") -> bool:
     text = "\n".join(line.rstrip() for line in content.strip().splitlines()).strip()
     has_completion_evidence = _has_completion_evidence(text)
     plan_requested = _prompt_explicitly_requests_plan(prompt)
+
+    if (
+        not _prompt_explicitly_requests_status(prompt)
+        and _looks_like_progress_only(text)
+    ):
+        return True
 
     promise = _PROMISE_ONLY_PREFIX_RE.search(text)
     if promise:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1947,6 +1947,22 @@ class TestCompletionContentContract:
         "I'll audit now. 0 tests passed because I have not run them.",
         "I'll audit now. Verdict: I will provide the result after I inspect it.",
     )
+    progress_nonanswers = (
+        "Continuing the inspection: locating related tests and exercising the "
+        "guard logic for concrete failure modes.",
+        "Resuming the audit: reading the receipt tests and tracing the failure path.",
+        "Proceeding with the review — checking the diff and running focused tests.",
+        "Continuing the inspection and locating related tests.",
+        "Continuing the inspection.",
+        "Continuing to inspect the completion guard and trace its tests.",
+        "Continuing work on the completion guard and its tests.",
+        "Continuing the review now: checking the remaining tests.",
+        "Still working on the analysis; gathering evidence and comparing behavior.",
+        "Progress update: still reviewing the adapter and gathering evidence.",
+        "Review in progress — checking the remaining cases.",
+        "Currently tracing the call path and collecting logs.",
+        "Currently checking which tests failed and gathering the logs.",
+    )
 
     @pytest.mark.parametrize(
         "content",
@@ -1955,6 +1971,7 @@ class TestCompletionContentContract:
             "   \n\t",
             *reproduced_promises,
             *wrapped_promises,
+            *progress_nonanswers,
             "Plan:\n1. Inspect the repository.\n2. Run the tests.\n3. Report the results.",
             "1. Inspect the repository.\n2. Run the tests.\n3. Report back.",
             "Here's what I'll do:\n1. Inspect the repository.\n2. Run the tests.",
@@ -1994,6 +2011,51 @@ class TestCompletionContentContract:
         ),
     )
     def test_accepts_substantive_answers_and_discussion_of_promises(self, content):
+        from src.utils import _is_nonanswer_completion
+
+        assert _is_nonanswer_completion(content, prompt="Audit the repository") is False
+
+    def test_accepts_progress_lead_when_it_delivers_findings(self):
+        from src.utils import _is_nonanswer_completion
+
+        answers = (
+            "Continuing the inspection: Findings: the bare ASCII hyphen was "
+            "accepted as an immediate-delivery delimiter.",
+            "Continuing the inspection: the guard fails because progress-only "
+            "retries are accepted.",
+            "Continuing the inspection, I found two bugs in src/utils.py.",
+            "Continuing the inspection: locating tests revealed the delimiter bug.",
+            "Continuing the explanation: TTL belongs in both prediction and training.",
+        )
+        for content in answers:
+            assert _is_nonanswer_completion(content, prompt="Audit the repository") is False
+
+    def test_accepts_progress_only_answer_when_status_was_requested(self):
+        from src.utils import _is_nonanswer_completion
+
+        content = "Review in progress — checking the remaining cases."
+        assert _is_nonanswer_completion(content, prompt="What is the review status?") is False
+
+    def test_progress_word_in_task_does_not_disable_guard(self):
+        from src.utils import _is_nonanswer_completion
+
+        content = TestCompletionContentContract.progress_nonanswers[0]
+        assert (
+            _is_nonanswer_completion(
+                content,
+                prompt="Audit the progress-only completion guard",
+            )
+            is True
+        )
+
+    @pytest.mark.parametrize(
+        "content",
+        (
+            "Findings: TTL is missing. Next, I'll inspect the tests.",
+            "The answer is 42. I still need to check the repository.",
+        ),
+    )
+    def test_accepts_result_first_answers_with_follow_up(self, content):
         from src.utils import _is_nonanswer_completion
 
         assert _is_nonanswer_completion(content, prompt="Audit the repository") is False
@@ -2201,6 +2263,42 @@ class TestHonestOutcomes:
         }
         assert mock_store.save_telemetry.await_args.args[2] is None
         assert mock_store.save_task_memory.await_args.kwargs["success"] is None
+
+    @pytest.mark.asyncio
+    async def test_fast_progress_only_retry_is_rejected(self, monkeypatch):
+        from src.utils import orchestrate
+
+        mock_store = self._mock_store()
+        promise = "I'll inspect the completion-contract guard and return findings."
+        progress = TestCompletionContentContract.progress_nonanswers[0]
+
+        with patch("src.utils._call_plane", new_callable=AsyncMock) as mock_call:
+            mock_call.side_effect = (
+                (promise, 10, 0.001, True),
+                (progress, 12, 0.002, True),
+            )
+            layer = await orchestrate(
+                prompt="Audit the repository",
+                mode="auto",
+                store=mock_store,
+                dynamic_sys_prompt="sys",
+                enable_agentic=False,
+            )
+
+        assert layer.generation == (
+            "Grok returned a non-answer completion twice; UniGrok "
+            "rejected both responses and produced no result."
+        )
+        assert layer.finish_reason == "error"
+        assert mock_call.await_count == 2
+        assert layer.routing_receipt["completion_recovery"] == {
+            "attempted": True,
+            "reason": "nonanswer_completion",
+            "succeeded": False,
+            "attempts": 1,
+        }
+        assert mock_store.save_telemetry.await_args.args[2] == 0
+        assert mock_store.save_task_memory.await_args.kwargs["success"] == 0
 
     @pytest.mark.asyncio
     async def test_fast_final_answer_remains_unverified(self, monkeypatch):


### PR DESCRIPTION
## Summary

The post-PR #72 live CLI smoke proved the delimiter bypass was fixed: UniGrok detected the first promise and performed its bounded same-plane retry. The retry then returned only an operational status—`Continuing the inspection: locating related tests...`—which the content contract still accepted as `final_answer`.

This patch adds a bounded phase-plus-activity guard for progress narration. It rejects continuing/resuming/in-progress operational work, while preserving:

- concrete findings and result-first answers with legitimate follow-up work,
- direct conclusions after a progress lead,
- explanations containing the word “continuing,”
- progress reports only when the user explicitly asked for status.

A first promise followed by a progress-only retry now terminates as an honest error with `completion_recovery.succeeded=false`.

The initial draft head was rejected during independent review. This amended head moves unfinished-language handling behind a verified progress lead, narrows the status exemption to explicit status questions, and covers additional continuation forms plus adversarial prompts.

## Exact handoff

- Commit: `45c0487ad9bb9f84e2fb6bd77329c510a542f224`
- Changed paths: `src/utils.py`, `tests/test_utils.py`
- Focused content-contract tests: 128 passed
- Full suite: 1,537 passed in 68.45s
- `git diff --check`: clean
- Attribution checker: passed
- Risk: bounded English completion grammar; explicit status-request, result-first, and substantive-result positive controls limit false rejection
- Human sponsor: David Johnston

Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=implementation

Agent-Assisted-By: xAI Grok | model=grok-4.5 | model-source=runtime-receipt | surface=UniGrok CLI | role=testing | evidence=live-cli-smoke:40343da