### PR TITLE
Needle campaign workflow: digest-verified mechanical gate authority

### DIFF
--- a/.claude/workflows/needle-training-campaign.js
+++ b/.claude/workflows/needle-training-campaign.js
@@ -1,0 +1,278 @@
+export const meta = {
+  name: 'needle-training-campaign',
+  description: 'Confusion-driven Needle training campaign with mechanical gates (mock-first; live requires a Codex-approved training manifest)',
+  whenToUse: 'Run the Needle training-experiment loop from an immutable training packet: corpus vetoes, arm lanes, Pareto/retention gates, evidence bundle. Default mode=mock replays committed research_dev artifacts and trains nothing.',
+  phases: [
+    { title: 'Preflight', detail: 'authorization, packet hashes, frozen split policy, env pins' },
+    { title: 'Corpus veto', detail: 'grouped-split, leakage, dedup, balance — hard gates' },
+    { title: 'Arm lanes', detail: 'per-arm train+eval+retention (mock: replay committed artifacts)' },
+    { title: 'Cross-arm gate', detail: 'trivial baselines, Pareto/forgetting, multi-seed rules' },
+    { title: 'Evidence', detail: 'manifest regen, report draft, adversarial claim verification' },
+  ],
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AUTHORIZATION CONTRACT (mirrors .agents/campaigns/gemma-needle-2000-v1)
+//
+// mode=mock (default): transport-free discipline. NO training run, NO dataset
+//   generation, NO sealed evaluation. Inputs are the committed research_dev
+//   bundle (evals/needle_lab/); arm records are REPLAYED from
+//   data/arm_candidates.json + logs, never invented. Purpose: prove the
+//   orchestration, veto, gate, ledger, and evidence contracts end-to-end —
+//   the same pattern as the campaign's stage1 mock safety gate.
+//
+// mode=live: requires args.manifest — a Codex-approved training manifest
+//   (exact-head approval, separate PR) with explicit bounds:
+//   { training_enabled: true, packet: <immutable packet path OUTSIDE
+//     research_dev>, max_lanes, seeds, max_iterations, wall_budget_min,
+//     sealed_evaluation_enabled }. The script throws before any work if the
+//   manifest is missing or does not authorize training. The sealed set path
+//   is never given to any agent except the single final sealed evaluation,
+//   and only when sealed_evaluation_enabled === true.
+//
+// The script is the mechanical authority: agents diagnose and draft; only
+// this control flow decides pass/fail, and every gate rule is code below.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Tolerate args arriving JSON-encoded as a string (observed in practice).
+const A = typeof args === 'string' ? JSON.parse(args) : (args || {})
+const MODE = A.mode || 'mock'
+const STOP_AFTER = A.stop_after || 'full' // preflight|veto|lanes|gate|full
+const RUN_STAMP = A.run_stamp || 'unstamped-run' // caller supplies; no Date.now in workflows
+const MAX_ITER = A.max_iterations || 1
+
+let manifest = null
+if (MODE === 'live') {
+  manifest = A.manifest
+  if (!manifest || manifest.training_enabled !== true || !manifest.packet) {
+    throw new Error(
+      'live mode refused: a Codex-approved training manifest with ' +
+      'training_enabled=true and an immutable packet path is required. ' +
+      'Run mode=mock to exercise the contracts.'
+    )
+  }
+  if (String(manifest.packet).includes('needle_lab')) {
+    throw new Error('live mode refused: research_dev quarantine data can never be a live training packet.')
+  }
+} else if (MODE !== 'mock') {
+  throw new Error(`unknown mode "${MODE}" — use mock or live`)
+}
+
+// Mock packet must be a research_dev needle_lab bundle (default: the one in
+// this checkout; override with args.packet when the bundle lives in another
+// worktree, e.g. before PR #64 lands).
+const PACKET = MODE === 'mock' ? (A.packet || 'evals/needle_lab') : manifest.packet
+if (MODE === 'mock' && !String(PACKET).includes('needle_lab')) {
+  throw new Error('mock mode refused: packet must be a research_dev needle_lab bundle.')
+}
+const SEEDS = MODE === 'mock' ? [42] : (manifest.seeds || [42, 43, 44])
+const LEDGER = [] // attempt-ledger discipline: one row per agent call
+
+const GATE_SCHEMA = {
+  type: 'object',
+  properties: {
+    pass: { type: 'boolean' },
+    violations: { type: 'array', items: { type: 'string' } },
+    facts: { type: 'string' },
+  },
+  required: ['pass', 'violations', 'facts'],
+}
+
+const LANE_SCHEMA = {
+  type: 'object',
+  properties: {
+    arm: { type: 'string' },
+    seed: { type: 'integer' },
+    trained: { type: 'boolean' },
+    vitals_veto: { type: 'string', description: 'ok | the exact F7-class violation observed' },
+    in_template: { type: 'number' },
+    dev_ood: { type: 'number' },
+    secondary_ood: { type: 'number' },
+    worst_class: { type: 'string' },
+    retention: { type: 'string' },
+    wall_seconds: { type: 'number' },
+    evidence_paths: { type: 'array', items: { type: 'string' } },
+    facts: { type: 'string' },
+  },
+  required: ['arm', 'seed', 'trained', 'vitals_veto', 'in_template', 'dev_ood', 'retention', 'evidence_paths', 'facts'],
+}
+
+const BASELINE_SCHEMA = {
+  type: 'object',
+  properties: {
+    baselines: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          metric: { type: 'string' },
+          score: { type: 'number' },
+        },
+        required: ['name', 'metric', 'score'],
+      },
+    },
+    facts: { type: 'string' },
+  },
+  required: ['baselines', 'facts'],
+}
+
+const CLAIMCHECK_SCHEMA = {
+  type: 'object',
+  properties: {
+    claims: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          claim: { type: 'string' },
+          artifact: { type: 'string' },
+          verdict: { type: 'string', enum: ['CONFIRMED', 'REFUTED', 'NO_ARTIFACT'] },
+        },
+        required: ['claim', 'artifact', 'verdict'],
+      },
+    },
+    facts: { type: 'string' },
+  },
+  required: ['claims', 'facts'],
+}
+
+const COMMON = `You are one stage of the needle-training-campaign workflow (run ${RUN_STAMP}, mode=${MODE}) in the uni-grok-mcp repository (work from the repository root of the current session). The workflow script — not you — decides pass/fail; your job is to run EXACT commands, read ONLY the files named in your task, and return precisely the structured result requested. Never touch, cite, or read any sealed evaluation set. Never generate training examples. Report measured values only; if something cannot be verified, say so in a violation/facts entry instead of guessing.`
+
+async function call(label, phase, prompt, schema, effort) {
+  const res = await agent(prompt, { label, phase, schema, effort: effort || 'low' })
+  LEDGER.push({ phase, label, ok: res !== null })
+  if (res === null) throw new Error(`agent ${label} returned null — treat as gate failure, not success`)
+  return res
+}
+
+// ── Phase 1: Preflight ───────────────────────────────────────────────────────
+phase('Preflight')
+const preflight = await call('preflight', 'Preflight', `${COMMON}
+
+Verify the training packet and environment WITHOUT modifying anything:
+1. Packet ${PACKET}: data manifest exists (data/manifest.json for mock; packet manifest for live) and EVERY listed sha256 matches the file bytes on disk (shasum -a 256). List every mismatch or unlisted data file as a violation.
+2. Split policy: confirm the split convention is recorded BEFORE corpus assembly (mock: needle _per_tool_split seed 42 pinned in the packet README/report; live: manifest.split_policy digest matches the packet). Violation if absent.
+3. Base checkpoint pin present (mock: sha256 prefix 40a32e91d1d4197b recorded in README). Do NOT download anything in mock mode.
+4. Env pins recorded (python/jax/flax versions). Violation only if unrecorded, not if the local env differs — record the difference in facts.
+Return pass=false if ANY violation.`, GATE_SCHEMA)
+
+if (!preflight.pass) return { verdict: 'REFUSED_PREFLIGHT', mode: MODE, violations: preflight.violations, ledger: LEDGER }
+if (STOP_AFTER === 'preflight') return { verdict: 'STOPPED_AFTER_PREFLIGHT', mode: MODE, preflight, ledger: LEDGER }
+
+// ── Phase 2: Corpus veto (hard gates — any violation kills the run) ─────────
+phase('Corpus veto')
+const veto = await call('corpus-veto', 'Corpus veto', `${COMMON}
+
+Run the mechanical corpus vetoes on ${PACKET}/data (READ-ONLY):
+1. Grouped-split/leakage: run \`python ${PACKET}/check_combined_contamination.py\` (or the packet's equivalent) and report the counts. In mock mode the committed combined.jsonl is a KNOWN-CONTAMINATED research control: expect nonzero counts and record them as facts, with the single violation string "combined.jsonl contaminated (known research control — excluded from any training corpus)". In live mode ANY nonzero count is a fatal violation.
+2. Exact-duplicate scan across every family JSONL (normalize each row to (query, answers); report duplicate counts per family). Known-voided families (mock: abstention 20/40, next_step prefix leakage) are recorded as violations with the marker "(known, quarantined)".
+3. Class balance per enum family (report counts; imbalance is a fact, not a violation).
+4. Secret/PII grep over all data files (any hit is fatal).
+pass=false only for NEW violations — i.e. anything not carrying a "(known" marker in mock mode; in live mode every violation is fatal.`, GATE_SCHEMA, 'medium')
+
+const newViolations = veto.violations.filter(v => MODE === 'live' || !v.includes('(known'))
+if (!veto.pass || newViolations.length > 0) {
+  return { verdict: 'REFUSED_CORPUS_VETO', mode: MODE, violations: veto.violations, ledger: LEDGER }
+}
+if (STOP_AFTER === 'veto') return { verdict: 'STOPPED_AFTER_VETO', mode: MODE, preflight, veto, ledger: LEDGER }
+
+// ── Phase 3+4: iteration loop — arm lanes, then cross-arm gate ──────────────
+const iterations = []
+let arms
+for (let iter = 1; iter <= MAX_ITER; iter++) {
+  phase('Arm lanes')
+  if (MODE === 'mock') {
+    // Replay ONLY committed candidate records — never invent data in mock.
+    const rec = await call('arm-records', 'Arm lanes', `${COMMON}
+
+Read ${PACKET}/data/arm_candidates.json and return facts as a compact JSON string of the array [{arm, dataset_hash, n, recipe}] — every committed record, nothing added. pass=true unless the file is missing/unparseable.`, GATE_SCHEMA)
+    arms = JSON.parse(rec.facts)
+  } else {
+    // Live arm design happens ONLY under the Codex manifest's bounds and is
+    // deliberately not implemented until that manifest exists. Fail loudly.
+    throw new Error('live arm design is blocked until a Codex-approved training manifest defines its bounds (confusion-cell inputs, generator diversity rules, per-arm budgets).')
+  }
+
+  const laneInputs = arms.flatMap(a => SEEDS.map(seed => ({ ...a, seed })))
+  const lanes = (await pipeline(
+    laneInputs,
+    lane => call(`lane:${lane.arm}/s${lane.seed}`, 'Arm lanes', `${COMMON}
+
+Arm lane ${lane.arm} seed ${lane.seed} (${MODE}).
+MOCK: do not train. Reconstruct this lane's result from committed artifacts ONLY: ${PACKET}/data/arm_results.json and the matching ${PACKET}/logs/ft-arm-*.log. NAMING: arm_candidates.json uses "arm_B/arm_C/arm_D/arm_E"; arm_results.json names the SAME arms "B_hardneg/C_metamorphic/D_balanced/E_worstcell" and the control "A_control" — match by the letter. FIELD MAP (legacy keys): results key "sealed" -> report as dev_ood (it is the adaptive OOD dev set); results key "dev_ood" -> report as secondary_ood; "in_template" as-is; "forgetting" -> retention. From the log take wall seconds and run the F7 vitals check (Total steps > 0, training completed, no NaN schedule) -> vitals_veto "ok" or the violation. trained=false. List the exact evidence paths used. Every arm B-E has a committed result row and log; return in_template=-1 ONLY if a read genuinely fails, and say why in facts.
+LIVE (never reached without a manifest): run the packet's ft driver wrapped with the vitals veto, then eval + retention.`, LANE_SCHEMA)
+  )).filter(Boolean)
+
+  if (STOP_AFTER === 'lanes' && iter === MAX_ITER) {
+    return { verdict: 'STOPPED_AFTER_LANES', mode: MODE, arms, lanes, ledger: LEDGER }
+  }
+
+  // ── Cross-arm gate: needs ALL lanes together (legitimate barrier) ─────────
+  phase('Cross-arm gate')
+  const baselines = await call('trivial-baselines', 'Cross-arm gate', `${COMMON}
+
+Run the trivial-baseline comparison that every learned candidate must beat (audit standing rule). Mock: run \`python ${PACKET}/tfidf_baseline.py\` and return each printed variant as {name, metric:"top1", score in [0,1]}. Also read the control arm A_control from ${PACKET}/data/arm_results.json and return {name:"control-arm-A", metric:"dev_ood", score:<A_control's legacy "sealed" key — the adaptive OOD dev metric, the SAME field lanes report as dev_ood>}.`, BASELINE_SCHEMA)
+
+  // Mechanical gate rules — CODE, not agent judgment:
+  const controlDev = (baselines.baselines.find(b => b.name === 'control-arm-A') || { score: 0 }).score
+  const judged = arms.map(a => {
+    const armLanes = lanes.filter(l => l.arm === a.arm && l.in_template >= 0)
+    const seedsRun = new Set(armLanes.map(l => l.seed)).size
+    const vitalsOk = armLanes.length > 0 && armLanes.every(l => l.vitals_veto === 'ok')
+    const retentionOk = armLanes.every(l => /^3\/3$|^full$/i.test(l.retention))
+    const devScores = armLanes.map(l => l.dev_ood)
+    const minDev = devScores.length ? Math.min(...devScores) : -1
+    const beatsControl = minDev > controlDev
+    const multiSeedOk = seedsRun >= (MODE === 'mock' ? 1 : 3)
+    return {
+      arm: a.arm,
+      seeds_run: seedsRun,
+      vitals_ok: vitalsOk,
+      retention_ok: retentionOk,
+      min_dev_ood: minDev,
+      beats_control: beatsControl,
+      multi_seed_ok: multiSeedOk,
+      // Promotion-candidate rule: every mechanical gate green. In mock,
+      // multi-seed is structurally impossible (1 historical seed) so no arm
+      // can be promotion-grade — which is exactly the audited conclusion.
+      promotion_candidate: vitalsOk && retentionOk && beatsControl && multiSeedOk && MODE === 'live',
+    }
+  })
+  iterations.push({ iter, arms: judged, baselines: baselines.baselines })
+
+  if (STOP_AFTER === 'gate' && iter === MAX_ITER) break
+  // Iterate only when live, authorized, and something is still improving.
+  if (MODE === 'mock' || iter === MAX_ITER) break
+  if (!judged.some(j => j.beats_control)) break
+}
+
+if (STOP_AFTER === 'gate') {
+  return { verdict: 'STOPPED_AFTER_GATE', mode: MODE, iterations, ledger: LEDGER }
+}
+
+// ── Phase 5: Evidence — draft, then adversarially verify every claim ────────
+phase('Evidence')
+const last = iterations[iterations.length - 1]
+const draft = await call('report-draft', 'Evidence', `${COMMON}
+
+Draft (in facts, as markdown) a concise campaign result summary for run ${RUN_STAMP}: mode; gate outcomes from PREFLIGHT ${JSON.stringify({ pass: preflight.pass, violations: preflight.violations })} and CORPUS VETO ${JSON.stringify({ pass: veto.pass, violations: veto.violations })}; per-arm table from this JSON: ${JSON.stringify(last.arms)}; baselines: ${JSON.stringify(last.baselines)}. State plainly that mock mode trains nothing and that promotion authority belongs to the Codex gate. Every sentence must restate the JSON above or cite a committed artifact by path — no claims about your own process or about anything not in the JSON.`, GATE_SCHEMA)
+
+const check = await call('claim-verify', 'Evidence', `${COMMON}
+
+Adversarially verify the draft below. For EVERY numeric or factual claim, name the committed artifact (file path) that backs it and verdict CONFIRMED, or REFUTED (artifact contradicts), or NO_ARTIFACT (nothing backs it). A claim sourced only from the workflow's own JSON is CONFIRMED with artifact "workflow-state" ONLY if it matches that JSON exactly.
+
+DRAFT:
+${draft.facts}`, CLAIMCHECK_SCHEMA, 'medium')
+
+const unbacked = check.claims.filter(c => c.verdict !== 'CONFIRMED')
+return {
+  verdict: unbacked.length === 0 ? 'EVIDENCE_CLEAN' : 'EVIDENCE_GAPS',
+  mode: MODE,
+  run: RUN_STAMP,
+  promotion: 'NONE — candidates + evidence only; promotion belongs to the Codex landing gate',
+  iterations,
+  report_draft: draft.facts,
+  claim_check: { unbacked, total: check.claims.length },
+  ledger: LEDGER,
+}

--- a/.claude/workflows/needle-training-campaign.js
+++ b/.claude/workflows/needle-training-campaign.js
@@ -3,11 +3,11 @@ export const meta = {
   description: 'Confusion-driven Needle training campaign with mechanical gates (mock-first; live requires a Codex-approved training manifest)',
   whenToUse: 'Run the Needle training-experiment loop from an immutable training packet: corpus vetoes, arm lanes, Pareto/retention gates, evidence bundle. Default mode=mock replays committed research_dev artifacts and trains nothing.',
   phases: [
-    { title: 'Preflight', detail: 'authorization, packet hashes, frozen split policy, env pins' },
-    { title: 'Corpus veto', detail: 'grouped-split, leakage, dedup, balance — hard gates' },
-    { title: 'Arm lanes', detail: 'per-arm train+eval+retention (mock: replay committed artifacts)' },
-    { title: 'Cross-arm gate', detail: 'trivial baselines, Pareto/forgetting, multi-seed rules' },
-    { title: 'Evidence', detail: 'manifest regen, report draft, adversarial claim verification' },
+    { title: 'Preflight', detail: 'digest-sealed validator receipt: packet hashes, frozen split policy, env pins' },
+    { title: 'Corpus veto', detail: 'digest-sealed validator receipt: leakage, dedup, balance, secrets — hard gates' },
+    { title: 'Arm lanes', detail: 'frozen arm records + mechanical lane vitals from validator receipts (mock: replay)' },
+    { title: 'Cross-arm gate', detail: 'control comparison, retention, multi-seed rules — computed here from verified payloads' },
+    { title: 'Evidence', detail: 'report draft, adversarial claim verification, typed next_harvest_request (request-only)' },
   ],
 }
 
