### PR TITLE
feat(needle): adaptive harvesting companion package (stacked on gate-receipt foundation)

### DIFF
--- a/evals/needle_harvest/__init__.py
+++ b/evals/needle_harvest/__init__.py
@@ -29,9 +29,15 @@ from evals.needle_harvest.contracts import (
     GenerationRecipe,
     HarvestManifest,
     HarvestRequest,
+    allocate_samples,
+    min_ceilings,
 )
 from evals.needle_harvest.harvester import HarvestSession
 from evals.needle_harvest.ledger import AttemptLedger
+from evals.needle_harvest.planning import (
+    WaveTemplate,
+    plan_wave_from_harvest_request,
+)
 from evals.needle_harvest.transport import (
     MockTransport,
     ProviderModel,
@@ -58,4 +64,8 @@ __all__ = [
     "TransportRequest",
     "TransportResult",
     "TransportStatus",
+    "WaveTemplate",
+    "allocate_samples",
+    "min_ceilings",
+    "plan_wave_from_harvest_request",
 ]

--- a/evals/needle_harvest/__init__.py
+++ b/evals/needle_harvest/__init__.py
@@ -1,0 +1,61 @@
+"""Adaptive data harvester for the Needle campaign (H000n generations).
+
+Companion to :mod:`evals.needle_gates`: evaluation (E000n) emits a typed,
+request-only ``next_harvest_request``; this package turns an *authorized*
+harvest into the next candidate dataset (D000n+1) and then stops for Codex
+review. It never trains, never touches sealed evaluation data, and never
+modifies the dataset currently being trained.
+
+Architecture donor: the GenFuncAgentixAI swarm_evolver/lora_forge tournament
+harvester, studied read-only. Reused ideas: same exact root fanned out to
+multiple donors, mechanical evaluation before model judging, failure
+aggregation into targeted variants, adaptive allocation, bounded concurrent
+lanes, plateau-based early stopping, explicit success and failure samples.
+Deliberately not copied: git-note concurrent writes, random UUID dataset
+splitting, positional pairing of unrelated rows, winner-versus-worst as the
+default, provider/transport failures as negative answers, raw hidden
+chain-of-thought, regex/AST scoring as semantic authority, workflow-owned
+API keys, weak execution isolation, unbounded loops.
+
+Provider boundary: everything flows through the provider-neutral transport
+contract in :mod:`evals.needle_harvest.transport`. This package reads no
+environment variables, no IDE configuration, and no credential files — the
+UniGrok MCP server owns credentials. Until that provider-neutral interface
+lands, only the typed interface and the deterministic mock transport exist.
+"""
+
+from evals.needle_harvest.contracts import (
+    Ceilings,
+    GenerationRecipe,
+    HarvestManifest,
+    HarvestRequest,
+)
+from evals.needle_harvest.harvester import HarvestSession
+from evals.needle_harvest.ledger import AttemptLedger
+from evals.needle_harvest.transport import (
+    MockTransport,
+    ProviderModel,
+    TransportRequest,
+    TransportResult,
+)
+from evals.needle_harvest.truth import (
+    EpisodeOutcome,
+    ProposalVerdict,
+    TransportStatus,
+)
+
+__all__ = [
+    "AttemptLedger",
+    "Ceilings",
+    "EpisodeOutcome",
+    "GenerationRecipe",
+    "HarvestManifest",
+    "HarvestRequest",
+    "HarvestSession",
+    "MockTransport",
+    "ProposalVerdict",
+    "ProviderModel",
+    "TransportRequest",
+    "TransportResult",
+    "TransportStatus",
+]

--- a/evals/needle_harvest/contracts.py
+++ b/evals/needle_harvest/contracts.py
@@ -11,6 +11,7 @@ calls or effects.
 from __future__ import annotations
 
 import hashlib
+import json
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -46,6 +47,45 @@ class Ceilings(StrictModel):
     max_seconds: float = Field(gt=0)
     max_cost_usd: float = Field(gt=0)
     max_roots: int = Field(gt=0)
+
+
+def min_ceilings(first: Ceilings, *rest: Ceilings) -> Ceilings:
+    """Elementwise minimum across request/session/manifest ceilings.
+
+    The effective budget for a wave is never looser than any party's
+    declared ceiling: the request, the session, and (live) the manifest all
+    bound it simultaneously.
+    """
+    values = first.model_dump()
+    for other in rest:
+        for name, value in other.model_dump().items():
+            values[name] = min(values[name], value)
+    return Ceilings(**values)
+
+
+def allocate_samples(allocation: dict[str, float], total: int) -> dict[str, int]:
+    """Deterministic largest-remainder conversion of donor weights into
+    bounded discrete sample counts summing to ``total``.
+
+    A 99/1 weighting therefore produces unequal call counts (possibly zero
+    for a starved donor) rather than being silently flattened into equal
+    per-donor sampling. Equal weights still divide evenly. Ties in the
+    fractional remainders break on the sorted donor key, so identical
+    inputs always allocate identically.
+    """
+    if total < 0:
+        raise ValueError("total samples must be non-negative")
+    donors = sorted(allocation)
+    if not donors:
+        raise ValueError("allocation needs at least one donor")
+    weight_sum = float(sum(allocation.values()))
+    quotas = {donor: allocation[donor] / weight_sum * total for donor in donors}
+    counts = {donor: int(quotas[donor]) for donor in donors}
+    remainder = total - sum(counts.values())
+    by_fraction = sorted(donors, key=lambda d: (-(quotas[d] - counts[d]), d))
+    for donor in by_fraction[:remainder]:
+        counts[donor] += 1
+    return counts
 
 
 class GenerationRecipe(StrictModel):
@@ -112,20 +152,30 @@ class HarvestRequest(StrictModel):
             raise ValueError("request authorizes no effects")
         return self
 
+    def canonical_semantics(self) -> str:
+        """Canonical JSON of the complete request semantics.
+
+        Everything that changes what example this request produces is in
+        here: objective, TTL facts (ttl_seconds/issued_at/expires_at),
+        leakage group, response type, authorized effects, source/target
+        datasets, and the full generation recipe — not just its id.
+        ``ceilings`` are deliberately excluded: budgets bound enforcement,
+        not example identity, so tightening a budget on resume cannot
+        orphan already-completed work.
+        """
+        payload = self.model_dump(mode="json", exclude={"ceilings"})
+        return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
     def work_key(self, donor: str, sample_index: int) -> str:
-        """Stable key for one provider call — identical across resumes."""
+        """Stable key for one provider call — identical across resumes.
+
+        Hashes the canonical complete request semantics, so materially
+        different examples (different objective, TTL window, leakage group,
+        recipe, …) can never collide, while a retry of the same work keeps
+        the same identity.
+        """
         return deterministic_id(
-            "work",
-            self.campaign_id,
-            self.target_dataset_id,
-            self.function_pack_id,
-            self.semantic_root_id,
-            self.function_contract_digest,
-            self.tool_catalog_digest,
-            self.recipe.recipe_id,
-            str(self.seed),
-            donor,
-            str(sample_index),
+            "work", self.canonical_semantics(), donor, str(sample_index)
         )
 
     def attempt_id(self, donor: str, sample_index: int) -> str:
@@ -133,6 +183,13 @@ class HarvestRequest(StrictModel):
 
     def effect_id(self, donor: str, sample_index: int) -> str:
         return deterministic_id("effect", self.work_key(donor, sample_index))
+
+    def sample_seed(self, donor: str, sample_index: int) -> int:
+        """Distinct deterministic seed for each donor/sample slot."""
+        digest = hashlib.sha256(
+            f"sample-seed\x1f{self.seed}\x1f{self.work_key(donor, sample_index)}".encode()
+        ).digest()
+        return int.from_bytes(digest[:8], "big")
 
     def expired(self, now: float) -> bool:
         return now >= self.expires_at

--- a/evals/needle_harvest/contracts.py
+++ b/evals/needle_harvest/contracts.py
@@ -1,0 +1,163 @@
+"""Typed contracts for adaptive harvesting.
+
+Every provider-facing unit of work is a :class:`HarvestRequest`. Its fields
+are strict (``extra="forbid"``): unknown fields — including any hidden
+chain-of-thought side channel — are rejected at parse depth. Attempt and
+effect identifiers are deterministic functions of request content, so a
+resumed harvest reuses the same work keys instead of duplicating provider
+calls or effects.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+CONTRACT_SCHEMA = "needle-harvest-request/v1"
+MANIFEST_SCHEMA = "needle-harvest-manifest/v1"
+
+# The only effects a harvest may ever be authorized to perform. Training and
+# sealed evaluation are structurally impossible to authorize here.
+ALLOWED_EFFECTS = frozenset({"provider_call", "ledger_append", "shard_write"})
+
+# Model-visible response surfaces. Deliberate, visible, redacted planning
+# fields only — no raw chain-of-thought aliases exist in this vocabulary.
+ResponseType = Literal["answer", "decision_summary", "plan_state"]
+
+
+def deterministic_id(prefix: str, *parts: str) -> str:
+    """Stable content-derived identifier (never a random UUID)."""
+    digest = hashlib.sha256("\x1f".join(parts).encode("utf-8")).hexdigest()
+    return f"{prefix}-{digest[:40]}"
+
+
+class StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class Ceilings(StrictModel):
+    """Hard budgets. Retries and adjudication count against these."""
+
+    max_provider_calls: int = Field(gt=0)
+    max_tokens: int = Field(gt=0)
+    max_retries: int = Field(ge=0)
+    max_seconds: float = Field(gt=0)
+    max_cost_usd: float = Field(gt=0)
+    max_roots: int = Field(gt=0)
+
+
+class GenerationRecipe(StrictModel):
+    """How candidates are sampled for one request."""
+
+    recipe_id: str
+    donor_allocation: dict[str, float]  # provider-neutral donor key -> weight
+    temperature: float = Field(ge=0.0, le=2.0)
+    top_p: float = Field(gt=0.0, le=1.0)
+    samples_per_donor: int = Field(gt=0, le=16)
+    prompt_surface: str = "default"
+    ttl_pressure: float = Field(ge=0.0, le=1.0, default=0.0)
+    observation_history_variant: str = "none"
+    recovery_arc: bool = False
+    tool_catalog_drift: bool = False
+
+    @model_validator(mode="after")
+    def _donors_normalized(self) -> GenerationRecipe:
+        if not self.donor_allocation:
+            raise ValueError("recipe needs at least one donor")
+        if any(w <= 0 for w in self.donor_allocation.values()):
+            raise ValueError("donor weights must be positive")
+        return self
+
+
+class HarvestRequest(StrictModel):
+    """One semantic root's worth of authorized harvesting work."""
+
+    schema_id: Literal["needle-harvest-request/v1"] = CONTRACT_SCHEMA
+    campaign_id: str
+    source_dataset_id: str
+    target_dataset_id: str
+    function_pack_id: str
+    semantic_root_id: str
+    leakage_group_id: str
+    function_contract_digest: str = Field(pattern=r"^[0-9a-f]{16,64}$")
+    model_visible_objective: str
+    ttl_seconds: float = Field(gt=0)
+    issued_at: float = Field(ge=0)
+    expires_at: float = Field(gt=0)
+    authorized_effects: tuple[str, ...]
+    tool_catalog_digest: str = Field(pattern=r"^[0-9a-f]{16,64}$")
+    recipe: GenerationRecipe
+    seed: int = Field(ge=0)
+    response_type: ResponseType = "answer"
+    ceilings: Ceilings
+
+    @model_validator(mode="after")
+    def _validate(self) -> HarvestRequest:
+        if self.source_dataset_id == self.target_dataset_id:
+            raise ValueError(
+                "target dataset must differ from source dataset "
+                "(harvesting never modifies the dataset being trained)"
+            )
+        if self.expires_at <= self.issued_at:
+            raise ValueError("expires_at must be after issued_at")
+        illegal = set(self.authorized_effects) - ALLOWED_EFFECTS
+        if illegal:
+            raise ValueError(
+                f"effects {sorted(illegal)} can never be authorized for harvesting "
+                f"(allowed: {sorted(ALLOWED_EFFECTS)})"
+            )
+        if not self.authorized_effects:
+            raise ValueError("request authorizes no effects")
+        return self
+
+    def work_key(self, donor: str, sample_index: int) -> str:
+        """Stable key for one provider call — identical across resumes."""
+        return deterministic_id(
+            "work",
+            self.campaign_id,
+            self.target_dataset_id,
+            self.function_pack_id,
+            self.semantic_root_id,
+            self.function_contract_digest,
+            self.tool_catalog_digest,
+            self.recipe.recipe_id,
+            str(self.seed),
+            donor,
+            str(sample_index),
+        )
+
+    def attempt_id(self, donor: str, sample_index: int) -> str:
+        return deterministic_id("attempt", self.work_key(donor, sample_index))
+
+    def effect_id(self, donor: str, sample_index: int) -> str:
+        return deterministic_id("effect", self.work_key(donor, sample_index))
+
+    def expired(self, now: float) -> bool:
+        return now >= self.expires_at
+
+
+class HarvestManifest(StrictModel):
+    """Codex-approved authorization to run a live harvest.
+
+    Live mode refuses to start unless this manifest exists, names the
+    reviewed head, is approved by Codex, and enables harvesting. Mock mode
+    never requires one (and never performs provider calls).
+    """
+
+    schema_id: Literal["needle-harvest-manifest/v1"] = MANIFEST_SCHEMA
+    campaign_id: str
+    approved_by: str
+    approved_head_sha: str = Field(pattern=r"^[0-9a-f]{40}$")
+    harvesting_enabled: bool
+    source_dataset_id: str
+    target_dataset_id: str
+    active_training_dataset_id: str
+    approved_dataset_ids: tuple[str, ...]
+    provider_allowlist: tuple[str, ...]  # provider-neutral donor keys
+    plane_allowlist: tuple[str, ...]
+    ceilings: Ceilings
+
+    def authorizes_live(self) -> bool:
+        return self.harvesting_enabled and self.approved_by.strip().lower() == "codex"

--- a/evals/needle_harvest/dataset.py
+++ b/evals/needle_harvest/dataset.py
@@ -27,11 +27,11 @@ import hashlib
 import json
 import re
 import unicodedata
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
 
-from evals.needle_harvest.truth import ProposalVerdict, TransportStatus
+from evals.needle_harvest.truth import EpisodeOutcome, ProposalVerdict, TransportStatus
 
 DATASET_MANIFEST_SCHEMA = "needle-harvest-dataset/v1"
 
@@ -98,7 +98,13 @@ def split_for_leakage_group(leakage_group_id: str) -> str:
 
 @dataclass(frozen=True)
 class CandidateSample:
-    """One evaluated candidate response bound to its request context."""
+    """One evaluated candidate response bound to its request context.
+
+    Carries the exact model-visible input (objective + TTL envelope), not
+    just the response: a training example is unlearnable without its
+    prompt. Provenance (provider receipt, judge votes) lives in separate
+    fields that never enter model-visible text.
+    """
 
     function_pack_id: str
     semantic_root_id: str
@@ -112,10 +118,16 @@ class CandidateSample:
     text: str
     transport_status: TransportStatus
     proposal_verdict: ProposalVerdict
+    episode_outcome: EpisodeOutcome
+    model_visible_objective: str
+    ttl_seconds: float
+    issued_at: float
+    expires_at: float
     score: float = 0.0
     confusion_cell: str = ""
     visible_fields: tuple[str, ...] = ("answer",)
     provenance_receipt: dict[str, str] = field(default_factory=dict)
+    judge_votes: tuple[tuple[str, bool], ...] = ()
 
     @property
     def content_id(self) -> str:
@@ -124,6 +136,67 @@ class CandidateSample:
             self.semantic_root_id,
             self.function_contract_digest,
             self.text,
+        )
+
+    @property
+    def input_digest(self) -> str:
+        """Digest of the exact model-visible input for this candidate."""
+        canonical = json.dumps(
+            {
+                "objective": self.model_visible_objective,
+                "ttl_seconds": self.ttl_seconds,
+                "issued_at": self.issued_at,
+                "expires_at": self.expires_at,
+                "function_contract_digest": self.function_contract_digest,
+                "tool_catalog_digest": self.tool_catalog_digest,
+                "response_type": self.response_type,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+    def to_payload(self) -> dict[str, Any]:
+        """JSON-safe dict carrying the complete candidate content."""
+        payload = asdict(self)
+        payload["transport_status"] = self.transport_status.value
+        payload["proposal_verdict"] = self.proposal_verdict.value
+        payload["episode_outcome"] = self.episode_outcome.value
+        payload["visible_fields"] = list(self.visible_fields)
+        payload["judge_votes"] = [
+            [judge_key, approves] for judge_key, approves in self.judge_votes
+        ]
+        return payload
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, Any]) -> CandidateSample:
+        """Reconstruct the exact candidate persisted by :meth:`to_payload`."""
+        return cls(
+            function_pack_id=payload["function_pack_id"],
+            semantic_root_id=payload["semantic_root_id"],
+            leakage_group_id=payload["leakage_group_id"],
+            function_contract_digest=payload["function_contract_digest"],
+            tool_catalog_digest=payload["tool_catalog_digest"],
+            ttl_condition=payload["ttl_condition"],
+            response_type=payload["response_type"],
+            donor_key=payload["donor_key"],
+            recipe_id=payload["recipe_id"],
+            text=payload["text"],
+            transport_status=TransportStatus(payload["transport_status"]),
+            proposal_verdict=ProposalVerdict(payload["proposal_verdict"]),
+            episode_outcome=EpisodeOutcome(payload["episode_outcome"]),
+            model_visible_objective=payload["model_visible_objective"],
+            ttl_seconds=payload["ttl_seconds"],
+            issued_at=payload["issued_at"],
+            expires_at=payload["expires_at"],
+            score=payload.get("score", 0.0),
+            confusion_cell=payload.get("confusion_cell", ""),
+            visible_fields=tuple(payload.get("visible_fields", ("answer",))),
+            provenance_receipt=dict(payload.get("provenance_receipt", {})),
+            judge_votes=tuple(
+                (str(judge_key), bool(approves))
+                for judge_key, approves in payload.get("judge_votes", [])
+            ),
         )
 
 
@@ -204,6 +277,25 @@ class DatasetBuilder:
         rows.sort(key=lambda r: r["content_id"])
         return rows
 
+    def provisional_sft_view(self) -> list[dict[str, Any]]:
+        """Judge-approved provisional SFT targets — an explicit opt-in view.
+
+        Unanimous ``JUDGE_PROVISIONAL`` approvals are imperfect but
+        learnable research data. They never enter the verified ``sft`` view
+        and are never relabeled ``VERIFIED_SUCCESS``; training recipes that
+        want them must opt into this view deliberately. Judge provenance is
+        preserved on every row.
+        """
+        rows = []
+        for sample in self._samples:
+            if sample.proposal_verdict is not ProposalVerdict.JUDGE_PROVISIONAL:
+                continue
+            if sample.episode_outcome is not EpisodeOutcome.SUCCESS:
+                continue
+            rows.append(self._row(sample, view="sft_provisional"))
+        rows.sort(key=lambda r: r["content_id"])
+        return rows
+
     def dpo_view(self) -> list[dict[str, Any]]:
         """DPO preference pairs under the same-contract rule.
 
@@ -274,6 +366,13 @@ class DatasetBuilder:
                 ProposalVerdict.JUDGE_PROVISIONAL,
             ):
                 return False
+            # A judge-approved provisional answer is (provisionally) good;
+            # it must not be spent as a preference negative.
+            if (
+                sample.proposal_verdict is ProposalVerdict.JUDGE_PROVISIONAL
+                and sample.episode_outcome is EpisodeOutcome.SUCCESS
+            ):
+                return False
             if sample.response_type != chosen.response_type:
                 return False
             return True
@@ -331,12 +430,29 @@ class DatasetBuilder:
             "split": split_for_leakage_group(sample.leakage_group_id),
             "ttl_condition": sample.ttl_condition,
             "response_type": sample.response_type,
+            # The exact model-visible input: without it a row is not a
+            # learnable example. ``text`` below is the target response.
+            "input": {
+                "objective": sample.model_visible_objective,
+                "ttl_seconds": sample.ttl_seconds,
+                "issued_at": sample.issued_at,
+                "expires_at": sample.expires_at,
+                "function_contract_digest": sample.function_contract_digest,
+                "tool_catalog_digest": sample.tool_catalog_digest,
+                "response_type": sample.response_type,
+            },
+            "input_digest": sample.input_digest,
             "text": sample.text,
             "label": sample.proposal_verdict.value,
+            "episode_outcome": sample.episode_outcome.value,
             "confusion_cell": sample.confusion_cell,
             # Provenance receipts stay out of model-visible text; the donor
             # key is neutral and the provider identity lives only here.
             "provenance": dict(sorted(sample.provenance_receipt.items())),
+            "judges": [
+                {"judge_key": judge_key, "approves": approves}
+                for judge_key, approves in sample.judge_votes
+            ],
             "donor_key": sample.donor_key,
             "recipe_id": sample.recipe_id,
         }
@@ -368,12 +484,32 @@ class DatasetBuilder:
         """Content-addressed shards + digest-only manifest.
 
         Massive data lives in the artifact store (``out_dir``); git is meant