@@ -17,21 +17,47 @@ export const meta = {
 // mode=mock (default): transport-free discipline. NO training run, NO dataset
 //   generation, NO sealed evaluation. Inputs are the committed research_dev
 //   bundle (evals/needle_lab/); arm records are REPLAYED from
-//   data/arm_candidates.json + logs, never invented. Purpose: prove the
-//   orchestration, veto, gate, ledger, and evidence contracts end-to-end —
-//   the same pattern as the campaign's stage1 mock safety gate.
+//   data/arm_candidates.json + logs, never invented.
 //
 // mode=live: requires args.manifest — a Codex-approved training manifest
 //   (exact-head approval, separate PR) with explicit bounds:
 //   { training_enabled: true, packet: <immutable packet path OUTSIDE
 //     research_dev>, max_lanes, seeds, max_iterations, wall_budget_min,
-//     sealed_evaluation_enabled }. The script throws before any work if the
-//   manifest is missing or does not authorize training. The sealed set path
-//   is never given to any agent except the single final sealed evaluation,
-//   and only when sealed_evaluation_enabled === true.
+//     sealed_evaluation_enabled, receipt_digest_pins: { preflight, corpus_veto,
+//     arm_records } }. The script throws before any work if the manifest is
+//   missing or does not authorize training. The sealed set path is never given
+//   to any agent except the single final sealed evaluation, and only when
+//   sealed_evaluation_enabled === true.
 //
-// The script is the mechanical authority: agents diagnose and draft; only
-// this control flow decides pass/fail, and every gate rule is code below.
+// MECHANICAL AUTHORITY — HOW GATE TRUTH IS ESTABLISHED
+//
+// Gate decisions are made by deterministic validators that live in executable
+// repository code: `evals/needle_gates` (Python, tested by
+// tests/test_needle_gates.py). Each validator emits a digest-sealed receipt:
+//
+//   { schema: "needle-gate-receipt/v1", validator, payload_b64,
+//     payload_sha256 }
+//
+// where payload_sha256 = SHA-256 over the exact base64-decoded payload bytes.
+// Agents in this workflow only RUN the validator CLI and TRANSCRIBE the
+// receipt back; they return no pass booleans and no measurements of their
+// own. This script base64-decodes the payload, recomputes SHA-256 with the
+// embedded implementation below, and derives every gate decision from the
+// verified typed payload. Any decode/digest/schema mismatch throws — fail
+// closed, never fall back to agent prose.
+//
+// Because this workflow runtime cannot execute the Python validators
+// directly, transcription alone cannot prove the receipt was produced by the
+// committed code. Two layers close that gap:
+//   • mock: receipts are written to disk (--out) so any reviewer can rerun
+//     `python -m evals.needle_gates verify --receipt <file> --expect-digest`
+//     and rerun the validators; the digest in this run's result binds the
+//     audit trail. Mock trains nothing, so the residual risk is bounded.
+//   • live: the Codex-approved manifest MUST pin the expected
+//     payload_sha256 for each gate receipt (receipt_digest_pins), computed
+//     by running the validators out-of-band during approval. A presented
+//     receipt whose digest does not match its pin throws. No pins → refuse
+//     to start. Agent prose can therefore never become gate truth.
 // ─────────────────────────────────────────────────────────────────────────────
 
 // Tolerate args arriving JSON-encoded as a string (observed in practice).
@@ -40,6 +66,9 @@ const MODE = A.mode || 'mock'
 const STOP_AFTER = A.stop_after || 'full' // preflight|veto|lanes|gate|full
 const RUN_STAMP = A.run_stamp || 'unstamped-run' // caller supplies; no Date.now in workflows
 const MAX_ITER = A.max_iterations || 1
+const CAMPAIGN_ID = A.campaign_id || 'needle-campaign'
+const SOURCE_DATASET = A.source_dataset_id || 'D0001'
+const TARGET_DATASET = A.target_dataset_id || 'D0002'
 
 let manifest = null
 if (MODE === 'live') {
@@ -54,6 +83,15 @@ if (MODE === 'live') {
   if (String(manifest.packet).includes('needle_lab')) {
     throw new Error('live mode refused: research_dev quarantine data can never be a live training packet.')
   }
+  const pins = manifest.receipt_digest_pins
+  if (!pins || !pins.preflight || !pins.corpus_veto || !pins.arm_records) {
+    throw new Error(
+      'live mode refused: manifest.receipt_digest_pins must pin the expected ' +
+      'payload_sha256 for preflight, corpus_veto, and arm_records receipts ' +
+      '(computed by running evals.needle_gates during Codex approval). ' +
+      'Without pins this runtime cannot verify validator provenance — fail closed.'
+    )
+  }
 } else if (MODE !== 'mock') {
   throw new Error(`unknown mode "${MODE}" — use mock or live`)
 }
@@ -66,55 +104,128 @@ if (MODE === 'mock' && !String(PACKET).includes('needle_lab')) {
   throw new Error('mock mode refused: packet must be a research_dev needle_lab bundle.')
 }
 const SEEDS = MODE === 'mock' ? [42] : (manifest.seeds || [42, 43, 44])
+const RECEIPTS_DIR = `/tmp/needle-gates-${RUN_STAMP}`
 const LEDGER = [] // attempt-ledger discipline: one row per agent call
 
-const GATE_SCHEMA = {
-  type: 'object',
-  properties: {
-    pass: { type: 'boolean' },
-    violations: { type: 'array', items: { type: 'string' } },
-    facts: { type: 'string' },
-  },
-  required: ['pass', 'violations', 'facts'],
+// ── Embedded receipt verification (base64 + SHA-256, no runtime deps) ───────
+// Receipts payloads are canonical ASCII JSON, so byte handling is exact.
+
+const B64_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+function b64decode(s) {
+  const clean = String(s).replace(/=+$/, '')
+  if (/[^A-Za-z0-9+/]/.test(clean)) throw new Error('receipt payload_b64 contains non-base64 characters')
+  const bytes = []
+  let buffer = 0
+  let bits = 0
+  for (const ch of clean) {
+    buffer = (buffer << 6) | B64_ALPHABET.indexOf(ch)
+    bits += 6
+    if (bits >= 8) {
+      bits -= 8
+      bytes.push((buffer >> bits) & 0xff)
+    }
+  }
+  return bytes
 }
 
-const LANE_SCHEMA = {
-  type: 'object',
-  properties: {
-    arm: { type: 'string' },
-    seed: { type: 'integer' },
-    trained: { type: 'boolean' },
-    vitals_veto: { type: 'string', description: 'ok | the exact F7-class violation observed' },
-    in_template: { type: 'number' },
-    dev_ood: { type: 'number' },
-    secondary_ood: { type: 'number' },
-    worst_class: { type: 'string' },
-    retention: { type: 'string' },
-    wall_seconds: { type: 'number' },
-    evidence_paths: { type: 'array', items: { type: 'string' } },
-    facts: { type: 'string' },
-  },
-  required: ['arm', 'seed', 'trained', 'vitals_veto', 'in_template', 'dev_ood', 'retention', 'evidence_paths', 'facts'],
+const SHA256_K = [
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+]
+function rotr(x, n) { return ((x >>> n) | (x << (32 - n))) >>> 0 }
+function sha256Hex(bytes) {
+  const h = [0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19]
+  const msg = bytes.slice()
+  const bitLenHi = Math.floor(bytes.length / 0x20000000)
+  const bitLenLo = (bytes.length << 3) >>> 0
+  msg.push(0x80)
+  while (msg.length % 64 !== 56) msg.push(0)
+  for (let i = 3; i >= 0; i--) msg.push((bitLenHi >>> (8 * i)) & 0xff)
+  for (let i = 3; i >= 0; i--) msg.push((bitLenLo >>> (8 * i)) & 0xff)
+  const w = new Array(64)
+  for (let off = 0; off < msg.length; off += 64) {
+    for (let i = 0; i < 16; i++) {
+      w[i] = ((msg[off + 4 * i] << 24) | (msg[off + 4 * i + 1] << 16) | (msg[off + 4 * i + 2] << 8) | msg[off + 4 * i + 3]) >>> 0
+    }
+    for (let i = 16; i < 64; i++) {
+      const s0 = rotr(w[i - 15], 7) ^ rotr(w[i - 15], 18) ^ (w[i - 15] >>> 3)
+      const s1 = rotr(w[i - 2], 17) ^ rotr(w[i - 2], 19) ^ (w[i - 2] >>> 10)
+      w[i] = (w[i - 16] + s0 + w[i - 7] + s1) >>> 0
+    }
+    let [a, b, c, d, e, f, g, hh] = h
+    for (let i = 0; i < 64; i++) {
+      const S1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25)
+      const ch = (e & f) ^ (~e & g)
+      const t1 = (hh + S1 + ch + SHA256_K[i] + w[i]) >>> 0
+      const S0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22)
+      const maj = (a & b) ^ (a & c) ^ (b & c)
+      const t2 = (S0 + maj) >>> 0
+      hh = g; g = f; f = e
+      e = (d + t1) >>> 0
+      d = c; c = b; b = a
+      a = (t1 + t2) >>> 0
+    }
+    h[0] = (h[0] + a) >>> 0; h[1] = (h[1] + b) >>> 0; h[2] = (h[2] + c) >>> 0; h[3] = (h[3] + d) >>> 0
+    h[4] = (h[4] + e) >>> 0; h[5] = (h[5] + f) >>> 0; h[6] = (h[6] + g) >>> 0; h[7] = (h[7] + hh) >>> 0
+  }
+  return h.map(x => x.toString(16).padStart(8, '0')).join('')
 }
 
-const BASELINE_SCHEMA = {
+// Verify a transcribed receipt envelope and return its typed payload.
+// Throws on ANY mismatch — fail closed; agent prose never becomes gate truth.
+function verifyReceipt(rawText, expectedValidator) {
+  let receipt
+  try {
+    receipt = typeof rawText === 'string' ? JSON.parse(rawText) : rawText
+  } catch (e) {
+    throw new Error(`gate failure: ${expectedValidator} receipt is not JSON (${e.message})`)
+  }
+  if (!receipt || receipt.schema !== 'needle-gate-receipt/v1') {
+    throw new Error(`gate failure: ${expectedValidator} receipt has wrong schema ${receipt && receipt.schema}`)
+  }
+  if (receipt.validator !== expectedValidator) {
+    throw new Error(`gate failure: receipt validator ${receipt.validator} != expected ${expectedValidator}`)
+  }
+  if (typeof receipt.payload_b64 !== 'string' || typeof receipt.payload_sha256 !== 'string') {
+    throw new Error(`gate failure: ${expectedValidator} receipt missing payload_b64/payload_sha256`)
+  }
+  const payloadBytes = b64decode(receipt.payload_b64)
+  const digest = sha256Hex(payloadBytes)
+  if (digest !== receipt.payload_sha256) {
+    throw new Error(`gate failure: ${expectedValidator} receipt digest mismatch (computed ${digest}, declared ${receipt.payload_sha256})`)
+  }
+  if (MODE === 'live') {
+    const pinned = manifest.receipt_digest_pins[expectedValidator]
+    if (pinned && pinned !== digest) {
+      throw new Error(`gate failure: ${expectedValidator} receipt digest ${digest} does not match Codex-pinned ${pinned}`)
+    }
+  }
+  let payload
+  try {
+    payload = JSON.parse(payloadBytes.map(b => String.fromCharCode(b)).join(''))
+  } catch (e) {
+    throw new Error(`gate failure: ${expectedValidator} receipt payload is not JSON (${e.message})`)
+  }
+  if (!payload || typeof payload !== 'object') {
+    throw new Error(`gate failure: ${expectedValidator} receipt payload is not an object`)
+  }
+  return { payload, digest }
+}
+
+// Agents transcribe receipts; they never return pass booleans or metrics.
+const RECEIPT_AGENT_SCHEMA = {
   type: 'object',
   properties: {
-    baselines: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: {
-          name: { type: 'string' },
-          metric: { type: 'string' },
-          score: { type: 'number' },
-        },
-        required: ['name', 'metric', 'score'],
-      },
-    },
-    facts: { type: 'string' },
+    receipt: { type: 'string', description: 'the EXACT receipt JSON emitted by the validator CLI, transcribed byte-for-byte' },
+    facts: { type: 'string', description: 'one-line summary of what you ran (advisory only; carries no gate authority)' },
   },
-  required: ['baselines', 'facts'],
+  required: ['receipt', 'facts'],
 }
 
 const CLAIMCHECK_SCHEMA = {
@@ -137,7 +248,13 @@ const CLAIMCHECK_SCHEMA = {
   required: ['claims', 'facts'],
 }
 
-const COMMON = `You are one stage of the needle-training-campaign workflow (run ${RUN_STAMP}, mode=${MODE}) in the uni-grok-mcp repository (work from the repository root of the current session). The workflow script — not you — decides pass/fail; your job is to run EXACT commands, read ONLY the files named in your task, and return precisely the structured result requested. Never touch, cite, or read any sealed evaluation set. Never generate training examples. Report measured values only; if something cannot be verified, say so in a violation/facts entry instead of guessing.`
+const DRAFT_SCHEMA = {
+  type: 'object',
+  properties: { facts: { type: 'string' } },
+  required: ['facts'],
+}
+
+const COMMON = `You are one stage of the needle-training-campaign workflow (run ${RUN_STAMP}, mode=${MODE}) in the uni-grok-mcp repository (work from the repository root of the current session). Deterministic validators in evals/needle_gates — not you, not this prompt — decide every gate; your job is to run EXACT commands and transcribe their receipt output byte-for-byte. Never touch, cite, or read any sealed evaluation set. Never generate training examples. If a command fails, transcribe whatever it printed and say what failed in facts — do not fabricate a receipt.`
 
 async function call(label, phase, prompt, schema, effort) {
   const res = await agent(prompt, { label, phase, schema, effort: effort || 'low' })
@@ -146,87 +263,164 @@ async function call(label, phase, prompt, schema, effort) {
   return res
 }
 
+// Run one validator through an agent and return its digest-verified payload.
+async function gateReceipt(label, phaseName, validator, cliArgs, effort) {
+  const outPath = `${RECEIPTS_DIR}/${validator}.json`
+  const res = await call(label, phaseName, `${COMMON}
+
+Run EXACTLY this command from the repository root (read-only on the packet; the receipt goes to /tmp):
+
+  uv run python -m evals.needle_gates ${cliArgs} --out ${outPath}
+
+Then return:
+- receipt: the full JSON text printed by the command (identical to ${outPath}), transcribed EXACTLY — no edits, no reformatting, no commentary inside the JSON.
+- facts: one line noting the command ran and where the receipt file is.
+You do not decide pass/fail; the workflow verifies the receipt digest itself.`, RECEIPT_AGENT_SCHEMA, effort)
+  const { payload, digest } = verifyReceipt(res.receipt, validator)
+  LEDGER.push({ phase: phaseName, label: `${label}:receipt-verified`, ok: true, payload_sha256: digest })
+  return { payload, digest, receipt_path: outPath }
+}
+
 // ── Phase 1: Preflight ───────────────────────────────────────────────────────
 phase('Preflight')
-const preflight = await call('preflight', 'Preflight', `${COMMON}
-
-Verify the training packet and environment WITHOUT modifying anything:
-1. Packet ${PACKET}: data manifest exists (data/manifest.json for mock; packet manifest for live) and EVERY listed sha256 matches the file bytes on disk (shasum -a 256). List every mismatch or unlisted data file as a violation.
-2. Split policy: confirm the split convention is recorded BEFORE corpus assembly (mock: needle _per_tool_split seed 42 pinned in the packet README/report; live: manifest.split_policy digest matches the packet). Violation if absent.
-3. Base checkpoint pin present (mock: sha256 prefix 40a32e91d1d4197b recorded in README). Do NOT download anything in mock mode.
-4. Env pins recorded (python/jax/flax versions). Violation only if unrecorded, not if the local env differs — record the difference in facts.
-Return pass=false if ANY violation.`, GATE_SCHEMA)
-
-if (!preflight.pass) return { verdict: 'REFUSED_PREFLIGHT', mode: MODE, violations: preflight.violations, ledger: LEDGER }
-if (STOP_AFTER === 'preflight') return { verdict: 'STOPPED_AFTER_PREFLIGHT', mode: MODE, preflight, ledger: LEDGER }
-
-// ── Phase 2: Corpus veto (hard gates — any violation kills the run) ─────────
-phase('Corpus veto')
-const veto = await call('corpus-veto', 'Corpus veto', `${COMMON}
-
-Run the mechanical corpus vetoes on ${PACKET}/data (READ-ONLY):
-1. Grouped-split/leakage: run \`python ${PACKET}/check_combined_contamination.py\` (or the packet's equivalent) and report the counts. In mock mode the committed combined.jsonl is a KNOWN-CONTAMINATED research control: expect nonzero counts and record them as facts, with the single violation string "combined.jsonl contaminated (known research control — excluded from any training corpus)". In live mode ANY nonzero count is a fatal violation.
-2. Exact-duplicate scan across every family JSONL (normalize each row to (query, answers); report duplicate counts per family). Known-voided families (mock: abstention 20/40, next_step prefix leakage) are recorded as violations with the marker "(known, quarantined)".
-3. Class balance per enum family (report counts; imbalance is a fact, not a violation).
-4. Secret/PII grep over all data files (any hit is fatal).
-pass=false only for NEW violations — i.e. anything not carrying a "(known" marker in mock mode; in live mode every violation is fatal.`, GATE_SCHEMA, 'medium')
-
-const newViolations = veto.violations.filter(v => MODE === 'live' || !v.includes('(known'))
-if (!veto.pass || newViolations.length > 0) {
-  return { verdict: 'REFUSED_CORPUS_VETO', mode: MODE, violations: veto.violations, ledger: LEDGER }
+const preflight = await gateReceipt(
+  'preflight', 'Preflight', 'preflight', `preflight --packet ${PACKET}`
+)
+// Gate truth: the verified typed payload — never the agent's words.
+if (preflight.payload.ok !== true || preflight.payload.violations.length > 0) {
+  return {
+    verdict: 'REFUSED_PREFLIGHT', mode: MODE,
+    violations: preflight.payload.violations,
+    receipt_sha256: preflight.digest, ledger: LEDGER,
+  }
 }
-if (STOP_AFTER === 'veto') return { verdict: 'STOPPED_AFTER_VETO', mode: MODE, preflight, veto, ledger: LEDGER }
+if (STOP_AFTER === 'preflight') {
+  return { verdict: 'STOPPED_AFTER_PREFLIGHT', mode: MODE, preflight: preflight.payload, receipt_sha256: preflight.digest, ledger: LEDGER }
+}
+
+// ── Phase 2: Corpus veto (hard gates — any NEW violation kills the run) ─────
+phase('Corpus veto')
+const veto = await gateReceipt(
+  'corpus-veto', 'Corpus veto', 'corpus_veto', `corpus-veto --packet ${PACKET}`, 'medium'
+)
+// The validator computes new_violations mechanically (known-quarantine markers
+// come from the committed packet manifest, never from prose). Recompute here
+// as defense in depth; live mode treats EVERY violation as fatal.
+const vetoViolations = veto.payload.violations || []
+const newViolations = MODE === 'live'
+  ? vetoViolations
+  : vetoViolations.filter(v => !v.includes('(known'))
+const validatorNew = veto.payload.new_violations || []
+if (veto.payload.ok !== true || newViolations.length > 0 || (MODE !== 'live' && validatorNew.length > 0)) {
+  return {
+    verdict: 'REFUSED_CORPUS_VETO', mode: MODE,
+    violations: vetoViolations, new_violations: MODE === 'live' ? vetoViolations : validatorNew,
+    receipt_sha256: veto.digest, ledger: LEDGER,
+  }
+}
+if (STOP_AFTER === 'veto') {
+  return { verdict: 'STOPPED_AFTER_VETO', mode: MODE, preflight: preflight.payload, veto: veto.payload, ledger: LEDGER }
+}
 
 // ── Phase 3+4: iteration loop — arm lanes, then cross-arm gate ──────────────
 const iterations = []
-let arms
+let armsPayload
+let metricsReceipt
 for (let iter = 1; iter <= MAX_ITER; iter++) {
   phase('Arm lanes')
-  if (MODE === 'mock') {
-    // Replay ONLY committed candidate records — never invent data in mock.
-    const rec = await call('arm-records', 'Arm lanes', `${COMMON}
+  // Arm records are FROZEN, manifest-declared data replayed through the
+  // validator — in every mode. No agent is ever asked to invent an arm or a
+  // dataset (they are only asked to run the CLI and transcribe its receipt).
+  const armRecords = await gateReceipt(
+    'arm-records', 'Arm lanes', 'arm_records', `arm-records --packet ${PACKET}`
+  )
+  if (armRecords.payload.ok !== true || armRecords.payload.arms.length === 0) {
+    return {
+      verdict: 'REFUSED_ARM_RECORDS', mode: MODE,
+      violations: armRecords.payload.violations,
+      receipt_sha256: armRecords.digest, ledger: LEDGER,
+    }
+  }
+  armsPayload = armRecords.payload.arms
 
-Read ${PACKET}/data/arm_candidates.json and return facts as a compact JSON string of the array [{arm, dataset_hash, n, recipe}] — every committed record, nothing added. pass=true unless the file is missing/unparseable.`, GATE_SCHEMA)
-    arms = JSON.parse(rec.facts)
-  } else {
-    // Live arm design happens ONLY under the Codex manifest's bounds and is
-    // deliberately not implemented until that manifest exists. Fail loudly.
-    throw new Error('live arm design is blocked until a Codex-approved training manifest defines its bounds (confusion-cell inputs, generator diversity rules, per-arm budgets).')
+  if (MODE === 'live') {
+    // Live lane TRAINING stays blocked until a Codex-approved manifest defines
+    // its bounds (per-arm budgets, generator diversity, confusion-cell
+    // inputs). The frozen arm records above are the only permitted inputs.
+    throw new Error('live lane training is blocked until a Codex-approved training manifest defines its bounds (confusion-cell inputs, generator diversity rules, per-arm budgets). Frozen arm records were loaded and verified; nothing was trained.')
   }
 
-  const laneInputs = arms.flatMap(a => SEEDS.map(seed => ({ ...a, seed })))
-  const lanes = (await pipeline(
-    laneInputs,
-    lane => call(`lane:${lane.arm}/s${lane.seed}`, 'Arm lanes', `${COMMON}
+  // Mock lanes: one arm-metrics receipt replays committed results and runs
+  // the F7 vitals checks (steps > 0, completed, no NaN) mechanically against
+  // the committed logs. The legacy field map (results "sealed" -> dev_ood,
+  // results "dev_ood" -> secondary_ood, "forgetting" -> retention) lives in
+  // the validator, in code.
+  metricsReceipt = await gateReceipt(
+    'arm-metrics', 'Arm lanes', 'arm_metrics', `arm-metrics --packet ${PACKET}`, 'medium'
+  )
+  if (metricsReceipt.payload.ok !== true) {
+    return {
+      verdict: 'REFUSED_ARM_METRICS', mode: MODE,
+      violations: metricsReceipt.payload.violations,
+      receipt_sha256: metricsReceipt.digest, ledger: LEDGER,
+    }
+  }
 
-Arm lane ${lane.arm} seed ${lane.seed} (${MODE}).
-MOCK: do not train. Reconstruct this lane's result from committed artifacts ONLY: ${PACKET}/data/arm_results.json and the matching ${PACKET}/logs/ft-arm-*.log. NAMING: arm_candidates.json uses "arm_B/arm_C/arm_D/arm_E"; arm_results.json names the SAME arms "B_hardneg/C_metamorphic/D_balanced/E_worstcell" and the control "A_control" — match by the letter. FIELD MAP (legacy keys): results key "sealed" -> report as dev_ood (it is the adaptive OOD dev set); results key "dev_ood" -> report as secondary_ood; "in_template" as-is; "forgetting" -> retention. From the log take wall seconds and run the F7 vitals check (Total steps > 0, training completed, no NaN schedule) -> vitals_veto "ok" or the violation. trained=false. List the exact evidence paths used. Every arm B-E has a committed result row and log; return in_template=-1 ONLY if a read genuinely fails, and say why in facts.
-LIVE (never reached without a manifest): run the packet's ft driver wrapped with the vitals veto, then eval + retention.`, LANE_SCHEMA)
-  )).filter(Boolean)
+  // Build lane rows from the VERIFIED payload only (mock: replay, trained=false).
+  const metricsByLetter = {}
+  for (const armMetric of metricsReceipt.payload.arms) {
+    metricsByLetter[armMetric.arm_letter] = armMetric
+  }
+  const lanes = []
+  for (const record of armsPayload) {
+    const letterMatch = /(?:^|_)([A-Z])(?:_|$)/.exec(record.arm)
+    const letter = letterMatch ? letterMatch[1] : ''
+    const metric = metricsByLetter[letter]
+    for (const seed of SEEDS) {
+      if (!metric) {
+        lanes.push({ arm: record.arm, seed, trained: false, vitals_veto: `no committed result row for ${record.arm}`, in_template: -1, dev_ood: -1, secondary_ood: -1, retention: '', wall_seconds: null })
+        continue
+      }
+      lanes.push({
+        arm: record.arm,
+        results_name: metric.results_name,
+        seed,
+        trained: false,
+        vitals_veto: metric.vitals.vitals_veto,
+        in_template: metric.in_template,
+        dev_ood: metric.dev_ood,
+        secondary_ood: metric.secondary_ood,
+        retention: metric.retention,
+        wall_seconds: metric.vitals.wall_seconds,
+        log_sha256: metric.vitals.log_sha256,
+      })
+    }
+  }
 
   if (STOP_AFTER === 'lanes' && iter === MAX_ITER) {
-    return { verdict: 'STOPPED_AFTER_LANES', mode: MODE, arms, lanes, ledger: LEDGER }
+    return { verdict: 'STOPPED_AFTER_LANES', mode: MODE, arms: armsPayload, lanes, receipt_sha256: metricsReceipt.digest, ledger: LEDGER }
   }
 
-  // ── Cross-arm gate: needs ALL lanes together (legitimate barrier) ─────────
+  // ── Cross-arm gate: mechanical rules computed HERE from verified payloads ──
   phase('Cross-arm gate')
-  const baselines = await call('trivial-baselines', 'Cross-arm gate', `${COMMON}
-
-Run the trivial-baseline comparison that every learned candidate must beat (audit standing rule). Mock: run \`python ${PACKET}/tfidf_baseline.py\` and return each printed variant as {name, metric:"top1", score in [0,1]}. Also read the control arm A_control from ${PACKET}/data/arm_results.json and return {name:"control-arm-A", metric:"dev_ood", score:<A_control's legacy "sealed" key — the adaptive OOD dev metric, the SAME field lanes report as dev_ood>}.`, BASELINE_SCHEMA)
-
-  // Mechanical gate rules — CODE, not agent judgment:
-  const controlDev = (baselines.baselines.find(b => b.name === 'control-arm-A') || { score: 0 }).score
-  const judged = arms.map(a => {
-    const armLanes = lanes.filter(l => l.arm === a.arm && l.in_template >= 0)
+  // The control comparison uses the verified control row from the arm-metrics
+  // receipt (control dev_ood = legacy "sealed" — the adaptive OOD dev metric).
+  const control = metricsReceipt.payload.control
+  if (!control) {
+    return { verdict: 'REFUSED_NO_CONTROL', mode: MODE, receipt_sha256: metricsReceipt.digest, ledger: LEDGER }
+  }
+  const controlDev = control.dev_ood
+  const judged = armsPayload.map(record => {
+    const armLanes = lanes.filter(l => l.arm === record.arm && l.in_template >= 0)
     const seedsRun = new Set(armLanes.map(l => l.seed)).size
     const vitalsOk = armLanes.length > 0 && armLanes.every(l => l.vitals_veto === 'ok')
-    const retentionOk = armLanes.every(l => /^3\/3$|^full$/i.test(l.retention))
+    const retentionOk = armLanes.length > 0 && armLanes.every(l => /^3\/3$|^full$/i.test(l.retention))
     const devScores = armLanes.map(l => l.dev_ood)
     const minDev = devScores.length ? Math.min(...devScores) : -1
     const beatsControl = minDev > controlDev
     const multiSeedOk = seedsRun >= (MODE === 'mock' ? 1 : 3)
     return {
-      arm: a.arm,
+      arm: record.arm,
       seeds_run: seedsRun,
       vitals_ok: vitalsOk,
       retention_ok: retentionOk,
@@ -239,7 +433,7 @@ Run the trivial-baseline comparison that every learned candidate must beat (audi
       promotion_candidate: vitalsOk && retentionOk && beatsControl && multiSeedOk && MODE === 'live',
     }
   })
-  iterations.push({ iter, arms: judged, baselines: baselines.baselines })
+  iterations.push({ iter, arms: judged, control: { name: control.results_name, dev_ood: controlDev } })
 
   if (STOP_AFTER === 'gate' && iter === MAX_ITER) break
   // Iterate only when live, authorized, and something is still improving.
@@ -251,16 +445,36 @@ if (STOP_AFTER === 'gate') {
   return { verdict: 'STOPPED_AFTER_GATE', mode: MODE, iterations, ledger: LEDGER }
 }
 
-// ── Phase 5: Evidence — draft, then adversarially verify every claim ────────
+// ── Phase 5: Evidence — harvest request, draft, adversarial claim check ─────
 phase('Evidence')
+
+// Typed next_harvest_request: derived by the validator from the SAME verified
+// evidence (weak confusion cells, retention cells, exact digests). It is a
+// REQUEST ONLY — it authorizes no generation and no training; acting on it
+// requires a separate Codex-approved harvesting manifest.
+const harvest = await gateReceipt(
+  'harvest-request', 'Evidence', 'harvest_request',
+  `harvest-request --packet ${PACKET} --campaign ${CAMPAIGN_ID} --source-dataset ${SOURCE_DATASET} --target-dataset ${TARGET_DATASET}`
+)
+if (harvest.payload.request_only !== true || harvest.payload.authorizes_generation !== false || harvest.payload.authorizes_training !== false) {
+  throw new Error('gate failure: next_harvest_request must be request-only (authorizes_generation=false, authorizes_training=false)')
+}
+
 const last = iterations[iterations.length - 1]
+const gateSummary = {
+  preflight: { ok: preflight.payload.ok, violations: preflight.payload.violations, receipt_sha256: preflight.digest },
+  corpus_veto: { ok: veto.payload.ok, violations: veto.payload.violations, receipt_sha256: veto.digest },
+  arms: last.arms,
+  control: last.control,
+}
+
 const draft = await call('report-draft', 'Evidence', `${COMMON}
 
-Draft (in facts, as markdown) a concise campaign result summary for run ${RUN_STAMP}: mode; gate outcomes from PREFLIGHT ${JSON.stringify({ pass: preflight.pass, violations: preflight.violations })} and CORPUS VETO ${JSON.stringify({ pass: veto.pass, violations: veto.violations })}; per-arm table from this JSON: ${JSON.stringify(last.arms)}; baselines: ${JSON.stringify(last.baselines)}. State plainly that mock mode trains nothing and that promotion authority belongs to the Codex gate. Every sentence must restate the JSON above or cite a committed artifact by path — no claims about your own process or about anything not in the JSON.`, GATE_SCHEMA)
+Draft (in facts, as markdown) a concise campaign result summary for run ${RUN_STAMP}: mode; gate outcomes and per-arm table from this verified JSON: ${JSON.stringify(gateSummary)}. State plainly that mock mode trains nothing, that every gate decision came from a digest-verified evals.needle_gates receipt, and that promotion authority belongs to the Codex gate. Every sentence must restate the JSON above or cite a committed artifact by path — no claims about your own process or about anything not in the JSON.`, DRAFT_SCHEMA)
 
 const check = await call('claim-verify', 'Evidence', `${COMMON}
 
-Adversarially verify the draft below. For EVERY numeric or factual claim, name the committed artifact (file path) that backs it and verdict CONFIRMED, or REFUTED (artifact contradicts), or NO_ARTIFACT (nothing backs it). A claim sourced only from the workflow's own JSON is CONFIRMED with artifact "workflow-state" ONLY if it matches that JSON exactly.
+Adversarially verify the draft below. For EVERY numeric or factual claim, name the committed artifact (file path) that backs it and verdict CONFIRMED, or REFUTED (artifact contradicts), or NO_ARTIFACT (nothing backs it). A claim sourced only from the workflow's own verified JSON is CONFIRMED with artifact "workflow-state" ONLY if it matches that JSON exactly. The verified JSON: ${JSON.stringify(gateSummary)}
 
 DRAFT:
 ${draft.facts}`, CLAIMCHECK_SCHEMA, 'medium')
@@ -272,6 +486,13 @@ return {
   run: RUN_STAMP,
   promotion: 'NONE — candidates + evidence only; promotion belongs to the Codex landing gate',
   iterations,
+  gate_receipts: {
+    preflight: preflight.digest,
+    corpus_veto: veto.digest,
+    arm_metrics: metricsReceipt ? metricsReceipt.digest : null,
+    harvest_request: harvest.digest,
+  },
+  next_harvest_request: harvest.payload,
   report_draft: draft.facts,
   claim_check: { unbacked, total: check.claims.length },
   ledger: LEDGER,

--- a/.claude/workflows/needle-training-campaign.js
+++ b/.claude/workflows/needle-training-campaign.js
@@ -64,11 +64,35 @@ export const meta = {
 const A = typeof args === 'string' ? JSON.parse(args) : (args || {})
 const MODE = A.mode || 'mock'
 const STOP_AFTER = A.stop_after || 'full' // preflight|veto|lanes|gate|full
-const RUN_STAMP = A.run_stamp || 'unstamped-run' // caller supplies; no Date.now in workflows
 const MAX_ITER = A.max_iterations || 1
-const CAMPAIGN_ID = A.campaign_id || 'needle-campaign'
-const SOURCE_DATASET = A.source_dataset_id || 'D0001'
-const TARGET_DATASET = A.target_dataset_id || 'D0002'
+
+// ── Strict validation of every value embedded in validator commands ─────────
+// These values are interpolated into the exact CLI commands agents run. A
+// hostile value must never smuggle shell syntax, whitespace, option injection
+// or path traversal into a command string — validate BEFORE any command is
+// built or any agent is called. Mirrors evals/needle_gates/identifiers.py.
+const SAFE_IDENTIFIER = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/
+const SAFE_PATH = /^\/?[A-Za-z0-9._][A-Za-z0-9._/-]*$/
+function safeIdentifier(name, value) {
+  if (typeof value !== 'string' || !SAFE_IDENTIFIER.test(value)) {
+    throw new Error(`${name} ${JSON.stringify(value)} rejected: must be a single [A-Za-z0-9._-] token (no shell syntax, no whitespace, no leading '-')`)
+  }
+  return value
+}
+function safePacketPath(value) {
+  if (typeof value !== 'string' || !SAFE_PATH.test(value)) {
+    throw new Error(`packet path ${JSON.stringify(value)} rejected: no shell syntax, no whitespace, no leading '-'`)
+  }
+  if (value.split('/').some(part => part === '..')) {
+    throw new Error(`packet path ${JSON.stringify(value)} rejected: '..' traversal is not allowed`)
+  }
+  return value
+}
+
+const RUN_STAMP = safeIdentifier('run_stamp', A.run_stamp || 'unstamped-run') // caller supplies; no Date.now in workflows
+const CAMPAIGN_ID = safeIdentifier('campaign_id', A.campaign_id || 'needle-campaign')
+const SOURCE_DATASET = safeIdentifier('source_dataset_id', A.source_dataset_id || 'D0001')
+const TARGET_DATASET = safeIdentifier('target_dataset_id', A.target_dataset_id || 'D0002')
 
 let manifest = null
 if (MODE === 'live') {
@@ -80,8 +104,8 @@ if (MODE === 'live') {
       'Run mode=mock to exercise the contracts.'
     )
   }
-  if (String(manifest.packet).includes('needle_lab')) {
-    throw new Error('live mode refused: research_dev quarantine data can never be a live training packet.')
+  if (String(manifest.packet).includes('needle_lab') || String(manifest.packet).includes('mock_packet')) {
+    throw new Error('live mode refused: research_dev quarantine data and committed mock fixtures can never be a live training packet.')
   }
   const pins = manifest.receipt_digest_pins
   if (!pins || !pins.preflight || !pins.corpus_veto || !pins.arm_records) {
@@ -96,12 +120,13 @@ if (MODE === 'live') {
   throw new Error(`unknown mode "${MODE}" — use mock or live`)
 }
 
-// Mock packet must be a research_dev needle_lab bundle (default: the one in
-// this checkout; override with args.packet when the bundle lives in another
-// worktree, e.g. before PR #64 lands).
-const PACKET = MODE === 'mock' ? (A.packet || 'evals/needle_lab') : manifest.packet
-if (MODE === 'mock' && !String(PACKET).includes('needle_lab')) {
-  throw new Error('mock mode refused: packet must be a research_dev needle_lab bundle.')
+// Mock packet default: the tiny committed fixture (present on main, validated
+// by tests/test_needle_gates.py). Override with args.packet to point at a
+// research_dev needle_lab bundle in another worktree — never anything else.
+const MOCK_FIXTURE_PACKET = 'evals/needle_gates/fixtures/mock_packet'
+const PACKET = safePacketPath(MODE === 'mock' ? (A.packet || MOCK_FIXTURE_PACKET) : String(manifest.packet))
+if (MODE === 'mock' && PACKET !== MOCK_FIXTURE_PACKET && !PACKET.includes('needle_lab')) {
+  throw new Error('mock mode refused: packet must be the committed mock fixture or a research_dev needle_lab bundle.')
 }
 const SEEDS = MODE === 'mock' ? [42] : (manifest.seeds || [42, 43, 44])
 const RECEIPTS_DIR = `/tmp/needle-gates-${RUN_STAMP}`
@@ -366,24 +391,30 @@ for (let iter = 1; iter <= MAX_ITER; iter++) {
     }
   }
 
-  // Build lane rows from the VERIFIED payload only (mock: replay, trained=false).
-  const metricsByLetter = {}
+  // Build lane rows from the VERIFIED payload only (mock: replay,
+  // trained=false). The validator already bound each frozen arm record to
+  // its exact results identity and dataset digest (rejecting duplicates,
+  // aliases, and unbound rows) — join here strictly by the exact arm name.
+  const metricsByArm = {}
   for (const armMetric of metricsReceipt.payload.arms) {
-    metricsByLetter[armMetric.arm_letter] = armMetric
+    metricsByArm[armMetric.arm] = armMetric
   }
   const lanes = []
   for (const record of armsPayload) {
-    const letterMatch = /(?:^|_)([A-Z])(?:_|$)/.exec(record.arm)
-    const letter = letterMatch ? letterMatch[1] : ''
-    const metric = metricsByLetter[letter]
+    const metric = metricsByArm[record.arm]
     for (const seed of SEEDS) {
       if (!metric) {
-        lanes.push({ arm: record.arm, seed, trained: false, vitals_veto: `no committed result row for ${record.arm}`, in_template: -1, dev_ood: -1, secondary_ood: -1, retention: '', wall_seconds: null })
+        lanes.push({ arm: record.arm, seed, trained: false, vitals_veto: `no bound results row for ${record.arm}`, in_template: -1, dev_ood: -1, secondary_ood: -1, retention: '', wall_seconds: null })
+        continue
+      }
+      if (metric.results_name !== record.results_name || metric.dataset_hash !== record.dataset_hash) {
+        lanes.push({ arm: record.arm, seed, trained: false, vitals_veto: `identity binding mismatch for ${record.arm}: results_name/dataset_hash do not match the frozen record`, in_template: -1, dev_ood: -1, secondary_ood: -1, retention: '', wall_seconds: null })
         continue
       }
       lanes.push({
         arm: record.arm,
         results_name: metric.results_name,
+        dataset_hash: metric.dataset_hash,
         seed,
         trained: false,
         vitals_veto: metric.vitals.vitals_veto,
@@ -403,13 +434,20 @@ for (let iter = 1; iter <= MAX_ITER; iter++) {
 
   // ── Cross-arm gate: mechanical rules computed HERE from verified payloads ──
   phase('Cross-arm gate')
-  // The control comparison uses the verified control row from the arm-metrics
-  // receipt (control dev_ood = legacy "sealed" — the adaptive OOD dev metric).
+  // Two comparisons, both required: the untrained control AND the trivial
+  // TF-IDF baseline (control dev_ood = legacy "sealed" — the adaptive OOD
+  // dev metric). A learned arm that cannot beat a trivial deterministic
+  // baseline is never promotion-grade, whatever it does to the control.
   const control = metricsReceipt.payload.control
   if (!control) {
     return { verdict: 'REFUSED_NO_CONTROL', mode: MODE, receipt_sha256: metricsReceipt.digest, ledger: LEDGER }
   }
+  const baseline = metricsReceipt.payload.baseline
+  if (!baseline) {
+    return { verdict: 'REFUSED_NO_BASELINE', mode: MODE, receipt_sha256: metricsReceipt.digest, ledger: LEDGER }
+  }
   const controlDev = control.dev_ood
+  const baselineDev = baseline.dev_ood
   const judged = armsPayload.map(record => {
     const armLanes = lanes.filter(l => l.arm === record.arm && l.in_template >= 0)
     const seedsRun = new Set(armLanes.map(l => l.seed)).size
@@ -418,27 +456,37 @@ for (let iter = 1; iter <= MAX_ITER; iter++) {
     const devScores = armLanes.map(l => l.dev_ood)
     const minDev = devScores.length ? Math.min(...devScores) : -1
     const beatsControl = minDev > controlDev
+    const beatsBaseline = minDev > baselineDev
     const multiSeedOk = seedsRun >= (MODE === 'mock' ? 1 : 3)
     return {
       arm: record.arm,
+      results_name: record.results_name,
+      dataset_hash: record.dataset_hash,
       seeds_run: seedsRun,
       vitals_ok: vitalsOk,
       retention_ok: retentionOk,
       min_dev_ood: minDev,
       beats_control: beatsControl,
+      beats_baseline: beatsBaseline,
       multi_seed_ok: multiSeedOk,
       // Promotion-candidate rule: every mechanical gate green. In mock,
       // multi-seed is structurally impossible (1 historical seed) so no arm
       // can be promotion-grade — which is exactly the audited conclusion.
-      promotion_candidate: vitalsOk && retentionOk && beatsControl && multiSeedOk && MODE === 'live',
+      promotion_candidate: vitalsOk && retentionOk && beatsControl && beatsBaseline && multiSeedOk && MODE === 'live',
     }
   })
-  iterations.push({ iter, arms: judged, control: { name: control.results_name, dev_ood: controlDev } })
+  iterations.push({
+    iter,
+    arms: judged,
+    control: { name: control.results_name, dev_ood: controlDev },
+    baseline: { name: baseline.results_name, dev_ood: baselineDev },
+  })
 
   if (STOP_AFTER === 'gate' && iter === MAX_ITER) break
-  // Iterate only when live, authorized, and something is still improving.
+  // Iterate only when live, authorized, and something is still improving
+  // against BOTH the control and the trivial baseline.
   if (MODE === 'mock' || iter === MAX_ITER) break
-  if (!judged.some(j => j.beats_control)) break
+  if (!judged.some(j => j.beats_control && j.beats_baseline)) break
 }
 
 if (STOP_AFTER === 'gate') {
@@ -466,6 +514,7 @@ const gateSummary = {
   corpus_veto: { ok: veto.payload.ok, violations: veto.payload.violations, receipt_sha256: veto.digest },
   arms: last.arms,
   control: last.control,
+  baseline: last.baseline,
 }
 
 const draft = await call('report-draft', 'Evidence', `${COMMON}

--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,9 @@ venv.bak/
 # UniGrok runtime state
 chats/
 logs/
+# Committed test fixture: mock training-log packet for needle gate validators
+!evals/needle_gates/fixtures/mock_packet/logs/
+!evals/needle_gates/fixtures/mock_packet/logs/*.log
 .unigrok-state/
 artifacts/
 .agents/data_shards/

--- a/evals/needle_gates/__init__.py
+++ b/evals/needle_gates/__init__.py
@@ -1,0 +1,29 @@
+"""Deterministic gate validators for the Needle training campaign.
+
+Mechanical gate authority lives here, in executable repository code — not in
+agent judgment. Each validator reads committed artifacts, computes typed JSON
+results with artifact digests, and seals them into a receipt whose integrity
+any consumer (including the ``.claude/workflows/needle-training-campaign.js``
+orchestrator) can re-verify byte-for-byte.
+
+Agents may *invoke* these validators and *summarize* their output; they may
+never decide gate truth. A workflow runtime that cannot execute the validators
+directly must require a precomputed receipt whose digest it recomputes and
+checks, and must fail closed on any mismatch.
+"""
+
+from evals.needle_gates.receipts import (
+    RECEIPT_SCHEMA_VERSION,
+    ReceiptError,
+    seal_receipt,
+    sha256_file,
+    verify_receipt,
+)
+
+__all__ = [
+    "RECEIPT_SCHEMA_VERSION",
+    "ReceiptError",
+    "seal_receipt",
+    "sha256_file",
+    "verify_receipt",
+]

--- a/evals/needle_gates/__main__.py
+++ b/evals/needle_gates/__main__.py
@@ -1,0 +1,117 @@
+"""CLI entry point: ``python -m evals.needle_gates <command> ...``.
+
+Agents run these commands and transcribe the emitted receipt envelope
+back to the orchestrator. The envelope's ``payload_sha256`` binds the
+typed payload byte-for-byte; the orchestrator (or any reviewer) verifies
+it independently and derives gate truth only from the verified payload.
+
+``verify`` exits non-zero on any mismatch so shell pipelines fail closed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from evals.needle_gates.harvest_request import (
+    DEFAULT_WEAK_RECALL_THRESHOLD,
+    build_next_harvest_request,
+)
+from evals.needle_gates.receipts import (
+    ReceiptError,
+    read_receipt,
+    seal_receipt,
+    verify_receipt,
+    write_receipt,
+)
+from evals.needle_gates.validators import (
+    validate_arm_metrics,
+    validate_arm_records,
+    validate_corpus,
+    validate_lane_vitals,
+    validate_preflight,
+)
+
+
+def _emit(receipt: dict, out: str | None) -> None:
+    if out:
+        write_receipt(receipt, Path(out))
+    print(json.dumps(receipt, sort_keys=True, indent=2))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="evals.needle_gates")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    for name in ("preflight", "corpus-veto", "arm-records", "arm-metrics"):
+        cmd = sub.add_parser(name)
+        cmd.add_argument("--packet", required=True)
+        cmd.add_argument("--out")
+
+    vitals = sub.add_parser("lane-vitals")
+    vitals.add_argument("--log", required=True)
+    vitals.add_argument("--arm", default="")
+    vitals.add_argument("--seed", type=int, default=0)
+    vitals.add_argument("--out")
+
+    harvest = sub.add_parser("harvest-request")
+    harvest.add_argument("--packet", required=True)
+    harvest.add_argument("--campaign", required=True)
+    harvest.add_argument("--source-dataset", required=True)
+    harvest.add_argument("--target-dataset", required=True)
+    harvest.add_argument(
+        "--recall-threshold", type=float, default=DEFAULT_WEAK_RECALL_THRESHOLD
+    )
+    harvest.add_argument("--out")
+
+    verify = sub.add_parser("verify")
+    verify.add_argument("--receipt", required=True)
+    verify.add_argument("--expect-validator")
+    verify.add_argument("--expect-digest")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "preflight":
+        payload = validate_preflight(Path(args.packet))
+        _emit(seal_receipt("preflight", payload), args.out)
+    elif args.command == "corpus-veto":
+        payload = validate_corpus(Path(args.packet))
+        _emit(seal_receipt("corpus_veto", payload), args.out)
+    elif args.command == "arm-records":
+        payload = validate_arm_records(Path(args.packet))
+        _emit(seal_receipt("arm_records", payload), args.out)
+    elif args.command == "arm-metrics":
+        payload = validate_arm_metrics(Path(args.packet))
+        _emit(seal_receipt("arm_metrics", payload), args.out)
+    elif args.command == "lane-vitals":
+        payload = validate_lane_vitals(Path(args.log), arm=args.arm, seed=args.seed)
+        _emit(seal_receipt("lane_vitals", payload), args.out)
+    elif args.command == "harvest-request":
+        payload = build_next_harvest_request(
+            Path(args.packet),
+            campaign_id=args.campaign,
+            source_dataset_id=args.source_dataset,
+            target_dataset_id=args.target_dataset,
+            weak_recall_threshold=args.recall_threshold,
+        )
+        _emit(seal_receipt("harvest_request", payload), args.out)
+    elif args.command == "verify":
+        try:
+            receipt = read_receipt(Path(args.receipt), args.expect_validator)
+            if args.expect_digest and receipt["payload_sha256"] != args.expect_digest:
+                raise ReceiptError(
+                    f"receipt digest {receipt['payload_sha256']} != "
+                    f"pinned {args.expect_digest}"
+                )
+            verify_receipt(receipt, args.expect_validator)
+        except ReceiptError as exc:
+            print(f"RECEIPT VERIFICATION FAILED: {exc}", file=sys.stderr)
+            return 1
+        print("receipt verified")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/evals/needle_gates/__main__.py
+++ b/evals/needle_gates/__main__.py
@@ -19,6 +19,11 @@ from evals.needle_gates.harvest_request import (
     DEFAULT_WEAK_RECALL_THRESHOLD,
     build_next_harvest_request,
 )
+from evals.needle_gates.identifiers import (
+    IdentifierError,
+    validate_identifier,
+    validate_packet_path,
+)
 from evals.needle_gates.receipts import (
     ReceiptError,
     read_receipt,
@@ -41,30 +46,46 @@ def _emit(receipt: dict, out: str | None) -> None:
     print(json.dumps(receipt, sort_keys=True, indent=2))
 
 
+def _packet_arg(value: str) -> str:
+    """argparse type: reject unsafe packet paths before anything runs."""
+    try:
+        return validate_packet_path(value)
+    except IdentifierError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
+def _identifier_arg(value: str) -> str:
+    """argparse type: reject unsafe campaign/dataset identifiers."""
+    try:
+        return validate_identifier("identifier", value)
+    except IdentifierError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="evals.needle_gates")
     sub = parser.add_subparsers(dest="command", required=True)
 
     for name in ("preflight", "corpus-veto", "arm-records", "arm-metrics"):
         cmd = sub.add_parser(name)
-        cmd.add_argument("--packet", required=True)
-        cmd.add_argument("--out")
+        cmd.add_argument("--packet", required=True, type=_packet_arg)
+        cmd.add_argument("--out", type=_packet_arg)
 
     vitals = sub.add_parser("lane-vitals")
-    vitals.add_argument("--log", required=True)
+    vitals.add_argument("--log", required=True, type=_packet_arg)
     vitals.add_argument("--arm", default="")
     vitals.add_argument("--seed", type=int, default=0)
-    vitals.add_argument("--out")
+    vitals.add_argument("--out", type=_packet_arg)
 
     harvest = sub.add_parser("harvest-request")
-    harvest.add_argument("--packet", required=True)
-    harvest.add_argument("--campaign", required=True)
-    harvest.add_argument("--source-dataset", required=True)
-    harvest.add_argument("--target-dataset", required=True)
+    harvest.add_argument("--packet", required=True, type=_packet_arg)
+    harvest.add_argument("--campaign", required=True, type=_identifier_arg)
+    harvest.add_argument("--source-dataset", required=True, type=_identifier_arg)
+    harvest.add_argument("--target-dataset", required=True, type=_identifier_arg)
     harvest.add_argument(
         "--recall-threshold", type=float, default=DEFAULT_WEAK_RECALL_THRESHOLD
     )
-    harvest.add_argument("--out")
+    harvest.add_argument("--out", type=_packet_arg)
 
     verify = sub.add_parser("verify")
     verify.add_argument("--receipt", required=True)

--- a/evals/needle_gates/fixtures/mock_packet/README.md
+++ b/evals/needle_gates/fixtures/mock_packet/README.md
@@ -1,0 +1,10 @@
+# Mock Needle packet (committed test fixture)
+
+Tiny synthetic packet so `needle-training-campaign.js` mock mode and the
+gate-validator tests run from `main` without any external bundle. All
+rows are fabricated; nothing here is or derives from sealed evaluation
+data, and this packet must never be used as a live training packet.
+
+Split policy: _per_tool_split seed 42 (pinned before corpus assembly).
+Base checkpoint sha256 prefix: 40a32e91d1d4197b
+Env: python 3.11, jax 0.4, flax 0.8

--- a/evals/needle_gates/fixtures/mock_packet/data/arm_candidates.json
+++ b/evals/needle_gates/fixtures/mock_packet/data/arm_candidates.json
@@ -1,0 +1,20 @@
+[
+ {
+  "arm": "arm_B",
+  "results_name": "B_hardneg",
+  "dataset_hash": "bbbbbbbbbbbbbbbbbbbbbbbb",
+  "log": "ft-arm-B_hardneg-seed42.log",
+  "n": 128,
+  "recipe": "hard_negatives",
+  "seed": 42
+ },
+ {
+  "arm": "arm_E",
+  "results_name": "E_worstcell",
+  "dataset_hash": "eeeeeeeeeeeeeeeeeeeeeeee",
+  "log": "ft-arm-E_worstcell-seed42.log",
+  "n": 128,
+  "recipe": "worst_cell",
+  "seed": 42
+ }
+]

--- a/evals/needle_gates/fixtures/mock_packet/data/arm_results.json
+++ b/evals/needle_gates/fixtures/mock_packet/data/arm_results.json
@@ -1,0 +1,72 @@
+[
+ {
+  "arm": "A_control",
+  "sealed": 0.4,
+  "dev_ood": 0.55,
+  "in_template": 0.9,
+  "forgetting": "3/3",
+  "sealed_recalls": {
+   "coding": 0.5,
+   "planning": 0.25,
+   "research": 0.5,
+   "vision": 0.25
+  },
+  "worst_class": [
+   "planning",
+   0.25
+  ]
+ },
+ {
+  "arm": "tfidf_baseline",
+  "sealed": 0.5,
+  "dev_ood": 0.5,
+  "in_template": 0.6,
+  "forgetting": "3/3",
+  "sealed_recalls": {
+   "coding": 0.5,
+   "planning": 0.5,
+   "research": 0.5,
+   "vision": 0.5
+  },
+  "worst_class": [
+   "coding",
+   0.5
+  ]
+ },
+ {
+  "arm": "B_hardneg",
+  "dataset_hash": "bbbbbbbbbbbbbbbbbbbbbbbb",
+  "sealed": 0.45,
+  "dev_ood": 0.6,
+  "in_template": 0.92,
+  "forgetting": "3/3",
+  "sealed_recalls": {
+   "coding": 0.75,
+   "planning": 0.25,
+   "research": 0.5,
+   "vision": 0.25
+  },
+  "worst_class": [
+   "planning",
+   0.25
+  ]
+ },
+ {
+  "arm": "E_worstcell",
+  "dataset_hash": "eeeeeeeeeeeeeeeeeeeeeeee",
+  "sealed": 0.525,
+  "dev_ood": 0.6,
+  "in_template": 0.93,
+  "forgetting": "3/3",
+  "sealed_recalls": {
+   "coding": 0.75,
+   "planning": 0.5,
+   "research": 0.5,
+   "vision": 0.35
+  },
+  "worst_class": [
+   "vision",
+   0.35
+  ]
+ }
+]

--- a/evals/needle_gates/fixtures/mock_packet/data/harvest_roots.json
+++ b/evals/needle_gates/fixtures/mock_packet/data/harvest_roots.json
@@ -1,0 +1,19 @@
+{
+ "planning": [
+  "root-mock-planning-0001",
+  "root-mock-planning-0002"
+ ],
+ "vision": [
+  "root-mock-vision-0001"
+ ],
+ "coding": [
+  "root-mock-coding-0001"
+ ],
+ "research": [
+  "root-mock-research-0001"
+ ],
+ "retention_probe": [
+  "root-mock-coding-0001",
+  "root-mock-research-0001"
+ ]
+}

--- a/evals/needle_gates/fixtures/mock_packet/data/manifest.json
+++ b/evals/needle_gates/fixtures/mock_packet/data/manifest.json
@@ -1,0 +1,32 @@
+[
+ {
+  "path": "evals/needle_gates/fixtures/mock_packet/data/arm_candidates.json",
+  "sha256": "1ac63fcf19a20876ad91b17e2ca6eee1b55c62b351ab24c0c34838a0086782dc",
+  "n": 2,
+  "generator": "committed mock fixture (synthetic, deterministic)"
+ },
+ {
+  "path": "evals/needle_gates/fixtures/mock_packet/data/arm_results.json",
+  "sha256": "d43ccb1fbb315a72849281dd9efd177c03dac2a1f9d06fa998d8585dde1c8b62",
+  "n": 2,
+  "generator": "committed mock fixture (synthetic, deterministic)"
+ },
+ {
+  "path": "evals/needle_gates/fixtures/mock_packet/data/harvest_roots.json",
+  "sha256": "a0bbaf403aa60c3b766de344ba1d6775277e85c2084ad0508c4cf52b4a9f5fd5",
+  "n": 2,
+  "generator": "committed mock fixture (synthetic, deterministic)"
+ },
+ {
+  "path": "evals/needle_gates/fixtures/mock_packet/data/route_selection.jsonl",
+  "sha256": "876f9ff10885d86ac4dfa3f97519c09ae7621db96a3191c80de99b01891c6105",
+  "n": 2,
+  "generator": "committed mock fixture (synthetic, deterministic)"
+ },
+ {
+  "path": "evals/needle_gates/fixtures/mock_packet/data/route_selection_sealed.jsonl",
+  "sha256": "36b3ceaeb3c4f22e95d7c72b453bf5265b5c2f1c593520a867c61c1300e2b2eb",
+  "n": 2,
+  "generator": "committed mock fixture (synthetic, deterministic)"
+ }
+]

--- a/evals/needle_gates/fixtures/mock_packet/data/route_selection.jsonl
+++ b/evals/needle_gates/fixtures/mock_packet/data/route_selection.jsonl
@@ -1,0 +1,2 @@
+{"query": "mock train: draft a unit test for the parser", "tools": "[{\"name\": \"t1\"}]", "answers": "[{\"route\": \"coding\"}]"}
+{"query": "mock train: summarize three papers on retrieval", "tools": "[{\"name\": \"t1\"}]", "answers": "[{\"route\": \"research\"}]"}

--- a/evals/needle_gates/fixtures/mock_packet/data/route_selection_sealed.jsonl
+++ b/evals/needle_gates/fixtures/mock_packet/data/route_selection_sealed.jsonl
@@ -1,0 +1,2 @@
+{"query": "mock dev-ood: plan a three-step migration", "tools": "[{\"name\": \"t1\"}]", "answers": "[{\"route\": \"planning\"}]"}
+{"query": "mock dev-ood: describe the chart contents", "tools": "[{\"name\": \"t1\"}]", "answers": "[{\"route\": \"vision\"}]"}

--- a/evals/needle_gates/fixtures/mock_packet/logs/ft-arm-B_hardneg-seed42.log
+++ b/evals/needle_gates/fixtures/mock_packet/logs/ft-arm-B_hardneg-seed42.log
@@ -1,0 +1,6 @@
+run start
+step 10 loss 2.31
+step 640 loss 0.42
+total steps: 640
+wall_seconds: 512.5
+training complete, best checkpoint saved

--- a/evals/needle_gates/fixtures/mock_packet/logs/ft-arm-E_worstcell-seed42.log
+++ b/evals/needle_gates/fixtures/mock_packet/logs/ft-arm-E_worstcell-seed42.log
@@ -1,0 +1,6 @@
+run start
+step 10 loss 2.31
+step 512 loss 0.42
+total steps: 512
+wall_seconds: 512.5
+training complete, best checkpoint saved

--- a/evals/needle_gates/harvest_request.py
+++ b/evals/needle_gates/harvest_request.py
@@ -1,0 +1,81 @@
+"""Typed ``next_harvest_request`` builder — a request, never a trigger.
+
+Evaluation (E000n) produces this document to *describe* what the next
+harvesting generation (H000n+1) should target: confusion cells that stayed
+weak, cells that must be retained, and the exact digests of the evidence
+that justified each entry. Emitting it starts nothing: it authorizes no
+generation, no provider call, and no training. A separate Codex-approved
+harvesting manifest is required before any harvester may act on it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from evals.needle_gates.validators import validate_arm_metrics
+
+HARVEST_REQUEST_SCHEMA = "needle-next-harvest-request/v1"
+DEFAULT_WEAK_RECALL_THRESHOLD = 0.5
+
+
+def build_next_harvest_request(
+    packet_root: Path,
+    *,
+    campaign_id: str,
+    source_dataset_id: str,
+    target_dataset_id: str,
+    weak_recall_threshold: float = DEFAULT_WEAK_RECALL_THRESHOLD,
+    arm_metrics_payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Derive the typed harvest request from verified arm metrics.
+
+    ``arm_metrics_payload`` may be supplied when the caller already holds a
+    verified arm-metrics payload; otherwise the metrics validator runs here.
+    The result is deterministic for identical inputs.
+    """
+    if source_dataset_id == target_dataset_id:
+        raise ValueError(
+            "target dataset must differ from source dataset "
+            "(harvesting never modifies the dataset being trained)"
+        )
+    metrics = arm_metrics_payload or validate_arm_metrics(Path(packet_root))
+
+    weak_cells: list[dict[str, Any]] = []
+    retention_cells: list[dict[str, Any]] = []
+    for arm in metrics.get("arms", []):
+        name = str(arm.get("results_name", ""))
+        for cell, recall in sorted((arm.get("class_recalls") or {}).items()):
+            recall = float(recall)
+            entry = {
+                "arm": name,
+                "cell": cell,
+                "recall": recall,
+            }
+            if recall < weak_recall_threshold:
+                weak_cells.append(entry)
+            else:
+                retention_cells.append(entry)
+        retention = str(arm.get("retention", ""))
+        if retention:
+            retention_cells.append(
+                {"arm": name, "cell": "retention_probe", "status": retention}
+            )
+
+    weak_cells.sort(key=lambda c: (c["cell"], c["arm"]))
+    retention_cells.sort(key=lambda c: (c["cell"], c["arm"]))
+
+    return {
+        "schema": HARVEST_REQUEST_SCHEMA,
+        "campaign_id": campaign_id,
+        "source_dataset_id": source_dataset_id,
+        "target_dataset_id": target_dataset_id,
+        "weak_recall_threshold": weak_recall_threshold,
+        "weak_confusion_cells": weak_cells,
+        "retention_cells": retention_cells,
+        "evidence_digests": dict(sorted(metrics.get("artifact_digests", {}).items())),
+        "request_only": True,
+        "authorizes_generation": False,
+        "authorizes_training": False,
+        "requires": "Codex-approved harvesting manifest before any generation",
+    }

--- a/evals/needle_gates/harvest_request.py
+++ b/evals/needle_gates/harvest_request.py
@@ -10,13 +10,38 @@ harvesting manifest is required before any harvester may act on it.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
+from evals.needle_gates.receipts import sha256_file
 from evals.needle_gates.validators import validate_arm_metrics
 
 HARVEST_REQUEST_SCHEMA = "needle-next-harvest-request/v1"
 DEFAULT_WEAK_RECALL_THRESHOLD = 0.5
+
+
+def _load_cell_roots(packet_root: Path) -> tuple[dict[str, list[str]], dict[str, str]]:
+    """Committed cell -> originating semantic root IDs map (never sealed text).
+
+    ``data/harvest_roots.json`` binds each confusion cell to the exact root
+    IDs whose evaluations produced it, so a downstream harvester can generate
+    variants of the *failing* root (and controlled variants of retained
+    roots) instead of guessing. Root IDs are opaque identifiers; no sealed
+    evaluation content is exposed.
+    """
+    roots_path = Path(packet_root) / "data" / "harvest_roots.json"
+    if not roots_path.is_file():
+        return {}, {}
+    raw = json.loads(roots_path.read_text())
+    if not isinstance(raw, dict):
+        raise ValueError("harvest_roots.json must map cell -> [root_id, ...]")
+    mapping = {
+        str(cell): sorted(str(r) for r in roots)
+        for cell, roots in raw.items()
+        if isinstance(roots, list)
+    }
+    return mapping, {str(roots_path): sha256_file(roots_path)}
 
 
 def build_next_harvest_request(
@@ -40,6 +65,7 @@ def build_next_harvest_request(
             "(harvesting never modifies the dataset being trained)"
         )
     metrics = arm_metrics_payload or validate_arm_metrics(Path(packet_root))
+    cell_roots, roots_digests = _load_cell_roots(packet_root)
 
     weak_cells: list[dict[str, Any]] = []
     retention_cells: list[dict[str, Any]] = []
@@ -51,6 +77,7 @@ def build_next_harvest_request(
                 "arm": name,
                 "cell": cell,
                 "recall": recall,
+                "root_ids": cell_roots.get(cell, []),
             }
             if recall < weak_recall_threshold:
                 weak_cells.append(entry)
@@ -59,11 +86,19 @@ def build_next_harvest_request(
         retention = str(arm.get("retention", ""))
         if retention:
             retention_cells.append(
-                {"arm": name, "cell": "retention_probe", "status": retention}
+                {
+                    "arm": name,
+                    "cell": "retention_probe",
+                    "status": retention,
+                    "root_ids": cell_roots.get("retention_probe", []),
+                }
             )
 
     weak_cells.sort(key=lambda c: (c["cell"], c["arm"]))
     retention_cells.sort(key=lambda c: (c["cell"], c["arm"]))
+
+    evidence_digests = dict(metrics.get("artifact_digests", {}))
+    evidence_digests.update(roots_digests)
 
     return {
         "schema": HARVEST_REQUEST_SCHEMA,
@@ -73,7 +108,7 @@ def build_next_harvest_request(
         "weak_recall_threshold": weak_recall_threshold,
         "weak_confusion_cells": weak_cells,
         "retention_cells": retention_cells,
-        "evidence_digests": dict(sorted(metrics.get("artifact_digests", {}).items())),
+        "evidence_digests": dict(sorted(evidence_digests.items())),
         "request_only": True,
         "authorizes_generation": False,
         "authorizes_training": False,

--- a/evals/needle_gates/identifiers.py
+++ b/evals/needle_gates/identifiers.py
@@ -1,0 +1,50 @@
+"""Strict identifier validation for values embedded in validator commands.
+
+The campaign workflow interpolates caller-supplied values (run stamp,
+campaign ID, dataset IDs, packet path) into the exact CLI commands agents
+are told to run. Every such value must match a strict allowlist *before*
+any command string is built, in the workflow runtime and again here at the
+CLI boundary, so a hostile value can never smuggle shell syntax, path
+traversal, or option injection into a validator invocation.
+"""
+
+from __future__ import annotations
+
+import re
+
+# run_stamp, campaign IDs, dataset IDs: single token, no shell metacharacters,
+# no whitespace, no leading '-' (option injection), bounded length.
+SAFE_IDENTIFIER = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+
+# Packet paths: POSIX-style relative or absolute paths from a fixed charset.
+# No whitespace, no shell metacharacters, no leading '-'.
+SAFE_PATH = re.compile(r"^/?[A-Za-z0-9._][A-Za-z0-9._/-]*$")
+
+
+class IdentifierError(ValueError):
+    """A caller-supplied identifier failed strict validation."""
+
+
+def validate_identifier(name: str, value: str) -> str:
+    """Return ``value`` when it is a safe single token; raise otherwise."""
+    if not isinstance(value, str) or not SAFE_IDENTIFIER.match(value):
+        raise IdentifierError(
+            f"{name} {value!r} rejected: must match {SAFE_IDENTIFIER.pattern} "
+            "(single token, no shell syntax, no whitespace, no leading '-')"
+        )
+    return value
+
+
+def validate_packet_path(value: str) -> str:
+    """Return ``value`` when it is a safe packet path; raise otherwise."""
+    if not isinstance(value, str) or not SAFE_PATH.match(value):
+        raise IdentifierError(
+            f"packet path {value!r} rejected: must match {SAFE_PATH.pattern} "
+            "(no shell syntax, no whitespace, no leading '-')"
+        )
+    parts = [p for p in value.split("/") if p]
+    if ".." in parts:
+        raise IdentifierError(
+            f"packet path {value!r} rejected: '..' traversal is not allowed"
+        )
+    return value

--- a/evals/needle_gates/receipts.py
+++ b/evals/needle_gates/receipts.py
@@ -1,0 +1,137 @@
+"""Digest-sealed receipt envelope for Needle gate validators.
+
+A receipt is the only unit of gate truth exchanged between the deterministic
+validators (Python, this package) and any orchestrator (for example the
+``.claude/workflows/needle-training-campaign.js`` workflow). The envelope is
+deliberately transport-hostile to tampering:
+
+- The typed payload is serialized to canonical JSON (sorted keys, compact
+  separators, ``ensure_ascii=True``) and stored as base64 of those exact
+  bytes in ``payload_b64``.
+- ``payload_sha256`` is the SHA-256 of those exact bytes. A consumer never
+  needs to re-canonicalize JSON (or agree on float formatting) to verify:
+  it base64-decodes, hashes, and compares.
+- A consumer that cannot run Python still verifies with nothing more than
+  base64 + SHA-256, both available in any workflow runtime.
+
+Any mismatch — wrong schema, wrong digest, undecodable payload — raises
+``ReceiptError``. Consumers must treat a raised error as gate failure
+(fail closed), never as an invitation to fall back to agent prose.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+RECEIPT_SCHEMA_VERSION = "needle-gate-receipt/v1"
+
+_ALLOWED_VALIDATORS = (
+    "preflight",
+    "corpus_veto",
+    "lane_vitals",
+    "arm_records",
+    "arm_metrics",
+    "harvest_request",
+)
+
+
+class ReceiptError(ValueError):
+    """A receipt failed structural or cryptographic verification."""
+
+
+def canonical_json_bytes(payload: dict[str, Any]) -> bytes:
+    """Serialize ``payload`` to the canonical byte form that gets digested."""
+    return json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("ascii")
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    """Stream a file's SHA-256 (files may be multi-megabyte JSONL shards)."""
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def seal_receipt(validator: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """Wrap a typed validator payload in the digest-sealed envelope."""
+    if validator not in _ALLOWED_VALIDATORS:
+        raise ReceiptError(f"unknown validator {validator!r}")
+    payload_bytes = canonical_json_bytes(payload)
+    return {
+        "schema": RECEIPT_SCHEMA_VERSION,
+        "validator": validator,
+        "payload_b64": base64.b64encode(payload_bytes).decode("ascii"),
+        "payload_sha256": sha256_bytes(payload_bytes),
+    }
+
+
+def verify_receipt(
+    receipt: dict[str, Any], expected_validator: str | None = None
+) -> dict[str, Any]:
+    """Verify an envelope and return the decoded payload.
+
+    Raises ``ReceiptError`` on any structural or digest mismatch. Callers
+    must fail closed on that error.
+    """
+    if not isinstance(receipt, dict):
+        raise ReceiptError("receipt is not an object")
+    if receipt.get("schema") != RECEIPT_SCHEMA_VERSION:
+        raise ReceiptError(
+            f"receipt schema {receipt.get('schema')!r} != {RECEIPT_SCHEMA_VERSION!r}"
+        )
+    validator = receipt.get("validator")
+    if validator not in _ALLOWED_VALIDATORS:
+        raise ReceiptError(f"unknown validator {validator!r}")
+    if expected_validator is not None and validator != expected_validator:
+        raise ReceiptError(
+            f"receipt validator {validator!r} != expected {expected_validator!r}"
+        )
+    payload_b64 = receipt.get("payload_b64")
+    payload_sha256 = receipt.get("payload_sha256")
+    if not isinstance(payload_b64, str) or not isinstance(payload_sha256, str):
+        raise ReceiptError("receipt missing payload_b64/payload_sha256 strings")
+    try:
+        payload_bytes = base64.b64decode(payload_b64.encode("ascii"), validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ReceiptError(f"payload_b64 is not valid base64: {exc}") from exc
+    actual = sha256_bytes(payload_bytes)
+    if actual != payload_sha256:
+        raise ReceiptError(
+            f"payload digest mismatch: computed {actual}, declared {payload_sha256}"
+        )
+    try:
+        payload = json.loads(payload_bytes.decode("ascii"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ReceiptError(f"payload is not canonical ASCII JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ReceiptError("payload is not an object")
+    return payload
+
+
+def write_receipt(receipt: dict[str, Any], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(receipt, sort_keys=True, indent=2) + "\n")
+
+
+def read_receipt(path: Path, expected_validator: str | None = None) -> dict[str, Any]:
+    """Load a receipt file and verify it before returning the payload."""
+    try:
+        raw = json.loads(path.read_text())
+    except FileNotFoundError as exc:
+        raise ReceiptError(f"receipt file missing: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ReceiptError(f"receipt file is not JSON: {path}: {exc}") from exc
+    verify_receipt(raw, expected_validator)
+    return raw

--- a/evals/needle_gates/validators.py
+++ b/evals/needle_gates/validators.py
@@ -1,0 +1,524 @@
+"""Deterministic Needle gate validators.
+
+Every function here is mechanical: it reads committed artifacts, applies
+fixed rules, and returns a typed JSON payload that includes the SHA-256 of
+every input it consumed. No model output, agent prose, or wall-clock state
+enters a payload — identical inputs always produce identical payloads, so
+receipts are reproducible and pinnable by digest.
+
+Gate truth is the typed ``ok``/``violations`` fields computed below.
+Agents may run these validators and quote their receipts; they may not
+decide the values.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+from evals.needle_gates.receipts import seal_receipt, sha256_file
+
+PREFLIGHT_SCHEMA = "needle-preflight/v1"
+CORPUS_VETO_SCHEMA = "needle-corpus-veto/v1"
+LANE_VITALS_SCHEMA = "needle-lane-vitals/v1"
+ARM_RECORDS_SCHEMA = "needle-arm-records/v1"
+ARM_METRICS_SCHEMA = "needle-arm-metrics/v1"
+
+# Default pins mirror the audited PR #64 research packet. Live packets
+# override these through their Codex-approved manifest, never through prose.
+DEFAULT_CHECKPOINT_PREFIX = "40a32e91d1d4197b"
+DEFAULT_SPLIT_POLICY_PATTERNS = (r"_per_tool_split", r"seed\s*42")
+DEFAULT_ENV_PIN_PATTERNS = (
+    r"(?i)python\s*[=:]?\s*\d+\.\d+",
+    r"(?i)jax\s*[=:]?\s*\d+",
+    r"(?i)flax\s*[=:]?\s*\d+",
+)
+
+# Committed packet metadata (never agent prose) marks a violation as "known".
+_KNOWN_MARKERS = ("voided", "quarantine", "research control", "known-contaminated")
+
+_SECRET_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("aws-access-key", re.compile(r"AKIA[0-9A-Z]{16}")),
+    ("github-token", re.compile(r"gh[pousr]_[A-Za-z0-9]{20,}")),
+    ("xai-key", re.compile(r"xai-[A-Za-z0-9]{20,}")),
+    ("openai-key", re.compile(r"sk-[A-Za-z0-9]{20,}")),
+    ("google-api-key", re.compile(r"AIza[0-9A-Za-z_-]{35}")),
+    ("private-key-block", re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----")),
+)
+
+_EVAL_FILE_MARKERS = ("_sealed", "_ood")
+
+_CLASS_KEYS = ("route", "class", "label", "category")
+
+
+def _packet_manifest_path(packet_root: Path) -> Path | None:
+    for candidate in (packet_root / "data" / "manifest.json", packet_root / "manifest.json"):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _load_manifest(manifest_path: Path) -> list[dict[str, Any]]:
+    raw = json.loads(manifest_path.read_text())
+    if not isinstance(raw, list):
+        raise ValueError("packet manifest must be a JSON array of file entries")
+    entries = []
+    for entry in raw:
+        if not isinstance(entry, dict) or "path" not in entry or "sha256" not in entry:
+            raise ValueError("manifest entry missing path/sha256")
+        entries.append(entry)
+    return entries
+
+
+def _resolve_entry_file(packet_root: Path, entry_path: str) -> Path:
+    """Manifest paths are repo-relative; resolve by basename inside the packet."""
+    name = Path(entry_path).name
+    for candidate in (packet_root / "data" / name, packet_root / name):
+        if candidate.is_file():
+            return candidate
+    return packet_root / "data" / name
+
+
+def _entry_is_known_quarantined(entry: dict[str, Any]) -> bool:
+    text = " ".join(
+        str(entry.get(key, "")) for key in ("generator", "note", "status")
+    ).lower()
+    return any(marker in text for marker in _KNOWN_MARKERS)
+
+
+def validate_preflight(
+    packet_root: Path,
+    *,
+    expected_checkpoint_prefix: str = DEFAULT_CHECKPOINT_PREFIX,
+    split_policy_patterns: tuple[str, ...] = DEFAULT_SPLIT_POLICY_PATTERNS,
+    env_pin_patterns: tuple[str, ...] = DEFAULT_ENV_PIN_PATTERNS,
+) -> dict[str, Any]:
+    """Packet integrity: manifest digests, split policy, checkpoint & env pins."""
+    violations: list[str] = []
+    facts: dict[str, Any] = {}
+    artifact_digests: dict[str, str] = {}
+
+    packet_root = Path(packet_root)
+    manifest_path = _packet_manifest_path(packet_root)
+    if manifest_path is None:
+        violations.append("packet manifest missing (data/manifest.json)")
+        entries: list[dict[str, Any]] = []
+    else:
+        artifact_digests[str(manifest_path)] = sha256_file(manifest_path)
+        try:
+            entries = _load_manifest(manifest_path)
+        except (ValueError, json.JSONDecodeError) as exc:
+            violations.append(f"packet manifest unreadable: {exc}")
+            entries = []
+
+    listed_names: set[str] = set()
+    for entry in sorted(entries, key=lambda e: str(e["path"])):
+        file_path = _resolve_entry_file(packet_root, str(entry["path"]))
+        listed_names.add(file_path.name)
+        if not file_path.is_file():
+            violations.append(f"manifest file missing on disk: {entry['path']}")
+            continue
+        actual = sha256_file(file_path)
+        artifact_digests[str(file_path)] = actual
+        if actual != entry["sha256"]:
+            violations.append(
+                f"sha256 mismatch for {entry['path']}: "
+                f"manifest {entry['sha256']}, disk {actual}"
+            )
+
+    data_dir = packet_root / "data"
+    if data_dir.is_dir():
+        for file_path in sorted(data_dir.iterdir()):
+            if file_path.name == "manifest.json" or not file_path.is_file():
+                continue
+            if file_path.suffix in (".jsonl", ".json") and file_path.name not in listed_names:
+                violations.append(f"unlisted data file: data/{file_path.name}")
+
+    readme_path = packet_root / "README.md"
+    readme_text = readme_path.read_text() if readme_path.is_file() else ""
+    if readme_path.is_file():
+        artifact_digests[str(readme_path)] = sha256_file(readme_path)
+
+    missing_split = [p for p in split_policy_patterns if not re.search(p, readme_text)]
+    if missing_split:
+        violations.append(
+            "split policy not pinned before corpus assembly "
+            f"(missing patterns: {', '.join(missing_split)})"
+        )
+    if expected_checkpoint_prefix and expected_checkpoint_prefix not in readme_text:
+        violations.append(
+            f"base checkpoint pin {expected_checkpoint_prefix} not recorded in README"
+        )
+    env_pins_found = [p for p in env_pin_patterns if re.search(p, readme_text)]
+    facts["env_pins_found"] = len(env_pins_found)
+    if not env_pins_found:
+        violations.append("environment pins unrecorded (python/jax/flax)")
+
+    return {
+        "schema": PREFLIGHT_SCHEMA,
+        "packet": str(packet_root),
+        "ok": not violations,
+        "violations": violations,
+        "facts": facts,
+        "artifact_digests": artifact_digests,
+    }
+
+
+def _read_jsonl_rows(path: Path) -> list[dict[str, Any]]:
+    rows = []
+    with open(path, encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            row = json.loads(line)
+            if isinstance(row, dict):
+                rows.append(row)
+    return rows
+
+
+def _row_identity(row: dict[str, Any]) -> tuple[str, str]:
+    return (str(row.get("query", "")), str(row.get("answers", "")))
+
+
+def _row_class(row: dict[str, Any]) -> str:
+    answers = row.get("answers", "")
+    if isinstance(answers, str):
+        try:
+            answers = json.loads(answers)
+        except json.JSONDecodeError:
+            return ""
+    candidates = answers if isinstance(answers, list) else [answers]
+    for item in candidates:
+        if isinstance(item, dict):
+            for key in _CLASS_KEYS:
+                value = item.get(key)
+                if isinstance(value, str):
+                    return value
+    return ""
+
+
+def validate_corpus(packet_root: Path) -> dict[str, Any]:
+    """Hard corpus gates: leakage, exact duplicates, balance facts, secrets.
+
+    A violation carries the ``(known, quarantined)`` marker only when the
+    committed packet manifest itself declares the file voided/quarantined —
+    that marker never comes from agent prose.
+    """
+    violations: list[str] = []
+    facts: dict[str, Any] = {"duplicates": {}, "class_balance": {}, "leakage": {}}
+    artifact_digests: dict[str, str] = {}
+
+    packet_root = Path(packet_root)
+    data_dir = packet_root / "data"
+    manifest_path = _packet_manifest_path(packet_root)
+    entries_by_name: dict[str, dict[str, Any]] = {}
+    if manifest_path is not None:
+        artifact_digests[str(manifest_path)] = sha256_file(manifest_path)
+        try:
+            for entry in _load_manifest(manifest_path):
+                entries_by_name[Path(str(entry["path"])).name] = entry
+        except (ValueError, json.JSONDecodeError):
+            violations.append("packet manifest unreadable during corpus veto")
+
+    jsonl_files = sorted(data_dir.glob("*.jsonl")) if data_dir.is_dir() else []
+    if not jsonl_files:
+        violations.append("no corpus JSONL files found under data/")
+
+    eval_rows: dict[tuple[str, str], str] = {}
+    train_files: list[tuple[Path, list[dict[str, Any]]]] = []
+
+    for file_path in jsonl_files:
+        artifact_digests[str(file_path)] = sha256_file(file_path)
+        try:
+            rows = _read_jsonl_rows(file_path)
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            violations.append(f"unparseable corpus file data/{file_path.name}: {exc}")
+            continue
+
+        seen: set[tuple[str, str]] = set()
+        dups = 0
+        for row in rows:
+            identity = _row_identity(row)
+            if identity in seen:
+                dups += 1
+            seen.add(identity)
+        facts["duplicates"][file_path.name] = dups
+        if dups:
+            entry = entries_by_name.get(file_path.name, {})
+            marker = " (known, quarantined)" if _entry_is_known_quarantined(entry) else ""
+            violations.append(
+                f"{dups} exact duplicates in data/{file_path.name}{marker}"
+            )
+
+        balance: dict[str, int] = {}
+        for row in rows:
+            label = _row_class(row)
+            if label:
+                balance[label] = balance.get(label, 0) + 1
+        facts["class_balance"][file_path.name] = dict(sorted(balance.items()))
+
+        if any(marker in file_path.name for marker in _EVAL_FILE_MARKERS):
+            for row in rows:
+                eval_rows.setdefault(_row_identity(row), file_path.name)
+        else:
+            train_files.append((file_path, rows))
+
+    for file_path, rows in train_files:
+        leaked = sum(1 for row in rows if _row_identity(row) in eval_rows)
+        facts["leakage"][file_path.name] = leaked
+        if leaked:
+            entry = entries_by_name.get(file_path.name, {})
+            marker = (
+                " (known research control — excluded from any training corpus)"
+                if _entry_is_known_quarantined(entry)
+                else ""
+            )
+            violations.append(
+                f"{leaked} eval rows leaked into data/{file_path.name}{marker}"
+            )
+
+    for file_path in jsonl_files:
+        try:
+            text = file_path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            violations.append(f"unreadable during secret scan: data/{file_path.name}: {exc}")
+            continue
+        for name, pattern in _SECRET_PATTERNS:
+            if pattern.search(text):
+                violations.append(
+                    f"secret pattern {name} found in data/{file_path.name}"
+                )
+
+    new_violations = [v for v in violations if "(known" not in v]
+    return {
+        "schema": CORPUS_VETO_SCHEMA,
+        "packet": str(packet_root),
+        "ok": not new_violations,
+        "violations": violations,
+        "new_violations": new_violations,
+        "facts": facts,
+        "artifact_digests": artifact_digests,
+    }
+
+
+_STEPS_PATTERNS = (
+    re.compile(r"(?i)total[ _]steps[:=]?\s*(\d+)"),
+    re.compile(r"(?i)\bstep[:= ]\s*(\d+)"),
+)
+_COMPLETED_PATTERN = re.compile(
+    r"(?i)(training complete|run complete|completed|best checkpoint saved|finished)"
+)
+_NAN_PATTERN = re.compile(r"(?i)(?<![a-z])nan(?![a-z])")
+_WALL_PATTERN = re.compile(r"(?i)wall[ _-]?(?:time|seconds)[:=]?\s*([0-9.]+)")
+
+
+def validate_lane_vitals(log_path: Path, *, arm: str = "", seed: int = 0) -> dict[str, Any]:
+    """F7-class vitals from a training log: steps > 0, completed, no NaN."""
+    log_path = Path(log_path)
+    violations: list[str] = []
+    total_steps = 0
+    completed = False
+    nan_found = False
+    wall_seconds: float | None = None
+    digest = ""
+
+    if not log_path.is_file():
+        violations.append(f"training log missing: {log_path}")
+    else:
+        digest = sha256_file(log_path)
+        text = log_path.read_text(encoding="utf-8", errors="replace")
+        for pattern in _STEPS_PATTERNS:
+            matches = pattern.findall(text)
+            if matches:
+                total_steps = max(int(m) for m in matches)
+                break
+        completed = bool(_COMPLETED_PATTERN.search(text))
+        nan_found = bool(_NAN_PATTERN.search(text))
+        wall_match = _WALL_PATTERN.search(text)
+        if wall_match:
+            wall_seconds = float(wall_match.group(1))
+        if total_steps <= 0:
+            violations.append("vitals: total steps not > 0")
+        if not completed:
+            violations.append("vitals: no completion marker in log")
+        if nan_found:
+            violations.append("vitals: NaN observed in log")
+
+    return {
+        "schema": LANE_VITALS_SCHEMA,
+        "arm": arm,
+        "seed": seed,
+        "log": str(log_path),
+        "log_sha256": digest,
+        "ok": not violations,
+        "vitals_veto": "ok" if not violations else "; ".join(violations),
+        "total_steps": total_steps,
+        "completed": completed,
+        "nan_found": nan_found,
+        "wall_seconds": wall_seconds,
+        "violations": violations,
+    }
+
+
+def validate_arm_records(packet_root: Path) -> dict[str, Any]:
+    """Replay the frozen arm candidate records — never invent an arm."""
+    packet_root = Path(packet_root)
+    candidates_path = packet_root / "data" / "arm_candidates.json"
+    violations: list[str] = []
+    arms: list[dict[str, Any]] = []
+    artifact_digests: dict[str, str] = {}
+
+    if not candidates_path.is_file():
+        violations.append("data/arm_candidates.json missing")
+    else:
+        artifact_digests[str(candidates_path)] = sha256_file(candidates_path)
+        try:
+            raw = json.loads(candidates_path.read_text())
+        except json.JSONDecodeError as exc:
+            violations.append(f"arm_candidates.json unparseable: {exc}")
+            raw = []
+        if not isinstance(raw, list):
+            violations.append("arm_candidates.json is not a JSON array")
+            raw = []
+        for entry in raw:
+            if not isinstance(entry, dict) or "arm" not in entry:
+                violations.append("arm candidate entry missing 'arm'")
+                continue
+            arms.append(
+                {
+                    "arm": str(entry["arm"]),
+                    "dataset_hash": str(entry.get("dataset_hash", "")),
+                    "n": int(entry.get("n", 0)),
+                    "recipe": str(entry.get("recipe", "")),
+                    "seed": int(entry.get("seed", 0)),
+                }
+            )
+
+    return {
+        "schema": ARM_RECORDS_SCHEMA,
+        "packet": str(packet_root),
+        "ok": not violations,
+        "violations": violations,
+        "arms": sorted(arms, key=lambda a: a["arm"]),
+        "artifact_digests": artifact_digests,
+    }
+
+
+_LEGACY_KEY_MAP = {
+    # results file legacy key -> typed metric name
+    "sealed": "dev_ood",  # adaptive OOD dev set (legacy name)
+    "dev_ood": "secondary_ood",
+    "forgetting": "retention",
+}
+
+
+def _arm_letter(name: str) -> str:
+    match = re.search(r"(?:^|_)([A-Z])(?:_|$)", name)
+    return match.group(1) if match else ""
+
+
+def _find_arm_log(logs_dir: Path, letter: str) -> Path | None:
+    if not logs_dir.is_dir() or not letter:
+        return None
+    pattern = re.compile(rf"(?i)ft-arm[-_]?{re.escape(letter)}(?![A-Za-z])")
+    for candidate in sorted(logs_dir.iterdir()):
+        if candidate.is_file() and pattern.search(candidate.name):
+            return candidate
+    return None
+
+
+def validate_arm_metrics(packet_root: Path, *, control_name: str = "A_control") -> dict[str, Any]:
+    """Typed per-arm metrics from frozen results + mechanical lane vitals.
+
+    Applies the audited legacy key map (results ``sealed`` -> ``dev_ood``,
+    results ``dev_ood`` -> ``secondary_ood``, ``forgetting`` -> ``retention``)
+    in code, so no agent has to remember or restate it.
+    """
+    packet_root = Path(packet_root)
+    results_path = packet_root / "data" / "arm_results.json"
+    logs_dir = packet_root / "logs"
+    violations: list[str] = []
+    arms: list[dict[str, Any]] = []
+    control: dict[str, Any] | None = None
+    artifact_digests: dict[str, str] = {}
+
+    if not results_path.is_file():
+        violations.append("data/arm_results.json missing")
+        raw: list[Any] = []
+    else:
+        artifact_digests[str(results_path)] = sha256_file(results_path)
+        try:
+            raw = json.loads(results_path.read_text())
+        except json.JSONDecodeError as exc:
+            violations.append(f"arm_results.json unparseable: {exc}")
+            raw = []
+        if not isinstance(raw, list):
+            violations.append("arm_results.json is not a JSON array")
+            raw = []
+
+    for entry in raw:
+        if not isinstance(entry, dict) or "arm" not in entry:
+            violations.append("arm result entry missing 'arm'")
+            continue
+        name = str(entry["arm"])
+        typed: dict[str, Any] = {
+            "results_name": name,
+            "arm_letter": _arm_letter(name),
+            "in_template": float(entry.get("in_template", -1)),
+            "dev_ood": float(entry.get("sealed", -1)),
+            "secondary_ood": float(entry.get("dev_ood", -1)),
+            "retention": str(entry.get("forgetting", "")),
+            "worst_class": entry.get("worst_class", []),
+            "class_recalls": dict(sorted((entry.get("sealed_recalls") or {}).items())),
+        }
+        if name == control_name:
+            control = typed
+            continue
+        letter = typed["arm_letter"]
+        log_path = _find_arm_log(logs_dir, letter)
+        if log_path is None:
+            vitals = {
+                "vitals_veto": f"vitals: no training log found for arm {name}",
+                "total_steps": 0,
+                "completed": False,
+                "nan_found": False,
+                "wall_seconds": None,
+                "log": "",
+                "log_sha256": "",
+                "ok": False,
+            }
+        else:
+            lane = validate_lane_vitals(log_path, arm=name)
+            artifact_digests[str(log_path)] = lane["log_sha256"]
+            vitals = {
+                "vitals_veto": lane["vitals_veto"],
+                "total_steps": lane["total_steps"],
+                "completed": lane["completed"],
+                "nan_found": lane["nan_found"],
+                "wall_seconds": lane["wall_seconds"],
+                "log": lane["log"],
+                "log_sha256": lane["log_sha256"],
+                "ok": lane["ok"],
+            }
+        typed["vitals"] = vitals
+        arms.append(typed)
+
+    if control is None:
+        violations.append(f"control arm {control_name} missing from arm_results.json")
+
+    return {
+        "schema": ARM_METRICS_SCHEMA,
+        "packet": str(packet_root),
+        "ok": not violations,
+        "violations": violations,
+        "control": control,
+        "arms": sorted(arms, key=lambda a: a["results_name"]),
+        "artifact_digests": artifact_digests,
+    }
+
+
+def build_receipt(validator: str, payload: dict[str, Any]) -> dict[str, Any]:
+    return seal_receipt(validator, payload)

--- a/evals/needle_gates/validators.py
+++ b/evals/needle_gates/validators.py
@@ -363,39 +363,92 @@ def validate_lane_vitals(log_path: Path, *, arm: str = "", seed: int = 0) -> dic
     }
 
 
-def validate_arm_records(packet_root: Path) -> dict[str, Any]:
-    """Replay the frozen arm candidate records — never invent an arm."""
-    packet_root = Path(packet_root)
+def _alias_key(name: str) -> str:
+    """Case/punctuation-insensitive form used only to *reject* near-duplicates."""
+    return re.sub(r"[^a-z0-9]+", "", name.lower())
+
+
+def _load_arm_records(
+    packet_root: Path,
+    violations: list[str],
+    artifact_digests: dict[str, str],
+) -> list[dict[str, Any]]:
+    """Load frozen arm candidate records with exact-identity discipline.
+
+    Each record binds an arm to its exact results identity (``results_name``,
+    defaulting to the arm name) and its dataset digest (``dataset_hash``,
+    required). Duplicate or aliased arm names — two records whose names
+    differ only in case or punctuation — are rejected so no downstream
+    consumer can ever join arms by a fuzzy or partial key.
+    """
     candidates_path = packet_root / "data" / "arm_candidates.json"
-    violations: list[str] = []
     arms: list[dict[str, Any]] = []
-    artifact_digests: dict[str, str] = {}
 
     if not candidates_path.is_file():
         violations.append("data/arm_candidates.json missing")
-    else:
-        artifact_digests[str(candidates_path)] = sha256_file(candidates_path)
-        try:
-            raw = json.loads(candidates_path.read_text())
-        except json.JSONDecodeError as exc:
-            violations.append(f"arm_candidates.json unparseable: {exc}")
-            raw = []
-        if not isinstance(raw, list):
-            violations.append("arm_candidates.json is not a JSON array")
-            raw = []
-        for entry in raw:
-            if not isinstance(entry, dict) or "arm" not in entry:
-                violations.append("arm candidate entry missing 'arm'")
-                continue
-            arms.append(
-                {
-                    "arm": str(entry["arm"]),
-                    "dataset_hash": str(entry.get("dataset_hash", "")),
-                    "n": int(entry.get("n", 0)),
-                    "recipe": str(entry.get("recipe", "")),
-                    "seed": int(entry.get("seed", 0)),
-                }
+        return arms
+    artifact_digests[str(candidates_path)] = sha256_file(candidates_path)
+    try:
+        raw = json.loads(candidates_path.read_text())
+    except json.JSONDecodeError as exc:
+        violations.append(f"arm_candidates.json unparseable: {exc}")
+        return arms
+    if not isinstance(raw, list):
+        violations.append("arm_candidates.json is not a JSON array")
+        return arms
+
+    seen_names: set[str] = set()
+    seen_aliases: dict[str, str] = {}
+    seen_results: dict[str, str] = {}
+    for entry in raw:
+        if not isinstance(entry, dict) or "arm" not in entry:
+            violations.append("arm candidate entry missing 'arm'")
+            continue
+        name = str(entry["arm"])
+        if name in seen_names:
+            violations.append(f"duplicate arm name in arm_candidates.json: {name}")
+            continue
+        alias = _alias_key(name)
+        if alias in seen_aliases:
+            violations.append(
+                f"aliased arm names in arm_candidates.json: {name!r} collides "
+                f"with {seen_aliases[alias]!r}"
             )
+            continue
+        dataset_hash = str(entry.get("dataset_hash", ""))
+        if not dataset_hash:
+            violations.append(f"arm {name}: dataset_hash missing — every arm record "
+                              "must bind its exact dataset digest")
+        results_name = str(entry.get("results_name", name))
+        if results_name in seen_results:
+            violations.append(
+                f"arm {name}: results identity {results_name!r} already claimed "
+                f"by arm {seen_results[results_name]!r}"
+            )
+            continue
+        seen_names.add(name)
+        seen_aliases[alias] = name
+        seen_results[results_name] = name
+        arms.append(
+            {
+                "arm": name,
+                "results_name": results_name,
+                "dataset_hash": dataset_hash,
+                "log": str(entry.get("log", "")),
+                "n": int(entry.get("n", 0)),
+                "recipe": str(entry.get("recipe", "")),
+                "seed": int(entry.get("seed", 0)),
+            }
+        )
+    return arms
+
+
+def validate_arm_records(packet_root: Path) -> dict[str, Any]:
+    """Replay the frozen arm candidate records — never invent an arm."""
+    packet_root = Path(packet_root)
+    violations: list[str] = []
+    artifact_digests: dict[str, str] = {}
+    arms = _load_arm_records(packet_root, violations, artifact_digests)
 
     return {
         "schema": ARM_RECORDS_SCHEMA,
@@ -414,28 +467,64 @@ _LEGACY_KEY_MAP = {
     "forgetting": "retention",
 }
 
+# The trivial deterministic baseline every learned arm must beat, in addition
+# to the A_control comparison. Dropping it silently would let a learned arm
+# be promoted for merely beating an untrained control.
+DEFAULT_BASELINE_NAME = "tfidf_baseline"
 
-def _arm_letter(name: str) -> str:
-    match = re.search(r"(?:^|_)([A-Z])(?:_|$)", name)
-    return match.group(1) if match else ""
+
+def _typed_metrics_row(name: str, entry: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "results_name": name,
+        "dataset_hash": str(entry.get("dataset_hash", "")),
+        "in_template": float(entry.get("in_template", -1)),
+        "dev_ood": float(entry.get("sealed", -1)),
+        "secondary_ood": float(entry.get("dev_ood", -1)),
+        "retention": str(entry.get("forgetting", "")),
+        "worst_class": entry.get("worst_class", []),
+        "class_recalls": dict(sorted((entry.get("sealed_recalls") or {}).items())),
+    }
 
 
-def _find_arm_log(logs_dir: Path, letter: str) -> Path | None:
-    if not logs_dir.is_dir() or not letter:
+def _find_arm_log(logs_dir: Path, record: dict[str, Any]) -> Path | None:
+    """Resolve an arm's training log by exact identity — never by a letter.
+
+    Precedence: the record's explicit ``log`` filename, then a filename that
+    contains the exact ``results_name``. Anything fuzzier (single-letter
+    matching) has been removed: it silently joined unrelated artifacts.
+    """
+    explicit = str(record.get("log", ""))
+    if explicit:
+        candidate = logs_dir / Path(explicit).name
+        return candidate if candidate.is_file() else None
+    results_name = str(record.get("results_name", ""))
+    if not logs_dir.is_dir() or not results_name:
         return None
-    pattern = re.compile(rf"(?i)ft-arm[-_]?{re.escape(letter)}(?![A-Za-z])")
     for candidate in sorted(logs_dir.iterdir()):
-        if candidate.is_file() and pattern.search(candidate.name):
+        if candidate.is_file() and results_name in candidate.name:
             return candidate
     return None
 
 
-def validate_arm_metrics(packet_root: Path, *, control_name: str = "A_control") -> dict[str, Any]:
-    """Typed per-arm metrics from frozen results + mechanical lane vitals.
+def validate_arm_metrics(
+    packet_root: Path,
+    *,
+    control_name: str = "A_control",
+    baseline_name: str = DEFAULT_BASELINE_NAME,
+) -> dict[str, Any]:
+    """Typed per-arm metrics bound to frozen arm records, plus lane vitals.
 
     Applies the audited legacy key map (results ``sealed`` -> ``dev_ood``,
     results ``dev_ood`` -> ``secondary_ood``, ``forgetting`` -> ``retention``)
     in code, so no agent has to remember or restate it.
+
+    Binding discipline: every emitted arm row is a frozen arm-candidate
+    record joined to its results row by the record's exact ``results_name``
+    and cross-checked against its ``dataset_hash``. Results rows that no
+    record claims (other than the control and the trivial baseline) are
+    violations, as are duplicate results identities and dataset-digest
+    mismatches. The trivial ``tfidf_baseline`` row is required: it is a
+    deterministic gate every learned arm must beat alongside the control.
     """
     packet_root = Path(packet_root)
     results_path = packet_root / "data" / "arm_results.json"
@@ -443,7 +532,10 @@ def validate_arm_metrics(packet_root: Path, *, control_name: str = "A_control") 
     violations: list[str] = []
     arms: list[dict[str, Any]] = []
     control: dict[str, Any] | None = None
+    baseline: dict[str, Any] | None = None
     artifact_digests: dict[str, str] = {}
+
+    records = _load_arm_records(packet_root, violations, artifact_digests)
 
     if not results_path.is_file():
         violations.append("data/arm_results.json missing")
@@ -459,29 +551,54 @@ def validate_arm_metrics(packet_root: Path, *, control_name: str = "A_control") 
             violations.append("arm_results.json is not a JSON array")
             raw = []
 
+    results_by_name: dict[str, dict[str, Any]] = {}
     for entry in raw:
         if not isinstance(entry, dict) or "arm" not in entry:
             violations.append("arm result entry missing 'arm'")
             continue
         name = str(entry["arm"])
-        typed: dict[str, Any] = {
-            "results_name": name,
-            "arm_letter": _arm_letter(name),
-            "in_template": float(entry.get("in_template", -1)),
-            "dev_ood": float(entry.get("sealed", -1)),
-            "secondary_ood": float(entry.get("dev_ood", -1)),
-            "retention": str(entry.get("forgetting", "")),
-            "worst_class": entry.get("worst_class", []),
-            "class_recalls": dict(sorted((entry.get("sealed_recalls") or {}).items())),
-        }
-        if name == control_name:
-            control = typed
+        if name in results_by_name:
+            violations.append(f"duplicate results identity in arm_results.json: {name}")
             continue
-        letter = typed["arm_letter"]
-        log_path = _find_arm_log(logs_dir, letter)
+        results_by_name[name] = entry
+
+    if control_name in results_by_name:
+        control = _typed_metrics_row(control_name, results_by_name.pop(control_name))
+    else:
+        violations.append(f"control arm {control_name} missing from arm_results.json")
+
+    if baseline_name in results_by_name:
+        baseline = _typed_metrics_row(baseline_name, results_by_name.pop(baseline_name))
+    else:
+        violations.append(
+            f"trivial baseline {baseline_name} missing from arm_results.json — "
+            "learned arms must be compared against the deterministic baseline"
+        )
+
+    for record in sorted(records, key=lambda r: r["arm"]):
+        results_name = record["results_name"]
+        entry = results_by_name.pop(results_name, None)
+        if entry is None:
+            violations.append(
+                f"arm {record['arm']}: no results row with exact identity "
+                f"{results_name!r} — arms are never joined by partial names"
+            )
+            continue
+        typed = _typed_metrics_row(results_name, entry)
+        typed["arm"] = record["arm"]
+        result_hash = typed["dataset_hash"]
+        if result_hash and record["dataset_hash"] and result_hash != record["dataset_hash"]:
+            violations.append(
+                f"arm {record['arm']}: dataset_hash mismatch — record "
+                f"{record['dataset_hash']} vs results {result_hash}"
+            )
+            continue
+        typed["dataset_hash"] = record["dataset_hash"] or result_hash
+
+        log_path = _find_arm_log(logs_dir, record)
         if log_path is None:
             vitals = {
-                "vitals_veto": f"vitals: no training log found for arm {name}",
+                "vitals_veto": f"vitals: no training log found for arm {record['arm']}",
                 "total_steps": 0,
                 "completed": False,
                 "nan_found": False,
@@ -491,7 +608,7 @@ def validate_arm_metrics(packet_root: Path, *, control_name: str = "A_control") 
                 "ok": False,
             }
         else:
-            lane = validate_lane_vitals(log_path, arm=name)
+            lane = validate_lane_vitals(log_path, arm=record["arm"])
             artifact_digests[str(log_path)] = lane["log_sha256"]
             vitals = {
                 "vitals_veto": lane["vitals_veto"],
@@ -506,8 +623,10 @@ def validate_arm_metrics(packet_root: Path, *, control_name: str = "A_control") 
         typed["vitals"] = vitals
         arms.append(typed)
 
-    if control is None:
-        violations.append(f"control arm {control_name} missing from arm_results.json")
+    for orphan in sorted(results_by_name):
+        violations.append(
+            f"results row {orphan!r} is not bound to any frozen arm record"
+        )
 
     return {
         "schema": ARM_METRICS_SCHEMA,
@@ -515,6 +634,7 @@ def validate_arm_metrics(packet_root: Path, *, control_name: str = "A_control") 
         "ok": not violations,
         "violations": violations,
         "control": control,
+        "baseline": baseline,
         "arms": sorted(arms, key=lambda a: a["results_name"]),
         "artifact_digests": artifact_digests,
     }

--- a/tests/js/needle_workflow.test.cjs
+++ b/tests/js/needle_workflow.test.cjs
@@ -1,0 +1,210 @@
+'use strict'
+// Executable test for .claude/workflows/needle-training-campaign.js.
+//
+// Runs the workflow body with a mock agent runtime whose "agents" execute the
+// EXACT validator commands the workflow constructs (via spawnSync with an
+// argument array — no shell), then transcribe the emitted receipts, exactly
+// as the real agents are instructed to. Covers:
+//   • command construction: only safe single-token values reach commands;
+//     hostile run_stamp / campaign / dataset / packet values throw before
+//     any agent call
+//   • receipt consumption: digests recomputed, tampered receipts refused
+//   • cross-arm gating: control AND trivial tf-idf baseline comparisons
+//   • live-mode refusals (no manifest; mock fixture as live packet)
+//
+// Invoked by tests/test_needle_workflow_js.py (skipped when node or uv is
+// unavailable). Runs nothing live: mock mode replays the committed fixture.
+
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+const { spawnSync } = require('node:child_process')
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..')
+const WORKFLOW_PATH = path.join(REPO_ROOT, '.claude', 'workflows', 'needle-training-campaign.js')
+const FIXTURE_PACKET = 'evals/needle_gates/fixtures/mock_packet'
+
+const SAFE_TOKEN = /^[A-Za-z0-9._/-]+$|^--[a-z-]+$/
+
+function loadWorkflow() {
+  const source = fs.readFileSync(WORKFLOW_PATH, 'utf8')
+  const body = source.replace('export const meta =', 'const meta =')
+  const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
+  return new AsyncFunction('args', 'agent', 'phase', body)
+}
+
+// Mock agent runtime: executes the exact CLI command found in the prompt.
+function makeAgentRuntime(options = {}) {
+  const calls = []
+  const commandLines = []
+  async function agent(prompt, opts) {
+    calls.push({ label: opts && opts.label })
+    const match = /^\s*uv run python -m evals\.needle_gates (.+)$/m.exec(prompt)
+    if (match) {
+      const tokens = match[1].trim().split(/\s+/)
+      commandLines.push(tokens.join(' '))
+      for (const token of tokens) {
+        assert.ok(
+          SAFE_TOKEN.test(token),
+          `workflow constructed a command token outside the safe charset: ${JSON.stringify(token)}`
+        )
+      }
+      const result = spawnSync(
+        'uv',
+        ['run', 'python', '-m', 'evals.needle_gates', ...tokens],
+        { cwd: REPO_ROOT, encoding: 'utf8', shell: false, timeout: 120000 }
+      )
+      assert.strictEqual(result.status, 0, `validator CLI failed: ${result.stderr}`)
+      let receipt = result.stdout
+      if (options.tamperLabel && opts.label === options.tamperLabel) {
+        const parsed = JSON.parse(receipt)
+        const flipped = (parsed.payload_b64[0] === 'A' ? 'B' : 'A') + parsed.payload_b64.slice(1)
+        receipt = JSON.stringify({ ...parsed, payload_b64: flipped })
+      }
+      return { receipt, facts: `ran ${tokens[0]}` }
+    }
+    if (opts && opts.label === 'report-draft') {
+      return { facts: 'Mock-mode campaign summary derived from workflow-state.' }
+    }
+    if (opts && opts.label === 'claim-verify') {
+      return {
+        claims: [{ claim: 'summary matches verified JSON', artifact: 'workflow-state', verdict: 'CONFIRMED' }],
+        facts: 'all claims confirmed against workflow-state',
+      }
+    }
+    throw new Error(`unexpected agent prompt for label ${opts && opts.label}`)
+  }
+  return { agent, calls, commandLines }
+}
+
+const phases = []
+function phase(name) {
+  phases.push(name)
+}
+
+async function expectThrow(fn, pattern, agentCalls, label) {
+  let threw = null
+  try {
+    await fn()
+  } catch (err) {
+    threw = err
+  }
+  assert.ok(threw, `${label}: expected workflow to throw`)
+  assert.ok(
+    pattern.test(String(threw.message || threw)),
+    `${label}: unexpected error message: ${threw.message}`
+  )
+  if (agentCalls) {
+    assert.strictEqual(agentCalls.length, 0, `${label}: agents were called before validation refused the input`)
+  }
+  console.log(`ok - ${label}`)
+}
+
+async function main() {
+  const workflow = loadWorkflow()
+
+  // 1. Happy path: full mock run on the committed fixture packet.
+  {
+    const runtime = makeAgentRuntime()
+    const result = await workflow(
+      { mode: 'mock', run_stamp: 'js-test-run', campaign_id: 'needle-js', source_dataset_id: 'D0001', target_dataset_id: 'D0002' },
+      runtime.agent,
+      phase
+    )
+    assert.strictEqual(result.verdict, 'EVIDENCE_CLEAN')
+    assert.strictEqual(result.mode, 'mock')
+    // Receipt consumption: every gate decision carries a verified digest.
+    for (const key of ['preflight', 'corpus_veto', 'arm_metrics', 'harvest_request']) {
+      assert.match(result.gate_receipts[key], /^[0-9a-f]{64}$/, `missing verified digest for ${key}`)
+    }
+    // Command construction: the workflow embedded the fixture packet and the
+    // validated identifiers, nothing else.
+    assert.ok(runtime.commandLines.some(c => c.includes(`--packet ${FIXTURE_PACKET}`)))
+    assert.ok(runtime.commandLines.some(c => c.includes('--campaign needle-js')))
+    // Cross-arm gating: control AND trivial baseline comparisons, from the
+    // fixture numbers (B beats control only; E beats both).
+    const iteration = result.iterations[result.iterations.length - 1]
+    assert.strictEqual(iteration.control.name, 'A_control')
+    assert.strictEqual(iteration.baseline.name, 'tfidf_baseline')
+    assert.ok(iteration.baseline.dev_ood > iteration.control.dev_ood)
+    const byArm = Object.fromEntries(iteration.arms.map(a => [a.arm, a]))
+    assert.strictEqual(byArm.arm_B.beats_control, true)
+    assert.strictEqual(byArm.arm_B.beats_baseline, false, 'trivial baseline must gate arms that only beat the control')
+    assert.strictEqual(byArm.arm_E.beats_control, true)
+    assert.strictEqual(byArm.arm_E.beats_baseline, true)
+    assert.ok(iteration.arms.every(a => a.promotion_candidate === false), 'mock mode can never mark promotion candidates')
+    assert.ok(iteration.arms.every(a => a.results_name && a.dataset_hash), 'judged arms must carry their exact identity binding')
+    // The typed harvest request is request-only and carries originating roots.
+    assert.strictEqual(result.next_harvest_request.request_only, true)
+    assert.strictEqual(result.next_harvest_request.authorizes_generation, false)
+    assert.ok(result.next_harvest_request.weak_confusion_cells.every(c => Array.isArray(c.root_ids)))
+    console.log('ok - mock run on committed fixture: gating + receipts + harvest request')
+  }
+
+  // 2-5. Hostile embedded values throw before any agent call.
+  for (const [label, args] of [
+    ['hostile run_stamp rejected', { mode: 'mock', run_stamp: 'x;rm -rf /tmp/x' }],
+    ['hostile campaign_id rejected', { mode: 'mock', run_stamp: 'ok-run', campaign_id: '$(whoami)' }],
+    ['hostile dataset id rejected', { mode: 'mock', run_stamp: 'ok-run', source_dataset_id: 'D0001|tee /tmp/x' }],
+    ['hostile packet path rejected', { mode: 'mock', run_stamp: 'ok-run', packet: '../../needle_lab' }],
+    ['whitespace packet rejected', { mode: 'mock', run_stamp: 'ok-run', packet: 'evals/needle_lab; touch pwned' }],
+  ]) {
+    const runtime = makeAgentRuntime()
+    await expectThrow(
+      () => workflow(args, runtime.agent, phase),
+      /rejected/,
+      runtime.calls,
+      label
+    )
+  }
+
+  // 6. Tampered receipt is refused (digest recomputed by the workflow).
+  {
+    const runtime = makeAgentRuntime({ tamperLabel: 'corpus-veto' })
+    await expectThrow(
+      () => workflow({ mode: 'mock', run_stamp: 'tamper-run' }, runtime.agent, phase),
+      /digest|base64|mismatch/i,
+      null,
+      'tampered receipt refused'
+    )
+  }
+
+  // 7. Live mode refusals: no manifest; mock fixture as live packet.
+  {
+    const runtime = makeAgentRuntime()
+    await expectThrow(
+      () => workflow({ mode: 'live', run_stamp: 'live-run' }, runtime.agent, phase),
+      /live mode refused/,
+      runtime.calls,
+      'live mode without manifest refused'
+    )
+  }
+  {
+    const runtime = makeAgentRuntime()
+    await expectThrow(
+      () => workflow(
+        {
+          mode: 'live',
+          run_stamp: 'live-run',
+          manifest: {
+            training_enabled: true,
+            packet: FIXTURE_PACKET,
+            receipt_digest_pins: { preflight: 'x', corpus_veto: 'x', arm_records: 'x' },
+          },
+        },
+        runtime.agent,
+        phase
+      ),
+      /live mode refused/,
+      runtime.calls,
+      'mock fixture as live packet refused'
+    )
+  }
+
+  console.log('all needle workflow JS tests passed')
+}
+
+main().catch(err => {
+  console.error(err && err.stack ? err.stack : String(err))
+  process.exit(1)
+})

--- a/tests/test_needle_gates.py
+++ b/tests/test_needle_gates.py
@@ -67,13 +67,16 @@ def build_packet(root: Path, *, tamper: bool = False) -> Path:
     arm_candidates = [
         {
             "arm": "arm_B",
+            "results_name": "B_hardneg",
             "dataset_hash": "b" * 24,
+            "log": "ft-arm-B-seed42.log",
             "n": 128,
             "recipe": "hard_negatives",
             "seed": 42,
         },
         {
             "arm": "arm_E",
+            "results_name": "E_worstcell",
             "dataset_hash": "e" * 24,
             "n": 128,
             "recipe": "worst_cell",
@@ -98,7 +101,22 @@ def build_packet(root: Path, *, tamper: bool = False) -> Path:
             "worst_class": ["planning", 0.25],
         },
         {
+            "arm": "tfidf_baseline",
+            "sealed": 0.50,
+            "dev_ood": 0.50,
+            "in_template": 0.60,
+            "forgetting": "3/3",
+            "sealed_recalls": {
+                "coding": 0.5,
+                "planning": 0.5,
+                "research": 0.5,
+                "vision": 0.5,
+            },
+            "worst_class": ["coding", 0.5],
+        },
+        {
             "arm": "B_hardneg",
+            "dataset_hash": "b" * 24,
             "sealed": 0.45,
             "dev_ood": 0.60,
             "in_template": 0.92,
@@ -113,6 +131,7 @@ def build_packet(root: Path, *, tamper: bool = False) -> Path:
         },
         {
             "arm": "E_worstcell",
+            "dataset_hash": "e" * 24,
             "sealed": 0.525,
             "dev_ood": 0.60,
             "in_template": 0.93,
@@ -128,8 +147,21 @@ def build_packet(root: Path, *, tamper: bool = False) -> Path:
     ]
     (data / "arm_results.json").write_text(json.dumps(arm_results, indent=1))
 
+    harvest_roots = {
+        "planning": ["root-planning-0001", "root-planning-0002"],
+        "vision": ["root-vision-0001"],
+        "coding": ["root-coding-0001"],
+        "research": ["root-research-0001"],
+        "retention_probe": ["root-coding-0001", "root-research-0001"],
+    }
+    (data / "harvest_roots.json").write_text(json.dumps(harvest_roots, indent=1))
+
     manifest = []
-    for name in sorted(files) + ["arm_candidates.json", "arm_results.json"]:
+    for name in sorted(files) + [
+        "arm_candidates.json",
+        "arm_results.json",
+        "harvest_roots.json",
+    ]:
         generator = "gen_datasets.py seed 42"
         if name == "combined.jsonl":
             generator = "concat; KNOWN-CONTAMINATED research control, quarantined"
@@ -159,7 +191,7 @@ def build_packet(root: Path, *, tamper: bool = False) -> Path:
         "training complete, best checkpoint saved\n"
     )
     (logs / "ft-arm-B-seed42.log").write_text(log_text)
-    (logs / "ft-arm-E-seed42.log").write_text(log_text.replace("640", "512"))
+    (logs / "ft-E_worstcell-seed42.log").write_text(log_text.replace("640", "512"))
 
     if tamper:
         (data / "route_selection.jsonl").write_text(_row("tampered", "coding") + "\n")
@@ -384,19 +416,27 @@ def test_arm_metrics_legacy_key_mapping_and_vitals_join(tmp_path):
     assert control["secondary_ood"] == 0.55  # legacy "dev_ood"
     assert control["retention"] == "3/3"  # legacy "forgetting"
 
+    baseline = payload["baseline"]
+    assert baseline["results_name"] == "tfidf_baseline"
+    assert baseline["dev_ood"] == 0.50
+
     by_name = {a["results_name"]: a for a in payload["arms"]}
     assert set(by_name) == {"B_hardneg", "E_worstcell"}
     b_arm = by_name["B_hardneg"]
+    assert b_arm["arm"] == "arm_B"  # bound to the frozen record's exact identity
+    assert b_arm["dataset_hash"] == "b" * 24
     assert b_arm["dev_ood"] == 0.45
     assert b_arm["vitals"]["ok"] is True
     assert b_arm["vitals"]["total_steps"] == 640
-    assert "ft-arm-B-seed42.log" in b_arm["vitals"]["log"]
-    assert by_name["E_worstcell"]["vitals"]["total_steps"] == 512
+    assert "ft-arm-B-seed42.log" in b_arm["vitals"]["log"]  # explicit log field
+    e_arm = by_name["E_worstcell"]
+    assert e_arm["vitals"]["total_steps"] == 512
+    assert "ft-E_worstcell-seed42.log" in e_arm["vitals"]["log"]  # exact-name match
 
 
 def test_arm_metrics_missing_log_vetoes_lane(tmp_path):
     packet = build_packet(tmp_path)
-    (packet / "logs" / "ft-arm-E-seed42.log").unlink()
+    (packet / "logs" / "ft-E_worstcell-seed42.log").unlink()
     payload = validate_arm_metrics(packet)
     by_name = {a["results_name"]: a for a in payload["arms"]}
     assert by_name["E_worstcell"]["vitals"]["ok"] is False
@@ -412,6 +452,88 @@ def test_arm_metrics_missing_control_fails(tmp_path):
     payload = validate_arm_metrics(packet)
     assert payload["ok"] is False
     assert any("control arm" in v for v in payload["violations"])
+
+
+def test_arm_metrics_missing_trivial_baseline_fails(tmp_path):
+    packet = build_packet(tmp_path)
+    results_path = packet / "data" / "arm_results.json"
+    rows = json.loads(results_path.read_text())
+    rows = [r for r in rows if r["arm"] != "tfidf_baseline"]
+    results_path.write_text(json.dumps(rows))
+    payload = validate_arm_metrics(packet)
+    assert payload["ok"] is False
+    assert payload["baseline"] is None
+    assert any("trivial baseline tfidf_baseline missing" in v for v in payload["violations"])
+
+
+def test_arm_metrics_rejects_dataset_hash_mismatch(tmp_path):
+    packet = build_packet(tmp_path)
+    results_path = packet / "data" / "arm_results.json"
+    rows = json.loads(results_path.read_text())
+    for row in rows:
+        if row["arm"] == "B_hardneg":
+            row["dataset_hash"] = "f" * 24
+    results_path.write_text(json.dumps(rows))
+    payload = validate_arm_metrics(packet)
+    assert payload["ok"] is False
+    assert any("dataset_hash mismatch" in v for v in payload["violations"])
+    assert all(a["results_name"] != "B_hardneg" for a in payload["arms"])
+
+
+def test_arm_metrics_rejects_unbound_results_row(tmp_path):
+    packet = build_packet(tmp_path)
+    results_path = packet / "data" / "arm_results.json"
+    rows = json.loads(results_path.read_text())
+    rows.append({"arm": "Z_orphan", "sealed": 0.9, "forgetting": "3/3"})
+    results_path.write_text(json.dumps(rows))
+    payload = validate_arm_metrics(packet)
+    assert payload["ok"] is False
+    assert any("not bound to any frozen arm record" in v for v in payload["violations"])
+
+
+def test_arm_metrics_never_joins_by_partial_name(tmp_path):
+    """A results row that merely shares a letter with a record must not bind."""
+    packet = build_packet(tmp_path)
+    results_path = packet / "data" / "arm_results.json"
+    rows = json.loads(results_path.read_text())
+    for row in rows:
+        if row["arm"] == "B_hardneg":
+            row["arm"] = "B_other_variant"  # same letter, different exact identity
+    results_path.write_text(json.dumps(rows))
+    payload = validate_arm_metrics(packet)
+    assert payload["ok"] is False
+    joined = "\n".join(payload["violations"])
+    assert "no results row with exact identity 'B_hardneg'" in joined
+    assert "'B_other_variant' is not bound" in joined
+
+
+def test_arm_records_rejects_duplicates_aliases_and_missing_hash(tmp_path):
+    packet = build_packet(tmp_path)
+    candidates_path = packet / "data" / "arm_candidates.json"
+    rows = json.loads(candidates_path.read_text())
+    rows.append(dict(rows[0]))  # exact duplicate name
+    rows.append({**rows[1], "arm": "ARM-E", "results_name": "E_alias"})  # alias of arm_E
+    rows.append({"arm": "arm_H", "results_name": "H_x", "n": 1, "recipe": "r", "seed": 1})
+    candidates_path.write_text(json.dumps(rows))
+    payload = validate_arm_records(packet)
+    assert payload["ok"] is False
+    joined = "\n".join(payload["violations"])
+    assert "duplicate arm name" in joined
+    assert "aliased arm names" in joined
+    assert "arm arm_H: dataset_hash missing" in joined
+
+
+def test_arm_records_rejects_duplicate_results_identity(tmp_path):
+    packet = build_packet(tmp_path)
+    candidates_path = packet / "data" / "arm_candidates.json"
+    rows = json.loads(candidates_path.read_text())
+    rows.append(
+        {"arm": "arm_F", "results_name": "B_hardneg", "dataset_hash": "f" * 24}
+    )
+    candidates_path.write_text(json.dumps(rows))
+    payload = validate_arm_records(packet)
+    assert payload["ok"] is False
+    assert any("already claimed" in v for v in payload["violations"])
 
 
 # --------------------------------------------------------- harvest request
@@ -436,10 +558,26 @@ def test_harvest_request_typed_and_request_only(tmp_path):
     assert ("E_worstcell", "vision") in weak
     assert ("B_hardneg", "coding") not in weak
 
+    # Every cell names the exact roots that produced it, so a harvester can
+    # generate variants of the FAILING root rather than guessing.
+    weak_by_cell = {c["cell"]: c for c in request["weak_confusion_cells"]}
+    assert weak_by_cell["planning"]["root_ids"] == [
+        "root-planning-0001",
+        "root-planning-0002",
+    ]
+    assert weak_by_cell["vision"]["root_ids"] == ["root-vision-0001"]
+
     retention = {(c["arm"], c["cell"]) for c in request["retention_cells"]}
     assert ("B_hardneg", "coding") in retention
     assert ("B_hardneg", "retention_probe") in retention
+    retention_by_cell = {c["cell"]: c for c in request["retention_cells"]}
+    assert retention_by_cell["coding"]["root_ids"] == ["root-coding-0001"]
+    assert retention_by_cell["retention_probe"]["root_ids"] == [
+        "root-coding-0001",
+        "root-research-0001",
+    ]
     assert request["evidence_digests"]  # exact digests present
+    assert any("harvest_roots.json" in k for k in request["evidence_digests"])
 
 
 def test_harvest_request_rejects_same_dataset(tmp_path):
@@ -463,6 +601,74 @@ def test_harvest_request_deterministic(tmp_path):
     first = seal_receipt("harvest_request", build_next_harvest_request(packet, **kwargs))
     second = seal_receipt("harvest_request", build_next_harvest_request(packet, **kwargs))
     assert first == second
+
+
+# ------------------------------------------------------------- identifiers
+
+
+def test_identifier_validation_allows_safe_and_rejects_shell_syntax():
+    from evals.needle_gates.identifiers import (
+        IdentifierError,
+        validate_identifier,
+        validate_packet_path,
+    )
+
+    assert validate_identifier("campaign", "needle-r2.v1_x") == "needle-r2.v1_x"
+    for bad in (
+        "a b",
+        "x;rm -rf /",
+        "$(whoami)",
+        "`id`",
+        "a|b",
+        "a>b",
+        "-flag",
+        "",
+        "x" * 70,
+        "über",
+    ):
+        with pytest.raises(IdentifierError):
+            validate_identifier("campaign", bad)
+
+    assert validate_packet_path("evals/needle_gates/fixtures/mock_packet")
+    assert validate_packet_path("/tmp/needle-gates-run1/preflight.json")
+    for bad in ("a b/c", "pkt;rm", "$(pwd)/pkt", "-pkt", "../secrets", "a/../../b"):
+        with pytest.raises(IdentifierError):
+            validate_packet_path(bad)
+
+
+# ------------------------------------------------------- committed fixture
+
+
+def test_committed_mock_packet_fixture_passes_all_gates():
+    """The default mock packet advertised by the workflow exists on this
+    branch and passes every validator, so the workflow never advertises a
+    packet absent from main."""
+    fixture = Path("evals/needle_gates/fixtures/mock_packet")
+    assert fixture.is_dir(), "committed mock packet fixture missing"
+
+    for func in (validate_preflight, validate_corpus, validate_arm_records):
+        payload = func(fixture)
+        assert payload["ok"] is True, payload["violations"]
+
+    metrics = validate_arm_metrics(fixture)
+    assert metrics["ok"] is True, metrics["violations"]
+    assert metrics["baseline"]["results_name"] == "tfidf_baseline"
+    assert metrics["control"]["results_name"] == "A_control"
+    # Fixture numbers make the trivial-baseline gate do real work:
+    # B_hardneg beats the control but NOT the baseline.
+    by_name = {a["results_name"]: a for a in metrics["arms"]}
+    assert by_name["B_hardneg"]["dev_ood"] > metrics["control"]["dev_ood"]
+    assert by_name["B_hardneg"]["dev_ood"] < metrics["baseline"]["dev_ood"]
+    assert by_name["E_worstcell"]["dev_ood"] > metrics["baseline"]["dev_ood"]
+
+    request = build_next_harvest_request(
+        fixture,
+        campaign_id="fixture-check",
+        source_dataset_id="D0001",
+        target_dataset_id="D0002",
+    )
+    assert request["request_only"] is True
+    assert all(c["root_ids"] for c in request["weak_confusion_cells"])
 
 
 # ----------------------------------------------------------- determinism
@@ -542,3 +748,55 @@ def test_cli_harvest_request(tmp_path, capsys):
     receipt = json.loads(capsys.readouterr().out)
     payload = verify_receipt(receipt, "harvest_request")
     assert payload["request_only"] is True
+
+
+def test_cli_rejects_unsafe_embedded_values(tmp_path, capsys):
+    """Shell syntax, whitespace, and traversal in caller-supplied values are
+    rejected at the argument boundary before any validator runs."""
+    from evals.needle_gates.__main__ import main
+
+    packet = build_packet(tmp_path)
+    bad_invocations = [
+        ["preflight", "--packet", "pkt;rm -rf /"],
+        ["preflight", "--packet", "pkt $(whoami)"],
+        ["preflight", "--packet", "../../../etc"],
+        ["arm-metrics", "--packet", str(packet), "--out", "/tmp/x;touch pwned"],
+        [
+            "harvest-request",
+            "--packet",
+            str(packet),
+            "--campaign",
+            "c1; curl evil",
+            "--source-dataset",
+            "D0001",
+            "--target-dataset",
+            "D0002",
+        ],
+        [
+            "harvest-request",
+            "--packet",
+            str(packet),
+            "--campaign",
+            "c1",
+            "--source-dataset",
+            "$(id)",
+            "--target-dataset",
+            "D0002",
+        ],
+        [
+            "harvest-request",
+            "--packet",
+            str(packet),
+            "--campaign",
+            "c1",
+            "--source-dataset",
+            "D0001",
+            "--target-dataset",
+            "D0002|tee /tmp/x",
+        ],
+    ]
+    for argv in bad_invocations:
+        with pytest.raises(SystemExit) as excinfo:
+            main(argv)
+        assert excinfo.value.code == 2, argv
+        capsys.readouterr()

--- a/tests/test_needle_gates.py
+++ b/tests/test_needle_gates.py
@@ -1,0 +1,544 @@
+"""Tests for evals.needle_gates — deterministic gate validators + receipts."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from evals.needle_gates.harvest_request import build_next_harvest_request
+from evals.needle_gates.receipts import (
+    RECEIPT_SCHEMA_VERSION,
+    ReceiptError,
+    canonical_json_bytes,
+    read_receipt,
+    seal_receipt,
+    sha256_file,
+    verify_receipt,
+    write_receipt,
+)
+from evals.needle_gates.validators import (
+    validate_arm_metrics,
+    validate_arm_records,
+    validate_corpus,
+    validate_lane_vitals,
+    validate_preflight,
+)
+
+
+def _row(query: str, answer_class: str) -> str:
+    return json.dumps(
+        {
+            "query": query,
+            "tools": json.dumps([{"name": "t1"}]),
+            "answers": json.dumps([{"route": answer_class}]),
+        }
+    )
+
+
+def build_packet(root: Path, *, tamper: bool = False) -> Path:
+    """Materialize a minimal-but-complete needle packet for validator tests."""
+    packet = root / "packet"
+    data = packet / "data"
+    logs = packet / "logs"
+    data.mkdir(parents=True)
+    logs.mkdir(parents=True)
+
+    files = {
+        "route_selection.jsonl": "\n".join(
+            [_row("train q1", "coding"), _row("train q2", "research")]
+        )
+        + "\n",
+        "route_selection_sealed.jsonl": "\n".join(
+            [_row("sealed q1", "planning"), _row("sealed q2", "vision")]
+        )
+        + "\n",
+        "combined.jsonl": "\n".join(
+            [_row("train q1", "coding"), _row("sealed q1", "planning")]
+        )
+        + "\n",
+    }
+    for name, text in files.items():
+        (data / name).write_text(text)
+
+    arm_candidates = [
+        {
+            "arm": "arm_B",
+            "dataset_hash": "b" * 24,
+            "n": 128,
+            "recipe": "hard_negatives",
+            "seed": 42,
+        },
+        {
+            "arm": "arm_E",
+            "dataset_hash": "e" * 24,
+            "n": 128,
+            "recipe": "worst_cell",
+            "seed": 42,
+        },
+    ]
+    (data / "arm_candidates.json").write_text(json.dumps(arm_candidates, indent=1))
+
+    arm_results = [
+        {
+            "arm": "A_control",
+            "sealed": 0.40,
+            "dev_ood": 0.55,
+            "in_template": 0.90,
+            "forgetting": "3/3",
+            "sealed_recalls": {
+                "coding": 0.5,
+                "planning": 0.25,
+                "research": 0.5,
+                "vision": 0.25,
+            },
+            "worst_class": ["planning", 0.25],
+        },
+        {
+            "arm": "B_hardneg",
+            "sealed": 0.45,
+            "dev_ood": 0.60,
+            "in_template": 0.92,
+            "forgetting": "3/3",
+            "sealed_recalls": {
+                "coding": 0.75,
+                "planning": 0.25,
+                "research": 0.5,
+                "vision": 0.25,
+            },
+            "worst_class": ["planning", 0.25],
+        },
+        {
+            "arm": "E_worstcell",
+            "sealed": 0.525,
+            "dev_ood": 0.60,
+            "in_template": 0.93,
+            "forgetting": "3/3",
+            "sealed_recalls": {
+                "coding": 0.75,
+                "planning": 0.5,
+                "research": 0.5,
+                "vision": 0.35,
+            },
+            "worst_class": ["vision", 0.35],
+        },
+    ]
+    (data / "arm_results.json").write_text(json.dumps(arm_results, indent=1))
+
+    manifest = []
+    for name in sorted(files) + ["arm_candidates.json", "arm_results.json"]:
+        generator = "gen_datasets.py seed 42"
+        if name == "combined.jsonl":
+            generator = "concat; KNOWN-CONTAMINATED research control, quarantined"
+        manifest.append(
+            {
+                "path": f"evals/needle_lab/data/{name}",
+                "sha256": sha256_file(data / name),
+                "n": 2,
+                "generator": generator,
+            }
+        )
+    (data / "manifest.json").write_text(json.dumps(manifest, indent=1))
+
+    (packet / "README.md").write_text(
+        "# Needle packet\n"
+        "Split policy: _per_tool_split seed 42 (pinned before corpus assembly).\n"
+        "Base checkpoint sha256 prefix: 40a32e91d1d4197b\n"
+        "Env: python 3.11, jax 0.4, flax 0.8\n"
+    )
+
+    log_text = (
+        "run start\n"
+        "step 10 loss 2.31\n"
+        "step 640 loss 0.42\n"
+        "total steps: 640\n"
+        "wall_seconds: 512.5\n"
+        "training complete, best checkpoint saved\n"
+    )
+    (logs / "ft-arm-B-seed42.log").write_text(log_text)
+    (logs / "ft-arm-E-seed42.log").write_text(log_text.replace("640", "512"))
+
+    if tamper:
+        (data / "route_selection.jsonl").write_text(_row("tampered", "coding") + "\n")
+    return packet
+
+
+# ---------------------------------------------------------------- receipts
+
+
+def test_receipt_roundtrip_and_determinism():
+    payload = {"schema": "x/v1", "ok": True, "violations": [], "n": 3}
+    first = seal_receipt("preflight", payload)
+    second = seal_receipt("preflight", payload)
+    assert first == second
+    assert first["schema"] == RECEIPT_SCHEMA_VERSION
+    decoded = verify_receipt(first, "preflight")
+    assert decoded == payload
+    raw = base64.b64decode(first["payload_b64"])
+    assert hashlib.sha256(raw).hexdigest() == first["payload_sha256"]
+
+
+def test_receipt_tamper_detection():
+    receipt = seal_receipt("corpus_veto", {"ok": False, "violations": ["x"]})
+    forged_payload = canonical_json_bytes({"ok": True, "violations": []})
+    tampered = dict(receipt)
+    tampered["payload_b64"] = base64.b64encode(forged_payload).decode()
+    with pytest.raises(ReceiptError, match="digest mismatch"):
+        verify_receipt(tampered)
+
+    bad_digest = dict(receipt)
+    bad_digest["payload_sha256"] = "0" * 64
+    with pytest.raises(ReceiptError, match="digest mismatch"):
+        verify_receipt(bad_digest)
+
+    with pytest.raises(ReceiptError, match="expected"):
+        verify_receipt(receipt, "preflight")
+
+    with pytest.raises(ReceiptError, match="unknown validator"):
+        seal_receipt("made_up", {"ok": True})
+
+    with pytest.raises(ReceiptError, match="schema"):
+        verify_receipt({"schema": "other/v9"})
+
+
+def test_receipt_file_roundtrip(tmp_path):
+    receipt = seal_receipt("lane_vitals", {"ok": True, "total_steps": 5})
+    path = tmp_path / "receipts" / "vitals.json"
+    write_receipt(receipt, path)
+    loaded = read_receipt(path, "lane_vitals")
+    assert loaded == receipt
+
+    tampered = json.loads(path.read_text())
+    tampered["payload_b64"] = base64.b64encode(
+        canonical_json_bytes({"ok": False, "total_steps": 0})
+    ).decode()
+    path.write_text(json.dumps(tampered))
+    with pytest.raises(ReceiptError):
+        read_receipt(path)
+
+    with pytest.raises(ReceiptError, match="missing"):
+        read_receipt(tmp_path / "nope.json")
+
+
+# --------------------------------------------------------------- preflight
+
+
+def test_preflight_clean_packet(tmp_path):
+    packet = build_packet(tmp_path)
+    payload = validate_preflight(packet)
+    assert payload["ok"] is True
+    assert payload["violations"] == []
+    assert any("manifest.json" in k for k in payload["artifact_digests"])
+
+
+def test_preflight_detects_digest_mismatch(tmp_path):
+    packet = build_packet(tmp_path, tamper=True)
+    payload = validate_preflight(packet)
+    assert payload["ok"] is False
+    assert any("sha256 mismatch" in v for v in payload["violations"])
+
+
+def test_preflight_detects_unlisted_file_and_missing_pins(tmp_path):
+    packet = build_packet(tmp_path)
+    (packet / "data" / "rogue.jsonl").write_text(_row("rogue", "coding") + "\n")
+    (packet / "README.md").write_text("# no pins here\n")
+    payload = validate_preflight(packet)
+    assert payload["ok"] is False
+    joined = "\n".join(payload["violations"])
+    assert "unlisted data file: data/rogue.jsonl" in joined
+    assert "split policy not pinned" in joined
+    assert "checkpoint pin" in joined
+    assert "environment pins unrecorded" in joined
+
+
+def test_preflight_missing_manifest_fails_closed(tmp_path):
+    payload = validate_preflight(tmp_path / "empty")
+    assert payload["ok"] is False
+    assert any("manifest missing" in v for v in payload["violations"])
+
+
+# ------------------------------------------------------------- corpus veto
+
+
+def test_corpus_known_contamination_is_marked_from_manifest(tmp_path):
+    packet = build_packet(tmp_path)
+    payload = validate_corpus(packet)
+    # combined.jsonl leaks a sealed row, but the packet manifest declares it
+    # quarantined, so the violation carries the known marker and does not
+    # trip the new-violation gate.
+    leaks = [v for v in payload["violations"] if "leaked" in v]
+    assert leaks and all("(known" in v for v in leaks)
+    assert payload["new_violations"] == []
+    assert payload["ok"] is True
+
+
+def test_corpus_new_leakage_fails(tmp_path):
+    packet = build_packet(tmp_path)
+    train = packet / "data" / "route_selection.jsonl"
+    train.write_text(train.read_text() + _row("sealed q2", "vision") + "\n")
+    payload = validate_corpus(packet)
+    assert payload["ok"] is False
+    assert any(
+        "leaked into data/route_selection.jsonl" in v and "(known" not in v
+        for v in payload["new_violations"]
+    )
+
+
+def test_corpus_duplicates_and_secrets_fail(tmp_path):
+    packet = build_packet(tmp_path)
+    train = packet / "data" / "route_selection.jsonl"
+    train.write_text(train.read_text() + _row("train q1", "coding") + "\n")
+    sealed = packet / "data" / "route_selection_sealed.jsonl"
+    sealed.write_text(
+        sealed.read_text()
+        + json.dumps({"query": "leak AKIA" + "A" * 16, "answers": "[]"})
+        + "\n"
+    )
+    payload = validate_corpus(packet)
+    assert payload["ok"] is False
+    joined = "\n".join(payload["new_violations"])
+    assert "exact duplicates in data/route_selection.jsonl" in joined
+    assert "secret pattern aws-access-key" in joined
+
+
+def test_corpus_reports_class_balance_facts(tmp_path):
+    packet = build_packet(tmp_path)
+    payload = validate_corpus(packet)
+    balance = payload["facts"]["class_balance"]["route_selection.jsonl"]
+    assert balance == {"coding": 1, "research": 1}
+
+
+# ------------------------------------------------------------- lane vitals
+
+
+def test_lane_vitals_ok(tmp_path):
+    packet = build_packet(tmp_path)
+    log = packet / "logs" / "ft-arm-B-seed42.log"
+    payload = validate_lane_vitals(log, arm="B_hardneg", seed=42)
+    assert payload["ok"] is True
+    assert payload["vitals_veto"] == "ok"
+    assert payload["total_steps"] == 640
+    assert payload["completed"] is True
+    assert payload["nan_found"] is False
+    assert payload["wall_seconds"] == 512.5
+    assert payload["log_sha256"] == sha256_file(log)
+
+
+def test_lane_vitals_veto_on_nan_and_incomplete(tmp_path):
+    log = tmp_path / "bad.log"
+    log.write_text("step 5 loss nan\n")
+    payload = validate_lane_vitals(log)
+    assert payload["ok"] is False
+    joined = payload["vitals_veto"]
+    assert "NaN" in joined
+    assert "no completion marker" in joined
+
+
+def test_lane_vitals_missing_log_fails_closed(tmp_path):
+    payload = validate_lane_vitals(tmp_path / "absent.log")
+    assert payload["ok"] is False
+    assert "training log missing" in payload["vitals_veto"]
+    assert payload["total_steps"] == 0
+
+
+def test_lane_vitals_zero_steps(tmp_path):
+    log = tmp_path / "empty.log"
+    log.write_text("training complete\n")
+    payload = validate_lane_vitals(log)
+    assert payload["ok"] is False
+    assert "total steps not > 0" in payload["vitals_veto"]
+
+
+# ------------------------------------------------------------- arm records
+
+
+def test_arm_records_replays_frozen_file(tmp_path):
+    packet = build_packet(tmp_path)
+    payload = validate_arm_records(packet)
+    assert payload["ok"] is True
+    assert [a["arm"] for a in payload["arms"]] == ["arm_B", "arm_E"]
+    assert all(a["seed"] == 42 for a in payload["arms"])
+    assert payload["arms"][0]["dataset_hash"] == "b" * 24
+
+
+def test_arm_records_missing_file_fails_closed(tmp_path):
+    payload = validate_arm_records(tmp_path / "empty")
+    assert payload["ok"] is False
+    assert payload["arms"] == []
+
+
+# ------------------------------------------------------------- arm metrics
+
+
+def test_arm_metrics_legacy_key_mapping_and_vitals_join(tmp_path):
+    packet = build_packet(tmp_path)
+    payload = validate_arm_metrics(packet)
+    assert payload["ok"] is True
+
+    control = payload["control"]
+    assert control["results_name"] == "A_control"
+    assert control["dev_ood"] == 0.40  # legacy "sealed"
+    assert control["secondary_ood"] == 0.55  # legacy "dev_ood"
+    assert control["retention"] == "3/3"  # legacy "forgetting"
+
+    by_name = {a["results_name"]: a for a in payload["arms"]}
+    assert set(by_name) == {"B_hardneg", "E_worstcell"}
+    b_arm = by_name["B_hardneg"]
+    assert b_arm["dev_ood"] == 0.45
+    assert b_arm["vitals"]["ok"] is True
+    assert b_arm["vitals"]["total_steps"] == 640
+    assert "ft-arm-B-seed42.log" in b_arm["vitals"]["log"]
+    assert by_name["E_worstcell"]["vitals"]["total_steps"] == 512
+
+
+def test_arm_metrics_missing_log_vetoes_lane(tmp_path):
+    packet = build_packet(tmp_path)
+    (packet / "logs" / "ft-arm-E-seed42.log").unlink()
+    payload = validate_arm_metrics(packet)
+    by_name = {a["results_name"]: a for a in payload["arms"]}
+    assert by_name["E_worstcell"]["vitals"]["ok"] is False
+    assert "no training log" in by_name["E_worstcell"]["vitals"]["vitals_veto"]
+
+
+def test_arm_metrics_missing_control_fails(tmp_path):
+    packet = build_packet(tmp_path)
+    results_path = packet / "data" / "arm_results.json"
+    rows = json.loads(results_path.read_text())
+    rows = [r for r in rows if r["arm"] != "A_control"]
+    results_path.write_text(json.dumps(rows))
+    payload = validate_arm_metrics(packet)
+    assert payload["ok"] is False
+    assert any("control arm" in v for v in payload["violations"])
+
+
+# --------------------------------------------------------- harvest request
+
+
+def test_harvest_request_typed_and_request_only(tmp_path):
+    packet = build_packet(tmp_path)
+    request = build_next_harvest_request(
+        packet,
+        campaign_id="needle-r2",
+        source_dataset_id="D0001",
+        target_dataset_id="D0002",
+    )
+    assert request["schema"] == "needle-next-harvest-request/v1"
+    assert request["request_only"] is True
+    assert request["authorizes_generation"] is False
+    assert request["authorizes_training"] is False
+
+    weak = {(c["arm"], c["cell"]) for c in request["weak_confusion_cells"]}
+    assert ("B_hardneg", "planning") in weak
+    assert ("B_hardneg", "vision") in weak
+    assert ("E_worstcell", "vision") in weak
+    assert ("B_hardneg", "coding") not in weak
+
+    retention = {(c["arm"], c["cell"]) for c in request["retention_cells"]}
+    assert ("B_hardneg", "coding") in retention
+    assert ("B_hardneg", "retention_probe") in retention
+    assert request["evidence_digests"]  # exact digests present
+
+
+def test_harvest_request_rejects_same_dataset(tmp_path):
+    packet = build_packet(tmp_path)
+    with pytest.raises(ValueError, match="never modifies"):
+        build_next_harvest_request(
+            packet,
+            campaign_id="needle-r2",
+            source_dataset_id="D0001",
+            target_dataset_id="D0001",
+        )
+
+
+def test_harvest_request_deterministic(tmp_path):
+    packet = build_packet(tmp_path)
+    kwargs = dict(
+        campaign_id="needle-r2",
+        source_dataset_id="D0001",
+        target_dataset_id="D0002",
+    )
+    first = seal_receipt("harvest_request", build_next_harvest_request(packet, **kwargs))
+    second = seal_receipt("harvest_request", build_next_harvest_request(packet, **kwargs))
+    assert first == second
+
+
+# ----------------------------------------------------------- determinism
+
+
+def test_validators_are_deterministic(tmp_path):
+    packet = build_packet(tmp_path)
+    for func in (validate_preflight, validate_corpus, validate_arm_metrics):
+        first = seal_receipt("preflight", func(packet))
+        second = seal_receipt("preflight", func(packet))
+        assert first == second
+
+
+# ------------------------------------------------------------------- CLI
+
+
+def test_cli_emits_and_verifies_receipts(tmp_path, capsys):
+    from evals.needle_gates.__main__ import main
+
+    packet = build_packet(tmp_path)
+    out = tmp_path / "receipts" / "preflight.json"
+    assert main(["preflight", "--packet", str(packet), "--out", str(out)]) == 0
+    receipt = json.loads(out.read_text())
+    payload = verify_receipt(receipt, "preflight")
+    assert payload["ok"] is True
+
+    assert (
+        main(
+            [
+                "verify",
+                "--receipt",
+                str(out),
+                "--expect-validator",
+                "preflight",
+                "--expect-digest",
+                receipt["payload_sha256"],
+            ]
+        )
+        == 0
+    )
+
+    # Pinned-digest mismatch fails closed (non-zero exit).
+    assert (
+        main(["verify", "--receipt", str(out), "--expect-digest", "0" * 64]) == 1
+    )
+
+    # Tampered payload fails closed.
+    forged = dict(receipt)
+    forged["payload_b64"] = base64.b64encode(
+        canonical_json_bytes({"ok": True, "violations": []})
+    ).decode()
+    out.write_text(json.dumps(forged))
+    assert main(["verify", "--receipt", str(out)]) == 1
+    capsys.readouterr()
+
+
+def test_cli_harvest_request(tmp_path, capsys):
+    from evals.needle_gates.__main__ import main
+
+    packet = build_packet(tmp_path)
+    assert (
+        main(
+            [
+                "harvest-request",
+                "--packet",
+                str(packet),
+                "--campaign",
+                "needle-r2",
+                "--source-dataset",
+                "D0001",
+                "--target-dataset",
+                "D0002",
+            ]
+        )
+        == 0
+    )
+    receipt = json.loads(capsys.readouterr().out)
+    payload = verify_receipt(receipt, "harvest_request")
+    assert payload["request_only"] is True

--- a/tests/test_needle_workflow_js.py
+++ b/tests/test_needle_workflow_js.py
@@ -1,0 +1,35 @@
+"""Executable JavaScript workflow test for needle-training-campaign.js.
+
+The campaign orchestrator is JavaScript; its command construction, receipt
+consumption, and cross-arm gating logic must be tested in its own language.
+This wrapper runs tests/js/needle_workflow.test.cjs under node with mock
+agents that execute the real ``evals.needle_gates`` CLI (mock fixture only —
+nothing live, no providers, no credentials).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+JS_TEST = REPO_ROOT / "tests" / "js" / "needle_workflow.test.cjs"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is not installed")
+@pytest.mark.skipif(shutil.which("uv") is None, reason="uv is not installed")
+def test_needle_workflow_js():
+    result = subprocess.run(
+        ["node", str(JS_TEST)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    assert result.returncode == 0, (
+        f"JS workflow test failed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "all needle workflow JS tests passed" in result.stdout


### PR DESCRIPTION
# Needle campaign foundation: mechanical gate authority (repaired, round 2)

> **Draft — awaiting Codex exact-head re-review.**
> **Exact head:** `e99de1cd25230eca76ce09d4ef80a76d8d24a5b3`
> Commits: `7130d30` (validators + workflow), `f93fde4` (workflow wiring), `e99de1c` (round-2 repair). Rebased onto `origin/main` = `40343da` as instructed; prior heads `62dd500`/`542ecef` superseded.

## What this PR does

Repairs the training-workflow authority problem: gate truth (preflight, corpus veto, lane vitals) now comes from executable, deterministic validators in `evals/needle_gates/` producing typed JSON receipts with recomputed artifact digests. Agents may invoke validators and summarize output but cannot decide gate truth; agent prose is never converted into success. Evaluation emits a typed, request-only `next_harvest_request` (weak confusion cells + retention cells + evidence digests, each cell bound to originating root IDs).

## Round-2 repairs (Codex NO-GO items)

1. **Rebased onto current `origin/main`** (`40343da`); content and attribution preserved, new SHAs as expected.
2. **Injection-safe identifiers** — `evals/needle_gates/identifiers.py` validates packet path, run stamp, campaign ID, and dataset IDs at the argparse boundary; the workflow JS re-validates every token against a safe charset before any agent sees a command and spawns with `shell:false`. Hostile `run_stamp`/`campaign`/`dataset`/`packet` values are rejected before any agent call (covered by JS tests).
3. **Exact arm identity binding** — duplicate/aliased arm names rejected; each arm record binds to its exact results identity and dataset digest; lanes join on full identity, never a bare letter.
4. **Trivial TF-IDF baseline restored as a deterministic gate** — a learned arm must beat both `A_control` and the trivial baseline; missing baseline ⇒ `REFUSED_NO_BASELINE`. Fixture numbers make the gate meaningful (B_hardneg 0.45 beats control 0.40 but loses to baseline 0.50; E_worstcell 0.525 beats both).
5. **No absent default packet** — mock mode defaults to the committed fixture `evals/needle_gates/fixtures/mock_packet/`; live mode requires an explicit non-fixture packet and refuses fixture/`needle_lab` packets.
6. **Executable JS workflow test** — `tests/js/needle_workflow.test.cjs` (9 cases: command construction, receipt consumption, cross-arm gating, hostile identifier refusals, tamper refusal, live refusals) + pytest wrapper `tests/test_needle_workflow_js.py`.
7. **Live training stays blocked** — live lanes consume frozen, manifest-declared arm records only; training agents never generate examples.

## Changed paths (20 files, +2,881)

- `.claude/workflows/needle-training-campaign.js` — orchestrator: safe-token validation, receipt-digest verification, control+baseline cross-arm gating
- `evals/needle_gates/{__init__,__main__,identifiers,receipts,validators,harvest_request}.py`
- `evals/needle_gates/fixtures/mock_packet/` — committed mock fixture (data + logs, real digests)
- `.gitignore` — negations so fixture logs stay committed
- `tests/test_needle_gates.py` (35 tests), `tests/js/needle_workflow.test.cjs` (9 cases), `tests/test_needle_workflow_js.py`

## Verification (at exact head `e99de1c`)

- Targeted: `pytest tests/test_needle_gates.py tests/test_needle_workflow_js.py` — 36 passed
- JS: `node tests/js/needle_workflow.test.cjs` — 9/9 pass
- Full suite: `uv run pytest -q` — **1554 passed**
- `ruff check evals tests/test_needle_gates.py tests/test_needle_workflow_js.py` — clean (14 pre-existing errors in unrelated test files exist identically on `origin/main`)
- `python -m compileall -q src evals main.py` — clean; `git diff --check` — clean

## Confirmations

- Zero live provider calls; zero training; zero sealed-evaluation access; zero credential access.
- PR #64 untouched. No merge/land/deploy/worktree deletion.

## Known risks / dependencies

- The workflow runtime cannot execute Python directly; live mode therefore requires precomputed validator receipts whose digests are recomputed and checked (fail closed). This is by design but means live gate latency depends on receipt freshness.
- PR #76 (adaptive harvester) stacks on this branch and consumes the typed `next_harvest_request`.

Sponsor: David Johnston
Agent-Assisted-By: Anthropic Claude | model=Fable 5 Ultracode | model-source=user-reported | surface=Copilot CLI | role=implementation