-        to carry only the manifest (schemas, digests, counts).
+        to carry only the manifest (schemas, digests, counts). An existing
+        populated manifest can never be replaced by an empty build — that
+        would silently destroy a dataset on a broken resume.
         """
         out_dir = Path(out_dir)
         out_dir.mkdir(parents=True, exist_ok=True)
+        views = (
+            ("sft", self.sft_view()),
+            ("sft_provisional", self.provisional_sft_view()),
+            ("dpo", self.dpo_view()),
+        )
+        new_total = sum(len(rows) for _, rows in views)
+        manifest_path = out_dir / "manifest.json"
+        if manifest_path.exists():
+            existing = json.loads(manifest_path.read_text())
+            existing_total = sum(
+                int(info.get("rows", 0))
+                for info in existing.get("shards", {}).values()
+            )
+            if existing_total > 0 and new_total == 0:
+                raise DatasetBuildError(
+                    "refusing to replace a populated dataset manifest with an "
+                    "empty build — resume must reconstruct candidates first"
+                )
         shards: dict[str, dict[str, Any]] = {}
-        for name, rows in (("sft", self.sft_view()), ("dpo", self.dpo_view())):
+        for name, rows in views:
             payload = "\n".join(json.dumps(r, sort_keys=True) for r in rows)
             payload += "\n" if rows else ""
             digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
@@ -392,7 +528,7 @@ class DatasetBuilder:
         manifest["manifest_sha256"] = hashlib.sha256(
             manifest_bytes.encode("utf-8")
         ).hexdigest()
-        (out_dir / "manifest.json").write_text(
+        manifest_path.write_text(
             json.dumps(manifest, sort_keys=True, indent=2) + "\n"
         )
         return manifest

--- a/evals/needle_harvest/dataset.py
+++ b/evals/needle_harvest/dataset.py
@@ -1,0 +1,398 @@
+"""Candidate dataset assembly: SFT and DPO views, packs, splits, shards.
+
+Rules enforced here (each with a test):
+
+- Distinct SFT-target and DPO-preference views.
+- A DPO pair's chosen and rejected must answer the same semantic root, TTL
+  condition, function contract, tool catalog, and response type. A rationale
+  is never paired with an answer.
+- Authentication/timeout/transport/empty/malformed failures are never DPO
+  negatives; preferred pairing is winner-versus-runner-up plus
+  confusion-specific hard negatives.
+- No hidden chain-of-thought: only deliberately generated, visible
+  ``decision_summary`` / ``plan_state`` surfaces may exist, and forbidden
+  field names are rejected at ingestion.
+- Deterministic semantic content IDs; exact and semantic deduplication.
+- A root and all its sibling variants share one leakage group, and the
+  partition is a deterministic function of the group — siblings can never
+  cross partitions.
+- One function pack per builder; cross-pack rows are rejected.
+- Never append to an approved dataset generation.
+- Shards are content-addressed files; the manifest carries digests only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import unicodedata
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from evals.needle_harvest.truth import ProposalVerdict, TransportStatus
+
+DATASET_MANIFEST_SCHEMA = "needle-harvest-dataset/v1"
+
+SPLITS = ("train", "dev", "holdout")
+_SPLIT_WEIGHTS = (8, 1, 1)  # deterministic 80/10/10 by leakage group
+
+# Any of these appearing as a candidate field means hidden reasoning is
+# trying to enter the artifact stream. Rejected at ingestion.
+FORBIDDEN_FIELDS = frozenset(
+    {
+        "chain_of_thought",
+        "cot",
+        "reasoning",
+        "raw_reasoning",
+        "hidden_reasoning",
+        "scratchpad",
+        "internal_monologue",
+        "thinking",
+    }
+)
+
+VISIBLE_RESPONSE_FIELDS = frozenset({"answer", "decision_summary", "plan_state"})
+
+# Transport-level failures that must never become preference negatives.
+_NON_SEMANTIC_STATUSES = frozenset(
+    {
+        TransportStatus.TIMEOUT,
+        TransportStatus.EMPTY,
+        TransportStatus.MALFORMED,
+        TransportStatus.REFUSED,
+        TransportStatus.ERROR,
+    }
+)
+
+
+def semantic_content_id(pack_id: str, root_id: str, contract_digest: str, text: str) -> str:
+    """Deterministic semantic content identity for dedup and provenance."""
+    normalized = _normalize_text(text)
+    digest = hashlib.sha256(
+        "\x1f".join((pack_id, root_id, contract_digest, normalized)).encode("utf-8")
+    ).hexdigest()
+    return f"content-{digest[:40]}"
+
+
+def _normalize_text(text: str) -> str:
+    text = unicodedata.normalize("NFKC", text).lower()
+    text = re.sub(r"\s+", " ", text).strip()
+    text = re.sub(r"[\u201c\u201d]", '"', text)
+    text = re.sub(r"[\u2018\u2019]", "'", text)
+    return text
+
+
+def split_for_leakage_group(leakage_group_id: str) -> str:
+    """Deterministic partition of a whole leakage group (never per-row)."""
+    digest = hashlib.sha256(leakage_group_id.encode("utf-8")).digest()
+    bucket = digest[0] % sum(_SPLIT_WEIGHTS)
+    edge = 0
+    for split, weight in zip(SPLITS, _SPLIT_WEIGHTS):
+        edge += weight
+        if bucket < edge:
+            return split
+    return SPLITS[0]
+
+
+@dataclass(frozen=True)
+class CandidateSample:
+    """One evaluated candidate response bound to its request context."""
+
+    function_pack_id: str
+    semantic_root_id: str
+    leakage_group_id: str
+    function_contract_digest: str
+    tool_catalog_digest: str
+    ttl_condition: str
+    response_type: str
+    donor_key: str
+    recipe_id: str
+    text: str
+    transport_status: TransportStatus
+    proposal_verdict: ProposalVerdict
+    score: float = 0.0
+    confusion_cell: str = ""
+    visible_fields: tuple[str, ...] = ("answer",)
+    provenance_receipt: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def content_id(self) -> str:
+        return semantic_content_id(
+            self.function_pack_id,
+            self.semantic_root_id,
+            self.function_contract_digest,
+            self.text,
+        )
+
+
+class DatasetBuildError(ValueError):
+    pass
+
+
+class DatasetBuilder:
+    """Builds one function pack's candidate dataset generation."""
+
+    def __init__(
+        self,
+        *,
+        function_pack_id: str,
+        target_dataset_id: str,
+        approved_dataset_ids: tuple[str, ...] = (),
+    ) -> None:
+        if target_dataset_id in approved_dataset_ids:
+            raise DatasetBuildError(
+                f"dataset {target_dataset_id} is already approved/frozen — "
+                "never append to an approved generation; propose the next one"
+            )
+        self.function_pack_id = function_pack_id
+        self.target_dataset_id = target_dataset_id
+        self._samples: list[CandidateSample] = []
+        self._exact_seen: set[str] = set()
+        self._semantic_seen: set[str] = set()
+        self._rejections: list[dict[str, str]] = []
+
+    # ------------------------------------------------------------ ingestion
+
+    def ingest(self, sample: CandidateSample, raw_fields: dict[str, Any] | None = None) -> bool:
+        """Admit one candidate; returns False (and records why) if rejected."""
+        if sample.function_pack_id != self.function_pack_id:
+            self._reject(sample, "cross-pack mixing rejected")
+            return False
+        raw_keys = {k.lower() for k in (raw_fields or {})}
+        hidden = raw_keys & FORBIDDEN_FIELDS
+        if hidden or set(sample.visible_fields) - VISIBLE_RESPONSE_FIELDS:
+            self._reject(sample, f"hidden chain-of-thought fields rejected: {sorted(hidden) or sorted(set(sample.visible_fields) - VISIBLE_RESPONSE_FIELDS)}")
+            return False
+        exact_key = hashlib.sha256(
+            f"{sample.semantic_root_id}\x1f{sample.text}".encode()
+        ).hexdigest()
+        if exact_key in self._exact_seen:
+            self._reject(sample, "exact duplicate rejected")
+            return False
+        if sample.content_id in self._semantic_seen:
+            self._reject(sample, "semantic duplicate rejected")
+            return False
+        self._exact_seen.add(exact_key)
+        self._semantic_seen.add(sample.content_id)
+        self._samples.append(sample)
+        return True
+
+    def _reject(self, sample: CandidateSample, reason: str) -> None:
+        self._rejections.append(
+            {
+                "content_id": sample.content_id,
+                "root": sample.semantic_root_id,
+                "reason": reason,
+            }
+        )
+
+    @property
+    def rejections(self) -> list[dict[str, str]]:
+        return list(self._rejections)
+
+    # ---------------------------------------------------------------- views
+
+    def sft_view(self) -> list[dict[str, Any]]:
+        """SFT targets: verified-success candidates only, split by group."""
+        rows = []
+        for sample in self._samples:
+            if sample.proposal_verdict is not ProposalVerdict.VERIFIED_SUCCESS:
+                continue
+            rows.append(self._row(sample, view="sft"))
+        rows.sort(key=lambda r: r["content_id"])
+        return rows
+
+    def dpo_view(self) -> list[dict[str, Any]]:
+        """DPO preference pairs under the same-contract rule.
+
+        Ranking per root: verified successes ordered by score. Chosen =
+        winner; rejected = runner-up when the runner-up is a *semantic*
+        failure candidate, else the best same-root verified/judged failure.
+        Confusion-specific hard negatives (same root, failing candidate
+        tagged with a confusion cell) are preferred over generic failures.
+        Winner-versus-worst is deliberately not the default.
+        """
+        by_root: dict[str, list[CandidateSample]] = {}
+        for sample in self._samples:
+            by_root.setdefault(sample.semantic_root_id, []).append(sample)
+
+        pairs = []
+        for root_id in sorted(by_root):
+            candidates = by_root[root_id]
+            winners = sorted(
+                (s for s in candidates if s.proposal_verdict is ProposalVerdict.VERIFIED_SUCCESS),
+                key=lambda s: (-s.score, s.content_id),
+            )
+            if not winners:
+                continue
+            chosen = winners[0]
+            rejected = self._pick_rejected(chosen, candidates, winners)
+            if rejected is None:
+                continue
+            self._assert_same_contract(chosen, rejected)
+            pairs.append(
+                {
+                    "pair_id": semantic_content_id(
+                        self.function_pack_id,
+                        root_id,
+                        chosen.function_contract_digest,
+                        chosen.text + "\x1f" + rejected.text,
+                    ),
+                    "root_id": root_id,
+                    "chosen": self._row(chosen, view="dpo"),
+                    "rejected": self._row(rejected, view="dpo"),
+                    "pairing": (
+                        "winner-vs-runner-up"
+                        if rejected in winners
+                        else (
+                            "confusion-hard-negative"
+                            if rejected.confusion_cell
+                            else "winner-vs-verified-failure"
+                        )
+                    ),
+                }
+            )
+        return pairs
+
+    def _pick_rejected(
+        self,
+        chosen: CandidateSample,
+        candidates: list[CandidateSample],
+        winners: list[CandidateSample],
+    ) -> CandidateSample | None:
+        def eligible(sample: CandidateSample) -> bool:
+            if sample is chosen:
+                return False
+            # Never pair infra failures; never pair unevaluated text.
+            if sample.transport_status in _NON_SEMANTIC_STATUSES:
+                return False
+            if sample.proposal_verdict not in (
+                ProposalVerdict.VERIFIED_SUCCESS,
+                ProposalVerdict.VERIFIED_FAILURE,
+                ProposalVerdict.JUDGE_PROVISIONAL,
+            ):
+                return False
+            if sample.response_type != chosen.response_type:
+                return False
+            return True
+
+        hard_negatives = sorted(
+            (
+                s
+                for s in candidates
+                if eligible(s)
+                and s.confusion_cell
+                and s.proposal_verdict is ProposalVerdict.VERIFIED_FAILURE
+            ),
+            key=lambda s: (-s.score, s.content_id),
+        )
+        if hard_negatives:
+            return hard_negatives[0]
+        if len(winners) > 1 and eligible(winners[1]):
+            return winners[1]
+        failures = sorted(
+            (
+                s
+                for s in candidates
+                if eligible(s) and s.proposal_verdict is ProposalVerdict.VERIFIED_FAILURE
+            ),
+            key=lambda s: (-s.score, s.content_id),
+        )
+        return failures[0] if failures else None
+
+    def _assert_same_contract(self, chosen: CandidateSample, rejected: CandidateSample) -> None:
+        mismatches = [
+            name
+            for name, a, b in (
+                ("root", chosen.semantic_root_id, rejected.semantic_root_id),
+                ("ttl_condition", chosen.ttl_condition, rejected.ttl_condition),
+                ("function_contract", chosen.function_contract_digest, rejected.function_contract_digest),
+                ("tool_catalog", chosen.tool_catalog_digest, rejected.tool_catalog_digest),
+                ("response_type", chosen.response_type, rejected.response_type),
+            )
+            if a != b
+        ]
+        if mismatches:
+            raise DatasetBuildError(
+                f"chosen/rejected contract mismatch on {', '.join(mismatches)} — "
+                "a preference pair must answer the same contract"
+            )
+
+    def _row(self, sample: CandidateSample, *, view: str) -> dict[str, Any]:
+        return {
+            "view": view,
+            "content_id": sample.content_id,
+            "pack": self.function_pack_id,
+            "dataset": self.target_dataset_id,
+            "root_id": sample.semantic_root_id,
+            "leakage_group": sample.leakage_group_id,
+            "split": split_for_leakage_group(sample.leakage_group_id),
+            "ttl_condition": sample.ttl_condition,
+            "response_type": sample.response_type,
+            "text": sample.text,
+            "label": sample.proposal_verdict.value,
+            "confusion_cell": sample.confusion_cell,
+            # Provenance receipts stay out of model-visible text; the donor
+            # key is neutral and the provider identity lives only here.
+            "provenance": dict(sorted(sample.provenance_receipt.items())),
+            "donor_key": sample.donor_key,
+            "recipe_id": sample.recipe_id,
+        }
+
+    # -------------------------------------------------------------- balance
+
+    def balance_report(self) -> dict[str, dict[str, int]]:
+        report: dict[str, dict[str, int]] = {
+            "by_label": {},
+            "by_donor": {},
+            "by_recipe": {},
+            "by_ttl_condition": {},
+            "by_split": {},
+        }
+        for sample in self._samples:
+            for key, value in (
+                ("by_label", sample.proposal_verdict.value),
+                ("by_donor", sample.donor_key),
+                ("by_recipe", sample.recipe_id),
+                ("by_ttl_condition", sample.ttl_condition),
+                ("by_split", split_for_leakage_group(sample.leakage_group_id)),
+            ):
+                report[key][value] = report[key].get(value, 0) + 1
+        return {k: dict(sorted(v.items())) for k, v in report.items()}
+
+    # --------------------------------------------------------------- shards
+
+    def write_shards(self, out_dir: Path) -> dict[str, Any]:
+        """Content-addressed shards + digest-only manifest.
+
+        Massive data lives in the artifact store (``out_dir``); git is meant
+        to carry only the manifest (schemas, digests, counts).
+        """
+        out_dir = Path(out_dir)
+        out_dir.mkdir(parents=True, exist_ok=True)
+        shards: dict[str, dict[str, Any]] = {}
+        for name, rows in (("sft", self.sft_view()), ("dpo", self.dpo_view())):
+            payload = "\n".join(json.dumps(r, sort_keys=True) for r in rows)
+            payload += "\n" if rows else ""
+            digest = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+            shard_path = out_dir / f"{digest}.jsonl"
+            shard_path.write_text(payload)
+            shards[name] = {"sha256": digest, "rows": len(rows), "path": shard_path.name}
+        manifest = {
+            "schema": DATASET_MANIFEST_SCHEMA,
+            "pack": self.function_pack_id,
+            "dataset": self.target_dataset_id,
+            "shards": shards,
+            "balance": self.balance_report(),
+            "rejections": len(self._rejections),
+        }
+        manifest_bytes = json.dumps(manifest, sort_keys=True, separators=(",", ":"))
+        manifest["manifest_sha256"] = hashlib.sha256(
+            manifest_bytes.encode("utf-8")
+        ).hexdigest()
+        (out_dir / "manifest.json").write_text(
+            json.dumps(manifest, sort_keys=True, indent=2) + "\n"
+        )
+        return manifest

--- a/evals/needle_harvest/harvester.py
+++ b/evals/needle_harvest/harvester.py
@@ -13,13 +13,23 @@ Safety properties enforced here:
   reviewed head SHA; mock mode performs zero network I/O by construction.
 - The active training dataset and any approved (frozen) dataset can never
   be a harvest target.
-- Work keys are deterministic, and completed work keys found in the ledger
-  are skipped on resume — a resumed harvest cannot duplicate provider calls
-  or effects.
-- Retries and adjudication calls charge the same hard budget meter as
-  first attempts.
-- Provider/model/plane receipt mismatches against the runtime-discovered
-  catalog (and, live, the manifest allowlists) quarantine the candidate.
+- Authorization precedes effects: authorized_effects, the donor catalog,
+  and the provider/plane allowlists are all checked *before* any transport
+  call, ledger write, or shard write happens for a work item.
+- Work keys hash the complete request semantics and are deterministic;
+  completed work keys found in the ledger are skipped on resume, and the
+  builder is rehydrated from persisted candidate content — a resumed
+  harvest reproduces the same dataset without duplicating a single
+  provider call or effect.
+- One wave = one campaign, one source dataset, one target dataset, one
+  function pack; each root binds to exactly one leakage group.
+- The effective budget is the elementwise minimum of request, session, and
+  manifest ceilings; retries and adjudication charge the same meter.
+- Returned work keys and receipt provider/model/plane/runtime are validated
+  against the runtime-discovered catalog (and, live, the manifest
+  allowlists); any mismatch fails closed.
+- Donor allocation weights become bounded discrete sample counts, and every
+  donor/sample slot gets its own deterministic seed.
 - Lanes are bounded: work is dispatched in deterministic batches of at most
   ``max_concurrent_lanes`` items.
 """
@@ -32,7 +42,13 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
-from evals.needle_harvest.contracts import Ceilings, HarvestManifest, HarvestRequest
+from evals.needle_harvest.contracts import (
+    Ceilings,
+    HarvestManifest,
+    HarvestRequest,
+    allocate_samples,
+    min_ceilings,
+)
 from evals.needle_harvest.dataset import CandidateSample, DatasetBuilder
 from evals.needle_harvest.ledger import AttemptLedger
 from evals.needle_harvest.proposer import ShadowProposer, WaveObservation
@@ -126,6 +142,8 @@ class HarvestSession:
         current_head_sha: str | None = None,
         ceilings: Ceilings | None = None,
         approved_dataset_ids: tuple[str, ...] = (),
+        provider_allowlist: tuple[str, ...] | None = None,
+        plane_allowlist: tuple[str, ...] | None = None,
         verifier_fn: VerifierFn | None = None,
         judge_fn: JudgeFn | None = None,
         adjudicate_fn: JudgeFn | None = None,
@@ -156,11 +174,24 @@ class HarvestSession:
                 )
             self.ceilings = manifest.ceilings
             self.approved_dataset_ids = tuple(manifest.approved_dataset_ids)
+            # Live allowlists come from the approved manifest, nowhere else.
+            self.provider_allowlist: tuple[str, ...] | None = tuple(
+                manifest.provider_allowlist
+            )
+            self.plane_allowlist: tuple[str, ...] | None = tuple(
+                manifest.plane_allowlist
+            )
         else:
             if ceilings is None:
                 raise HarvestAuthorizationError("mock mode requires explicit ceilings")
             self.ceilings = ceilings
             self.approved_dataset_ids = tuple(approved_dataset_ids)
+            self.provider_allowlist = (
+                tuple(provider_allowlist) if provider_allowlist is not None else None
+            )
+            self.plane_allowlist = (
+                tuple(plane_allowlist) if plane_allowlist is not None else None
+            )
         if not (1 <= max_concurrent_lanes <= 64):
             raise HarvestAuthorizationError("max_concurrent_lanes must be in [1, 64]")
         self.mode = mode
@@ -189,6 +220,15 @@ class HarvestSession:
                 f"dataset {request.target_dataset_id} is approved/frozen; "
                 "harvest into the next candidate generation instead"
             )
+        # Effects are checked before anything happens: a request that does
+        # not authorize provider calls or ledger appends cannot be run at
+        # all — there is no partially-authorized execution path.
+        for effect in ("provider_call", "ledger_append"):
+            if effect not in request.authorized_effects:
+                raise HarvestAuthorizationError(
+                    f"request for root {request.semantic_root_id} does not "
+                    f"authorize {effect!r} — refusing before any effect"
+                )
         if self.mode == "live" and self.manifest is not None:
             if request.campaign_id != self.manifest.campaign_id:
                 raise HarvestAuthorizationError(
@@ -211,20 +251,56 @@ class HarvestSession:
     ) -> dict:
         if not requests:
             raise HarvestAuthorizationError("no harvest requests supplied")
+        # Wave consistency: one campaign, one source dataset, one target
+        # dataset, one function pack per wave — and one leakage group for
+        # each root and all its siblings.
+        for label, values in (
+            ("campaign", {r.campaign_id for r in requests}),
+            ("source dataset", {r.source_dataset_id for r in requests}),
+            ("target dataset", {r.target_dataset_id for r in requests}),
+        ):
+            if len(values) > 1:
+                raise HarvestAuthorizationError(
+                    f"wave consistency violated: one wave, one {label} "
+                    f"(got {sorted(values)})"
+                )
         packs = {r.function_pack_id for r in requests}
         if len(packs) > 1:
             raise HarvestAuthorizationError(
                 f"cross-function mixing rejected: one wave, one pack (got {sorted(packs)})"
             )
-        if len(requests) > self.ceilings.max_roots:
+        root_groups: dict[str, str] = {}
+        for request in requests:
+            bound = root_groups.setdefault(
+                request.semantic_root_id, request.leakage_group_id
+            )
+            if bound != request.leakage_group_id:
+                raise HarvestAuthorizationError(
+                    f"root {request.semantic_root_id} appears with two leakage "
+                    f"groups ({bound!r}, {request.leakage_group_id!r}) — a root "
+                    "and its siblings share exactly one group"
+                )
+        if shard_dir is not None:
+            for request in requests:
+                if "shard_write" not in request.authorized_effects:
+                    raise HarvestAuthorizationError(
+                        f"request for root {request.semantic_root_id} does not "
+                        "authorize shard_write — refusing before any effect"
+                    )
+        # Effective ceilings: the elementwise minimum of the session (live:
+        # manifest) budget and every request's own budget.
+        effective_ceilings = min_ceilings(
+            self.ceilings, *[r.ceilings for r in requests]
+        )
+        if len(requests) > effective_ceilings.max_roots:
             raise HarvestAuthorizationError(
                 f"{len(requests)} roots exceed the max_roots ceiling "
-                f"({self.ceilings.max_roots})"
+                f"({effective_ceilings.max_roots})"
             )
         for request in requests:
             self._guard_request(request)
 
-        meter = BudgetMeter(self.ceilings)
+        meter = BudgetMeter(effective_ceilings)
         catalog = {model.donor_key: model for model in self.transport.discover()}
         completed = self.ledger.completed_work_keys()
         builder = DatasetBuilder(
@@ -232,19 +308,25 @@ class HarvestSession:
             target_dataset_id=requests[0].target_dataset_id,
             approved_dataset_ids=self.approved_dataset_ids,
         )
+        # Resume rehydration: rebuild the dataset from candidate content
+        # persisted in the ledger, in original ledger order, so a resumed
+        # run reproduces identical nonempty shards.
+        self._rehydrate_builder(builder, completed, requests[0].target_dataset_id)
 
         work_items = self._plan_work(requests)
         counts = {
             "planned": len(work_items),
             "skipped_resume": 0,
             "accepted": 0,
+            "provisional": 0,
             "verified_failure": 0,
             "quarantined": 0,
+            "refused_unauthorized": 0,
             "transport_failure": 0,
             "expired": 0,
             "budget_stopped": 0,
         }
-        failed_cells: list[str] = []
+        failed: list[tuple[str, HarvestRequest]] = []
         donor_accepts: dict[str, list[int]] = {}
         budget_stop = False
 
@@ -294,23 +376,27 @@ class HarvestSession:
                 )
                 if outcome == "ACCEPTED":
                     counts["accepted"] += 1
+                elif outcome == "PROVISIONAL":
+                    counts["provisional"] += 1
                 elif outcome == "REJECTED":
                     counts["verified_failure"] += 1
                 elif outcome == "QUARANTINED":
                     counts["quarantined"] += 1
+                elif outcome == "REFUSED_UNAUTHORIZED":
+                    counts["refused_unauthorized"] += 1
                 elif outcome == "TRANSPORT_FAILURE":
                     counts["transport_failure"] += 1
                 elif outcome == "EXPIRED":
                     counts["expired"] += 1
                 if outcome == "REJECTED" and cell:
-                    failed_cells.append(cell)
+                    failed.append((cell, item.request))
 
         report = self._build_report(
             requests=list(requests),
             counts=counts,
             meter=meter,
             builder=builder,
-            failed_cells=failed_cells,
+            failed=failed,
             donor_accepts=donor_accepts,
             shard_dir=shard_dir,
             validation_score=validation_score,
@@ -318,12 +404,40 @@ class HarvestSession:
         )
         return report
 
+    def _rehydrate_builder(
+        self,
+        builder: DatasetBuilder,
+        completed_work_keys: set[str],
+        target_dataset_id: str,
+    ) -> None:
+        """Rebuild the dataset from candidate content persisted in the
+        ledger, in original ledger order, for work that will be skipped."""
+        for row in self.ledger.rows():
+            candidate = row.get("candidate")
+            if not candidate or not candidate.get("ingested"):
+                continue
+            if row.get("work_key") not in completed_work_keys:
+                continue
+            if (
+                candidate.get("function_pack_id") != builder.function_pack_id
+                or candidate.get("target_dataset_id") != target_dataset_id
+            ):
+                continue
+            builder.ingest(CandidateSample.from_payload(candidate))
+
     def _plan_work(self, requests: Sequence[HarvestRequest]) -> list[_WorkItem]:
         items: list[_WorkItem] = []
         for request in requests:
-            # The same exact root goes to every allocated donor.
-            for donor_key in sorted(request.recipe.donor_allocation):
-                for sample_index in range(request.recipe.samples_per_donor):
+            # The same exact root goes to the allocated donors. Allocation
+            # weights become bounded discrete counts (largest remainder), so
+            # a 99/1 weighting yields genuinely unequal call counts.
+            donor_counts = allocate_samples(
+                request.recipe.donor_allocation,
+                total=request.recipe.samples_per_donor
+                * len(request.recipe.donor_allocation),
+            )
+            for donor_key in sorted(donor_counts):
+                for sample_index in range(donor_counts[donor_key]):
                     items.append(
                         _WorkItem(
                             request=request,
@@ -348,18 +462,47 @@ class HarvestSession:
         attempt_id = request.attempt_id(donor_key, item.sample_index)
         effect_id = request.effect_id(donor_key, item.sample_index)
 
-        meter.charge_call()
-        result = self.transport.call(
-            TransportRequest(
-                work_key=item.work_key,
-                donor_key=donor_key,
-                objective=request.model_visible_objective,
-                temperature=request.recipe.temperature,
-                top_p=request.recipe.top_p,
-                seed=request.seed,
-                max_tokens=min(request.ceilings.max_tokens, 4096),
+        # Authorization precedes effects: the donor must exist in the
+        # runtime-discovered catalog and its provider/plane must be on the
+        # allowlist BEFORE any transport call is attempted.
+        model = catalog.get(donor_key)
+        refusal = ""
+        if model is None:
+            refusal = f"donor {donor_key!r} is not in the discovered catalog"
+        elif (
+            self.provider_allowlist is not None
+            and model.provider not in self.provider_allowlist
+        ):
+            refusal = (
+                f"provider {model.provider!r} is not in the approved allowlist"
             )
+        elif (
+            self.plane_allowlist is not None
+            and model.plane not in self.plane_allowlist
+        ):
+            refusal = f"plane {model.plane!r} is not in the approved allowlist"
+        if refusal:
+            self.ledger.append(
+                work_key=item.work_key,
+                attempt_id=attempt_id,
+                effect_id=effect_id,
+                status="REFUSED_UNAUTHORIZED",
+                detail=f"refused before transport call: {refusal}",
+            )
+            return "REFUSED_UNAUTHORIZED", ""
+
+        sample_seed = request.sample_seed(donor_key, item.sample_index)
+        transport_request = TransportRequest(
+            work_key=item.work_key,
+            donor_key=donor_key,
+            objective=request.model_visible_objective,
+            temperature=request.recipe.temperature,
+            top_p=request.recipe.top_p,
+            seed=sample_seed,
+            max_tokens=min(meter.ceilings.max_tokens, 4096),
         )
+        meter.charge_call()
+        result = self.transport.call(transport_request)
 
         retry_index = 0
         while result.transport_status in _RETRYABLE and meter.can_retry():
@@ -373,17 +516,8 @@ class HarvestSession:
                 transport_status=result.transport_status,
                 detail=f"transport {result.transport_status}; retry {retry_index}",
             )
-            result = self.transport.call(
-                TransportRequest(
-                    work_key=item.work_key,
-                    donor_key=donor_key,
-                    objective=request.model_visible_objective,
-                    temperature=request.recipe.temperature,
-                    top_p=request.recipe.top_p,
-                    seed=request.seed,
-                    max_tokens=min(request.ceilings.max_tokens, 4096),
-                )
-            )
+            # Retry keeps the same work identity, effect ID, and seed.
+            result = self.transport.call(transport_request)
 
         transport_status = TransportStatus(result.transport_status)
         if transport_status is not TransportStatus.OK:
@@ -399,18 +533,30 @@ class HarvestSession:
             return "TRANSPORT_FAILURE", ""
 
         # Receipt validation against the runtime-discovered catalog and, in
-        # live mode, the manifest allowlists. Mismatch fails closed.
+        # live mode, the manifest allowlists. The transport must echo the
+        # exact work key it executed. Mismatch fails closed.
         receipt = result.receipt
-        model = catalog.get(donor_key)
         receipt_problem = ""
-        if receipt is None or model is None:
-            receipt_problem = "missing provider receipt or unknown donor"
+        if result.work_key != item.work_key:
+            receipt_problem = "returned work_key mismatch fails closed"
+        elif receipt is None:
+            receipt_problem = "missing provider receipt"
         elif (
             receipt.provider != model.provider
             or receipt.model_id != model.model_id
             or receipt.plane != model.plane
         ):
             receipt_problem = "receipt does not match discovered catalog identity"
+        elif self.mode == "mock" and receipt.runtime != "mock":
+            receipt_problem = (
+                f"receipt runtime {receipt.runtime!r} is not the mock runtime"
+            )
+        elif self.mode == "live" and (
+            not receipt.runtime or receipt.runtime == "mock"
+        ):
+            receipt_problem = (
+                f"receipt runtime {receipt.runtime!r} is not a live runtime"
+            )
         elif self.mode == "live" and self.manifest is not None:
             if receipt.provider not in self.manifest.provider_allowlist:
                 receipt_problem = "provider not in approved allowlist"
@@ -452,6 +598,7 @@ class HarvestSession:
 
         # Judge disagreement gets one bounded adjudication round; the
         # adjudication call charges the same meter as any provider call.
+        combined_votes = judge_votes
         if (
             evaluation.proposal_verdict is ProposalVerdict.INDETERMINATE
             and judge_votes
@@ -462,6 +609,7 @@ class HarvestSession:
             extra_votes = self.adjudicate_fn(
                 request.model_visible_objective, result.text
             )
+            combined_votes = judge_votes + extra_votes
             evaluation = evaluate_candidate(
                 transport_status=transport_status,
                 now=self.now_fn(),
@@ -469,7 +617,7 @@ class HarvestSession:
                 required_artifact_present=check.artifact_present,
                 oracle=check.oracle,
                 verifier=verifier,
-                judge_votes=judge_votes + extra_votes,
+                judge_votes=combined_votes,
             )
 
         receipt_dict = {
@@ -491,19 +639,6 @@ class HarvestSession:
                 provider_receipt=receipt_dict,
             )
             return "EXPIRED", check.confusion_cell
-        if evaluation.episode_outcome is EpisodeOutcome.QUARANTINED:
-            self.ledger.append(
-                work_key=item.work_key,
-                attempt_id=attempt_id,
-                effect_id=effect_id,
-                status="QUARANTINED",
-                transport_status=transport_status.value,
-                proposal_verdict=evaluation.proposal_verdict.value,
-                episode_outcome=evaluation.episode_outcome.value,
-                detail=evaluation.reason,
-                provider_receipt=receipt_dict,
-            )
-            return "QUARANTINED", check.confusion_cell
 
         sample = CandidateSample(
             function_pack_id=request.function_pack_id,
@@ -518,33 +653,67 @@ class HarvestSession:
             text=result.text,
             transport_status=transport_status,
             proposal_verdict=evaluation.proposal_verdict,
+            episode_outcome=evaluation.episode_outcome,
+            model_visible_objective=request.model_visible_objective,
+            ttl_seconds=request.ttl_seconds,
+            issued_at=request.issued_at,
+            expires_at=request.expires_at,
             score=check.score,
             confusion_cell=check.confusion_cell,
             provenance_receipt=receipt_dict,
+            judge_votes=tuple(
+                (vote.judge_key, vote.approves) for vote in combined_votes
+            ),
         )
+
+        def _candidate_payload(ingested: bool) -> dict:
+            payload = sample.to_payload()
+            payload["ingested"] = ingested
+            payload["target_dataset_id"] = request.target_dataset_id
+            return payload
+
+        if evaluation.episode_outcome is EpisodeOutcome.QUARANTINED:
+            # Substantive but unresolved answers keep their full content in
+            # the ledger so future waves can build hard negatives from them.
+            self.ledger.append(
+                work_key=item.work_key,
+                attempt_id=attempt_id,
+                effect_id=effect_id,
+                status="QUARANTINED",
+                transport_status=transport_status.value,
+                proposal_verdict=evaluation.proposal_verdict.value,
+                episode_outcome=evaluation.episode_outcome.value,
+                detail=evaluation.reason,
+                provider_receipt=receipt_dict,
+                candidate=_candidate_payload(False),
+            )
+            return "QUARANTINED", check.confusion_cell
+
         ingested = builder.ingest(sample)
-        accepted = (
-            ingested
-            and evaluation.proposal_verdict is ProposalVerdict.VERIFIED_SUCCESS
-        )
+        if not ingested:
+            status = "QUARANTINED"
+        elif evaluation.proposal_verdict is ProposalVerdict.VERIFIED_SUCCESS:
+            status = "ACCEPTED"
+        elif evaluation.proposal_verdict is ProposalVerdict.JUDGE_PROVISIONAL:
+            # Unanimous judge approval stays provisional: retained for the
+            # opt-in provisional training view, never verified, never
+            # converted into a rejection.
+            status = "PROVISIONAL"
+        else:
+            status = "REJECTED"
         self.ledger.append(
             work_key=item.work_key,
             attempt_id=attempt_id,
             effect_id=effect_id,
-            status=(
-                "ACCEPTED"
-                if accepted
-                else ("REJECTED" if ingested else "QUARANTINED")
-            ),
+            status=status,
             transport_status=transport_status.value,
             proposal_verdict=evaluation.proposal_verdict.value,
             episode_outcome=evaluation.episode_outcome.value,
             detail=evaluation.reason if ingested else "rejected by dataset rules",
             provider_receipt=receipt_dict,
+            candidate=_candidate_payload(ingested),
         )
-        if not ingested:
-            return "QUARANTINED", check.confusion_cell
-        return ("ACCEPTED" if accepted else "REJECTED"), check.confusion_cell
+        return status, check.confusion_cell
 
     # ------------------------------------------------------------- report
 
@@ -555,7 +724,7 @@ class HarvestSession:
         counts: dict[str, int],
         meter: BudgetMeter,
         builder: DatasetBuilder,
-        failed_cells: list[str],
+        failed: list[tuple[str, HarvestRequest]],
         donor_accepts: dict[str, list[int]],
         shard_dir: Path | None,
         validation_score: float,
@@ -565,6 +734,7 @@ class HarvestSession:
         if shard_dir is not None:
             dataset_manifest = builder.write_shards(shard_dir)
 
+        failed_cells = [cell for cell, _ in failed]
         stop_decision = {"stop": True, "reason": "single-wave session complete"}
         proposed_recipe_ids: list[str] = []
         if self.proposer is not None:
@@ -587,27 +757,37 @@ class HarvestSession:
             stop_decision = {"stop": decision.stop, "reason": decision.reason}
             proposed_recipe_ids = [r.recipe_id for r in self.proposer.propose()]
 
-        # Targeted variant *requests* from aggregated failures. Request-only:
-        # nothing here executes them; they await review / the next wave.
+        # Targeted variant *requests* from aggregated failures. Each variant
+        # derives from the ORIGINATING request, so a weak root produces
+        # variants of that root — never clones of the first request.
+        # Request-only: nothing here executes them; they await review.
         variant_requests = []
-        base = requests[0]
         now = self.now_fn()
-        for cell in sorted(set(failed_cells)):
-            variant = base.model_copy(
+        seen_variants: set[tuple[str, str]] = set()
+        for cell, origin in sorted(
+            failed, key=lambda pair: (pair[0], pair[1].semantic_root_id)
+        ):
+            key = (cell, origin.semantic_root_id)
+            if key in seen_variants:
+                continue
+            seen_variants.add(key)
+            variant = origin.model_copy(
                 update={
-                    "recipe": base.recipe.model_copy(
+                    "recipe": origin.recipe.model_copy(
                         update={
-                            "recipe_id": f"{base.recipe.recipe_id}-variant-{cell}",
+                            "recipe_id": f"{origin.recipe.recipe_id}-variant-{cell}",
                             "prompt_surface": "confusion-targeted",
                         }
                     ),
                     "issued_at": now,
-                    "expires_at": now + base.ttl_seconds,
+                    "expires_at": now + origin.ttl_seconds,
                 }
             )
             variant_requests.append(
                 {
                     "confusion_cell": cell,
+                    "root_id": variant.semantic_root_id,
+                    "leakage_group_id": variant.leakage_group_id,
                     "recipe_id": variant.recipe.recipe_id,
                     "work_key_root": variant.work_key(
                         sorted(variant.recipe.donor_allocation)[0], 0

--- a/evals/needle_harvest/harvester.py
+++ b/evals/needle_harvest/harvester.py
@@ -1,0 +1,643 @@
+"""Harvest session orchestrator.
+
+Runs one authorized harvesting wave: fans the same exact root out to
+multiple donors through the provider-neutral transport, applies mechanical
+evaluation before any model judging, records every attempt in the
+append-only ledger, aggregates failures into targeted variant *requests*
+(never auto-executed), and assembles the next candidate dataset shards.
+Then it stops for Codex review.
+
+Safety properties enforced here:
+
+- Live mode refuses to start without a Codex-approved manifest bound to the
+  reviewed head SHA; mock mode performs zero network I/O by construction.
+- The active training dataset and any approved (frozen) dataset can never
+  be a harvest target.
+- Work keys are deterministic, and completed work keys found in the ledger
+  are skipped on resume — a resumed harvest cannot duplicate provider calls
+  or effects.
+- Retries and adjudication calls charge the same hard budget meter as
+  first attempts.
+- Provider/model/plane receipt mismatches against the runtime-discovered
+  catalog (and, live, the manifest allowlists) quarantine the candidate.
+- Lanes are bounded: work is dispatched in deterministic batches of at most
+  ``max_concurrent_lanes`` items.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from evals.needle_harvest.contracts import Ceilings, HarvestManifest, HarvestRequest
+from evals.needle_harvest.dataset import CandidateSample, DatasetBuilder
+from evals.needle_harvest.ledger import AttemptLedger
+from evals.needle_harvest.proposer import ShadowProposer, WaveObservation
+from evals.needle_harvest.transport import Transport, TransportRequest
+from evals.needle_harvest.truth import (
+    EpisodeOutcome,
+    JudgeVote,
+    OracleResult,
+    ProposalVerdict,
+    TransportStatus,
+    VerifierResult,
+    evaluate_candidate,
+)
+
+REPORT_SCHEMA = "needle-harvest-report/v1"
+
+_RETRYABLE = frozenset({"TIMEOUT", "ERROR", "EMPTY"})
+
+
+class HarvestAuthorizationError(RuntimeError):
+    """Raised when a session may not start or a request may not run."""
+
+
+class BudgetExhausted(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class MechanicalCheck:
+    """Result of mechanical, pre-judge evaluation of one candidate."""
+
+    artifact_present: bool
+    oracle: OracleResult | None = None
+    score: float = 0.0
+    confusion_cell: str = ""
+
+
+MechanicalFn = Callable[[HarvestRequest, str], MechanicalCheck]
+VerifierFn = Callable[[HarvestRequest, str], VerifierResult | None]
+JudgeFn = Callable[[str, str], tuple[JudgeVote, ...]]
+
+
+class BudgetMeter:
+    """Hard ceilings. Every provider call — first attempt, retry, or
+    adjudication — charges the same meter."""
+
+    def __init__(self, ceilings: Ceilings) -> None:
+        self.ceilings = ceilings
+        self.provider_calls = 0
+        self.retries = 0
+
+    def can_call(self) -> bool:
+        return self.provider_calls < self.ceilings.max_provider_calls
+
+    def charge_call(self) -> None:
+        if not self.can_call():
+            raise BudgetExhausted("max_provider_calls ceiling reached")
+        self.provider_calls += 1
+
+    def can_retry(self) -> bool:
+        return self.retries < self.ceilings.max_retries and self.can_call()
+
+    def charge_retry(self) -> None:
+        if self.retries >= self.ceilings.max_retries:
+            raise BudgetExhausted("max_retries ceiling reached")
+        self.retries += 1
+        self.charge_call()
+
+
+@dataclass(frozen=True)
+class _WorkItem:
+    request: HarvestRequest
+    donor_key: str
+    sample_index: int
+    work_key: str
+
+
+class HarvestSession:
+    """One bounded harvesting wave for a single function pack."""
+
+    def __init__(
+        self,
+        *,
+        mode: str,
+        transport: Transport,
+        ledger: AttemptLedger,
+        active_training_dataset_id: str,
+        mechanical_fn: MechanicalFn,
+        now_fn: Callable[[], float],
+        manifest: HarvestManifest | None = None,
+        current_head_sha: str | None = None,
+        ceilings: Ceilings | None = None,
+        approved_dataset_ids: tuple[str, ...] = (),
+        verifier_fn: VerifierFn | None = None,
+        judge_fn: JudgeFn | None = None,
+        adjudicate_fn: JudgeFn | None = None,
+        max_concurrent_lanes: int = 4,
+        proposer: ShadowProposer | None = None,
+    ) -> None:
+        if mode not in ("mock", "live"):
+            raise HarvestAuthorizationError(f"unknown mode {mode!r}")
+        if mode == "live":
+            if manifest is None:
+                raise HarvestAuthorizationError(
+                    "live harvesting refused: no Codex-approved harvest manifest"
+                )
+            if not manifest.authorizes_live():
+                raise HarvestAuthorizationError(
+                    "live harvesting refused: manifest is not Codex-approved "
+                    "or harvesting is disabled"
+                )
+            if current_head_sha != manifest.approved_head_sha:
+                raise HarvestAuthorizationError(
+                    "live harvesting refused: current head does not match the "
+                    "manifest's approved head SHA (fail closed)"
+                )
+            if manifest.active_training_dataset_id != active_training_dataset_id:
+                raise HarvestAuthorizationError(
+                    "live harvesting refused: manifest and session disagree on "
+                    "the active training dataset"
+                )
+            self.ceilings = manifest.ceilings
+            self.approved_dataset_ids = tuple(manifest.approved_dataset_ids)
+        else:
+            if ceilings is None:
+                raise HarvestAuthorizationError("mock mode requires explicit ceilings")
+            self.ceilings = ceilings
+            self.approved_dataset_ids = tuple(approved_dataset_ids)
+        if not (1 <= max_concurrent_lanes <= 64):
+            raise HarvestAuthorizationError("max_concurrent_lanes must be in [1, 64]")
+        self.mode = mode
+        self.transport = transport
+        self.ledger = ledger
+        self.active_training_dataset_id = active_training_dataset_id
+        self.manifest = manifest
+        self.mechanical_fn = mechanical_fn
+        self.verifier_fn = verifier_fn
+        self.judge_fn = judge_fn
+        self.adjudicate_fn = adjudicate_fn
+        self.now_fn = now_fn
+        self.max_concurrent_lanes = max_concurrent_lanes
+        self.proposer = proposer
+
+    # ------------------------------------------------------------- guards
+
+    def _guard_request(self, request: HarvestRequest) -> None:
+        if request.target_dataset_id == self.active_training_dataset_id:
+            raise HarvestAuthorizationError(
+                "harvesting must never modify the dataset currently being "
+                f"trained ({self.active_training_dataset_id})"
+            )
+        if request.target_dataset_id in self.approved_dataset_ids:
+            raise HarvestAuthorizationError(
+                f"dataset {request.target_dataset_id} is approved/frozen; "
+                "harvest into the next candidate generation instead"
+            )
+        if self.mode == "live" and self.manifest is not None:
+            if request.campaign_id != self.manifest.campaign_id:
+                raise HarvestAuthorizationError(
+                    "request campaign does not match the approved manifest"
+                )
+            if request.target_dataset_id != self.manifest.target_dataset_id:
+                raise HarvestAuthorizationError(
+                    "request target dataset does not match the approved manifest"
+                )
+
+    # ---------------------------------------------------------------- run
+
+    def run(
+        self,
+        requests: Sequence[HarvestRequest],
+        *,
+        shard_dir: Path | None = None,
+        validation_score: float = 0.0,
+        wave_index: int = 0,
+    ) -> dict:
+        if not requests:
+            raise HarvestAuthorizationError("no harvest requests supplied")
+        packs = {r.function_pack_id for r in requests}
+        if len(packs) > 1:
+            raise HarvestAuthorizationError(
+                f"cross-function mixing rejected: one wave, one pack (got {sorted(packs)})"
+            )
+        if len(requests) > self.ceilings.max_roots:
+            raise HarvestAuthorizationError(
+                f"{len(requests)} roots exceed the max_roots ceiling "
+                f"({self.ceilings.max_roots})"
+            )
+        for request in requests:
+            self._guard_request(request)
+
+        meter = BudgetMeter(self.ceilings)
+        catalog = {model.donor_key: model for model in self.transport.discover()}
+        completed = self.ledger.completed_work_keys()
+        builder = DatasetBuilder(
+            function_pack_id=next(iter(packs)),
+            target_dataset_id=requests[0].target_dataset_id,
+            approved_dataset_ids=self.approved_dataset_ids,
+        )
+
+        work_items = self._plan_work(requests)
+        counts = {
+            "planned": len(work_items),
+            "skipped_resume": 0,
+            "accepted": 0,
+            "verified_failure": 0,
+            "quarantined": 0,
+            "transport_failure": 0,
+            "expired": 0,
+            "budget_stopped": 0,
+        }
+        failed_cells: list[str] = []
+        donor_accepts: dict[str, list[int]] = {}
+        budget_stop = False
+
+        # Bounded lanes: deterministic batches of at most
+        # ``max_concurrent_lanes`` items. The transport contract is
+        # synchronous here; a live async transport applies the same bound.
+        for batch_start in range(0, len(work_items), self.max_concurrent_lanes):
+            if budget_stop:
+                break
+            batch = work_items[batch_start : batch_start + self.max_concurrent_lanes]
+            for item in batch:
+                if item.work_key in completed:
+                    counts["skipped_resume"] += 1
+                    continue
+                if item.request.expired(self.now_fn()):
+                    counts["expired"] += 1
+                    self.ledger.append(
+                        work_key=item.work_key,
+                        attempt_id=item.request.attempt_id(
+                            item.donor_key, item.sample_index
+                        ),
+                        effect_id=item.request.effect_id(
+                            item.donor_key, item.sample_index
+                        ),
+                        status="EXPIRED",
+                        detail="request TTL expired before dispatch (fail closed)",
+                    )
+                    continue
+                if not meter.can_call():
+                    counts["budget_stopped"] += 1
+                    self.ledger.append(
+                        work_key=item.work_key,
+                        attempt_id=item.request.attempt_id(
+                            item.donor_key, item.sample_index
+                        ),
+                        effect_id=item.request.effect_id(
+                            item.donor_key, item.sample_index
+                        ),
+                        status="BUDGET_EXHAUSTED",
+                        detail="provider-call ceiling reached before dispatch",
+                    )
+                    budget_stop = True
+                    break
+                outcome, cell = self._process(item, meter, catalog, builder)
+                donor_accepts.setdefault(item.donor_key, []).append(
+                    1 if outcome == "ACCEPTED" else 0
+                )
+                if outcome == "ACCEPTED":
+                    counts["accepted"] += 1
+                elif outcome == "REJECTED":
+                    counts["verified_failure"] += 1
+                elif outcome == "QUARANTINED":
+                    counts["quarantined"] += 1
+                elif outcome == "TRANSPORT_FAILURE":
+                    counts["transport_failure"] += 1
+                elif outcome == "EXPIRED":
+                    counts["expired"] += 1
+                if outcome == "REJECTED" and cell:
+                    failed_cells.append(cell)
+
+        report = self._build_report(
+            requests=list(requests),
+            counts=counts,
+            meter=meter,
+            builder=builder,
+            failed_cells=failed_cells,
+            donor_accepts=donor_accepts,
+            shard_dir=shard_dir,
+            validation_score=validation_score,
+            wave_index=wave_index,
+        )
+        return report
+
+    def _plan_work(self, requests: Sequence[HarvestRequest]) -> list[_WorkItem]:
+        items: list[_WorkItem] = []
+        for request in requests:
+            # The same exact root goes to every allocated donor.
+            for donor_key in sorted(request.recipe.donor_allocation):
+                for sample_index in range(request.recipe.samples_per_donor):
+                    items.append(
+                        _WorkItem(
+                            request=request,
+                            donor_key=donor_key,
+                            sample_index=sample_index,
+                            work_key=request.work_key(donor_key, sample_index),
+                        )
+                    )
+        items.sort(key=lambda item: item.work_key)
+        return items
+
+    # ------------------------------------------------------------ process
+
+    def _process(
+        self,
+        item: _WorkItem,
+        meter: BudgetMeter,
+        catalog: dict,
+        builder: DatasetBuilder,
+    ) -> tuple[str, str]:
+        request, donor_key = item.request, item.donor_key
+        attempt_id = request.attempt_id(donor_key, item.sample_index)
+        effect_id = request.effect_id(donor_key, item.sample_index)
+
+        meter.charge_call()
+        result = self.transport.call(
+            TransportRequest(
+                work_key=item.work_key,
+                donor_key=donor_key,
+                objective=request.model_visible_objective,
+                temperature=request.recipe.temperature,
+                top_p=request.recipe.top_p,
+                seed=request.seed,
+                max_tokens=min(request.ceilings.max_tokens, 4096),
+            )
+        )
+
+        retry_index = 0
+        while result.transport_status in _RETRYABLE and meter.can_retry():
+            retry_index += 1
+            meter.charge_retry()
+            self.ledger.append(
+                work_key=item.work_key,
+                attempt_id=f"{attempt_id}-retry{retry_index}",
+                effect_id=effect_id,
+                status="RETRIED",
+                transport_status=result.transport_status,
+                detail=f"transport {result.transport_status}; retry {retry_index}",
+            )
+            result = self.transport.call(
+                TransportRequest(
+                    work_key=item.work_key,
+                    donor_key=donor_key,
+                    objective=request.model_visible_objective,
+                    temperature=request.recipe.temperature,
+                    top_p=request.recipe.top_p,
+                    seed=request.seed,
+                    max_tokens=min(request.ceilings.max_tokens, 4096),
+                )
+            )
+
+        transport_status = TransportStatus(result.transport_status)
+        if transport_status is not TransportStatus.OK:
+            self.ledger.append(
+                work_key=item.work_key,
+                attempt_id=attempt_id,
+                effect_id=effect_id,
+                status="TRANSPORT_FAILURE",
+                transport_status=transport_status.value,
+                episode_outcome=EpisodeOutcome.TRANSPORT_FAILURE.value,
+                detail="infrastructure failure — recorded, never a negative answer",
+            )
+            return "TRANSPORT_FAILURE", ""
+
+        # Receipt validation against the runtime-discovered catalog and, in
+        # live mode, the manifest allowlists. Mismatch fails closed.
+        receipt = result.receipt
+        model = catalog.get(donor_key)
+        receipt_problem = ""
+        if receipt is None or model is None:
+            receipt_problem = "missing provider receipt or unknown donor"
+        elif (
+            receipt.provider != model.provider
+            or receipt.model_id != model.model_id
+            or receipt.plane != model.plane
+        ):
+            receipt_problem = "receipt does not match discovered catalog identity"
+        elif self.mode == "live" and self.manifest is not None:
+            if receipt.provider not in self.manifest.provider_allowlist:
+                receipt_problem = "provider not in approved allowlist"
+            elif receipt.plane not in self.manifest.plane_allowlist:
+                receipt_problem = "plane not in approved allowlist"
+        if receipt_problem:
+            self.ledger.append(
+                work_key=item.work_key,
+                attempt_id=attempt_id,
+                effect_id=effect_id,
+                status="QUARANTINED",
+                transport_status=transport_status.value,
+                episode_outcome=EpisodeOutcome.QUARANTINED.value,
+                detail=f"receipt mismatch fails closed: {receipt_problem}",
+            )
+            return "QUARANTINED", ""
+
+        check = self.mechanical_fn(request, result.text)
+        verifier = self.verifier_fn(request, result.text) if self.verifier_fn else None
+        judge_votes: tuple[JudgeVote, ...] = ()
+        if check.oracle is None and verifier is None and self.judge_fn is not None:
+            # Blinded judging: judges see the objective and the text only —
+            # never the donor identity.
+            if meter.can_call():
+                meter.charge_call()
+                judge_votes = self.judge_fn(
+                    request.model_visible_objective, result.text
+                )
+
+        evaluation = evaluate_candidate(
+            transport_status=transport_status,
+            now=self.now_fn(),
+            expires_at=request.expires_at,
+            required_artifact_present=check.artifact_present,
+            oracle=check.oracle,
+            verifier=verifier,
+            judge_votes=judge_votes,
+        )
+
+        # Judge disagreement gets one bounded adjudication round; the
+        # adjudication call charges the same meter as any provider call.
+        if (
+            evaluation.proposal_verdict is ProposalVerdict.INDETERMINATE
+            and judge_votes
+            and self.adjudicate_fn is not None
+            and meter.can_call()
+        ):
+            meter.charge_call()
+            extra_votes = self.adjudicate_fn(
+                request.model_visible_objective, result.text
+            )
+            evaluation = evaluate_candidate(
+                transport_status=transport_status,
+                now=self.now_fn(),
+                expires_at=request.expires_at,
+                required_artifact_present=check.artifact_present,
+                oracle=check.oracle,
+                verifier=verifier,
+                judge_votes=judge_votes + extra_votes,
+            )
+
+        receipt_dict = {
+            "provider": receipt.provider,
+            "model_id": receipt.model_id,
+            "plane": receipt.plane,
+            "runtime": receipt.runtime,
+        }
+        if evaluation.episode_outcome is EpisodeOutcome.EXPIRED:
+            self.ledger.append(
+                work_key=item.work_key,
+                attempt_id=attempt_id,
+                effect_id=effect_id,
+                status="EXPIRED",
+                transport_status=transport_status.value,
+                proposal_verdict=evaluation.proposal_verdict.value,
+                episode_outcome=evaluation.episode_outcome.value,
+                detail=evaluation.reason,
+                provider_receipt=receipt_dict,
+            )
+            return "EXPIRED", check.confusion_cell
+        if evaluation.episode_outcome is EpisodeOutcome.QUARANTINED:
+            self.ledger.append(
+                work_key=item.work_key,
+                attempt_id=attempt_id,
+                effect_id=effect_id,
+                status="QUARANTINED",
+                transport_status=transport_status.value,
+                proposal_verdict=evaluation.proposal_verdict.value,
+                episode_outcome=evaluation.episode_outcome.value,
+                detail=evaluation.reason,
+                provider_receipt=receipt_dict,
+            )
+            return "QUARANTINED", check.confusion_cell
+
+        sample = CandidateSample(
+            function_pack_id=request.function_pack_id,
+            semantic_root_id=request.semantic_root_id,
+            leakage_group_id=request.leakage_group_id,
+            function_contract_digest=request.function_contract_digest,
+            tool_catalog_digest=request.tool_catalog_digest,
+            ttl_condition=f"ttl-{request.ttl_seconds:g}s",
+            response_type=request.response_type,
+            donor_key=donor_key,
+            recipe_id=request.recipe.recipe_id,
+            text=result.text,
+            transport_status=transport_status,
+            proposal_verdict=evaluation.proposal_verdict,
+            score=check.score,
+            confusion_cell=check.confusion_cell,
+            provenance_receipt=receipt_dict,
+        )
+        ingested = builder.ingest(sample)
+        accepted = (
+            ingested
+            and evaluation.proposal_verdict is ProposalVerdict.VERIFIED_SUCCESS
+        )
+        self.ledger.append(
+            work_key=item.work_key,
+            attempt_id=attempt_id,
+            effect_id=effect_id,
+            status=(
+                "ACCEPTED"
+                if accepted
+                else ("REJECTED" if ingested else "QUARANTINED")
+            ),
+            transport_status=transport_status.value,
+            proposal_verdict=evaluation.proposal_verdict.value,
+            episode_outcome=evaluation.episode_outcome.value,
+            detail=evaluation.reason if ingested else "rejected by dataset rules",
+            provider_receipt=receipt_dict,
+        )
+        if not ingested:
+            return "QUARANTINED", check.confusion_cell
+        return ("ACCEPTED" if accepted else "REJECTED"), check.confusion_cell
+
+    # ------------------------------------------------------------- report
+
+    def _build_report(
+        self,
+        *,
+        requests: list[HarvestRequest],
+        counts: dict[str, int],
+        meter: BudgetMeter,
+        builder: DatasetBuilder,
+        failed_cells: list[str],
+        donor_accepts: dict[str, list[int]],
+        shard_dir: Path | None,
+        validation_score: float,
+        wave_index: int,
+    ) -> dict:
+        dataset_manifest = None
+        if shard_dir is not None:
+            dataset_manifest = builder.write_shards(shard_dir)
+
+        stop_decision = {"stop": True, "reason": "single-wave session complete"}
+        proposed_recipe_ids: list[str] = []
+        if self.proposer is not None:
+            attempted = counts["planned"] - counts["skipped_resume"]
+            self.proposer.observe(
+                WaveObservation(
+                    wave_index=wave_index,
+                    accepted=counts["accepted"],
+                    attempted=max(attempted, 1),
+                    validation_score=validation_score,
+                    weak_confusion_cells=tuple(sorted(set(failed_cells))),
+                    retention_cells=(),
+                    donor_acceptance={
+                        donor: (sum(flags) / len(flags) if flags else 0.0)
+                        for donor, flags in sorted(donor_accepts.items())
+                    },
+                )
+            )
+            decision = self.proposer.should_stop()
+            stop_decision = {"stop": decision.stop, "reason": decision.reason}
+            proposed_recipe_ids = [r.recipe_id for r in self.proposer.propose()]
+
+        # Targeted variant *requests* from aggregated failures. Request-only:
+        # nothing here executes them; they await review / the next wave.
+        variant_requests = []
+        base = requests[0]
+        now = self.now_fn()
+        for cell in sorted(set(failed_cells)):
+            variant = base.model_copy(
+                update={
+                    "recipe": base.recipe.model_copy(
+                        update={
+                            "recipe_id": f"{base.recipe.recipe_id}-variant-{cell}",
+                            "prompt_surface": "confusion-targeted",
+                        }
+                    ),
+                    "issued_at": now,
+                    "expires_at": now + base.ttl_seconds,
+                }
+            )
+            variant_requests.append(
+                {
+                    "confusion_cell": cell,
+                    "recipe_id": variant.recipe.recipe_id,
+                    "work_key_root": variant.work_key(
+                        sorted(variant.recipe.donor_allocation)[0], 0
+                    ),
+                }
+            )
+
+        body = {
+            "schema": REPORT_SCHEMA,
+            "mode": self.mode,
+            "campaign_id": requests[0].campaign_id,
+            "function_pack_id": requests[0].function_pack_id,
+            "source_dataset_id": requests[0].source_dataset_id,
+            "target_dataset_id": requests[0].target_dataset_id,
+            "counts": counts,
+            "budget": {
+                "provider_calls": meter.provider_calls,
+                "retries": meter.retries,
+                "max_provider_calls": meter.ceilings.max_provider_calls,
+                "max_retries": meter.ceilings.max_retries,
+            },
+            "dataset_manifest": dataset_manifest,
+            "rejections": builder.rejections,
+            "variant_requests": variant_requests,
+            "stop_decision": stop_decision,
+            "proposed_recipe_ids": proposed_recipe_ids,
+            "authorizes_training": False,
+            "authorizes_sealed_evaluation": False,
+            "next_step": "codex review and dataset freeze",
+        }
+        canonical = json.dumps(body, sort_keys=True, separators=(",", ":"))
+        body["report_sha256"] = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+        return body

--- a/evals/needle_harvest/ledger.py
+++ b/evals/needle_harvest/ledger.py
@@ -1,10 +1,12 @@
 """Append-only, resumable attempt ledger.
 
-Every attempt — success, failure, timeout, empty response, invalid schema,
-judge disagreement, quarantine — becomes one immutable JSONL row keyed by
-its deterministic work key. Resuming a harvest replays the ledger first and
-skips any work key that already reached a terminal state, so a resume can
-never duplicate a provider call or an effect.
+Every attempt — success, provisional judge approval, failure, timeout,
+empty response, invalid schema, judge disagreement, quarantine — becomes
+one immutable JSONL row keyed by its deterministic work key. Rows for
+evaluated candidates carry the full candidate content (or an immutable
+artifact reference), so a resumed harvest can reconstruct the complete
+dataset — accepted, provisional, and semantically failed examples alike —
+without a single duplicate provider call or effect.
 """
 
 from __future__ import annotations
@@ -18,8 +20,10 @@ LEDGER_SCHEMA = "needle-harvest-ledger/v1"
 TERMINAL_STATUSES = frozenset(
     {
         "ACCEPTED",
+        "PROVISIONAL",
         "REJECTED",
         "QUARANTINED",
+        "REFUSED_UNAUTHORIZED",
         "EXPIRED",
         "BUDGET_EXHAUSTED",
         "TRANSPORT_FAILURE",
@@ -55,6 +59,7 @@ class AttemptLedger:
         episode_outcome: str = "",
         detail: str = "",
         provider_receipt: dict[str, str] | None = None,
+        candidate: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         row = {
             "schema": LEDGER_SCHEMA,
@@ -68,6 +73,9 @@ class AttemptLedger:
             "episode_outcome": episode_outcome,
             "detail": detail,
             "provider_receipt": provider_receipt or {},
+            # Full candidate content (or immutable artifact reference) for
+            # evaluated responses — resume rebuilds the dataset from these.
+            "candidate": candidate,
         }
         # Append-only: open in "a" every time; rows are never rewritten.
         with open(self._path, "a", encoding="utf-8") as handle:

--- a/evals/needle_harvest/ledger.py
+++ b/evals/needle_harvest/ledger.py
@@ -1,0 +1,94 @@
+"""Append-only, resumable attempt ledger.
+
+Every attempt — success, failure, timeout, empty response, invalid schema,
+judge disagreement, quarantine — becomes one immutable JSONL row keyed by
+its deterministic work key. Resuming a harvest replays the ledger first and
+skips any work key that already reached a terminal state, so a resume can
+never duplicate a provider call or an effect.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+LEDGER_SCHEMA = "needle-harvest-ledger/v1"
+
+TERMINAL_STATUSES = frozenset(
+    {
+        "ACCEPTED",
+        "REJECTED",
+        "QUARANTINED",
+        "EXPIRED",
+        "BUDGET_EXHAUSTED",
+        "TRANSPORT_FAILURE",
+    }
+)
+
+
+class AttemptLedger:
+    def __init__(self, path: Path) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._rows: list[dict[str, Any]] = []
+        if self._path.exists():
+            with open(self._path, encoding="utf-8") as handle:
+                for line in handle:
+                    line = line.strip()
+                    if line:
+                        self._rows.append(json.loads(line))
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def append(
+        self,
+        *,
+        work_key: str,
+        attempt_id: str,
+        effect_id: str,
+        status: str,
+        transport_status: str = "",
+        proposal_verdict: str = "",
+        episode_outcome: str = "",
+        detail: str = "",
+        provider_receipt: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        row = {
+            "schema": LEDGER_SCHEMA,
+            "sequence": len(self._rows),
+            "work_key": work_key,
+            "attempt_id": attempt_id,
+            "effect_id": effect_id,
+            "status": status,
+            "transport_status": transport_status,
+            "proposal_verdict": proposal_verdict,
+            "episode_outcome": episode_outcome,
+            "detail": detail,
+            "provider_receipt": provider_receipt or {},
+        }
+        # Append-only: open in "a" every time; rows are never rewritten.
+        with open(self._path, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(row, sort_keys=True) + "\n")
+        self._rows.append(row)
+        return row
+
+    def rows(self) -> list[dict[str, Any]]:
+        return list(self._rows)
+
+    def completed_work_keys(self) -> set[str]:
+        """Work keys that reached a terminal state — skipped on resume."""
+        return {
+            row["work_key"]
+            for row in self._rows
+            if row.get("status") in TERMINAL_STATUSES
+        }
+
+    def effect_ids_by_work_key(self) -> dict[str, str]:
+        return {
+            row["work_key"]: row["effect_id"]
+            for row in self._rows
+            if row.get("effect_id")
+        }

--- a/evals/needle_harvest/planning.py
+++ b/evals/needle_harvest/planning.py
@@ -1,0 +1,157 @@
+"""Wave planning: consume the typed ``next_harvest_request`` from E000n.
+
+The evaluation gate (``evals.needle_gates.harvest_request``) emits a typed,
+request-only document naming the weak confusion cells and retention cells,
+each bound to the exact semantic root IDs whose evaluations produced it.
+This module converts that document into concrete :class:`HarvestRequest`
+objects for the next wave:
+
+- every weak cell yields variants generated *from the failing root* (never
+  a clone of some unrelated first request), and
+- every retention cell with roots yields controlled variants of the
+  successful root, so retained behavior keeps fresh coverage.
+
+Planning is pure: it performs no provider calls, no ledger writes, and no
+shard writes. The resulting requests still require a Codex-approved
+manifest before a live harvester may execute them.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import Field
+
+from evals.needle_harvest.contracts import (
+    Ceilings,
+    GenerationRecipe,
+    HarvestRequest,
+    ResponseType,
+    StrictModel,
+)
+
+ACCEPTED_REQUEST_SCHEMA = "needle-next-harvest-request/v1"
+
+
+class WavePlanError(ValueError):
+    """The harvest-request document or template cannot produce a wave."""
+
+
+class WaveTemplate(StrictModel):
+    """Wave-constant facts the evaluation document does not carry.
+
+    One template covers exactly one function pack, contract, and tool
+    catalog — matching the one-pack-per-wave rule. Per-root facts (the
+    exact model-visible objective and the leakage group binding the root
+    with all its siblings) come from committed, reviewed maps.
+    """
+
+    function_pack_id: str
+    function_contract_digest: str = Field(pattern=r"^[0-9a-f]{16,64}$")
+    tool_catalog_digest: str = Field(pattern=r"^[0-9a-f]{16,64}$")
+    response_type: ResponseType = "answer"
+    base_recipe: GenerationRecipe
+    seed: int = Field(ge=0)
+    ttl_seconds: float = Field(gt=0)
+    issued_at: float = Field(ge=0)
+    ceilings: Ceilings
+    authorized_effects: tuple[str, ...] = (
+        "provider_call",
+        "ledger_append",
+        "shard_write",
+    )
+    root_objectives: dict[str, str]
+    root_leakage_groups: dict[str, str]
+
+
+def _cell_entries(doc: dict[str, Any], key: str) -> list[dict[str, Any]]:
+    entries = doc.get(key, [])
+    if not isinstance(entries, list):
+        raise WavePlanError(f"{key} must be a list of cell entries")
+    return sorted(
+        (dict(e) for e in entries if isinstance(e, dict)),
+        key=lambda e: (str(e.get("cell", "")), str(e.get("arm", ""))),
+    )
+
+
+def plan_wave_from_harvest_request(
+    doc: dict[str, Any], template: WaveTemplate
+) -> list[HarvestRequest]:
+    """Typed requests for the next wave, derived from evaluation evidence.
+
+    Fails closed on anything that is not a genuine request-only harvest
+    request document. Weak-cell variants target the failing root; retention
+    variants target the retained root under a controlled recipe. A root
+    referenced by the document but absent from the template's objective or
+    leakage-group maps is an error, never a silent skip.
+    """
+    if doc.get("schema") != ACCEPTED_REQUEST_SCHEMA:
+        raise WavePlanError(
+            f"unrecognized harvest-request schema {doc.get('schema')!r}"
+        )
+    if doc.get("request_only") is not True or doc.get("authorizes_generation"):
+        raise WavePlanError(
+            "document is not request-only — refusing to plan from it"
+        )
+    campaign_id = str(doc.get("campaign_id", ""))
+    source_dataset_id = str(doc.get("source_dataset_id", ""))
+    target_dataset_id = str(doc.get("target_dataset_id", ""))
+    if not campaign_id or not source_dataset_id or not target_dataset_id:
+        raise WavePlanError("document lacks campaign/source/target identifiers")
+
+    plans: list[tuple[str, str, str]] = []  # (root_id, cell, kind)
+    for entry in _cell_entries(doc, "weak_confusion_cells"):
+        for root_id in entry.get("root_ids", []):
+            plans.append((str(root_id), str(entry.get("cell", "")), "weak"))
+    for entry in _cell_entries(doc, "retention_cells"):
+        for root_id in entry.get("root_ids", []):
+            plans.append((str(root_id), str(entry.get("cell", "")), "retention"))
+
+    requests: list[HarvestRequest] = []
+    seen: set[tuple[str, str]] = set()
+    for root_id, cell, kind in plans:
+        objective = template.root_objectives.get(root_id)
+        leakage_group = template.root_leakage_groups.get(root_id)
+        if objective is None or leakage_group is None:
+            raise WavePlanError(
+                f"root {root_id!r} from the harvest request has no committed "
+                "objective/leakage-group binding — fail closed"
+            )
+        if kind == "weak":
+            recipe_id = f"{template.base_recipe.recipe_id}-weak-{cell}-{root_id}"
+            prompt_surface = "confusion-targeted"
+        else:
+            recipe_id = f"{template.base_recipe.recipe_id}-retain-{cell}-{root_id}"
+            prompt_surface = "retention-controlled"
+        if (root_id, recipe_id) in seen:
+            continue
+        seen.add((root_id, recipe_id))
+        recipe = template.base_recipe.model_copy(
+            update={"recipe_id": recipe_id, "prompt_surface": prompt_surface}
+        )
+        requests.append(
+            HarvestRequest(
+                campaign_id=campaign_id,
+                source_dataset_id=source_dataset_id,
+                target_dataset_id=target_dataset_id,
+                function_pack_id=template.function_pack_id,
+                semantic_root_id=root_id,
+                leakage_group_id=leakage_group,
+                function_contract_digest=template.function_contract_digest,
+                model_visible_objective=objective,
+                ttl_seconds=template.ttl_seconds,
+                issued_at=template.issued_at,
+                expires_at=template.issued_at + template.ttl_seconds,
+                authorized_effects=template.authorized_effects,
+                tool_catalog_digest=template.tool_catalog_digest,
+                recipe=recipe,
+                seed=template.seed,
+                response_type=template.response_type,
+                ceilings=template.ceilings,
+            )
+        )
+    if not requests:
+        raise WavePlanError(
+            "harvest request document yielded no plannable roots"
+        )
+    return requests

--- a/evals/needle_harvest/proposer.py
+++ b/evals/needle_harvest/proposer.py
@@ -1,0 +1,194 @@
+"""Shadow-mode swarm recipe proposer.
+
+Adapted (architecture only) from the donor system's swarm evolver: adaptive
+donor/recipe/temperature/sampling allocation driven by observed outcomes.
+It is a *proposer*, never a correctness authority — its output is a list of
+bounded recipe deltas for the next harvesting wave, and the truth hierarchy
+in :mod:`evals.needle_harvest.truth` remains the only judge of candidates.
+
+Signals it may react to: underperforming confusion cells, retention
+variants of strong cells, donor/judge diversity, vocabulary and
+prompt-surface variation, TTL pressure, observation-history variation,
+recovery/repair arcs, and tool-catalog drift.
+
+Stopping: accepted-data yield plateau, validation-improvement plateau, or
+any expired budget — whichever comes first.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from evals.needle_harvest.contracts import GenerationRecipe
+
+PROMPT_SURFACES = (
+    "baseline",
+    "vocab-shift",
+    "observation-history-long",
+    "observation-history-short",
+    "recovery-arc",
+)
+
+
+@dataclass(frozen=True)
+class WaveObservation:
+    """What one completed harvesting wave looked like to the proposer."""
+
+    wave_index: int
+    accepted: int
+    attempted: int
+    validation_score: float
+    weak_confusion_cells: tuple[str, ...] = ()
+    retention_cells: tuple[str, ...] = ()
+    donor_acceptance: dict[str, float] = field(default_factory=dict)
+
+    @property
+    def yield_rate(self) -> float:
+        return self.accepted / self.attempted if self.attempted else 0.0
+
+
+@dataclass(frozen=True)
+class StopDecision:
+    stop: bool
+    reason: str = ""
+
+
+class ShadowProposer:
+    """Bounded, deterministic recipe proposer (mock/shadow mode only)."""
+
+    def __init__(
+        self,
+        *,
+        base_recipe: GenerationRecipe,
+        max_waves: int,
+        yield_plateau_epsilon: float = 0.02,
+        validation_plateau_epsilon: float = 0.005,
+        plateau_patience: int = 2,
+        max_temperature_delta: float = 0.15,
+    ) -> None:
+        self.base_recipe = base_recipe
+        self.max_waves = max_waves
+        self.yield_plateau_epsilon = yield_plateau_epsilon
+        self.validation_plateau_epsilon = validation_plateau_epsilon
+        self.plateau_patience = plateau_patience
+        self.max_temperature_delta = max_temperature_delta
+        self._history: list[WaveObservation] = []
+
+    def observe(self, observation: WaveObservation) -> None:
+        self._history.append(observation)
+
+    # ------------------------------------------------------------- stopping
+
+    def should_stop(self) -> StopDecision:
+        if len(self._history) >= self.max_waves:
+            return StopDecision(True, "wave budget expired")
+        if len(self._history) > self.plateau_patience:
+            recent = self._history[-(self.plateau_patience + 1) :]
+            yield_gains = [
+                b.yield_rate - a.yield_rate for a, b in zip(recent, recent[1:])
+            ]
+            if all(g <= self.yield_plateau_epsilon for g in yield_gains):
+                return StopDecision(True, "accepted-data yield plateaued")
+            validation_gains = [
+                b.validation_score - a.validation_score
+                for a, b in zip(recent, recent[1:])
+            ]
+            if all(g <= self.validation_plateau_epsilon for g in validation_gains):
+                return StopDecision(True, "validation improvement plateaued")
+        return StopDecision(False)
+
+    # ------------------------------------------------------------ proposals
+
+    def propose(self) -> list[GenerationRecipe]:
+        """Bounded recipe deltas for the next wave (advisory only)."""
+        if not self._history:
+            return [self.base_recipe]
+        last = self._history[-1]
+        proposals: list[GenerationRecipe] = []
+
+        # Weak confusion cells get focused variants under TTL pressure and a
+        # slightly hotter temperature (bounded).
+        for cell in sorted(last.weak_confusion_cells):
+            proposals.append(
+                self._delta(
+                    recipe_id=f"{self.base_recipe.recipe_id}-confusion-{cell}",
+                    temperature_delta=min(0.1, self.max_temperature_delta),
+                    prompt_surface="vocab-shift",
+                    ttl_pressure=0.8,
+                )
+            )
+
+        # Retention cells get controlled variants of successes (cooler).
+        for cell in sorted(last.retention_cells):
+            proposals.append(
+                self._delta(
+                    recipe_id=f"{self.base_recipe.recipe_id}-retention-{cell}",
+                    temperature_delta=-min(0.1, self.max_temperature_delta),
+                    prompt_surface="observation-history-long",
+                    ttl_pressure=0.0,
+                )
+            )
+
+        # Donor diversity: shift allocation toward accepted donors while
+        # keeping every donor sampled (floor share), deterministically.
+        if last.donor_acceptance:
+            floor = 0.1
+            keys = sorted(last.donor_acceptance)
+            raw = {k: max(last.donor_acceptance[k], floor) for k in keys}
+            total = sum(raw.values())
+            allocation = {k: round(raw[k] / total, 4) for k in keys}
+            proposals.append(
+                self.base_recipe.model_copy(
+                    update={
+                        "recipe_id": f"{self.base_recipe.recipe_id}-donor-mix",
+                        "donor_allocation": allocation,
+                    }
+                )
+            )
+
+        # Recovery/repair arc + tool-catalog drift probes (fixed, bounded).
+        proposals.append(
+            self._delta(
+                recipe_id=f"{self.base_recipe.recipe_id}-recovery-arc",
+                temperature_delta=0.0,
+                prompt_surface="recovery-arc",
+                ttl_pressure=0.0,
+                recovery_arc=True,
+            )
+        )
+        proposals.append(
+            self._delta(
+                recipe_id=f"{self.base_recipe.recipe_id}-catalog-drift",
+                temperature_delta=0.0,
+                prompt_surface="baseline",
+                ttl_pressure=0.0,
+                tool_catalog_drift=True,
+            )
+        )
+        return proposals
+
+    def _delta(
+        self,
+        *,
+        recipe_id: str,
+        temperature_delta: float,
+        prompt_surface: str,
+        ttl_pressure: float,
+        recovery_arc: bool = False,
+        tool_catalog_drift: bool = False,
+    ) -> GenerationRecipe:
+        if abs(temperature_delta) > self.max_temperature_delta:
+            raise ValueError("proposer attempted an unbounded temperature change")
+        if prompt_surface not in PROMPT_SURFACES:
+            raise ValueError(f"unknown prompt surface {prompt_surface!r}")
+        temperature = min(1.5, max(0.0, self.base_recipe.temperature + temperature_delta))
+        return self.base_recipe.model_copy(
+            update={
+                "recipe_id": recipe_id,
+                "temperature": round(temperature, 3),
+                "prompt_surface": prompt_surface,
+                "ttl_pressure": ttl_pressure,
+                "recovery_arc": recovery_arc,
+                "tool_catalog_drift": tool_catalog_drift,
+            }
+        )

--- a/evals/needle_harvest/transport.py
+++ b/evals/needle_harvest/transport.py
@@ -1,0 +1,154 @@
+"""Provider-neutral transport contract + deterministic mock.
+
+The harvester speaks only this typed interface. The real implementation is
+the UniGrok MCP gateway, which owns every credential; until that interface
+lands, :class:`MockTransport` is the only concrete transport, and
+:func:`live_transport` refuses to construct anything else.
+
+This module — like the whole package — performs no network I/O, reads no
+environment variables, and opens no credential files. Provider and model
+catalogs are *discovered at runtime* through :meth:`Transport.discover`,
+never assumed from product names.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field
+
+TransportStatusLiteral = Literal[
+    "OK", "TIMEOUT", "EMPTY", "MALFORMED", "REFUSED", "ERROR"
+]
+
+
+class StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class ProviderModel(StrictModel):
+    """One runtime-discovered donor/judge identity (provider-neutral key)."""
+
+    donor_key: str  # neutral handle used everywhere model-visible text exists
+    provider: str  # provenance only; never enters training text
+    model_id: str
+    plane: str  # e.g. "api" | "cli" | "mock"
+
+
+class ProviderReceipt(StrictModel):
+    """Validated provenance for one call. Kept out of model-visible text."""
+
+    provider: str
+    model_id: str
+    plane: str
+    runtime: str
+
+
+class TransportRequest(StrictModel):
+    work_key: str
+    donor_key: str
+    objective: str  # model-visible objective text only
+    temperature: float = Field(ge=0.0, le=2.0)
+    top_p: float = Field(gt=0.0, le=1.0)
+    seed: int = Field(ge=0)
+    max_tokens: int = Field(gt=0)
+
+
+class TransportResult(StrictModel):
+    """Outcome of one provider call.
+
+    ``transport_status`` is deliberately independent from any semantic
+    verdict: a TIMEOUT/EMPTY/MALFORMED/ERROR result is an infrastructure
+    fact, never an answer, and never a preference negative.
+    """
+
+    work_key: str
+    transport_status: TransportStatusLiteral
+    text: str = ""
+    receipt: ProviderReceipt | None = None
+
+
+class Transport(Protocol):
+    def discover(self) -> tuple[ProviderModel, ...]:
+        """Runtime catalog of configured donors (exact identities)."""
+        ...
+
+    def call(self, request: TransportRequest) -> TransportResult:
+        """Execute one bounded provider call."""
+        ...
+
+
+class MockTransport:
+    """Deterministic, network-free transport for mock harvesting.
+
+    Responses come from an injected cassette: ``{(donor_key, root_id_hint):
+    [entry, ...]}`` where each entry is ``{"status": ..., "text": ...}``
+    consumed round-robin by sample index derived from the work key. When no
+    cassette entry matches, a deterministic synthetic response is derived
+    from the work key, so identical inputs always produce identical outputs.
+    """
+
+    def __init__(
+        self,
+        catalog: tuple[ProviderModel, ...],
+        cassette: dict[str, list[dict[str, str]]] | None = None,
+    ) -> None:
+        self._catalog = tuple(catalog)
+        self._cassette = {k: list(v) for k, v in (cassette or {}).items()}
+        self._cursor: dict[str, int] = {}
+        self.calls: list[TransportRequest] = []
+
+    def discover(self) -> tuple[ProviderModel, ...]:
+        return self._catalog
+
+    def call(self, request: TransportRequest) -> TransportResult:
+        self.calls.append(request)
+        model = next(
+            (m for m in self._catalog if m.donor_key == request.donor_key), None
+        )
+        if model is None:
+            return TransportResult(
+                work_key=request.work_key, transport_status="REFUSED"
+            )
+        receipt = ProviderReceipt(
+            provider=model.provider,
+            model_id=model.model_id,
+            plane=model.plane,
+            runtime="mock",
+        )
+        entries = self._cassette.get(request.donor_key)
+        if entries:
+            index = self._cursor.get(request.donor_key, 0)
+            entry = entries[index % len(entries)]
+            self._cursor[request.donor_key] = index + 1
+            status = entry.get("status", "OK")
+            return TransportResult(
+                work_key=request.work_key,
+                transport_status=status,  # type: ignore[arg-type]
+                text=entry.get("text", "") if status == "OK" else "",
+                receipt=receipt,
+            )
+        synthetic = hashlib.sha256(
+            f"{request.work_key}|{request.donor_key}|{request.seed}".encode()
+        ).hexdigest()
+        return TransportResult(
+            work_key=request.work_key,
+            transport_status="OK",
+            text=f"mock-answer-{synthetic[:16]}",
+            receipt=receipt,
+        )
+
+
+def live_transport(*_args: object, **_kwargs: object) -> Transport:
+    """Placeholder for the provider-neutral UniGrok MCP transport.
+
+    The interface is typed above; the implementation is deliberately absent
+    until the UniGrok MCP contract lands. No direct vendor client will ever
+    be created here — the MCP server owns credentials.
+    """
+    raise NotImplementedError(
+        "live transport requires the provider-neutral UniGrok MCP interface, "
+        "which is not landed; only MockTransport exists. Direct vendor "
+        "clients are forbidden by the provider boundary."
+    )

--- a/evals/needle_harvest/truth.py
+++ b/evals/needle_harvest/truth.py
@@ -1,0 +1,203 @@
+"""Truth hierarchy for harvested candidates.
+
+Order of authority:
+
+1. Mechanical oracle / downstream-effect receipts — the only source of
+   ``VERIFIED_SUCCESS`` or ``VERIFIED_FAILURE``.
+2. Claim-scoped verifier — verifies exactly the claims it is scoped to.
+3. Blinded cross-provider judge — only when exact verification is
+   impossible; can produce at most ``JUDGE_PROVISIONAL``. Disagreement is
+   ``INDETERMINATE`` and quarantined or adjudicated within a fixed budget.
+
+``transport_status`` (infrastructure), ``proposal_verdict`` (semantics), and
+``episode_outcome`` (whole-episode disposition) are kept independent: a
+timeout is not a wrong answer; a wrong answer is not a transport error.
+
+There is no promise-phrase regex anywhere in this module: wording never
+proves completion. A response that lacks the required completed artifact or
+receipt is structurally incomplete regardless of what it says.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+
+
+class TransportStatus(str, enum.Enum):
+    OK = "OK"
+    TIMEOUT = "TIMEOUT"
+    EMPTY = "EMPTY"
+    MALFORMED = "MALFORMED"
+    REFUSED = "REFUSED"
+    ERROR = "ERROR"
+
+
+class ProposalVerdict(str, enum.Enum):
+    VERIFIED_SUCCESS = "VERIFIED_SUCCESS"
+    VERIFIED_FAILURE = "VERIFIED_FAILURE"
+    JUDGE_PROVISIONAL = "JUDGE_PROVISIONAL"
+    INDETERMINATE = "INDETERMINATE"
+    STRUCTURALLY_INCOMPLETE = "STRUCTURALLY_INCOMPLETE"
+    NOT_EVALUATED = "NOT_EVALUATED"
+
+
+class EpisodeOutcome(str, enum.Enum):
+    SUCCESS = "SUCCESS"
+    FAILURE = "FAILURE"
+    QUARANTINED = "QUARANTINED"
+    EXPIRED = "EXPIRED"
+    TRANSPORT_FAILURE = "TRANSPORT_FAILURE"
+
+
+@dataclass(frozen=True)
+class OracleResult:
+    """Output of a mechanical oracle or a downstream-effect receipt check."""
+
+    passed: bool
+    receipt_digest: str  # digest of the oracle evidence; required
+
+
+@dataclass(frozen=True)
+class VerifierResult:
+    """Claim-scoped verifier outcome (claims listed explicitly)."""
+
+    passed: bool
+    claims_checked: tuple[str, ...]
+    receipt_digest: str
+
+
+@dataclass(frozen=True)
+class JudgeVote:
+    """One blinded judge's vote. Judges never see donor identities."""
+
+    judge_key: str
+    approves: bool
+
+
+@dataclass(frozen=True)
+class Evaluation:
+    transport_status: TransportStatus
+    proposal_verdict: ProposalVerdict
+    episode_outcome: EpisodeOutcome
+    reason: str = ""
+    evidence_digests: tuple[str, ...] = field(default_factory=tuple)
+
+
+def evaluate_candidate(
+    *,
+    transport_status: TransportStatus,
+    now: float,
+    expires_at: float,
+    required_artifact_present: bool,
+    oracle: OracleResult | None = None,
+    verifier: VerifierResult | None = None,
+    judge_votes: tuple[JudgeVote, ...] = (),
+) -> Evaluation:
+    """Apply the truth hierarchy to one candidate response."""
+    # TTL is checked first and fails closed: post-expiry work is void even
+    # if a beautiful answer arrived.
+    if now >= expires_at:
+        return Evaluation(
+            transport_status=transport_status,
+            proposal_verdict=ProposalVerdict.NOT_EVALUATED,
+            episode_outcome=EpisodeOutcome.EXPIRED,
+            reason="request TTL expired before evaluation",
+        )
+
+    # Infrastructure failures are infrastructure facts — never semantic
+    # verdicts, never negatives.
+    if transport_status is not TransportStatus.OK:
+        return Evaluation(
+            transport_status=transport_status,
+            proposal_verdict=ProposalVerdict.NOT_EVALUATED,
+            episode_outcome=EpisodeOutcome.TRANSPORT_FAILURE,
+            reason=f"transport {transport_status.value} is not an answer",
+        )
+
+    # Structural completeness precedes any wording: no artifact/receipt, no
+    # success — regardless of how confident the text sounds.
+    if not required_artifact_present:
+        return Evaluation(
+            transport_status=transport_status,
+            proposal_verdict=ProposalVerdict.STRUCTURALLY_INCOMPLETE,
+            episode_outcome=EpisodeOutcome.FAILURE,
+            reason="required completed artifact/receipt missing",
+        )
+
+    if oracle is not None:
+        if not oracle.receipt_digest:
+            return Evaluation(
+                transport_status=transport_status,
+                proposal_verdict=ProposalVerdict.STRUCTURALLY_INCOMPLETE,
+                episode_outcome=EpisodeOutcome.FAILURE,
+                reason="oracle result lacks a receipt digest",
+            )
+        verdict = (
+            ProposalVerdict.VERIFIED_SUCCESS
+            if oracle.passed
+            else ProposalVerdict.VERIFIED_FAILURE
+        )
+        return Evaluation(
+            transport_status=transport_status,
+            proposal_verdict=verdict,
+            episode_outcome=(
+                EpisodeOutcome.SUCCESS if oracle.passed else EpisodeOutcome.FAILURE
+            ),
+            reason="mechanical oracle",
+            evidence_digests=(oracle.receipt_digest,),
+        )
+
+    if verifier is not None:
+        if not verifier.claims_checked or not verifier.receipt_digest:
+            return Evaluation(
+                transport_status=transport_status,
+                proposal_verdict=ProposalVerdict.INDETERMINATE,
+                episode_outcome=EpisodeOutcome.QUARANTINED,
+                reason="verifier result without explicit claim scope/receipt",
+            )
+        verdict = (
+            ProposalVerdict.VERIFIED_SUCCESS
+            if verifier.passed
+            else ProposalVerdict.VERIFIED_FAILURE
+        )
+        return Evaluation(
+            transport_status=transport_status,
+            proposal_verdict=verdict,
+            episode_outcome=(
+                EpisodeOutcome.SUCCESS if verifier.passed else EpisodeOutcome.FAILURE
+            ),
+            reason="claim-scoped verifier",
+            evidence_digests=(verifier.receipt_digest,),
+        )
+
+    if judge_votes:
+        approvals = [v.approves for v in judge_votes]
+        if all(approvals):
+            # A model judge can never mint VERIFIED_SUCCESS.
+            return Evaluation(
+                transport_status=transport_status,
+                proposal_verdict=ProposalVerdict.JUDGE_PROVISIONAL,
+                episode_outcome=EpisodeOutcome.SUCCESS,
+                reason="unanimous blinded judges (provisional only)",
+            )
+        if not any(approvals):
+            return Evaluation(
+                transport_status=transport_status,
+                proposal_verdict=ProposalVerdict.JUDGE_PROVISIONAL,
+                episode_outcome=EpisodeOutcome.FAILURE,
+                reason="unanimous blinded judges against (provisional only)",
+            )
+        return Evaluation(
+            transport_status=transport_status,
+            proposal_verdict=ProposalVerdict.INDETERMINATE,
+            episode_outcome=EpisodeOutcome.QUARANTINED,
+            reason="judge disagreement — quarantined pending adjudication budget",
+        )
+
+    return Evaluation(
+        transport_status=transport_status,
+        proposal_verdict=ProposalVerdict.INDETERMINATE,
+        episode_outcome=EpisodeOutcome.QUARANTINED,
+        reason="no oracle, verifier, or judges available",
+    )

--- a/tests/test_needle_harvest.py
+++ b/tests/test_needle_harvest.py
@@ -20,6 +20,8 @@ from evals.needle_harvest.contracts import (
     GenerationRecipe,
     HarvestManifest,
     HarvestRequest,
+    allocate_samples,
+    min_ceilings,
 )
 from evals.needle_harvest.dataset import (
     CandidateSample,
@@ -33,11 +35,17 @@ from evals.needle_harvest.harvester import (
     MechanicalCheck,
 )
 from evals.needle_harvest.ledger import AttemptLedger
+from evals.needle_harvest.planning import (
+    WavePlanError,
+    WaveTemplate,
+    plan_wave_from_harvest_request,
+)
 from evals.needle_harvest.transport import (
     MockTransport,
     ProviderModel,
 )
 from evals.needle_harvest.truth import (
+    EpisodeOutcome,
     JudgeVote,
     OracleResult,
     ProposalVerdict,
@@ -162,9 +170,19 @@ def make_sample(**overrides) -> CandidateSample:
         text="the answer is 42",
         transport_status=TransportStatus.OK,
         proposal_verdict=ProposalVerdict.VERIFIED_SUCCESS,
+        model_visible_objective="resolve the root task",
+        ttl_seconds=3600.0,
+        issued_at=1000.0,
+        expires_at=10000.0,
         score=1.0,
     )
     values.update(overrides)
+    values.setdefault(
+        "episode_outcome",
+        EpisodeOutcome.SUCCESS
+        if values["proposal_verdict"] is ProposalVerdict.VERIFIED_SUCCESS
+        else EpisodeOutcome.FAILURE,
+    )
     return CandidateSample(**values)
 
 
@@ -336,9 +354,10 @@ def test_05_receipt_mismatch_fails_closed(tmp_path):
     report2 = session2.run([make_request()])
     assert report2["counts"]["quarantined"] == 4
 
-    # Live mode: provider outside the approved allowlist is quarantined.
+    # Live mode: provider outside the approved allowlist is refused BEFORE
+    # any transport call is made.
     manifest = make_manifest(provider_allowlist=("prov-y",))
-    session3, _, ledger3 = make_session(
+    session3, transport3, ledger3 = make_session(
         tmp_path,
         mode="live",
         manifest=manifest,
@@ -348,7 +367,8 @@ def test_05_receipt_mismatch_fails_closed(tmp_path):
     report3 = session3.run(
         [make_request(recipe=make_recipe(donor_allocation={"donor-a": 1.0}))]
     )
-    assert report3["counts"]["quarantined"] == 2
+    assert report3["counts"]["refused_unauthorized"] == 2
+    assert transport3.calls == []  # refusal precedes the provider call
     assert any("allowlist" in row["detail"] for row in ledger3.rows())
 
 
@@ -748,3 +768,452 @@ def test_variant_requests_are_request_only(tmp_path):
     assert report["counts"]["verified_failure"] == 1
     assert [v["confusion_cell"] for v in report["variant_requests"]] == ["cell-a-vs-b"]
     assert report["next_step"] == "codex review and dataset freeze"
+
+
+# ---------------------------------------------------------------------------
+# Codex re-review regression proofs (round 2)
+# ---------------------------------------------------------------------------
+
+
+def test_work_identity_covers_complete_request_semantics():
+    base = make_request()
+    variations = dict(
+        model_visible_objective="a different objective entirely",
+        ttl_seconds=60.0,
+        issued_at=1_500.0,
+        leakage_group_id="lg-999",
+        response_type="decision_summary",
+        authorized_effects=("provider_call", "ledger_append"),
+        source_dataset_id="D0000",
+        recipe=make_recipe(prompt_surface="adversarial"),
+    )
+    for field_name, value in variations.items():
+        changed = make_request(**{field_name: value})
+        assert changed.work_key("donor-a", 0) != base.work_key("donor-a", 0), (
+            f"changing {field_name} must change the work identity"
+        )
+    # Identical semantics → identical identity (retry keeps the same key).
+    assert make_request().work_key("donor-a", 0) == base.work_key("donor-a", 0)
+    # Ceilings are budgets, not semantics: raising a budget must not orphan
+    # already-completed work on resume.
+    richer = make_request(ceilings=make_ceilings(max_provider_calls=999))
+    assert richer.work_key("donor-a", 0) == base.work_key("donor-a", 0)
+
+
+def test_sft_and_dpo_rows_carry_model_input_and_target_output(tmp_path):
+    cassette = {
+        "donor-a": [
+            {"status": "OK", "text": "mock-answer-learnable"},
+            {"status": "OK", "text": "a substantive but wrong answer"},
+        ]
+    }
+    transport = MockTransport(CATALOG, cassette=cassette)
+    session, _, _ = make_session(tmp_path, transport=transport)
+    shard_dir = tmp_path / "shards"
+    report = session.run(
+        [make_request(recipe=make_recipe(donor_allocation={"donor-a": 1.0}))],
+        shard_dir=shard_dir,
+    )
+    manifest = report["dataset_manifest"]
+    assert manifest["shards"]["sft"]["rows"] >= 1
+    assert manifest["shards"]["dpo"]["rows"] >= 1
+
+    sft_rows = [
+        json.loads(line)
+        for line in (shard_dir / manifest["shards"]["sft"]["path"])
+        .read_text()
+        .splitlines()
+    ]
+    for row in sft_rows:
+        assert row["input"]["objective"] == "resolve the root task"
+        assert row["input"]["ttl_seconds"] == 3_600.0
+        assert row["input_digest"]
+        assert row["text"]  # the target response
+
+    dpo_rows = [
+        json.loads(line)
+        for line in (shard_dir / manifest["shards"]["dpo"]["path"])
+        .read_text()
+        .splitlines()
+    ]
+    for pair in dpo_rows:
+        for side in ("chosen", "rejected"):
+            assert pair[side]["input"]["objective"] == "resolve the root task"
+            assert pair[side]["input_digest"]
+            assert pair[side]["text"]
+
+
+def test_judge_approved_provisional_survives_into_provisional_view(tmp_path):
+    def no_oracle(request, text):
+        return MechanicalCheck(artifact_present=True, oracle=None, score=0.5)
+
+    def approving_judges(objective, text):
+        return (JudgeVote("judge-1", True), JudgeVote("judge-2", True))
+
+    session, _, ledger = make_session(
+        tmp_path, mechanical_fn=no_oracle, judge_fn=approving_judges
+    )
+    shard_dir = tmp_path / "shards"
+    report = session.run([make_request()], shard_dir=shard_dir)
+
+    assert report["counts"]["provisional"] == 4
+    assert report["counts"]["verified_failure"] == 0  # never becomes REJECTED
+    statuses = {row["status"] for row in ledger.rows()}
+    assert statuses == {"PROVISIONAL"}
+    verdicts = {row["proposal_verdict"] for row in ledger.rows()}
+    assert verdicts == {"JUDGE_PROVISIONAL"}  # judges cannot mint VERIFIED_SUCCESS
+
+    manifest = report["dataset_manifest"]
+    assert manifest["shards"]["sft"]["rows"] == 0  # not verified → not in sft
+    assert manifest["shards"]["sft_provisional"]["rows"] == 4
+    rows = [
+        json.loads(line)
+        for line in (shard_dir / manifest["shards"]["sft_provisional"]["path"])
+        .read_text()
+        .splitlines()
+    ]
+    for row in rows:
+        assert row["label"] == "JUDGE_PROVISIONAL"
+        assert row["view"] == "sft_provisional"
+        assert {j["judge_key"] for j in row["judges"]} == {"judge-1", "judge-2"}
+        assert row["text"]
+
+
+def test_resume_reproduces_identical_nonempty_shards(tmp_path):
+    cassette = {
+        "donor-a": [
+            {"status": "OK", "text": "mock-answer-kept"},
+            {"status": "OK", "text": "a substantive but wrong answer"},
+        ]
+    }
+    ledger_path = tmp_path / "ledger.jsonl"
+    request = make_request(recipe=make_recipe(donor_allocation={"donor-a": 1.0}))
+
+    session1, transport1, _ = make_session(
+        tmp_path,
+        transport=MockTransport(CATALOG, cassette=cassette),
+        ledger=AttemptLedger(ledger_path),
+    )
+    report1 = session1.run([request], shard_dir=tmp_path / "shards1")
+    manifest1 = report1["dataset_manifest"]
+    assert sum(s["rows"] for s in manifest1["shards"].values()) > 0
+    assert len(transport1.calls) == 2
+
+    # Fresh session, same ledger: zero new calls, identical nonempty shards.
+    session2, transport2, _ = make_session(
+        tmp_path,
+        transport=MockTransport(CATALOG, cassette=cassette),
+        ledger=AttemptLedger(ledger_path),
+    )
+    report2 = session2.run([request], shard_dir=tmp_path / "shards2")
+    manifest2 = report2["dataset_manifest"]
+    assert transport2.calls == []
+    assert report2["counts"]["skipped_resume"] == 2
+    assert {k: v["sha256"] for k, v in manifest2["shards"].items()} == {
+        k: v["sha256"] for k, v in manifest1["shards"].items()
+    }
+    assert sum(s["rows"] for s in manifest2["shards"].values()) == sum(
+        s["rows"] for s in manifest1["shards"].values()
+    )
+
+    # An empty builder can never silently replace a populated manifest.
+    empty = DatasetBuilder(function_pack_id="pack-alpha", target_dataset_id="D0002")
+    with pytest.raises(DatasetBuildError, match="refusing to replace"):
+        empty.write_shards(tmp_path / "shards1")
+
+
+def test_weak_cells_generate_variants_of_the_failing_root(tmp_path):
+    # Root-2 fails; root-1 succeeds. Variants must derive from root-2.
+    def mech(request, text):
+        good = request.semantic_root_id == "root-001"
+        return MechanicalCheck(
+            artifact_present=True,
+            oracle=OracleResult(passed=good, receipt_digest="c" * 40),
+            score=1.0 if good else 0.0,
+            confusion_cell="" if good else "cell-2",
+        )
+
+    session, _, _ = make_session(tmp_path, mechanical_fn=mech)
+    report = session.run(
+        [
+            make_request(),
+            make_request(
+                semantic_root_id="root-002",
+                leakage_group_id="lg-002",
+                recipe=make_recipe(recipe_id="recipe-two"),
+            ),
+        ]
+    )
+    variants = report["variant_requests"]
+    assert variants, "failing cells must produce variant requests"
+    assert {v["root_id"] for v in variants} == {"root-002"}
+    assert {v["leakage_group_id"] for v in variants} == {"lg-002"}
+    assert all(v["recipe_id"].startswith("recipe-two-variant-") for v in variants)
+
+
+def make_wave_template(**overrides) -> WaveTemplate:
+    values = dict(
+        function_pack_id="pack-alpha",
+        function_contract_digest="a" * 40,
+        tool_catalog_digest="b" * 40,
+        base_recipe=make_recipe(),
+        seed=7,
+        ttl_seconds=3_600.0,
+        issued_at=1_000.0,
+        ceilings=make_ceilings(),
+        root_objectives={
+            "root-001": "objective for root one",
+            "root-002": "objective for root two",
+        },
+        root_leakage_groups={"root-001": "lg-001", "root-002": "lg-002"},
+    )
+    values.update(overrides)
+    return WaveTemplate(**values)
+
+
+def make_harvest_request_doc(**overrides) -> dict:
+    doc = {
+        "schema": "needle-next-harvest-request/v1",
+        "campaign_id": "needle-campaign-1",
+        "source_dataset_id": "D0001",
+        "target_dataset_id": "D0002",
+        "weak_confusion_cells": [
+            {"arm": "B", "cell": "cell-2", "recall": 0.4, "root_ids": ["root-002"]}
+        ],
+        "retention_cells": [
+            {"arm": "B", "cell": "cell-1", "recall": 0.97, "root_ids": ["root-001"]}
+        ],
+        "evidence_digests": {"results": "d" * 64},
+        "request_only": True,
+        "authorizes_generation": False,
+        "authorizes_training": False,
+    }
+    doc.update(overrides)
+    return doc
+
+
+def test_planning_consumes_typed_next_harvest_request():
+    template = make_wave_template()
+    requests = plan_wave_from_harvest_request(make_harvest_request_doc(), template)
+
+    weak = [r for r in requests if r.recipe.prompt_surface == "confusion-targeted"]
+    retention = [
+        r for r in requests if r.recipe.prompt_surface == "retention-controlled"
+    ]
+    # Weak-cell variants come from the failing root, with its own objective
+    # and leakage group — never cloned from the first request.
+    assert weak and all(r.semantic_root_id == "root-002" for r in weak)
+    assert all(r.leakage_group_id == "lg-002" for r in weak)
+    assert all(r.model_visible_objective == "objective for root two" for r in weak)
+    # Successful retention cells produce controlled variants of their root.
+    assert retention and all(r.semantic_root_id == "root-001" for r in retention)
+    assert all(r.leakage_group_id == "lg-001" for r in retention)
+    # The whole wave stays consistent.
+    assert {r.campaign_id for r in requests} == {"needle-campaign-1"}
+    assert {r.target_dataset_id for r in requests} == {"D0002"}
+
+    # Fail closed on anything that is not genuinely request-only.
+    with pytest.raises(WavePlanError, match="request-only"):
+        plan_wave_from_harvest_request(
+            make_harvest_request_doc(request_only=False), template
+        )
+    with pytest.raises(WavePlanError, match="request-only"):
+        plan_wave_from_harvest_request(
+            make_harvest_request_doc(authorizes_generation=True), template
+        )
+    with pytest.raises(WavePlanError, match="schema"):
+        plan_wave_from_harvest_request({"schema": "something-else"}, template)
+    # A referenced root with no committed binding is an error, not a skip.
+    with pytest.raises(WavePlanError, match="fail closed"):
+        plan_wave_from_harvest_request(
+            make_harvest_request_doc(
+                weak_confusion_cells=[
+                    {"arm": "B", "cell": "cell-9", "recall": 0.1, "root_ids": ["root-unknown"]}
+                ]
+            ),
+            template,
+        )
+
+
+def test_donor_allocation_produces_unequal_bounded_counts(tmp_path):
+    counts = allocate_samples({"donor-a": 99.0, "donor-b": 1.0}, total=4)
+    assert counts == {"donor-a": 4, "donor-b": 0}
+    assert sum(counts.values()) == 4
+    counts_even = allocate_samples({"donor-a": 1.0, "donor-b": 1.0}, total=4)
+    assert counts_even == {"donor-a": 2, "donor-b": 2}
+
+    session, transport, _ = make_session(tmp_path)
+    report = session.run(
+        [
+            make_request(
+                recipe=make_recipe(donor_allocation={"donor-a": 99.0, "donor-b": 1.0})
+            )
+        ]
+    )
+    assert report["counts"]["planned"] == 4
+    donors_called = [call.donor_key for call in transport.calls]
+    assert donors_called.count("donor-a") == 4
+    assert donors_called.count("donor-b") == 0
+
+
+def test_per_sample_seeds_differ_deterministically(tmp_path):
+    request = make_request()
+    seeds = {
+        (donor, index): request.sample_seed(donor, index)
+        for donor in ("donor-a", "donor-b")
+        for index in range(2)
+    }
+    assert len(set(seeds.values())) == 4  # all distinct
+    # …and stable across reconstruction of the same request.
+    again = make_request()
+    for (donor, index), seed in seeds.items():
+        assert again.sample_seed(donor, index) == seed
+
+    session, transport, _ = make_session(tmp_path)
+    session.run([request])
+    called_seeds = [call.seed for call in transport.calls]
+    assert len(set(called_seeds)) == len(called_seeds) == 4
+
+
+def test_wave_consistency_is_enforced(tmp_path):
+    session, _, _ = make_session(tmp_path)
+    with pytest.raises(HarvestAuthorizationError, match="one target dataset"):
+        session.run(
+            [
+                make_request(),
+                make_request(
+                    semantic_root_id="root-002",
+                    leakage_group_id="lg-002",
+                    target_dataset_id="D0003",
+                ),
+            ]
+        )
+    with pytest.raises(HarvestAuthorizationError, match="one campaign"):
+        session.run(
+            [
+                make_request(),
+                make_request(
+                    semantic_root_id="root-002",
+                    leakage_group_id="lg-002",
+                    campaign_id="needle-campaign-9",
+                ),
+            ]
+        )
+    with pytest.raises(HarvestAuthorizationError, match="one group"):
+        session.run(
+            [
+                make_request(),
+                make_request(leakage_group_id="lg-777"),
+            ]
+        )
+
+
+def test_disallowed_provider_refused_before_transport_call(tmp_path):
+    session, transport, ledger = make_session(
+        tmp_path, provider_allowlist=("prov-x",)
+    )
+    report = session.run([make_request()])
+    assert report["counts"]["refused_unauthorized"] == 2  # donor-b's items
+    assert report["counts"]["accepted"] == 2  # donor-a still runs
+    assert all(call.donor_key == "donor-a" for call in transport.calls)
+    refused = [r for r in ledger.rows() if r["status"] == "REFUSED_UNAUTHORIZED"]
+    assert len(refused) == 2
+    assert all("allowlist" in r["detail"] for r in refused)
+
+    # Plane allowlists gate identically.
+    session2, transport2, _ = make_session(
+        tmp_path,
+        plane_allowlist=("some-other-plane",),
+        ledger=AttemptLedger(tmp_path / "l2.jsonl"),
+    )
+    report2 = session2.run([make_request()])
+    assert report2["counts"]["refused_unauthorized"] == 4
+    assert transport2.calls == []
+
+
+def test_authorized_effects_checked_before_any_effect(tmp_path):
+    # Missing shard_write with a shard_dir refuses before any call.
+    session, transport, ledger = make_session(tmp_path)
+    with pytest.raises(HarvestAuthorizationError, match="shard_write"):
+        session.run(
+            [
+                make_request(
+                    authorized_effects=("provider_call", "ledger_append")
+                )
+            ],
+            shard_dir=tmp_path / "shards",
+        )
+    assert transport.calls == []
+    assert ledger.rows() == []
+
+    # Missing provider_call / ledger_append refuse in the request guard.
+    for missing, kept in (
+        ("provider_call", ("ledger_append", "shard_write")),
+        ("ledger_append", ("provider_call", "shard_write")),
+    ):
+        with pytest.raises(HarvestAuthorizationError, match=missing):
+            session.run([make_request(authorized_effects=kept)])
+    assert transport.calls == []
+
+
+class WrongWorkKeyTransport:
+    def __init__(self, inner: MockTransport) -> None:
+        self.inner = inner
+        self.calls = inner.calls
+
+    def discover(self):
+        return self.inner.discover()
+
+    def call(self, request):
+        result = self.inner.call(request)
+        return result.model_copy(update={"work_key": "not-the-requested-key"})
+
+
+class WrongRuntimeTransport:
+    def __init__(self, inner: MockTransport) -> None:
+        self.inner = inner
+        self.calls = inner.calls
+
+    def discover(self):
+        return self.inner.discover()
+
+    def call(self, request):
+        result = self.inner.call(request)
+        if result.receipt is None:
+            return result
+        return result.model_copy(
+            update={"receipt": result.receipt.model_copy(update={"runtime": "prod"})}
+        )
+
+
+def test_returned_work_key_and_receipt_runtime_are_validated(tmp_path):
+    session, _, ledger = make_session(
+        tmp_path, transport=WrongWorkKeyTransport(MockTransport(CATALOG))
+    )
+    report = session.run([make_request()])
+    assert report["counts"]["quarantined"] == 4
+    assert all("work_key mismatch" in row["detail"] for row in ledger.rows())
+
+    session2, _, ledger2 = make_session(
+        tmp_path,
+        transport=WrongRuntimeTransport(MockTransport(CATALOG)),
+        ledger=AttemptLedger(tmp_path / "l2.jsonl"),
+    )
+    report2 = session2.run([make_request()])
+    assert report2["counts"]["quarantined"] == 4
+    assert all("runtime" in row["detail"] for row in ledger2.rows())
+
+
+def test_effective_budget_is_min_of_request_and_session_ceilings(tmp_path):
+    lo = make_ceilings(max_provider_calls=3, max_tokens=64)
+    hi = make_ceilings(max_provider_calls=200, max_tokens=2048)
+    merged = min_ceilings(hi, lo)
+    assert merged.max_provider_calls == 3
+    assert merged.max_tokens == 64
+
+    session, transport, _ = make_session(tmp_path)  # session ceiling: 200 calls
+    report = session.run([make_request(ceilings=lo)])
+    assert report["budget"]["max_provider_calls"] == 3
+    assert report["counts"]["budget_stopped"] == 1  # 4 planned, 3 allowed
+    assert len(transport.calls) == 3
+    assert all(call.max_tokens <= 64 for call in transport.calls)

--- a/tests/test_needle_harvest.py
+++ b/tests/test_needle_harvest.py
@@ -1,0 +1,750 @@
+"""The sixteen required mock-mode proofs for the adaptive harvester.
+
+Each test is numbered to match the harvesting specification. Everything
+here is pure and offline: no network, no credentials, no training, no
+sealed evaluation.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import socket
+from pathlib import Path
+
+import pytest
+
+from evals.needle_harvest.contracts import (
+    ALLOWED_EFFECTS,
+    Ceilings,
+    GenerationRecipe,
+    HarvestManifest,
+    HarvestRequest,
+)
+from evals.needle_harvest.dataset import (
+    CandidateSample,
+    DatasetBuildError,
+    DatasetBuilder,
+    split_for_leakage_group,
+)
+from evals.needle_harvest.harvester import (
+    HarvestAuthorizationError,
+    HarvestSession,
+    MechanicalCheck,
+)
+from evals.needle_harvest.ledger import AttemptLedger
+from evals.needle_harvest.transport import (
+    MockTransport,
+    ProviderModel,
+)
+from evals.needle_harvest.truth import (
+    JudgeVote,
+    OracleResult,
+    ProposalVerdict,
+    TransportStatus,
+    evaluate_candidate,
+)
+
+PACKAGE_DIR = Path(__file__).resolve().parent.parent / "evals" / "needle_harvest"
+
+NOW = 2_000.0
+HEAD_SHA = "f" * 40
+
+
+def make_ceilings(**overrides) -> Ceilings:
+    values = dict(
+        max_provider_calls=200,
+        max_tokens=2048,
+        max_retries=2,
+        max_seconds=300.0,
+        max_cost_usd=2.0,
+        max_roots=16,
+    )
+    values.update(overrides)
+    return Ceilings(**values)
+
+
+def make_recipe(**overrides) -> GenerationRecipe:
+    values = dict(
+        recipe_id="recipe-base",
+        donor_allocation={"donor-a": 0.5, "donor-b": 0.5},
+        temperature=0.7,
+        top_p=0.9,
+        samples_per_donor=2,
+    )
+    values.update(overrides)
+    return GenerationRecipe(**values)
+
+
+def make_request(**overrides) -> HarvestRequest:
+    values = dict(
+        campaign_id="needle-campaign-1",
+        source_dataset_id="D0001",
+        target_dataset_id="D0002",
+        function_pack_id="pack-alpha",
+        semantic_root_id="root-001",
+        leakage_group_id="lg-001",
+        function_contract_digest="a" * 40,
+        model_visible_objective="resolve the root task",
+        ttl_seconds=3_600.0,
+        issued_at=1_000.0,
+        expires_at=10_000.0,
+        authorized_effects=("provider_call", "ledger_append", "shard_write"),
+        tool_catalog_digest="b" * 40,
+        recipe=make_recipe(),
+        seed=7,
+        ceilings=make_ceilings(),
+    )
+    values.update(overrides)
+    return HarvestRequest(**values)
+
+
+def make_manifest(**overrides) -> HarvestManifest:
+    values = dict(
+        campaign_id="needle-campaign-1",
+        approved_by="codex",
+        approved_head_sha=HEAD_SHA,
+        harvesting_enabled=True,
+        source_dataset_id="D0001",
+        target_dataset_id="D0002",
+        active_training_dataset_id="D0001",
+        approved_dataset_ids=("D0001",),
+        provider_allowlist=("prov-x", "prov-y"),
+        plane_allowlist=("mock",),
+        ceilings=make_ceilings(),
+    )
+    values.update(overrides)
+    return HarvestManifest(**values)
+
+
+CATALOG = (
+    ProviderModel(donor_key="donor-a", provider="prov-x", model_id="model-1", plane="mock"),
+    ProviderModel(donor_key="donor-b", provider="prov-y", model_id="model-2", plane="mock"),
+)
+
+
+def oracle_mechanical(request, text) -> MechanicalCheck:
+    return MechanicalCheck(
+        artifact_present=True,
+        oracle=OracleResult(passed=text.startswith("mock-answer-"), receipt_digest="c" * 40),
+        score=1.0 if text.startswith("mock-answer-") else 0.0,
+    )
+
+
+def make_session(tmp_path: Path, **overrides) -> tuple[HarvestSession, MockTransport, AttemptLedger]:
+    transport = overrides.pop("transport", None) or MockTransport(CATALOG)
+    ledger = overrides.pop("ledger", None) or AttemptLedger(tmp_path / "ledger.jsonl")
+    values = dict(
+        mode="mock",
+        transport=transport,
+        ledger=ledger,
+        active_training_dataset_id="D0001",
+        mechanical_fn=oracle_mechanical,
+        now_fn=lambda: NOW,
+        ceilings=make_ceilings(),
+    )
+    values.update(overrides)
+    session = HarvestSession(**values)
+    return session, transport, ledger
+
+
+def make_sample(**overrides) -> CandidateSample:
+    values = dict(
+        function_pack_id="pack-alpha",
+        semantic_root_id="root-001",
+        leakage_group_id="lg-001",
+        function_contract_digest="a" * 40,
+        tool_catalog_digest="b" * 40,
+        ttl_condition="ttl-3600s",
+        response_type="answer",
+        donor_key="donor-a",
+        recipe_id="recipe-base",
+        text="the answer is 42",
+        transport_status=TransportStatus.OK,
+        proposal_verdict=ProposalVerdict.VERIFIED_SUCCESS,
+        score=1.0,
+    )
+    values.update(overrides)
+    return CandidateSample(**values)
+
+
+# ---------------------------------------------------------------------------
+# 1. Mock mode makes zero provider/network calls and reads zero credentials.
+# ---------------------------------------------------------------------------
+
+
+def test_01_mock_mode_zero_network_zero_credentials(tmp_path, monkeypatch):
+    def _blocked(*_a, **_k):
+        raise AssertionError("network access attempted during mock harvesting")
+
+    monkeypatch.setattr(socket, "socket", _blocked)
+    monkeypatch.setattr(socket, "create_connection", _blocked)
+
+    import os
+
+    accessed: list[str] = []
+    real_getenv = os.getenv
+    monkeypatch.setattr(
+        os, "getenv", lambda key, default=None: (accessed.append(key), real_getenv(key, default))[1]
+    )
+
+    session, transport, _ = make_session(tmp_path)
+    report = session.run([make_request()], shard_dir=tmp_path / "shards")
+    assert report["counts"]["accepted"] == 4
+    assert len(transport.calls) == 4  # in-memory mock only
+
+    credentialish = [
+        k
+        for k in accessed
+        if re.search(r"KEY|TOKEN|SECRET|AUTH|CRED", k, re.IGNORECASE)
+    ]
+    assert credentialish == []
+
+    # Structural proof: the package never touches env/credential/network APIs.
+    deny = re.compile(
+        r"\bimport os\b|\bos\.environ\b|\bgetenv\b|\bdotenv\b|auth\.json|"
+        r"\.grok\b|XAI_API_KEY|keyring|\bimport requests\b|\bimport httpx\b|"
+        r"\bimport urllib\b|\bimport socket\b|\bimport aiohttp\b"
+    )
+    for source_file in sorted(PACKAGE_DIR.glob("*.py")):
+        assert not deny.search(source_file.read_text()), source_file.name
+
+
+# ---------------------------------------------------------------------------
+# 2. Live mode refuses to start without a Codex-approved harvesting manifest.
+# ---------------------------------------------------------------------------
+
+
+def test_02_live_mode_requires_codex_manifest(tmp_path):
+    with pytest.raises(HarvestAuthorizationError, match="no Codex-approved"):
+        make_session(tmp_path, mode="live", manifest=None, current_head_sha=HEAD_SHA)
+
+    for bad in (
+        make_manifest(approved_by="someone-else"),
+        make_manifest(harvesting_enabled=False),
+    ):
+        with pytest.raises(HarvestAuthorizationError, match="not Codex-approved|disabled"):
+            make_session(tmp_path, mode="live", manifest=bad, current_head_sha=HEAD_SHA)
+
+    with pytest.raises(HarvestAuthorizationError, match="approved head"):
+        make_session(
+            tmp_path, mode="live", manifest=make_manifest(), current_head_sha="0" * 40
+        )
+
+    # A fully valid manifest does construct.
+    session, _, _ = make_session(
+        tmp_path, mode="live", manifest=make_manifest(), current_head_sha=HEAD_SHA
+    )
+    assert session.mode == "live"
+
+
+# ---------------------------------------------------------------------------
+# 3. Harvesting cannot mutate the active training dataset.
+# ---------------------------------------------------------------------------
+
+
+def test_03_active_training_dataset_is_untouchable(tmp_path):
+    session, _, _ = make_session(tmp_path)
+    with pytest.raises(HarvestAuthorizationError, match="currently being"):
+        session.run([make_request(target_dataset_id="D0001", source_dataset_id="D0000")])
+
+    # Approved (frozen) generations are equally untouchable.
+    session2, _, _ = make_session(
+        tmp_path, ledger=AttemptLedger(tmp_path / "l2.jsonl"), approved_dataset_ids=("D0002",)
+    )
+    with pytest.raises(HarvestAuthorizationError, match="approved/frozen"):
+        session2.run([make_request()])
+
+    # The contract itself refuses source == target.
+    with pytest.raises(ValueError, match="never modifies"):
+        make_request(source_dataset_id="D0002", target_dataset_id="D0002")
+
+    # DatasetBuilder refuses to append to an approved generation.
+    with pytest.raises(DatasetBuildError, match="approved/frozen"):
+        DatasetBuilder(
+            function_pack_id="pack-alpha",
+            target_dataset_id="D0001",
+            approved_dataset_ids=("D0001",),
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. Expired TTL fails closed.
+# ---------------------------------------------------------------------------
+
+
+def test_04_expired_ttl_fails_closed(tmp_path):
+    session, transport, ledger = make_session(tmp_path, now_fn=lambda: 99_999.0)
+    report = session.run([make_request()])
+    assert report["counts"]["expired"] == report["counts"]["planned"] == 4
+    assert report["counts"]["accepted"] == 0
+    assert transport.calls == []  # expiry precedes dispatch
+    assert {row["status"] for row in ledger.rows()} == {"EXPIRED"}
+
+    evaluation = evaluate_candidate(
+        transport_status=TransportStatus.OK,
+        now=11_000.0,
+        expires_at=10_000.0,
+        required_artifact_present=True,
+        oracle=OracleResult(passed=True, receipt_digest="c" * 40),
+    )
+    assert evaluation.episode_outcome.value == "EXPIRED"
+    assert evaluation.proposal_verdict is ProposalVerdict.NOT_EVALUATED
+
+
+# ---------------------------------------------------------------------------
+# 5. Provider/model/plane or receipt mismatches fail closed.
+# ---------------------------------------------------------------------------
+
+
+class TamperedReceiptTransport:
+    def __init__(self, inner: MockTransport, plane: str = "rogue") -> None:
+        self.inner = inner
+        self.plane = plane
+
+    def discover(self):
+        return self.inner.discover()
+
+    def call(self, request):
+        result = self.inner.call(request)
+        if result.receipt is None:
+            return result
+        return result.model_copy(
+            update={"receipt": result.receipt.model_copy(update={"plane": self.plane})}
+        )
+
+
+def test_05_receipt_mismatch_fails_closed(tmp_path):
+    tampered = TamperedReceiptTransport(MockTransport(CATALOG))
+    session, _, ledger = make_session(tmp_path, transport=tampered)
+    report = session.run([make_request()])
+    assert report["counts"]["quarantined"] == 4
+    assert report["counts"]["accepted"] == 0
+    assert all("receipt mismatch" in row["detail"] for row in ledger.rows())
+
+    # Missing receipt entirely also fails closed.
+    class NoReceiptTransport(TamperedReceiptTransport):
+        def call(self, request):
+            result = self.inner.call(request)
+            return result.model_copy(update={"receipt": None})
+
+    session2, _, ledger2 = make_session(
+        tmp_path,
+        transport=NoReceiptTransport(MockTransport(CATALOG)),
+        ledger=AttemptLedger(tmp_path / "l2.jsonl"),
+    )
+    report2 = session2.run([make_request()])
+    assert report2["counts"]["quarantined"] == 4
+
+    # Live mode: provider outside the approved allowlist is quarantined.
+    manifest = make_manifest(provider_allowlist=("prov-y",))
+    session3, _, ledger3 = make_session(
+        tmp_path,
+        mode="live",
+        manifest=manifest,
+        current_head_sha=HEAD_SHA,
+        ledger=AttemptLedger(tmp_path / "l3.jsonl"),
+    )
+    report3 = session3.run(
+        [make_request(recipe=make_recipe(donor_allocation={"donor-a": 1.0}))]
+    )
+    assert report3["counts"]["quarantined"] == 2
+    assert any("allowlist" in row["detail"] for row in ledger3.rows())
+
+
+# ---------------------------------------------------------------------------
+# 6. Resumption preserves effect IDs and does not duplicate calls.
+# ---------------------------------------------------------------------------
+
+
+def test_06_resume_preserves_effects_and_never_duplicates_calls(tmp_path):
+    ledger_path = tmp_path / "ledger.jsonl"
+    request = make_request()
+
+    session1, transport1, ledger1 = make_session(tmp_path, ledger=AttemptLedger(ledger_path))
+    report1 = session1.run([request])
+    assert report1["counts"]["accepted"] == 4
+    first_calls = len(transport1.calls)
+    effects_before = ledger1.effect_ids_by_work_key()
+
+    # Fresh session + fresh transport, same ledger file: full resume.
+    session2, transport2, ledger2 = make_session(tmp_path, ledger=AttemptLedger(ledger_path))
+    report2 = session2.run([request])
+    assert transport2.calls == []  # zero duplicated provider calls
+    assert report2["counts"]["skipped_resume"] == first_calls == 4
+    assert ledger2.effect_ids_by_work_key() == effects_before
+
+    # Deterministic IDs: recomputing yields the same work/effect keys.
+    assert request.work_key("donor-a", 0) == make_request().work_key("donor-a", 0)
+    assert request.effect_id("donor-a", 0) == make_request().effect_id("donor-a", 0)
+
+
+# ---------------------------------------------------------------------------
+# 7. Sibling variants cannot cross dataset partitions.
+# ---------------------------------------------------------------------------
+
+
+def test_07_sibling_variants_share_one_partition(tmp_path):
+    builder = DatasetBuilder(function_pack_id="pack-alpha", target_dataset_id="D0002")
+    splits = set()
+    for index in range(6):  # root + 5 variants, one leakage group
+        sample = make_sample(
+            semantic_root_id=f"root-001-v{index}",
+            leakage_group_id="lg-001",
+            text=f"variant answer {index}",
+        )
+        assert builder.ingest(sample)
+        splits.add(split_for_leakage_group(sample.leakage_group_id))
+    assert len(splits) == 1  # siblings can never straddle partitions
+
+    # The partition is a pure function of the leakage group…
+    assert split_for_leakage_group("lg-001") == split_for_leakage_group("lg-001")
+    # …and across many groups every split actually gets used.
+    all_splits = {split_for_leakage_group(f"lg-{i:04d}") for i in range(200)}
+    assert all_splits == {"train", "dev", "holdout"}
+
+
+# ---------------------------------------------------------------------------
+# 8. Cross-function mixing is rejected.
+# ---------------------------------------------------------------------------
+
+
+def test_08_cross_function_mixing_rejected(tmp_path):
+    session, _, _ = make_session(tmp_path)
+    with pytest.raises(HarvestAuthorizationError, match="cross-function"):
+        session.run(
+            [
+                make_request(),
+                make_request(function_pack_id="pack-beta", semantic_root_id="root-002"),
+            ]
+        )
+
+    builder = DatasetBuilder(function_pack_id="pack-alpha", target_dataset_id="D0002")
+    assert not builder.ingest(make_sample(function_pack_id="pack-beta"))
+    assert builder.rejections[0]["reason"] == "cross-pack mixing rejected"
+
+
+# ---------------------------------------------------------------------------
+# 9. Semantic duplicates are rejected.
+# ---------------------------------------------------------------------------
+
+
+def test_09_semantic_duplicates_rejected():
+    builder = DatasetBuilder(function_pack_id="pack-alpha", target_dataset_id="D0002")
+    assert builder.ingest(make_sample(text="The answer is 42."))
+    # Exact duplicate.
+    assert not builder.ingest(make_sample(text="The answer is 42."))
+    # Semantic duplicate: case/whitespace/quote-style differences only.
+    assert not builder.ingest(make_sample(text="  the ANSWER is\u00a042. "))
+    reasons = [r["reason"] for r in builder.rejections]
+    assert "exact duplicate rejected" in reasons
+    assert "semantic duplicate rejected" in reasons
+    # A genuinely different answer is admitted.
+    assert builder.ingest(make_sample(text="The answer is 43."))
+
+
+# ---------------------------------------------------------------------------
+# 10. Provider failures never become preference negatives.
+# ---------------------------------------------------------------------------
+
+
+def test_10_transport_failures_never_dpo_negatives():
+    builder = DatasetBuilder(function_pack_id="pack-alpha", target_dataset_id="D0002")
+    assert builder.ingest(make_sample(text="winning answer", score=1.0))
+    # A timeout with the same root: recorded upstream, but structurally
+    # ineligible as a rejected side.
+    assert builder.ingest(
+        make_sample(
+            text="",
+            transport_status=TransportStatus.TIMEOUT,
+            proposal_verdict=ProposalVerdict.VERIFIED_FAILURE,
+            donor_key="donor-b",
+            score=0.0,
+        )
+    )
+    assert builder.dpo_view() == []  # no semantic negative -> no pair at all
+
+    # With a genuine semantic failure available, the pair uses it instead.
+    assert builder.ingest(
+        make_sample(
+            text="confidently wrong answer",
+            proposal_verdict=ProposalVerdict.VERIFIED_FAILURE,
+            donor_key="donor-b",
+            score=0.4,
+        )
+    )
+    pairs = builder.dpo_view()
+    assert len(pairs) == 1
+    assert pairs[0]["rejected"]["text"] == "confidently wrong answer"
+    assert pairs[0]["pairing"] == "winner-vs-verified-failure"
+
+
+# ---------------------------------------------------------------------------
+# 11. Chosen/rejected contract mismatches are rejected.
+# ---------------------------------------------------------------------------
+
+
+def test_11_pair_contract_mismatch_rejected():
+    builder = DatasetBuilder(function_pack_id="pack-alpha", target_dataset_id="D0002")
+    assert builder.ingest(make_sample(text="winner", score=1.0))
+    assert builder.ingest(
+        make_sample(
+            text="loser under a drifted tool catalog",
+            proposal_verdict=ProposalVerdict.VERIFIED_FAILURE,
+            tool_catalog_digest="d" * 40,
+            donor_key="donor-b",
+        )
+    )
+    with pytest.raises(DatasetBuildError, match="tool_catalog"):
+        builder.dpo_view()
+
+    # A rationale can never be paired against an answer: differing
+    # response types make the candidate ineligible outright.
+    builder2 = DatasetBuilder(function_pack_id="pack-alpha", target_dataset_id="D0002")
+    assert builder2.ingest(make_sample(text="winner", score=1.0))
+    assert builder2.ingest(
+        make_sample(
+            text="a plan-state rationale",
+            response_type="plan_state",
+            proposal_verdict=ProposalVerdict.VERIFIED_FAILURE,
+            donor_key="donor-b",
+            visible_fields=("plan_state",),
+        )
+    )
+    assert builder2.dpo_view() == []
+
+
+# ---------------------------------------------------------------------------
+# 12. Judge disagreement stays provisional or indeterminate.
+# ---------------------------------------------------------------------------
+
+
+def test_12_judges_cannot_mint_verified_success(tmp_path):
+    agree = (JudgeVote("judge-1", True), JudgeVote("judge-2", True))
+    split = (JudgeVote("judge-1", True), JudgeVote("judge-2", False))
+
+    unanimous = evaluate_candidate(
+        transport_status=TransportStatus.OK,
+        now=NOW,
+        expires_at=10_000.0,
+        required_artifact_present=True,
+        judge_votes=agree,
+    )
+    assert unanimous.proposal_verdict is ProposalVerdict.JUDGE_PROVISIONAL
+
+    disagreement = evaluate_candidate(
+        transport_status=TransportStatus.OK,
+        now=NOW,
+        expires_at=10_000.0,
+        required_artifact_present=True,
+        judge_votes=split,
+    )
+    assert disagreement.proposal_verdict is ProposalVerdict.INDETERMINATE
+    assert disagreement.episode_outcome.value == "QUARANTINED"
+
+    # Through the harvester with blinded judges that keep disagreeing even
+    # after the bounded adjudication round: quarantined, never accepted.
+    session, _, ledger = make_session(
+        tmp_path,
+        mechanical_fn=lambda request, text: MechanicalCheck(artifact_present=True),
+        judge_fn=lambda objective, text: split,
+        adjudicate_fn=lambda objective, text: (JudgeVote("judge-3", True),),
+        ceilings=make_ceilings(),
+    )
+    report = session.run(
+        [make_request(recipe=make_recipe(donor_allocation={"donor-a": 1.0}, samples_per_donor=1))]
+    )
+    assert report["counts"]["quarantined"] == 1
+    assert report["counts"]["accepted"] == 0
+    verdicts = {row["proposal_verdict"] for row in ledger.rows() if row["proposal_verdict"]}
+    assert verdicts <= {"INDETERMINATE", "JUDGE_PROVISIONAL"}
+    assert "VERIFIED_SUCCESS" not in verdicts
+
+
+# ---------------------------------------------------------------------------
+# 13. Retry and adjudication calls count against hard ceilings.
+# ---------------------------------------------------------------------------
+
+
+def test_13_retries_and_adjudication_charge_the_budget(tmp_path):
+    # All calls time out; retries burn the shared provider-call ceiling and
+    # the remaining work fails closed as BUDGET_EXHAUSTED.
+    cassette = {"donor-a": [{"status": "TIMEOUT"}], "donor-b": [{"status": "TIMEOUT"}]}
+    transport = MockTransport(CATALOG, cassette=cassette)
+    session, _, ledger = make_session(
+        tmp_path,
+        transport=transport,
+        ceilings=make_ceilings(max_provider_calls=3, max_retries=2),
+    )
+    report = session.run([make_request()])
+    assert report["budget"]["provider_calls"] == 3  # never exceeds the ceiling
+    assert report["budget"]["retries"] == 2
+    assert report["counts"]["budget_stopped"] >= 1
+    statuses = {row["status"] for row in ledger.rows()}
+    assert "BUDGET_EXHAUSTED" in statuses
+    assert "RETRIED" in statuses
+    assert len(transport.calls) == 3
+
+    # Adjudication charges the same meter: 1 transport + 1 judge + 1
+    # adjudication = 3 provider calls for a single work item.
+    split = (JudgeVote("judge-1", True), JudgeVote("judge-2", False))
+    session2, transport2, _ = make_session(
+        tmp_path,
+        ledger=AttemptLedger(tmp_path / "l2.jsonl"),
+        mechanical_fn=lambda request, text: MechanicalCheck(artifact_present=True),
+        judge_fn=lambda objective, text: split,
+        adjudicate_fn=lambda objective, text: (JudgeVote("judge-3", True),),
+    )
+    report2 = session2.run(
+        [make_request(recipe=make_recipe(donor_allocation={"donor-a": 1.0}, samples_per_donor=1))]
+    )
+    assert report2["budget"]["provider_calls"] == 3
+    assert len(transport2.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# 14. Hidden CoT cannot enter artifacts.
+# ---------------------------------------------------------------------------
+
+
+def test_14_hidden_cot_cannot_enter_artifacts(tmp_path):
+    # Contract depth: unknown fields are rejected at parse time.
+    with pytest.raises(Exception, match="chain_of_thought"):
+        HarvestRequest(**{**make_request().model_dump(), "chain_of_thought": "secret"})
+    with pytest.raises(Exception):
+        make_request(response_type="chain_of_thought")
+
+    # Ingestion depth: forbidden raw fields and non-visible surfaces.
+    builder = DatasetBuilder(function_pack_id="pack-alpha", target_dataset_id="D0002")
+    assert not builder.ingest(make_sample(), raw_fields={"reasoning": "hidden steps"})
+    assert not builder.ingest(
+        make_sample(text="other"), raw_fields={"scratchpad": "hidden"}
+    )
+    assert not builder.ingest(
+        make_sample(text="third", visible_fields=("reasoning",))
+    )
+    assert all("chain-of-thought" in r["reason"] for r in builder.rejections)
+
+    # Artifact depth: shards contain only whitelisted visible surfaces.
+    assert builder.ingest(make_sample(text="clean answer"))
+    manifest = builder.write_shards(tmp_path / "shards")
+    for shard in (tmp_path / "shards").glob("*.jsonl"):
+        for line in shard.read_text().splitlines():
+            row = json.loads(line)
+            forbidden = {"reasoning", "chain_of_thought", "cot", "scratchpad", "thinking"}
+            assert not (set(row) & forbidden)
+    assert manifest["rejections"] == 3
+
+
+# ---------------------------------------------------------------------------
+# 15. No training or sealed evaluation can occur from the harvester.
+# ---------------------------------------------------------------------------
+
+
+def test_15_training_and_sealed_eval_are_unauthorizable(tmp_path):
+    assert "train" not in ALLOWED_EFFECTS
+    assert "sealed_evaluation" not in ALLOWED_EFFECTS
+    for effect in ("train", "training", "sealed_evaluation", "sealed_eval_read"):
+        with pytest.raises(ValueError, match="never be authorized"):
+            make_request(authorized_effects=(effect,))
+
+    # The report structurally denies both, and the public API exposes no
+    # training or sealed-evaluation entry point.
+    session, _, _ = make_session(tmp_path)
+    report = session.run([make_request()])
+    assert report["authorizes_training"] is False
+    assert report["authorizes_sealed_evaluation"] is False
+
+    import evals.needle_harvest as pkg
+
+    banned = re.compile(r"train|sealed", re.IGNORECASE)
+    assert not [name for name in pkg.__all__ if banned.search(name)]
+
+
+# ---------------------------------------------------------------------------
+# 16. The same mock inputs produce identical manifests and digests.
+# ---------------------------------------------------------------------------
+
+
+def test_16_same_inputs_identical_manifests_and_digests(tmp_path):
+    reports = []
+    manifests = []
+    for run_index in range(2):
+        run_dir = tmp_path / f"run{run_index}"
+        session, _, _ = make_session(run_dir, ledger=AttemptLedger(run_dir / "ledger.jsonl"))
+        report = session.run([make_request()], shard_dir=run_dir / "shards")
+        manifests.append((run_dir / "shards" / "manifest.json").read_bytes())
+        reports.append(report)
+
+    assert reports[0]["report_sha256"] == reports[1]["report_sha256"]
+    assert reports[0] == reports[1]
+    assert manifests[0] == manifests[1]  # byte-identical manifest files
+    shard_digests = {
+        name: info["sha256"] for name, info in reports[0]["dataset_manifest"]["shards"].items()
+    }
+    assert shard_digests == {
+        name: info["sha256"] for name, info in reports[1]["dataset_manifest"]["shards"].items()
+    }
+
+
+# ---------------------------------------------------------------------------
+# Supporting proofs: ledger failure classes and structural incompleteness.
+# ---------------------------------------------------------------------------
+
+
+def test_ledger_records_all_failure_classes(tmp_path):
+    cassette = {
+        "donor-a": [{"status": "EMPTY"}],
+        "donor-b": [{"status": "MALFORMED"}],
+    }
+    transport = MockTransport(CATALOG, cassette=cassette)
+    session, _, ledger = make_session(
+        tmp_path, transport=transport, ceilings=make_ceilings(max_retries=0)
+    )
+    report = session.run(
+        [make_request(recipe=make_recipe(samples_per_donor=1))]
+    )
+    assert report["counts"]["transport_failure"] == 2
+    recorded = {row["transport_status"] for row in ledger.rows()}
+    assert recorded == {"EMPTY", "MALFORMED"}
+    # Rows are append-only and replayable from disk.
+    replay = AttemptLedger(ledger.path)
+    assert replay.rows() == ledger.rows()
+
+
+def test_wording_never_beats_missing_artifacts():
+    # "I have completed the task" with no artifact is structurally
+    # incomplete regardless of phrasing — no promise-phrase regex exists.
+    evaluation = evaluate_candidate(
+        transport_status=TransportStatus.OK,
+        now=NOW,
+        expires_at=10_000.0,
+        required_artifact_present=False,
+        judge_votes=(JudgeVote("judge-1", True), JudgeVote("judge-2", True)),
+    )
+    assert evaluation.proposal_verdict is ProposalVerdict.STRUCTURALLY_INCOMPLETE
+    assert evaluation.episode_outcome.value == "FAILURE"
+
+
+def test_variant_requests_are_request_only(tmp_path):
+    # Failed cells surface as targeted variant *requests* that nothing in
+    # this package executes automatically.
+    cassette = {"donor-a": [{"status": "OK", "text": "wrong"}]}
+    transport = MockTransport(CATALOG, cassette=cassette)
+
+    def mech(request, text):
+        good = text.startswith("mock-answer-")
+        return MechanicalCheck(
+            artifact_present=True,
+            oracle=OracleResult(passed=good, receipt_digest="c" * 40),
+            score=1.0 if good else 0.0,
+            confusion_cell="" if good else "cell-a-vs-b",
+        )
+
+    session, _, _ = make_session(tmp_path, transport=transport, mechanical_fn=mech)
+    report = session.run(
+        [make_request(recipe=make_recipe(donor_allocation={"donor-a": 1.0}, samples_per_donor=1))]
+    )
+    assert report["counts"]["verified_failure"] == 1
+    assert [v["confusion_cell"] for v in report["variant_requests"]] == ["cell-a-vs-b"]
+    assert report["next_step"] == "codex review and dataset freeze"


### PR DESCRIPTION
# Needle adaptive harvester: H000n companion package (repaired, round 2)

> **Draft — awaiting Codex exact-head re-review. Stacked on #75** (base `claude/new-session-8e79e9`, not retargeted).
> **Exact head:** `b10e3773d9b81b6a676d60a9cbdc074f088a9a15`
> Commits: `f912c9b` (harvester package, rebased onto repaired foundation `e99de1c`), `b10e377` (round-2 repair). Prior head `3bdbf9d` superseded.

## What this PR does

Adds `evals/needle_harvest/`: a mock-first adaptive harvesting companion for the D000n→T000n→E000n→H000n+1 lifecycle. Same exact root fanned to multiple donors over a provider-neutral transport, mechanical evaluation before model judging, append-only resumable ledger, failure aggregation into targeted variant *requests*, adaptive donor allocation, bounded lanes, plateau-based stopping. Harvesting never modifies the active training dataset and stops for Codex review.

## Round-2 repairs (Codex NO-GO items)

1. **Model input preserved** — `CandidateSample` carries the exact model-visible objective, TTL envelope (`ttl_seconds`/`issued_at`/`expires_at`), and an `input_digest`; SFT and DPO shard rows contain both the model input and the target response; provenance (provider receipt, judge keys) stays outside model-visible text.
2. **Judge-approved data preserved** — unanimous `JUDGE_PROVISIONAL` approval persists as `PROVISIONAL` (never `REJECTED`/`verified_failure`) into an explicit opt-in `sft_provisional` view with judge provenance, and is never promoted to `VERIFIED_SUCCESS`. Judge disagreement stays quarantined — with full candidate content kept in the ledger for future hard-negative construction.
3. **Resume reconstructs the complete dataset** — every evaluated attempt's candidate content is persisted in the ledger row; a resumed completed run rehydrates the builder in original order and reproduces identical nonempty shard digests with zero duplicated provider calls; an empty builder can never replace a populated manifest (`DatasetBuildError`).
4. **Work identity fixed** — `work_key` hashes the canonical complete request semantics (objective, TTL facts, leakage group, response type, effects, source/target datasets, full recipe). Materially different examples cannot collide; retries keep the same identity; ceilings are excluded so budget raises don't orphan completed work.
5. **PR #75 connected** — new `planning.py` consumes the typed `next_harvest_request` (`needle-next-harvest-request/v1`): weak cells generate confusion-targeted variants of the *failing* root; retention cells generate controlled variants of the retained root; root→objective/leakage-group bindings are required (fail closed); report `variant_requests` derive from each failing root's originating request — never cloned from `requests[0]`.
6. **Wave consistency enforced** — one campaign, source dataset, target dataset, and function pack per wave; one leakage group per root and its siblings; all checked before any effect.
7. **Adaptation is real** — `allocate_samples` converts donor weights into bounded discrete counts (99/1 ⇒ 4/0, not 2/2); `sample_seed` derives a distinct deterministic seed per donor/sample; unsuccessful substantive answers persist in candidate/quarantine ledger artifacts.
8. **Authorization precedes effects** — provider/plane allowlists and the donor catalog are checked *before* `transport.call` (`REFUSED_UNAUTHORIZED`); `authorized_effects` (`provider_call`, `ledger_append`, `shard_write`) are enforced before provider calls, ledger writes, or shard writes; returned `work_key` and receipt runtime are validated (mock⇒`mock`, live⇒non-mock); the effective budget is the elementwise `min` of request/session/manifest ceilings.

## Required regression proofs (all green)

Different objectives/TTL windows ⇒ different work IDs · SFT/DPO rows contain input+output · provisional examples survive into `sft_provisional` · resume reproduces original nonempty shard digests · weak root-2 creates root-2 variants · retention cells generate controlled variants · 99/1 allocation ⇒ unequal calls · per-sample seeds differ deterministically · mixed dataset generations / inconsistent leakage groups rejected · disallowed providers rejected before `transport.call` · hostile workflow strings cannot execute shell syntax (JS, #75) · trivial baseline stays in the cross-arm comparison (#75).

## Changed paths (10 files)

- `evals/needle_harvest/{__init__,contracts,transport,ledger,truth,dataset,planning,proposer,harvester}.py`
- `tests/test_needle_harvest.py` — 32 tests (16 original mock proofs + round-2 regression proofs)

## Verification (at exact head `b10e377`)

- Targeted: `pytest tests/test_needle_harvest.py` — **32 passed**
- Full suite: `uv run pytest -q` — **1586 passed**
- `ruff check evals tests/test_needle_harvest.py` — clean; `python -m compileall -q src evals main.py` — clean; `git diff --check` — clean

## Confirmations

- Mock mode makes zero provider/network calls and reads zero credentials (deny-list + socket-guard tests).
- Zero training and zero sealed-evaluation exposure are unauthorizable from this package.
- PR #64 untouched. No merge/retarget/deploy/worktree deletion.

## Known risks / dependencies

- Stacked on #75: must land after the foundation branch; the `next_harvest_request` schema is the coupling point.
- Live transport is intentionally absent — only the typed interface + mock transport exist until the provider-neutral UniGrok MCP interface lands.
- Live runs additionally require a Codex-approved manifest bound to the reviewed head SHA.

Sponsor: David Johnston
Agent-Assisted-By: Anthropic Claude | model=Fable 5 Ultracode | model-source=user-reported | surface=Copilot CLI | role=implementation
