### PR TITLE
Align runtime documentation with shipped behavior

### DIFF
--- a/.agents/skills/uni-grok-mcp/SKILL.md
+++ b/.agents/skills/uni-grok-mcp/SKILL.md
@@ -28,8 +28,11 @@ http://localhost:4765/mcp
 Start or refresh the service from the primary checkout with:
 ```bash
 docker compose up --build -d
-curl -s http://localhost:4765/healthz
+curl --fail -s http://localhost:4765/healthz
 ```
+
+After at least one Grok credential plane is configured, use `/readyz` as the
+model-access gate.
 
 For IDE setup, use [docs/ide-setup.md](../../../docs/ide-setup.md) as the source of truth. Each IDE should use the same endpoint and set a stable `X-Client-ID` header (`codex`, `claude-code`, `vscode`, `antigravity`, etc.) so sessions and telemetry stay separated.
 
@@ -71,15 +74,21 @@ uv run python main.py --http
 
 ## 3. Specialized Tools & Resources
 
-When querying Grok or using this server, take advantage of the following custom capabilities:
+Capability names are surface-specific. Treat the connected server's live
+`tools/list`, `resources/list`, and `prompts/list` responses as authoritative:
 
-- **Unified Agent (`agent` tool)**: The core entry point for complex tasks. It handles multi-step reasoning, tool routing, and returns structured metadata.
-- **Deferred Research Jobs**:
+- **Stable HTTP (`:4765/mcp`)**: `agent`, read-only PR review, status,
+  discovery, and the disabled-by-default restart helper. This service is
+  workspace-neutral.
+- **Contributor Forge HTTP (`:4766/mcp`)**: the stable surface plus
+  repository-scoped workspace-memory and Swarm tools.
+- **Trusted stdio**: the full source registry, including deferred research:
   - `submit_research_job`: Start a deferred research job in xAI's infrastructure.
   - `get_research_job`: Check the status/polling updates of a deferred job.
   - `list_research_jobs`: List recently submitted jobs.
-- **MCP Resources**: The server exposes system state as resources under the `grok://` scheme (e.g. `grok://models`, `grok://status`, `grok://sessions`, `grok://jobs/{id}`).
-- **MCP Prompts**: Common workflows are exposed as prompts (e.g. `research_topic`, `fix_and_test`).
+  Trusted stdio also registers `grok://` resources and reusable prompts such
+  as `research_topic` and `fix_and_test`. Their presence in source does not
+  imply that stable HTTP exposes them.
 
 ---
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,8 @@ RUN useradd --create-home --uid 1000 --shell /usr/sbin/nologin appuser \
     && chown -R appuser:appuser /app /state /home/appuser/.grok
 USER appuser
 
-# Expose port (optional for stdio, required for HTTP transport later if I will add it)
+# The container command runs the current HTTP gateway on its internal port.
+# Host publication remains explicit and loopback-bound in the default Compose file.
 EXPOSE 8080
 
 # Containers must listen on all interfaces: the container loopback is not

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Start the shared service:
 
 ```bash
 docker compose up --build -d
-curl -s http://localhost:4765/healthz
+curl --fail -s http://localhost:4765/healthz
 ```
 
 For the SuperGrok subscription path, authenticate once per machine:
@@ -94,9 +94,18 @@ startup is noninteractive. The service is usable when either the API plane or
 the CLI plane is ready; features that exist only on the other plane remain
 unavailable until that credential is configured.
 
-You are done when health reports `{"status":"healthy"}` and the Control Center
-at `http://localhost:4765/ui/` says the gateway is live. Use host port `4765`
-for IDEs and browsers; `8080` is only the container's internal port.
+After configuring at least one credential path, run the final readiness gate:
+
+```bash
+curl --fail -s http://localhost:4765/readyz
+```
+
+You are done when `/readyz` reports `{"status":"ready", ...}` and the Control
+Center at `http://localhost:4765/ui/` says the gateway is live. `/healthz`
+only proves that the HTTP process is answering. `/readyz` checks that an API
+credential is configured or the CLI OAuth probe succeeds, plus writable state
+and SQLite. It does not make a paid API call to validate an API key. Use host
+port `4765` for IDEs and browsers; `8080` is only the container's internal port.
 
 For an explicit no-API-billing agent call, set `plane="cli"` and
 `fallback_policy="same_plane"`. Use `plane="api"` for a strict metered API
@@ -180,7 +189,7 @@ globally) and paste:
     "unigrok": {
       "url": "http://localhost:4765/mcp",
       "name": "UniGrok MCP Gateway",
-      "description": "Shared Grok agent with live Control Center, cost tracking, reasoning guard, OKF + WebMCP self-discovery",
+      "description": "Shared Grok agent with live Control Center, cost tracking, OKF + WebMCP self-discovery",
       "headers": { "X-Client-ID": "cursor" }
     }
   }
@@ -295,10 +304,13 @@ surface centered on:
 
 - `agent`: auto-routed Grok agent with modes `auto`, `fast`, `reasoning`,
   `thinking`, and `research`.
-- status and discovery tools that explain readiness without running inference.
+- `review_pull_request`: read-only review of caller-supplied PR evidence.
+- `grok_mcp_status` and `grok_mcp_discover_self`: non-secret status,
+  capability, model-catalog, and onboarding information.
+- `grok_mcp_restart_container`: a maintenance helper that is present but
+  refuses to act unless a trusted local operator explicitly enables it.
 
-Trusted stdio and contributor modes additionally expose specialist tools such
-as:
+Trusted stdio additionally exposes specialist tools such as:
 
 - `grok_reflect`: focused structured critique for plans, code-review notes,
   outputs, and architecture decisions.
@@ -326,6 +338,11 @@ as:
   the stable workspace-neutral service.
 - `generate_image`, `generate_video`, `extend_video`: Grok Imagine media.
 
+Contributor Forge HTTP (`:4766/mcp`) adds only commit-anchored workspace-memory
+and Swarm tools to the stable five-tool surface. It does not expose the trusted
+stdio chat, media, research, file, Git, or test registries directly. Always use
+live MCP `tools/list` as the authority for a connected surface.
+
 ### Explainable model selection
 
 `agent(model=None, mode="auto")` uses one deterministic, local-first selector:
@@ -333,8 +350,9 @@ as:
 - capability classes are `planning`, `coding`, `vision`, and `research`;
 - planning cold-starts on `grok-4.5`, coding on `grok-build-0.1`, and research
   on the live Grok 4.20 multi-agent slug;
-- explicit model pins and `UNIGROK_*_MODEL` overrides win only after strict
-  plane/catalog compatibility validation;
+- explicit model pins and `UNIGROK_*_MODEL` overrides take selection
+  precedence. Strict `plane="cli"` and `plane="api"` requests validate against
+  that plane; `plane="auto"` may defer availability checks to execution;
 - the live catalog is cached for 15 minutes and a discovery failure uses the
   bundled model directory instead of blocking a request;
 - fresh eval calibration is considered before local telemetry, but a peer
@@ -356,10 +374,11 @@ Workspace-memory operations are also available locally as
 `unigrok-mcp memory import`. The Git Notes ref is local provenance and is not
 part of ordinary branch pushes.
 
-The public HTTP surface stays intentionally small: `agent`, status, discovery,
-and the disabled-by-default maintenance helper. In unrelated projects, call
-`agent` normally and add `workspace_context` only when local project evidence
-is needed.
+The public HTTP surface stays intentionally small: `agent`, read-only PR
+review, status, discovery, and the disabled-by-default maintenance helper. In
+unrelated projects, call `agent` normally and add `workspace_context` only when
+local project evidence is needed. Treat the live MCP `tools/list` response as
+the authority for a running deployment.
 
 ## Architecture
 
@@ -447,8 +466,10 @@ The directory `/docs/okf/` contains a fully self-describing documentation bundle
 
 ### 2. WebMCP-Enabled Docs & Console
 When running the HTTP gateway, visiting `http://localhost:4765/ui/` exposes browser-native WebMCP tools under `document.modelContext`.
-Any agent visiting this page can automatically discover and call:
-- `get_schema(tool_name)`: Returns the Pydantic JSON schema of a given UniGrok tool.
+Any compatible agent visiting this page can discover and call:
+- `get_result_shape_example(tool_name)`: Returns an illustrative field map for
+  common result types. It is not a wire schema; live MCP `tools/list` is
+  authoritative.
 - `example_call(mode)`: Returns JSON templates/examples for different operational modes.
 - `simulate_reasoning_guard`: Simulates checking if a model meets the required reasoning level.
 - `fetch_okf_bundle`: Returns the metadata and file paths in the OKF bundle.
@@ -518,15 +539,16 @@ curl --fail --silent --show-error \
 
 For the subscription-backed CLI plane, open **Setup & Status** in the Control
 Center. If authentication is missing, run `docker compose run --rm
-grok-cli-auth` and complete the device-code login. UniGrok uses `grok --check`
-inside the service as its readiness probe.
+grok-cli-auth` and complete the device-code login. UniGrok probes the
+authenticated CLI with `grok models` in an API-key-stripped environment.
+`grok --check` is a prompt self-verification option, not a readiness command.
 
 </details>
 
 <details>
 <summary><strong><code>mcp-remote</code> cannot connect</strong></summary>
 
-1. Confirm the server is running: `curl http://localhost:4765/healthz`.
+1. Confirm the service is usable: `curl --fail http://localhost:4765/readyz`.
 2. Point the IDE at `http://localhost:4765/mcp`, not `/sse`.
 3. Restart the IDE's MCP client after changing its configuration.
 
@@ -549,7 +571,9 @@ inside the service as its readiness probe.
 - `example.env` is a template only. The runtime loads `.env` when present and
   rejects the placeholder key.
 - Docker publishes `127.0.0.1:4765` by default.
-- Set `UNIGROK_API_KEYS` before exposing the gateway beyond loopback.
+- Before exposing the gateway beyond loopback, require either static client
+  tokens with `UNIGROK_API_KEYS` or the documented OAuth introspection
+  boundary. Do not enable both on the production OAuth service.
 - Git write tools are disabled unless local runtime flags explicitly enable
   them.
 - Container restart is disabled by default and should only be enabled for a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,10 +30,13 @@ a GitHub Security Advisory and request a CVE when appropriate.
 ## Deployment Boundary
 
 UniGrok binds Docker Compose to `127.0.0.1` by default. Before binding to a LAN
-or public interface, configure `UNIGROK_API_KEYS`, terminate TLS at a trusted
-proxy, restrict allowed origins, and rotate any credential that may have been
-exposed. Keep local git mutation and container restart capabilities disabled
-unless the process is running in a trusted local environment.
+or public interface, terminate TLS at a trusted proxy, restrict allowed
+origins, and configure one reviewed client-authentication boundary: static
+deployments may use `UNIGROK_API_KEYS`; the private remote deployment uses
+scoped OAuth with `UNIGROK_OAUTH_INTROSPECTION_URL`. Do not keep a static-key
+bypass on the production OAuth service. Rotate any credential that may have
+been exposed. Keep local git mutation and container restart capabilities
+disabled unless the process is running in a trusted local environment.
 
 See [docs/threat-model.md](docs/threat-model.md) for actors, assets, identity
 composition, credential flows, and residual risks.

--- a/docs/chatgpt-github-app.md
+++ b/docs/chatgpt-github-app.md
@@ -24,13 +24,14 @@ ChatGPT connects to a remote HTTPS MCP URL, not directly to localhost. For a
 private local server, prefer OpenAI's Secure MCP Tunnel. For temporary
 development, an HTTPS tunnel may forward to `http://127.0.0.1:4765`.
 
-1. Confirm `http://localhost:4765/healthz` is healthy.
+1. Confirm `http://localhost:4765/readyz` returns ready.
 2. Establish a trusted HTTPS tunnel to host port `4765` without exposing the
    Docker-internal port `8080`.
 3. In ChatGPT Developer Mode, create a private app using
    `https://<trusted-host>/mcp`.
-4. Configure the app's authentication to send a UniGrok client token when
-   `UNIGROK_API_KEYS` protects the endpoint.
+4. For the private remote service, configure the app through UniGrok's OAuth
+   discovery flow. For a temporary local tunnel protected by
+   `UNIGROK_API_KEYS`, send only that narrowly scoped gateway client token.
 5. Scan tools and confirm `review_pull_request` is read-only.
 6. Refresh the app after tool metadata or widget URI changes.
 
@@ -53,8 +54,9 @@ does not need to operate Git or babysit the runner):
 3. Ensure workflow permissions allow pull-request reads and timeline comments;
    the checked-in workflow uses `contents: read` and `pull-requests: write`
    without contents, actions, deployments, or administration write access.
-4. Open or update a PR, manually dispatch the workflow, or comment
-   `@grok review` on a PR.
+4. Manually dispatch the workflow with a PR number, or have an owner, member,
+   or collaborator comment `@grok review` on a PR. Opening or updating a PR
+   does not trigger this workflow.
 
 The checked-in defaults intentionally preserve this local path:
 
@@ -66,16 +68,17 @@ The checked-in defaults intentionally preserve this local path:
 ## Security contract
 
 - PR diffs and comments are untrusted evidence, not instructions.
-- The workflow uses `pull_request_target` only to execute the trusted workflow
-  and script from the default branch.
-- Because this is a public repository, automatic and comment-triggered runs
-  are restricted to the owner, members, and collaborators. Outside
-  contributors cannot schedule work on the Mac runner themselves.
+- The workflow has only `issue_comment` and `workflow_dispatch` triggers. It
+  never uses `pull_request` or `pull_request_target`; every run checks out the
+  trusted default branch rather than contributor code.
+- Because this is a public repository, comment-triggered runs require an
+  owner, member, or collaborator. Outside contributors cannot schedule work on
+  the Mac runner themselves.
 - It never checks out, builds, imports, or runs code from the reviewed PR.
 - GitHub API responses are bounded before sending them to UniGrok.
-- An automatic `pull_request_target` run must match the event base and head
-  SHAs. Review evidence comes from the immutable compare endpoint for those
-  commits, and both are checked again before a comment is written.
+- The runner resolves the PR's current base and head, fetches evidence from the
+  immutable `base...head` compare endpoint, and checks both commits again
+  before writing a comment.
 - The tool and workflow cannot merge, push, tag, release, or change protection.
 - The review comment explicitly hands authority back to Codex.
 

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -12,10 +12,10 @@ host-facing MCP, health, and Control Center URLs always use port `4765`;
 ## Start the service
 
 ```bash
-cd /path/to/uni-grok-mcp        # the real checkout, not a worktree
+cd /path/to/grok-mcp-server     # the primary checkout, not a task worktree
 uv run python main.py init      # first time only; creates .env if absent
 docker compose up -d --build
-curl -s http://localhost:4765/healthz   # -> {"status":"healthy"}
+curl --fail -s http://localhost:4765/healthz
 ```
 
 Choose at least one credential path:
@@ -27,22 +27,34 @@ Choose at least one credential path:
 - **Both:** recommended for maximum coverage. The default `cli_first` policy
   prefers compatible subscription work while preserving API-only features.
 
-Open `http://localhost:4765/ui/` and use **Setup & Status** to confirm which
+After configuring at least one credential path, run:
+
+```bash
+curl --fail -s http://localhost:4765/readyz
+```
+
+`/healthz` only proves that the HTTP process is alive. A successful `/readyz`
+checks API credential presence or a live CLI OAuth probe, writable state, and
+SQLite. It does not spend a request to validate an API key. Open
+`http://localhost:4765/ui/` and use **Setup & Status** to confirm which
 credential planes are ready before configuring every IDE.
 
 Compose loads secrets from the launched checkout's `.env`. Agent worktrees
 often do not have that gitignored file; set
-`UNIGROK_ENV_FILE=/path/to/.env` before `docker compose up` to use a secret
-file from another checkout.
+`UNIGROK_ENV_FILE=/path/to/grok-mcp-server/.env` before `docker compose up` to
+use the primary checkout's secret file.
 
 The stable compose file runs the image's baked application at `/app`, stores
 mutable data in a Docker volume mounted at `/state`, and publishes
 `127.0.0.1:4765`. It does not mount the UniGrok checkout or an IDE project.
 Compose declares that this is a trusted loopback-only host publication so the
-local service can run without a client token. The application still requires `UNIGROK_API_KEYS` for any
-direct non-loopback bind or Cloud Run deployment. Remove the
-`UNIGROK_TRUSTED_LOOPBACK_PROXY` declaration and set `UNIGROK_API_KEYS` before
-changing the port mapping to `0.0.0.0:4765:8080` or `4765:8080`.
+local service can run without a client token. Any direct non-loopback bind must
+enable authentication: static deployments use `UNIGROK_API_KEYS`; the private
+Cloud Run deployment instead uses `UNIGROK_OAUTH_INTROSPECTION_URL` and the
+associated OAuth discovery settings. Remove the
+`UNIGROK_TRUSTED_LOOPBACK_PROXY` declaration and configure one of those
+documented authentication boundaries before changing the port mapping to
+`0.0.0.0:4765:8080` or `4765:8080`.
 
 Do not edit Compose to mount each project you open. MCP registration is global
 service access, not filesystem authority. A calling IDE supplies only the
@@ -99,8 +111,11 @@ even if both assert `X-Client-ID: vscode`. Budgets bind to the authenticated
 principal. Omitting the header shares that principal's client-neutral
 namespace.
 
-If `UNIGROK_API_KEYS` is set, also add
+If the local/static gateway sets `UNIGROK_API_KEYS`, also add
 `"Authorization": "Bearer <one-of-those-keys>"` to each config's headers.
+OAuth-protected remote clients obtain a scoped access token through the
+published RFC 9728 metadata; they do not reuse an xAI key or a local static
+gateway token.
 
 ## Cursor (`.cursor/mcp.json` in project root, or `~/.cursor/mcp.json`)
 
@@ -112,7 +127,7 @@ With Cursor joining the xAI family, it's the natural first-class Grok IDE.
     "unigrok": {
       "url": "http://localhost:4765/mcp",
       "name": "UniGrok MCP Gateway",
-      "description": "Shared Grok agent with live Control Center, cost tracking, reasoning guard, OKF + WebMCP self-discovery",
+      "description": "Shared Grok agent with live Control Center, cost tracking, OKF + WebMCP self-discovery",
       "headers": { "X-Client-ID": "cursor" }
     }
   }

--- a/docs/okf/agent-tool.md
+++ b/docs/okf/agent-tool.md
@@ -2,20 +2,31 @@
 okf_version: "0.1"
 title: "Agent Entrypoint Tool"
 type: "topic"
-description: "Detailed guide on using the unified UniGrok agent tool, modes, progress reporting, and multi-agent fan-out."
+description: "Surface-scoped guide to the stable HTTP agent and trusted stdio agent tools."
 ---
 
 # Agent Entrypoint Tool
 
-The `agent` tool is the headline unified entrypoint for UniGrok. It automatically manages model routing, plane failover, context injection, and local filesystem access (web search, X search, and sandboxed python execution).
+The `agent` tool is the headline unified entrypoint for UniGrok.
+
+> **Surface scope:** the stable HTTP service at `:4765/mcp` exposes the public
+> `agent` documented first below. It is workspace-neutral and cannot browse the
+> IDE's files. Trusted stdio has a different `agent` signature and the broader
+> source tool set; contributor Forge at `:4766/mcp` adds repository memory and
+> Swarm tools to the stable HTTP surface. Always use live MCP `tools/list` as
+> the deployed contract.
 
 ## Tool Signatures & Schemas
 
-### `agent`
-Primary entry point for any agent task.
+### Stable HTTP `agent`
+Primary entry point for ordinary IDE calls to `:4765/mcp`.
 - **Parameters**:
-  - `task` (string, required): The goal or instruction.
+  - `prompt` (string, required): The goal or instruction.
   - `session` (string, optional): Context thread persistence.
+  - `system_prompt` (string, optional): Additional system instruction.
+  - `workspace_context` (string, optional): Deliberately selected project text
+    supplied by the calling IDE; it grants no filesystem authority.
+  - `workspace_label` (string, optional): Human-readable label for that text.
   - `mode` (string, optional): `"auto"` (default), `"fast"`, `"reasoning"`, `"thinking"`, or `"research"`.
   - `model` (string, optional): Enforce a specific Grok model ID.
   - `plane` (string, optional): `"auto"` (backward-compatible), `"cli"`
@@ -23,7 +34,6 @@ Primary entry point for any agent task.
   - `fallback_policy` (string, optional): `"same_plane"` forbids crossing the
     billing boundary; `"cross_plane"` preserves automatic recovery for legacy
     auto callers.
-  - `require_reasoning_level` (string, optional): `"low"`, `"medium"`, or `"high"`.
 - **Response Shape (`AgentResult`)**:
   ```json
   {
@@ -37,7 +47,7 @@ Primary entry point for any agent task.
     "latency_sec": 4.25,
     "route": "agentic",
     "plane": "API",
-    "reasoning_effort": "high",
+    "reasoning_effort": null,
     "citations": [
       {
         "url": "https://example.com/source"
@@ -75,8 +85,17 @@ Primary entry point for any agent task.
   }
   ```
 
-### `grok_agent`
-Dedicated tool wrapping a ReAct AgentLoop in a schema-enforced reflection review loop with strict iteration and budget constraints.
+### Trusted stdio `agent`
+
+The full stdio server also registers an `agent` whose required input is
+`task`. It adds `require_reasoning_level` and MCP progress reporting, and it may
+use local file/git/test tools within the resolved trusted workspace. An
+explicit `WORKSPACE_ROOT` wins; ordinary local stdio otherwise resolves to the
+UniGrok service root, never whichever IDE project happens to call it. That
+signature is not the stable HTTP contract.
+
+### Trusted stdio `grok_agent`
+Dedicated tool wrapping a ReAct AgentLoop in a schema-enforced reflection review loop with strict iteration and budget constraints. It is not exposed by the stable or Forge HTTP service.
 - **Parameters**:
   - `prompt` (string, required): Task description.
   - `session` (string, optional): Persistent conversation thread.
@@ -110,6 +129,7 @@ installation, device-auth, or secret-configuration actions. Never request
 `XAI_API_KEY` in chat or store it in the caller's project.
 
 When CLI-first is active, the selected CLI slug comes from the authenticated
-live catalog carried by the health probe. Coding prefers composer; reasoning
-prefers the CLI's reported default. Explicit API model pins remain on API even
-when the same slug is also exposed by the CLI subscription.
+live catalog returned by the `grok models` readiness probe. Coding prefers
+composer; reasoning prefers the CLI's reported default. Explicit API model
+pins remain on API even when the same slug is also exposed by the CLI
+subscription.

--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -8,6 +8,10 @@ description: "Auto-generated API reference from the UniGrok codebase."
 # API Reference
 
 This deterministic reference is generated from documented public Python symbols.
+It is a source-code inventory, not the MCP `tools/list` contract: a Python
+symbol appearing here does not mean it is exposed by the stable HTTP service.
+Use live MCP discovery for the deployed surface. Topic guides label stable
+HTTP, contributor Forge, and trusted stdio capabilities explicitly.
 Run `uv run python scripts/generate_okf.py --write` after changing the public API.
 
 ## cli.py {#cli}

--- a/docs/okf/chat-modes.md
+++ b/docs/okf/chat-modes.md
@@ -2,12 +2,20 @@
 okf_version: "0.1"
 title: "Chat & Context Modes"
 type: "topic"
-description: "Detailed description of direct chat, stateful conversation, vision-capable analysis, and document-backed chats."
+description: "Trusted-stdio chat, stateful conversation, vision, and file tools, with explicit HTTP scope."
 ---
 
 # Chat & Context Modes
 
-UniGrok supports direct message completion, stateful conversation continuation, vision analysis, file ingestion, and structured critique.
+UniGrok's full trusted stdio server supports direct completion, stateful
+conversation continuation, vision analysis, file ingestion, and structured
+critique.
+
+> **Surface scope:** none of the tools on this page are exposed by the stable
+> HTTP service at `:4765/mcp`. Contributor Forge at `:4766/mcp` adds
+> repository-memory and Swarm tools, not these chat tools. HTTP clients use the
+> public `agent` entrypoint instead. Confirm every deployment with MCP
+> `tools/list`.
 
 ## Schema contracts
 
@@ -33,7 +41,7 @@ All chat and context tools return `ChatResult` (inheriting from `BaseResult`) wi
 }
 ```
 
-## Available Tools
+## Trusted stdio tools
 
 ### 1. `chat`
 Sends a direct text prompt to a Grok model.
@@ -42,7 +50,13 @@ Sends a direct text prompt to a Grok model.
   - `session` (string, optional): Local session name.
   - `model` (string, optional): Default `"grok-build-0.1"`.
   - `system_prompt` (string, optional): Injected instructions.
+  - `agent_count` (integer, optional): `4` or `16`, only for a compatible
+    Grok 4.20 multi-agent model.
   - `enable_agentic` (boolean, optional): If `True` (default), runs in ReAct loop.
+  - `require_reasoning_level` (string, optional): `"low"`, `"medium"`, or
+    `"high"`; enforced before inference execution. Live catalog discovery may
+    occur first. Current bundled profiles
+    declare no effort, so any value above `none` fails closed.
 
 ### 2. `stateful_chat`
 Appends to a server-side conversation thread at xAI.
@@ -61,6 +75,10 @@ Analyzes local image files or public image URLs.
   - `image_paths` (array of strings, optional): Paths to local files (PNG/JPG).
   - `image_urls` (array of strings, optional): Public URLs.
   - `detail` (string, optional): `"auto"`, `"low"`, `"high"`.
+
+Local paths resolve inside the trusted stdio workspace. An explicit
+`WORKSPACE_ROOT` wins; ordinary local stdio otherwise uses the UniGrok service
+root. Merely registering stable HTTP does not grant access to an IDE project.
 
 ### 4. `chat_with_files`
 Infers across uploaded document files.

--- a/docs/okf/faq.md
+++ b/docs/okf/faq.md
@@ -257,8 +257,9 @@ Check the gateway health endpoint with:
 curl -s http://localhost:4765/healthz
 ```
 
-Use `/readyz` when you also need readiness checks for model authentication,
-state storage, and SQLite. Inspect the non-secret CLI state with:
+Use `/readyz` when you also need readiness checks for API credential presence
+or a live CLI OAuth probe, state storage, and SQLite. It does not spend a
+request to validate an API key. Inspect the non-secret CLI state with:
 
 ```bash
 curl -s http://localhost:4765/runtimez

--- a/docs/okf/grok-4.5-pinning.md
+++ b/docs/okf/grok-4.5-pinning.md
@@ -9,36 +9,58 @@ description: "Model selection profiles, aliases (planning/coding), live discover
 
 UniGrok supports runtime model pinning, live model catalog discovery, hyperparameter profiling, and keyless local CLI fallback paths.
 
+> **Surface scope:** stable and Forge HTTP clients pin models through the
+> public `agent(model=..., plane=..., fallback_policy=...)` contract. Trusted
+> stdio tools expose additional model-bearing functions. A model appearing in
+> this document or the generated source reference is not proof that it exists
+> on either credential plane; use `grok_mcp_discover_self(include_models=true)`
+> or the live provider catalogs.
+
 ## Model Profiles & Hyperparameters
 
-Profiles are loaded from JSON files inside `.grok/hyperparams/` and control settings like temperature, top_p, thinking mode, and default reasoning effort.
-For example, a model's profile may declare:
+Profiles are loaded from JSON files inside `.grok/hyperparams/` and control
+settings such as temperature, top_p, thinking mode, and the system prompt.
+For example, a current bundled reasoning profile declares:
 ```json
 {
-  "profile": "grok-4.5-reasoning-high",
-  "temperature": 0.3,
+  "temperature": 0.4,
   "top_p": 0.95,
   "thinking_mode": true,
-  "reasoning_effort": "high",
-  "system_prompt_ref": "default-coding.txt"
+  "system_prompt_ref": "grok_adapter.md"
 }
 ```
 
-## API vs CLI Routing Paths
+Current bundled profiles omit `reasoning_effort`, so the normalized value is
+`null` (`none` for guard comparison). Do not infer an effort level from the
+model slug or `thinking_mode`.
 
-### 1. API Plane (Main Path)
+## API and CLI credential planes
+
+### 1. CLI Plane (preferred compatible path)
+
+The local default policy is `UNIGROK_PLANE_POLICY=cli_first`.
+
+- Uses the service's Grok CLI grok.com OAuth session, not `XAI_API_KEY`.
+- Readiness is a bounded, API-key-stripped `grok models` probe.
+- Exact model availability comes from that authenticated catalog.
+- Native CLI session IDs provide continuation for compatible calls.
+- The CLI adapter does not expose every API ReAct/server-tool capability.
+
+### 2. API Plane
 Direct HTTPS connections to the xAI endpoint (`api.x.ai`).
 - Uses `XAI_API_KEY` from the environment.
 - Supports streaming, tool calling, and full structured output (critique JSON schemas).
 
-### 2. CLI Plane (Local Fallback)
-If the server environment lacks an xAI API Key but has a mounted `grok` CLI subscription binary:
-- The router automatically detects the keyless state.
-- Executes prompts through local subshell command calls to the `grok` CLI.
-- Resets conversation context session IDs (`api_thread_id`) to prevent upstream state desynchronization.
+Explicit `plane="cli"` or `plane="api"` requests are strict. Use
+`fallback_policy="same_plane"` when crossing subscription and metered billing
+boundaries is forbidden. `cross_plane` allows only bounded, compatible
+recovery; it does not make a model available on a catalog where it is absent.
 
 ## Live Catalog Discovery & Fallbacks
-If the live xAI endpoint is unreachable or model listing fails, UniGrok falls back to a hardcoded list of supported IDs:
+UniGrok caches live catalog discovery. If API discovery fails, its bundled
+directory supplies routing candidates, but execution still requires the
+selected model to be available on the resolved credential plane. Current
+cold-start capability defaults include:
 - **Premier default**: `grok-4.5`
 - **Default coding**: `grok-build-0.1`
 - **Planning default**: `grok-4.5`
@@ -48,4 +70,6 @@ If the live xAI endpoint is unreachable or model listing fails, UniGrok falls ba
 Auto-routing does not equate "newest" with "best." It filters a bounded
 capability-class candidate list, keeps a stable cold-start default, and only
 lets fresh calibration or mature local telemetry promote a peer by the
-configured quality margin. Explicit pins and environment overrides always win.
+configured quality margin. Explicit pins and environment overrides take
+selection precedence. Strict `plane="cli"` and `plane="api"` requests validate
+against that plane; `plane="auto"` may defer availability checks to execution.

--- a/docs/okf/index.md
+++ b/docs/okf/index.md
@@ -21,14 +21,30 @@ Welcome, Agent. This is the Open Knowledge Format (OKF) index for UniGrok, a
 local-first gateway for xAI's Grok model family built for the Model Context
 Protocol (MCP).
 
-Use this bundle to discover tool schemas, routing details, reasoning levels, media generation capabilities, and gateway observability.
+Use this bundle for routing, schema, and operational reference. It documents
+more than one execution surface; it is not a substitute for MCP `tools/list`.
+
+## Surface map
+
+- **Stable HTTP (`:4765/mcp`)**: `agent`, `review_pull_request`,
+  `grok_mcp_status`, `grok_mcp_discover_self`, and the disabled-by-default
+  `grok_mcp_restart_container` maintenance helper.
+- **Contributor Forge HTTP (`:4766/mcp`)**: the stable surface plus
+  repository-scoped workspace-memory and Swarm tools.
+- **Trusted stdio**: the full source tool registry, including direct chat,
+  local workspace, media, knowledge, and research tools.
+- **Generated API reference**: documented Python symbols, including internal
+  and surface-specific functions. Presence there never implies MCP exposure.
+
+Deployments can vary by version and mode. Treat their live `tools/list` as
+authoritative.
 
 ## Navigation Map
-- [Agent Entrypoint](agent-tool.md): The unified agent-level execution tool.
-- [Chat & Context Modes](chat-modes.md): Direct text, stateful threads, files, and vision analysis.
-- [Reasoning Guard & Level Enforcement](reasoning-guard.md): Preventing intelligence degradation at the router level.
+- [Agent Entrypoint](agent-tool.md): Stable HTTP and trusted stdio agent contracts.
+- [Chat & Context Modes](chat-modes.md): Trusted-stdio direct text, stateful threads, files, and vision tools.
+- [Reasoning Guard & Level Enforcement](reasoning-guard.md): Trusted-stdio minimum-profile enforcement and its HTTP boundary.
 - [Model Pinning & Profiles](grok-4.5-pinning.md): API vs CLI paths, fallback parameters, and Grok 4.5 capabilities.
-- [Media Generation](media-imagine.md): Image and video generation schemas.
+- [Media Generation](media-imagine.md): Trusted-stdio API-plane image and video schemas.
 - [Observability & Metrics](metrics-tool.md): Aggregated telemetry and status monitoring.
 - [Insider Intelligence Payload Profiles](intelligence-payload-profiles-v1.md): Manifest-closed GNO envelopes, evidenced OptiBench cohorts, direct-Pareto preference pairs, and bounded Needle projections carried beside the immutable Capsule v1 format.
 - [Verified FAQ](faq.md): Curated operational answers that Grok consults only when relevant.

--- a/docs/okf/media-imagine.md
+++ b/docs/okf/media-imagine.md
@@ -7,7 +7,17 @@ description: "How to generate and edit images and videos using Grok Imagine, wit
 
 # Media Generation
 
-UniGrok integrates xAI's image generation (Grok Imagine) and video generation capabilities into the MCP server.
+UniGrok's full trusted stdio server integrates xAI's image and video generation
+capabilities.
+
+> **Surface scope:** `generate_image`, `generate_video`, and `extend_video` are
+> API-plane tools on trusted stdio only. They are not exposed by stable HTTP at
+> `:4765/mcp`, and contributor Forge does not add them. A caller must confirm
+> live `tools/list` before relying on these names. Local file inputs resolve
+> only within the trusted stdio workspace; URL inputs do not grant filesystem
+> access. In ordinary local trusted stdio, the resolved workspace
+> defaults to the UniGrok service root unless `WORKSPACE_ROOT` is set; it never
+> follows the calling IDE project implicitly.
 
 ## Media Tools Schema Contract
 
@@ -16,7 +26,7 @@ All media tools return `MediaResult` (inheriting from `BaseResult`) to guarantee
 ### `MediaResult` Output Schema
 ```json
 {
-  "response": "Summary text description of generated media...",
+  "response": "https://img.x.ai/image-xyz.png",
   "text": "Human-formatted summary markdown...",
   "finish_reason": "final_answer",
   "cost_usd": 0.05,
@@ -38,7 +48,7 @@ All media tools return `MediaResult` (inheriting from `BaseResult`) to guarantee
 }
 ```
 
-## Available Media Tools
+## Trusted stdio media tools
 
 ### 1. `generate_image`
 Generates new images or edits existing ones using text instructions.

--- a/docs/okf/metrics-tool.md
+++ b/docs/okf/metrics-tool.md
@@ -9,10 +9,16 @@ description: "UniGrok gateway diagnostics, Prometheus http endpoint, circuit bre
 
 UniGrok is built for zero-trust swarm environments, providing rich operational telemetry, billing budget controls, and circuit breakers.
 
+> **Surface scope:** `grok_mcp_status` is available on stable HTTP, Forge HTTP,
+> and trusted stdio. `/metrics` is an HTTP route, not an MCP tool. Remote
+> access requires the `unigrok:status` OAuth scope or a configured static
+> gateway token; verified local operator access follows the loopback boundary.
+
 ## Telemetry Observability
 
-### 1. Stdio Status Tool (`grok_mcp_status`)
-For stdio MCP hosts, querying gateway metrics can be done directly through the tool:
+### 1. MCP Status Tool (`grok_mcp_status`)
+Query gateway metrics through the MCP tool on any surface where live
+`tools/list` exposes it:
 - `view=text` (default) returns the human-readable operational report.
 - `view=json` returns the stable structured usage ledger consumed by the Control Center: today/lifetime summaries, per-plane/model/caller activity, data coverage, circuit breakers, and billing-source metadata.
 
@@ -32,9 +38,18 @@ failover facts. JSON metrics expose the newest receipts under
 `selection_reasons`. The UI renders these values directly; it never infers why
 a model ran from a model name or dollar amount.
 
-Rows created before v0.5.0 naturally have no receipt. They remain valid for
-cost, latency, success, model, caller, token, and plane aggregates, while
-`data_quality.routing_receipt_rows` states the exact explainability coverage.
+Rows created before routing receipts remain valid for operational fields such
+as cost, latency, model, caller, token, and plane. They do not become explained
+routes retroactively; `data_quality.routing_receipt_rows` states the exact
+coverage.
+
+Outcome truth is tri-state: `success=1` requires an explicit verifier;
+`success=0` records an explicit gateway failure or verifier-established
+failure; and `NULL` means the completion remains unverified. Success rates use
+the non-null outcomes as the denominator and remain `null` when no such outcome
+exists. Schema v14 cleared unsupported historical positive labels, so old
+completion text is never treated as semantic success merely because a
+transport returned normally.
 
 ## Billing Truth
 
@@ -60,10 +75,17 @@ prompts until the notice id changes.
 
 ## Circuit Breakers & Failover
 
-The gateway maintains a circuit breaker status to prevent flooding xAI APIs during outages:
+The gateway maintains per-model circuit breakers to prevent repeated xAI API
+calls during outages:
 - If error rates spike, the circuit trips to **Open** state.
-- During Open state, new calls automatically failover to local CLI execution or return cached fallbacks immediately.
+- During Open state, the selected API model is blocked. A request may use the
+  CLI plane only when its requested plane, model compatibility, and
+  `fallback_policy` permit that crossing; otherwise it fails explicitly.
 - The status resets to **Closed** after error rates recover.
 
 ## Billing Spending Budgets
-Spending limits are enforced per-caller based on client authorization bearer tokens or MCP client info names. Once a caller reaches their daily limit (defined in `UNIGROK_CALLER_BUDGETS`), the gateway throws a budget exceeded exception immediately, protecting operators from run-away agent loops.
+Spending limits are enforced against the authenticated principal: OAuth
+subject remotely, static-key alias for keyed gateways, and MCP client identity
+only as the stdio fallback. `X-Client-ID` remains a reporting/session label and
+cannot change an OAuth subject's budget. Once a matching principal reaches its
+daily `UNIGROK_CALLER_BUDGETS` limit, model work fails before execution.

--- a/docs/okf/okf-manifest.json
+++ b/docs/okf/okf-manifest.json
@@ -2,7 +2,7 @@
   "okf_version": "0.1",
   "name": "uni-grok-mcp",
   "title": "UniGrok MCP Knowledge Bundle",
-  "description": "Agent-readable documentation for the UniGrok Grok-native Model Context Protocol (MCP) server.",
+  "description": "Surface-scoped documentation for UniGrok stable HTTP, contributor Forge, and trusted stdio capabilities.",
   "root": "index.md",
   "files": [
     "index.md",

--- a/docs/okf/reasoning-guard.md
+++ b/docs/okf/reasoning-guard.md
@@ -2,27 +2,46 @@
 okf_version: "0.1"
 title: "Reasoning Guard & Level Enforcement"
 type: "topic"
-description: "How UniGrok enforces reasoning effort constraints and prevents intelligence fallback at the routing boundary."
+description: "Trusted-stdio reasoning-effort guard and its boundary from the stable HTTP agent."
 ---
 
 # Reasoning Guard & Level Enforcement
 
-UniGrok includes a model-level **Reasoning Guard** to prevent critical requests from degrading to low-intelligence fallback models during periods of high failover rates or configuration errors.
+UniGrok's trusted stdio tool set includes a model-profile **Reasoning Guard**
+for callers that explicitly request a minimum reasoning effort.
+
+> **Surface scope:** stable HTTP `agent` at `:4765/mcp` does not accept
+> `require_reasoning_level`. Use its `mode`, optional model pin, `plane`, and
+> `fallback_policy` fields. The guard described below belongs to the full
+> trusted stdio `agent` and `chat` signatures. Contributor Forge does not add a
+> second public agent signature.
 
 ## Guard Mechanism
 
-When calling the `agent` or `chat` tools, clients can pass `require_reasoning_level`.
-The gateway performs a pre-execution lookup against the resolved model's configuration profile (from `.grok/hyperparams`). If the chosen model's reasoning effort profile is below the requested threshold, the gateway throws a `ValueError` immediately *before* making the remote API request. This prevents unnecessary cost and latency on an inadequate fallback model.
+When calling the trusted stdio `agent` or `chat` tools, clients can pass `require_reasoning_level`.
+The gateway performs a pre-execution lookup against the resolved model's
+configuration profile (from `.grok/hyperparams`). If the chosen model's
+reasoning effort profile is below the requested threshold, the gateway throws
+a `ValueError` before inference execution. Model-catalog discovery may already
+have contacted a provider, so this is not a guarantee of zero provider traffic.
+It does prevent the requested inference turn and its associated generation
+cost on an inadequate fallback model.
+
+**Current limitation:** the bundled profiles do not declare
+`reasoning_effort`. The loader therefore normalizes every current profile to
+`none`. A trusted-stdio request requiring `low`, `medium`, or `high` currently
+fails closed for every bundled model. A model name, `thinking_mode`, or the
+word `reasoning` in a profile filename does not establish an effort level.
 
 ## Reasoning Level Weights
 Intelligence levels are graded on a strict threshold hierarchy:
 
-| Level | Weight | Description | Typical Target Models |
-|---|---|---|---|
-| `none` | 0 | Fast toolless completions / lightweight utilities | `grok-build-0.1` |
-| `low` | 1 | Standard reasoning with low reflection cycles | Standard API completion fallback profiles |
-| `medium` | 2 | Moderate reasoning limits (e.g. debugging/refactoring) | `grok-4.3` |
-| `high` | 3 | Full cognitive plane execution / planning loops | `grok-4.5`, `grok-4.20-multi-agent` |
+| Level | Weight | Meaning |
+|---|---|---|
+| `none` | 0 | No minimum profile effort required |
+| `low` | 1 | Requires an explicit profile declaration of `low` or higher |
+| `medium` | 2 | Requires an explicit profile declaration of `medium` or higher |
+| `high` | 3 | Requires an explicit profile declaration of `high` |
 
 ## Enforcement Flow Example
 
@@ -31,8 +50,8 @@ graph TD
     A[Client Call with require_reasoning_level='high'] --> B[Router selects/resolves model]
     B --> C[Load Model Hyperparams Profile]
     C --> D{chosen model reasoning >= high?}
-    D -- Yes --> E[Execute Run on target API]
-    D -- No --> F[Raise ValueError & Abort before API call]
+    D -- Yes --> E[Execute Run on resolved provider plane]
+    D -- No --> F[Raise ValueError & Abort before inference execution]
 ```
 
 ## Python Example (Direct Call)
@@ -40,8 +59,13 @@ graph TD
 try:
     res = await agent(
         task="Write a compiler in assembly.",
-        require_reasoning_level="high"
+        require_reasoning_level="low"
     )
 except ValueError as e:
     print(f"Aborted: {e}")
 ```
+
+The Control Center's WebMCP `simulate_reasoning_guard` helper is a static
+inspection of this release's bundled profile state: every listed model reports
+`none`/undeclared. It does not invoke the router and is not evidence that the
+stable HTTP MCP tool accepts this field.

--- a/docs/release-v0.4.0-draft.md
+++ b/docs/release-v0.4.0-draft.md
@@ -19,8 +19,8 @@ This release introduces the all-new, high-fidelity **UniGrok Control Center UI v
 1. **Control Center UI Redesign (v0.4.0)**
    The `/ui/` interface has been completely transformed into a rich multi-tab interactive workbench for developers and agents alike:
    - **Quick Test Console**: A prompt sandbox featuring selectable execution modes (`auto`, `fast`, `reasoning`, `thinking`, `research`) and live conversation bubbles.
-   - **Schema Explorer**: Interactive tool mapping the backend Pydantic v2 schemas (`AgentResult`, `ChatResult`, etc.) dynamically.
-   - **Reasoning Guard Simulator**: Pre-flight test sandbox demonstrating router policies and block/pass states.
+   - **Result Shape Guide**: Illustrative result-field examples; live MCP `tools/list` remains the authoritative schema source.
+   - **Reasoning Guard Preview**: Local preview of reasoning-level checks; it does not execute or prove the live router path.
    - **OKF Browser**: Renders Open Knowledge Format documentation dynamically with YAML headers stripped.
    - **WebMCP Tester**: Manifest inspector and client bridge prober.
    - **Telemetry & Metrics**: Displays cost tracking, average latency, and raw Prometheus metrics.

--- a/docs/remote-mcp-deployment.md
+++ b/docs/remote-mcp-deployment.md
@@ -18,7 +18,7 @@ Deploy the repository `Dockerfile` to a dedicated Cloud Run service and set:
 | `UNIGROK_OAUTH_SCOPES` | `unigrok:connect,unigrok:invoke,unigrok:review,unigrok:chat,unigrok:status` |
 | `UNIGROK_ALLOWED_ORIGINS` | Exact reviewed browser origins only; omit when no browser client is approved |
 | `UNIGROK_CALLER_BUDGETS` | JSON daily cost caps keyed by authenticated OAuth subject |
-| `UNIGROK_STATE_DIR` | `/tmp/unigrok` unless a durable store is deliberately attached |
+| `UNIGROK_STATE_DIR` | `/tmp/uni-grok` unless a durable store is deliberately attached |
 
 Inject `XAI_API_KEY` from a version-pinned Secret Manager resource. Do not set
 `UNIGROK_API_KEYS` on the production OAuth service; a static bearer must not

--- a/mcp_ui/.well-known/webmcp
+++ b/mcp_ui/.well-known/webmcp
@@ -5,8 +5,16 @@
   "description": "Agent-callable documentation and verification helper tools for the UniGrok MCP gateway.",
   "tools": [
     {
+      "name": "unigrok_ui_layout_get",
+      "description": "Returns Control Center layout metadata for browser clients."
+    },
+    {
+      "name": "get_result_shape_example",
+      "description": "Returns a non-authoritative example of selected result fields. Live tools/list is authoritative."
+    },
+    {
       "name": "get_schema",
-      "description": "Returns the Pydantic/JSON schema of a given UniGrok tool."
+      "description": "Deprecated compatibility alias for get_result_shape_example; it returns examples, not authoritative schemas."
     },
     {
       "name": "example_call",
@@ -14,7 +22,7 @@
     },
     {
       "name": "simulate_reasoning_guard",
-      "description": "Simulates checking if a model meets the required reasoning level."
+      "description": "Previews a local reasoning-level check without calling a provider."
     },
     {
       "name": "fetch_okf_bundle",

--- a/mcp_ui/app.js
+++ b/mcp_ui/app.js
@@ -1,9 +1,9 @@
-import { parseMarkdown, sanitizeHref } from "./markdown.js?v=grok-v0.6.0-r3";
+import { parseMarkdown, sanitizeHref } from "./markdown.js?v=grok-v0.6.0-r4";
 
 // Must match the <meta name="unigrok-ui-version"> baked into index.html and
 // src/version.py UI_ASSET_VERSION; a mismatch means the browser paired a
 // cached page with a different script build (the stale-skew failure class).
-const UI_ASSET_VERSION = "grok-v0.6.0-r3";
+const UI_ASSET_VERSION = "grok-v0.6.0-r4";
 
 const LAYOUT_KEY = "unigrok.mcp.console.layout.v2";
 
@@ -336,10 +336,12 @@ function switchTab(tabId) {
   }
 }
 
-// --- Hardcoded Pydantic schemas (from results.py) ---
-const enforcedSchemas = {
+// --- Illustrative result shapes (not wire schemas) ---
+// Live MCP tools/list output is authoritative. These compact examples exist
+// only to make common response fields easier to browse in the console.
+const resultShapeExamples = {
   AgentResult: {
-    description: "Enforced response model for unified agent actions.",
+    description: "Illustrative fields commonly returned by unified agent actions.",
     properties: {
       response: { type: "string", description: "Core generated text content." },
       text: { type: "string", description: "Formatted markdown string with citation footers." },
@@ -357,10 +359,9 @@ const enforcedSchemas = {
       degraded: { type: "boolean", description: "True if model fallback triggered." },
       trace: { type: "array", description: "Structured multi-step execution trace." }
     },
-    required: ["response", "finish_reason", "cost_usd"]
   },
   ChatResult: {
-    description: "Response model returned by completions (chat, stateful_chat).",
+    description: "Illustrative fields commonly returned by chat completions.",
     properties: {
       response: { type: "string" },
       text: { type: "string" },
@@ -372,10 +373,9 @@ const enforcedSchemas = {
       response_id: { type: "string", description: "xAI upstream conversation turn identifier." },
       session: { type: "string", description: "Local persistent session name." }
     },
-    required: ["response", "response_id"]
   },
   ReflectionResult: {
-    description: "Critique review structure returned by grok_reflect.",
+    description: "Illustrative critique fields returned by grok_reflect.",
     properties: {
       ok: { type: "boolean", description: "True if reflection succeeded." },
       critique: {
@@ -390,10 +390,9 @@ const enforcedSchemas = {
         }
       }
     },
-    required: ["ok", "critique"]
   },
   MediaResult: {
-    description: "Enforced structure for Grok Imagine image and video tools.",
+    description: "Illustrative Grok Imagine image and video result fields.",
     properties: {
       response: { type: "string" },
       text: { type: "string" },
@@ -402,7 +401,6 @@ const enforcedSchemas = {
       duration_sec: { type: "number" },
       imagine_params: { type: "object", description: "Prompt parameters context for reproducibility." }
     },
-    required: ["response"]
   },
   SystemResult: {
     description: "Payload format for search execution and system checks.",
@@ -411,7 +409,6 @@ const enforcedSchemas = {
       text: { type: "string" },
       data: { type: "object", description: "Raw structured JSON outputs (citations, environment variables)." }
     },
-    required: ["response"]
   }
 };
 
@@ -432,9 +429,9 @@ function setupSchemaExplorer() {
 }
 
 function renderActiveSchema() {
-  const schema = enforcedSchemas[state.activeSchema];
-  setText("schemaNameTitle", `${state.activeSchema}.json`);
-  setText("schemaCodeBlock", schema ? JSON.stringify(schema, null, 2) : "Schema not found.");
+  const schema = resultShapeExamples[state.activeSchema];
+  setText("schemaNameTitle", `${state.activeSchema}.example.json`);
+  setText("schemaCodeBlock", schema ? JSON.stringify({ authoritative: false, ...schema }, null, 2) : "Result shape not found.");
 }
 
 // --- Reasoning Guard Simulator ---
@@ -444,10 +441,17 @@ function setupReasoningGuard() {
     const level = $("guardLevel").value;
 
     const weights = { none: 0, low: 1, medium: 2, high: 3 };
+    // Current bundled profiles omit reasoning_effort. The runtime normalizes
+    // omission to "none"; never infer capability from a model slug.
+    const modelEfforts = {
+      "grok-build-0.1": "none",
+      "grok-4.3": "none",
+      "grok-4.5": "none",
+    };
     const modelWeights = {
       "grok-build-0.1": 0,
-      "grok-4.3": 2,
-      "grok-4.5": 3,
+      "grok-4.3": 0,
+      "grok-4.5": 0,
     };
 
     const requiredWeight = weights[level];
@@ -459,28 +463,28 @@ function setupReasoningGuard() {
     if (modelWeight < requiredWeight) {
       card.classList.add("block");
       $("simStatus").innerText = "BLOCKED BY GUARD";
-      renderGuardExplanation({ blocked: true, model, modelWeight, level, requiredWeight });
+      renderGuardExplanation({ blocked: true, model, modelEffort: modelEfforts[model], modelWeight, level, requiredWeight });
     } else {
       card.classList.add("pass");
       $("simStatus").innerText = "PASS";
-      renderGuardExplanation({ blocked: false, model, modelWeight, level, requiredWeight });
+      renderGuardExplanation({ blocked: false, model, modelEffort: modelEfforts[model], modelWeight, level, requiredWeight });
     }
   });
 }
 
-function renderGuardExplanation({ blocked, model, modelWeight, level, requiredWeight }) {
+function renderGuardExplanation({ blocked, model, modelEffort, modelWeight, level, requiredWeight }) {
   const explanation = $("simExplanation");
   const lead = document.createElement("strong");
   lead.textContent = blocked ? "Error:" : "Success:";
   const modelCode = document.createElement("code");
   modelCode.textContent = model;
   const detail = document.createTextNode(blocked
-    ? ` provides reasoning level weight ${modelWeight}, which falls below your required threshold of '${level}' (weight ${requiredWeight}).`
-    : ` (weight ${modelWeight}) satisfies the required guard threshold of '${level}' (weight ${requiredWeight}).`);
+    ? ` has bundled profile effort '${modelEffort}' (weight ${modelWeight}), which falls below your required threshold of '${level}' (weight ${requiredWeight}).`
+    : ` has bundled profile effort '${modelEffort}' (weight ${modelWeight}), which satisfies the required guard threshold of '${level}' (weight ${requiredWeight}).`);
   const outcome = document.createElement("p");
   outcome.textContent = blocked
-    ? "The gateway will throw a ValueError and abort the request before hitting the API."
-    : "The orchestrator will safely route this call.";
+    ? "The profile gate will abort before inference execution; model discovery may already have occurred."
+    : "The profile gate would not block this request. This does not prove route availability or answer quality.";
   explanation.replaceChildren(lead, document.createTextNode(blocked ? " The target model " : " Model "), modelCode, detail, outcome);
 }
 
@@ -1766,26 +1770,38 @@ async function registerWebMcpTools() {
       }),
     });
 
+    const resultShapeInputSchema = {
+      type: "object",
+      properties: {
+        tool_name: { type: "string", enum: ["agent", "chat", "grok_reflect", "generate_image"] }
+      },
+      required: ["tool_name"]
+    };
+    const getResultShapeExample = async ({ tool_name }) => {
+      const schemaName = tool_name === "agent" ? "AgentResult" : tool_name === "chat" ? "ChatResult" : tool_name === "grok_reflect" ? "ReflectionResult" : tool_name === "generate_image" ? "MediaResult" : "AgentResult";
+      const schema = resultShapeExamples[schemaName];
+      return {
+        content: [{
+          type: "text",
+          text: schema
+            ? JSON.stringify({ authoritative: false, source: "ui_example", ...schema }, null, 2)
+            : `Tool '${tool_name}' not found.`
+        }]
+      };
+    };
+
+    await ctx.registerTool({
+      name: "get_result_shape_example",
+      description: "Returns an illustrative result field map. Live MCP tools/list schemas are authoritative.",
+      inputSchema: resultShapeInputSchema,
+      execute: getResultShapeExample
+    });
+
     await ctx.registerTool({
       name: "get_schema",
-      description: "Returns the Pydantic/JSON schema of a given UniGrok tool.",
-      inputSchema: {
-        type: "object",
-        properties: {
-          tool_name: { type: "string", enum: ["agent", "chat", "grok_reflect", "generate_image"] }
-        },
-        required: ["tool_name"]
-      },
-      execute: async ({ tool_name }) => {
-        const schemaName = tool_name === "agent" ? "AgentResult" : tool_name === "chat" ? "ChatResult" : tool_name === "grok_reflect" ? "ReflectionResult" : tool_name === "generate_image" ? "MediaResult" : "AgentResult";
-        const schema = enforcedSchemas[schemaName];
-        return {
-          content: [{
-            type: "text",
-            text: schema ? JSON.stringify(schema, null, 2) : `Tool '${tool_name}' not found.`
-          }]
-        };
-      }
+      description: "Deprecated compatibility alias. Returns a non-authoritative result example; live MCP tools/list schemas are authoritative.",
+      inputSchema: resultShapeInputSchema,
+      execute: getResultShapeExample
     });
 
     await ctx.registerTool({
@@ -1800,11 +1816,11 @@ async function registerWebMcpTools() {
       },
       execute: async ({ mode }) => {
         const examples = {
-          auto: { task: "Describe quantum computing.", mode: "auto" },
-          fast: { prompt: "Hello!", enable_agentic: false },
-          reasoning: { task: "Design a relational database backup schema.", mode: "reasoning" },
-          thinking: { task: "Perform deep multi-step verification of our endpoints.", mode: "thinking" },
-          research: { task: "Compare WebMCP vs custom IETF discovery protocols.", mode: "research" }
+          auto: { prompt: "Describe quantum computing.", mode: "auto" },
+          fast: { prompt: "Hello!", mode: "fast" },
+          reasoning: { prompt: "Design a relational database backup schema.", mode: "reasoning" },
+          thinking: { prompt: "Perform deep multi-step verification of our endpoints.", mode: "thinking" },
+          research: { prompt: "Compare WebMCP vs custom IETF discovery protocols.", mode: "research" }
         };
         return {
           content: [{
@@ -1817,7 +1833,7 @@ async function registerWebMcpTools() {
 
     await ctx.registerTool({
       name: "simulate_reasoning_guard",
-      description: "Simulates checking if a model meets the required reasoning level.",
+      description: "Inspects guard behavior against this release's bundled profile effort declarations.",
       inputSchema: {
         type: "object",
         properties: {
@@ -1830,8 +1846,8 @@ async function registerWebMcpTools() {
         const levels = { none: 0, low: 1, medium: 2, high: 3 };
         const modelLevels = {
           "grok-build-0.1": 0,
-          "grok-4.3": 2,
-          "grok-4.5": 3
+          "grok-4.3": 0,
+          "grok-4.5": 0
         };
         const requiredWeight = levels[required_level];
         const modelWeight = modelLevels[model] || 0;
@@ -1840,7 +1856,7 @@ async function registerWebMcpTools() {
           return {
             content: [{
               type: "text",
-              text: `ERROR: Model '${model}' has reasoning level weight ${modelWeight}, which fails the required guard threshold of '${required_level}' (${requiredWeight}). Pre-flight abort triggered!`
+              text: `ERROR: Model '${model}' has no declared reasoning_effort in this release's bundled profile (normalized weight ${modelWeight}), which fails the required guard threshold of '${required_level}' (${requiredWeight}). Pre-flight abort triggered!`
             }],
             isError: true
           };
@@ -1849,7 +1865,7 @@ async function registerWebMcpTools() {
         return {
           content: [{
             type: "text",
-            text: `SUCCESS: Model '${model}' (weight ${modelWeight}) satisfies required reasoning level '${required_level}' (weight ${requiredWeight}). Guard passed.`
+            text: `SUCCESS: Model '${model}' has no declared reasoning_effort in this release's bundled profile (normalized weight ${modelWeight}) and satisfies required level '${required_level}' (weight ${requiredWeight}). Guard passed.`
           }]
         };
       }

--- a/mcp_ui/index.html
+++ b/mcp_ui/index.html
@@ -7,9 +7,9 @@
     <meta name="unigrok-ui-regions" content="navigation,workbench,rpc-inspector,rpc-logs,result-facts" />
     <!-- Version handshake: app.js compares this against its own build constant
          and self-heals a stale-cached page with one revalidating reload. -->
-    <meta name="unigrok-ui-version" content="grok-v0.6.0-r3" />
-  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r3" />
-  <link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r3" />
+    <meta name="unigrok-ui-version" content="grok-v0.6.0-r4" />
+  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r4" />
+  <link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r4" />
   </head>
   <body>
     <main class="app-shell">
@@ -91,8 +91,8 @@
           <details id="advancedNav" class="nav-advanced">
           <summary class="nav-title nav-title-group">Advanced</summary>
           <div class="nav-advanced-items">
-          <button id="tab-btn-schemas" type="button" class="nav-btn" data-tab="tab-schemas" role="tab" aria-selected="false" aria-controls="tab-schemas" tabindex="-1" title="Schema Explorer">
-            <span class="btn-icon" aria-hidden="true">📋</span><span class="btn-label">Schema Explorer</span>
+          <button id="tab-btn-schemas" type="button" class="nav-btn" data-tab="tab-schemas" role="tab" aria-selected="false" aria-controls="tab-schemas" tabindex="-1" title="Result Shape Guide">
+            <span class="btn-icon" aria-hidden="true">📋</span><span class="btn-label">Result Shapes</span>
           </button>
           <button id="tab-btn-guard" type="button" class="nav-btn" data-tab="tab-guard" role="tab" aria-selected="false" aria-controls="tab-guard" tabindex="-1" title="Reasoning Guard">
             <span class="btn-icon" aria-hidden="true">🛡️</span><span class="btn-label">Reasoning Guard</span>
@@ -234,17 +234,17 @@
             </section>
           </div>
 
-          <!-- TAB 2: Schema Explorer -->
+          <!-- TAB 2: Result Shape Guide -->
           <div id="tab-schemas" class="tab-panel">
             <div class="panel-header">
-              <h2>Schema Explorer</h2>
-              <button id="copySchemaBtn" type="button" class="small-btn-glow">Copy Schema JSON</button>
+              <h2>Result Shape Guide</h2>
+              <button id="copySchemaBtn" type="button" class="small-btn-glow">Copy Example JSON</button>
             </div>
-            <p class="panel-desc">Discover the strict Grok-native schemas enforced on the wire. Powered by Pydantic v2.</p>
+            <p class="panel-desc">Browse compact, illustrative result field maps. Live MCP <code>tools/list</code> schemas are authoritative.</p>
             
             <div class="schemas-layout">
               <div class="schema-list-container">
-                <div class="section-title">Enforced Models</div>
+                <div class="section-title">Example Models</div>
                 <div id="schemaNav" class="schema-nav-buttons">
                   <button type="button" class="schema-btn active" data-schema="AgentResult">AgentResult</button>
                   <button type="button" class="schema-btn" data-schema="ChatResult">ChatResult</button>
@@ -263,9 +263,9 @@
           <!-- TAB 3: Reasoning Guard Simulator -->
           <div id="tab-guard" class="tab-panel">
             <div class="panel-header">
-              <h2>Reasoning Guard Simulator</h2>
+              <h2>Bundled Profile Guard Simulator</h2>
             </div>
-            <p class="panel-desc">Simulate how the router enforces reasoning level policies to prevent cognitive fallbacks during remote outages.</p>
+            <p class="panel-desc">Inspect fail-closed guard behavior against this release's bundled profiles. They currently declare no reasoning_effort, so each normalizes to none.</p>
 
             <div class="guard-simulator-box">
               <div class="form-layout card-base">
@@ -273,9 +273,9 @@
                   <label for="guardModel">
                     Target Model Profile
                     <select id="guardModel">
-                      <option value="grok-build-0.1">grok-build-0.1 (Lightweight / None)</option>
-                      <option value="grok-4.3">grok-4.3 (Standard / Medium)</option>
-                      <option value="grok-4.5">grok-4.5 (Premier / High)</option>
+                      <option value="grok-build-0.1">grok-build-0.1 (undeclared / none)</option>
+                      <option value="grok-4.3">grok-4.3 (undeclared / none)</option>
+                      <option value="grok-4.5">grok-4.5 (undeclared / none)</option>
                     </select>
                   </label>
                   <label for="guardLevel">
@@ -299,7 +299,7 @@
                   <span class="sim-label">Simulation Status</span>
                   <strong id="simStatus">READY</strong>
                 </div>
-                <p id="simExplanation" class="sim-explanation">Select a model and threshold level to verify routing guard enforcement.</p>
+                <p id="simExplanation" class="sim-explanation">Select a model and threshold. This static inspector uses the current bundled profile declarations, not a live provider capability guess.</p>
               </div>
             </div>
           </div>
@@ -310,7 +310,7 @@
               <h2>Knowledge (OKF)</h2>
               <button id="copyOkfPathBtn" type="button" class="small-btn-glow">Copy Path</button>
             </div>
-            <p class="panel-desc">Browse the project knowledge bundle (Open Knowledge Format). Headless agents ingest this context on startup.</p>
+            <p class="panel-desc">Browse the project knowledge bundle (Open Knowledge Format). Agents can discover and fetch it on demand; startup ingestion is not automatic.</p>
 
             <div class="okf-layout">
               <div class="okf-sidebar">
@@ -600,6 +600,6 @@ docker compose up --build -d</code></pre>
 
       </section>
     </main>
-  <script type="module" src="./app.js?v=grok-v0.6.0-r3"></script>
+  <script type="module" src="./app.js?v=grok-v0.6.0-r4"></script>
   </body>
 </html>

--- a/mcp_ui/swarm.html
+++ b/mcp_ui/swarm.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>UniGrok Swarm Optimizer — Pareto Playground</title>
-  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r3" />
+  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r4" />
   <style>
     /* Page vocabulary aliases onto the shared UniGrok tokens (tokens.css) so
        the Swarm Optimizer and the Control Center read as one product. */
@@ -270,6 +270,6 @@
     hidden. "Verified" means: the task's own <code>test_target</code> passed.
   </div>
 
-  <script src="./swarm.js?v=grok-v0.6.0-r3"></script>
+  <script src="./swarm.js?v=grok-v0.6.0-r4"></script>
 </body>
 </html>

--- a/mcp_ui/swarm.js
+++ b/mcp_ui/swarm.js
@@ -10,7 +10,7 @@
 // Must match src/version.py UI_ASSET_VERSION and the query token on the
 // swarm.js reference in swarm.html. The sample uses the same token so a
 // revalidated page cannot pair new logic with a heuristically cached payload.
-const UI_ASSET_VERSION = "grok-v0.6.0-r3";
+const UI_ASSET_VERSION = "grok-v0.6.0-r4";
 
 const $ = (id) => document.getElementById(id);
 const SVG_NS = "http://www.w3.org/2000/svg";

--- a/scripts/generate_okf.py
+++ b/scripts/generate_okf.py
@@ -119,6 +119,10 @@ def render_api_reference() -> str:
         "# API Reference",
         "",
         "This deterministic reference is generated from documented public Python symbols.",
+        "It is a source-code inventory, not the MCP `tools/list` contract: a Python",
+        "symbol appearing here does not mean it is exposed by the stable HTTP service.",
+        "Use live MCP discovery for the deployed surface. Topic guides label stable",
+        "HTTP, contributor Forge, and trusted stdio capabilities explicitly.",
         "Run `uv run python scripts/generate_okf.py --write` after changing the public API.",
         "",
     ]

--- a/sites/unigrok-control-center/README.md
+++ b/sites/unigrok-control-center/README.md
@@ -18,17 +18,19 @@ reusable, idless installer template.
 
 ## Authentication is not authorization
 
-The public Sites build retains a fail-closed SIWC/bootstrap fallback for
-rollback only. Production control runs the same source as a standalone Next.js
-service. It implements GitHub OAuth with PKCE, discards the GitHub user token
-after identity lookup, stores only a signed HttpOnly identity session, and
-performs a fresh installation-token collaborator check for every protected
-request.
+Canonical production control runs this source as a standalone Next.js service
+with `CONTROL_CENTER_MODE=github`. In that mode, `/control` reads a signed
+GitHub identity session established by OAuth with PKCE, discards the GitHub
+user token after identity lookup, and performs a fresh installation-token
+collaborator check for every protected request. It does not call
+`requireChatGPTUser` and does not depend on ChatGPT identity headers.
 
-`/control` first calls `requireChatGPTUser("/control")`. A successful ChatGPT
-sign-in identifies the viewer, but does not prove GitHub project membership.
-The server then applies `getGitHubProjectAuthorization()` as an independent,
-fail-closed check.
+The public Sites build is a separate rollback surface. In Sites mode, the
+route redirects to `CONTROL_CENTER_ORIGIN` when configured. Only the
+fail-closed fallback with no canonical redirect calls
+`requireChatGPTUser("/control")` and then applies
+`getGitHubProjectAuthorization()` to the server-held bootstrap mapping. A
+successful ChatGPT sign-in alone never proves GitHub project membership.
 
 The legacy Sites fallback authorization adapter reads
 `UNIGROK_GITHUB_IDENTITY_BINDINGS` from the hosted server environment. It is a
@@ -89,6 +91,8 @@ impact.
 | Variable | Purpose | Repository value |
 | --- | --- | --- |
 | `GITHUB_REPOSITORY` | Public repository label and links | `djtelicloud/grok-mcp-server` |
+| `CONTROL_CENTER_MODE` | `github` for canonical standalone control; `sites` for the hosted Sites surface | `sites` when unset |
+| `CONTROL_CENTER_ORIGIN` | Canonical standalone origin used by the Sites redirect | empty |
 | `UNIGROK_CONNECTION_MODE` | Wizard state: `unconfigured`, `local`, or `tunnel` | `unconfigured` |
 | `UNIGROK_LOCAL_BASE_URL` | Local-only loopback metadata | `http://127.0.0.1:4765` |
 | `UNIGROK_TUNNEL_PROFILE` | Non-secret tunnel profile label | `unigrok` |
@@ -107,9 +111,12 @@ npm ci
 npm run dev
 ```
 
-The public root works locally. The production control route expects
-Sites-provided ChatGPT identity headers. Use `/preview` for local visual work;
-that route is unavailable in production builds.
+The public root works locally. The default Sites mode expects
+Sites-provided ChatGPT identity headers only when exercising the rollback
+fallback. To exercise canonical control, set `CONTROL_CENTER_MODE=github` and
+the complete GitHub App configuration documented in
+`docs/cloud-run-deployment.md`. Use `/preview` for local visual work; that route
+is unavailable in production builds.
 
 ## Verification and deployment
 
@@ -130,11 +137,14 @@ Before deployment:
 
 1. inspect the full source diff;
 2. verify anonymous access to `/` and all three public metadata routes;
-3. verify anonymous `/control` redirects to dispatch-owned SIWC;
-4. verify a signed-in but unbound viewer sees only the denial surface;
-5. verify the configured owner binding reaches the control center without
-   serializing the ChatGPT email;
-6. confirm the hosted binding value and the Sites audience policy;
+3. verify the Sites `/control` route redirects to `CONTROL_CENTER_ORIGIN`;
+4. verify the standalone origin offers GitHub sign-in and denies a GitHub user
+   without current repository permission;
+5. verify an authorized collaborator reaches the control center after the
+   live installation-token check;
+6. separately test the SIWC/bootstrap mapping only when validating the Sites
+   rollback fallback, including denial for an unbound viewer and no serialized
+   ChatGPT email;
 7. save and review a version before approving production deployment.
 
 Every Sites deployment URL is production. See the current

--- a/sites/unigrok-control-center/public/docs/okf/agent-tool.md
+++ b/sites/unigrok-control-center/public/docs/okf/agent-tool.md
@@ -2,20 +2,31 @@
 okf_version: "0.1"
 title: "Agent Entrypoint Tool"
 type: "topic"
-description: "Detailed guide on using the unified UniGrok agent tool, modes, progress reporting, and multi-agent fan-out."
+description: "Surface-scoped guide to the stable HTTP agent and trusted stdio agent tools."
 ---
 
 # Agent Entrypoint Tool
 
-The `agent` tool is the headline unified entrypoint for UniGrok. It automatically manages model routing, plane failover, context injection, and local filesystem access (web search, X search, and sandboxed python execution).
+The `agent` tool is the headline unified entrypoint for UniGrok.
+
+> **Surface scope:** the stable HTTP service at `:4765/mcp` exposes the public
+> `agent` documented first below. It is workspace-neutral and cannot browse the
+> IDE's files. Trusted stdio has a different `agent` signature and the broader
+> source tool set; contributor Forge at `:4766/mcp` adds repository memory and
+> Swarm tools to the stable HTTP surface. Always use live MCP `tools/list` as
+> the deployed contract.
 
 ## Tool Signatures & Schemas
 
-### `agent`
-Primary entry point for any agent task.
+### Stable HTTP `agent`
+Primary entry point for ordinary IDE calls to `:4765/mcp`.
 - **Parameters**:
-  - `task` (string, required): The goal or instruction.
+  - `prompt` (string, required): The goal or instruction.
   - `session` (string, optional): Context thread persistence.
+  - `system_prompt` (string, optional): Additional system instruction.
+  - `workspace_context` (string, optional): Deliberately selected project text
+    supplied by the calling IDE; it grants no filesystem authority.
+  - `workspace_label` (string, optional): Human-readable label for that text.
   - `mode` (string, optional): `"auto"` (default), `"fast"`, `"reasoning"`, `"thinking"`, or `"research"`.
   - `model` (string, optional): Enforce a specific Grok model ID.
   - `plane` (string, optional): `"auto"` (backward-compatible), `"cli"`
@@ -23,7 +34,6 @@ Primary entry point for any agent task.
   - `fallback_policy` (string, optional): `"same_plane"` forbids crossing the
     billing boundary; `"cross_plane"` preserves automatic recovery for legacy
     auto callers.
-  - `require_reasoning_level` (string, optional): `"low"`, `"medium"`, or `"high"`.
 - **Response Shape (`AgentResult`)**:
   ```json
   {
@@ -37,7 +47,7 @@ Primary entry point for any agent task.
     "latency_sec": 4.25,
     "route": "agentic",
     "plane": "API",
-    "reasoning_effort": "high",
+    "reasoning_effort": null,
     "citations": [
       {
         "url": "https://example.com/source"
@@ -75,8 +85,17 @@ Primary entry point for any agent task.
   }
   ```
 
-### `grok_agent`
-Dedicated tool wrapping a ReAct AgentLoop in a schema-enforced reflection review loop with strict iteration and budget constraints.
+### Trusted stdio `agent`
+
+The full stdio server also registers an `agent` whose required input is
+`task`. It adds `require_reasoning_level` and MCP progress reporting, and it may
+use local file/git/test tools within the resolved trusted workspace. An
+explicit `WORKSPACE_ROOT` wins; ordinary local stdio otherwise resolves to the
+UniGrok service root, never whichever IDE project happens to call it. That
+signature is not the stable HTTP contract.
+
+### Trusted stdio `grok_agent`
+Dedicated tool wrapping a ReAct AgentLoop in a schema-enforced reflection review loop with strict iteration and budget constraints. It is not exposed by the stable or Forge HTTP service.
 - **Parameters**:
   - `prompt` (string, required): Task description.
   - `session` (string, optional): Persistent conversation thread.
@@ -110,6 +129,7 @@ installation, device-auth, or secret-configuration actions. Never request
 `XAI_API_KEY` in chat or store it in the caller's project.
 
 When CLI-first is active, the selected CLI slug comes from the authenticated
-live catalog carried by the health probe. Coding prefers composer; reasoning
-prefers the CLI's reported default. Explicit API model pins remain on API even
-when the same slug is also exposed by the CLI subscription.
+live catalog returned by the `grok models` readiness probe. Coding prefers
+composer; reasoning prefers the CLI's reported default. Explicit API model
+pins remain on API even when the same slug is also exposed by the CLI
+subscription.

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -8,6 +8,10 @@ description: "Auto-generated API reference from the UniGrok codebase."
 # API Reference
 
 This deterministic reference is generated from documented public Python symbols.
+It is a source-code inventory, not the MCP `tools/list` contract: a Python
+symbol appearing here does not mean it is exposed by the stable HTTP service.
+Use live MCP discovery for the deployed surface. Topic guides label stable
+HTTP, contributor Forge, and trusted stdio capabilities explicitly.
 Run `uv run python scripts/generate_okf.py --write` after changing the public API.
 
 ## cli.py {#cli}

--- a/sites/unigrok-control-center/public/docs/okf/chat-modes.md
+++ b/sites/unigrok-control-center/public/docs/okf/chat-modes.md
@@ -2,12 +2,20 @@
 okf_version: "0.1"
 title: "Chat & Context Modes"
 type: "topic"
-description: "Detailed description of direct chat, stateful conversation, vision-capable analysis, and document-backed chats."
+description: "Trusted-stdio chat, stateful conversation, vision, and file tools, with explicit HTTP scope."
 ---
 
 # Chat & Context Modes
 
-UniGrok supports direct message completion, stateful conversation continuation, vision analysis, file ingestion, and structured critique.
+UniGrok's full trusted stdio server supports direct completion, stateful
+conversation continuation, vision analysis, file ingestion, and structured
+critique.
+
+> **Surface scope:** none of the tools on this page are exposed by the stable
+> HTTP service at `:4765/mcp`. Contributor Forge at `:4766/mcp` adds
+> repository-memory and Swarm tools, not these chat tools. HTTP clients use the
+> public `agent` entrypoint instead. Confirm every deployment with MCP
+> `tools/list`.
 
 ## Schema contracts
 
@@ -33,7 +41,7 @@ All chat and context tools return `ChatResult` (inheriting from `BaseResult`) wi
 }
 ```
 
-## Available Tools
+## Trusted stdio tools
 
 ### 1. `chat`
 Sends a direct text prompt to a Grok model.
@@ -42,7 +50,13 @@ Sends a direct text prompt to a Grok model.
   - `session` (string, optional): Local session name.
   - `model` (string, optional): Default `"grok-build-0.1"`.
   - `system_prompt` (string, optional): Injected instructions.
+  - `agent_count` (integer, optional): `4` or `16`, only for a compatible
+    Grok 4.20 multi-agent model.
   - `enable_agentic` (boolean, optional): If `True` (default), runs in ReAct loop.
+  - `require_reasoning_level` (string, optional): `"low"`, `"medium"`, or
+    `"high"`; enforced before inference execution. Live catalog discovery may
+    occur first. Current bundled profiles
+    declare no effort, so any value above `none` fails closed.
 
 ### 2. `stateful_chat`
 Appends to a server-side conversation thread at xAI.
@@ -61,6 +75,10 @@ Analyzes local image files or public image URLs.
   - `image_paths` (array of strings, optional): Paths to local files (PNG/JPG).
   - `image_urls` (array of strings, optional): Public URLs.
   - `detail` (string, optional): `"auto"`, `"low"`, `"high"`.
+
+Local paths resolve inside the trusted stdio workspace. An explicit
+`WORKSPACE_ROOT` wins; ordinary local stdio otherwise uses the UniGrok service
+root. Merely registering stable HTTP does not grant access to an IDE project.
 
 ### 4. `chat_with_files`
 Infers across uploaded document files.

--- a/sites/unigrok-control-center/public/docs/okf/faq.md
+++ b/sites/unigrok-control-center/public/docs/okf/faq.md
@@ -257,8 +257,9 @@ Check the gateway health endpoint with:
 curl -s http://localhost:4765/healthz
 ```
 
-Use `/readyz` when you also need readiness checks for model authentication,
-state storage, and SQLite. Inspect the non-secret CLI state with:
+Use `/readyz` when you also need readiness checks for API credential presence
+or a live CLI OAuth probe, state storage, and SQLite. It does not spend a
+request to validate an API key. Inspect the non-secret CLI state with:
 
 ```bash
 curl -s http://localhost:4765/runtimez

--- a/sites/unigrok-control-center/public/docs/okf/grok-4.5-pinning.md
+++ b/sites/unigrok-control-center/public/docs/okf/grok-4.5-pinning.md
@@ -9,36 +9,58 @@ description: "Model selection profiles, aliases (planning/coding), live discover
 
 UniGrok supports runtime model pinning, live model catalog discovery, hyperparameter profiling, and keyless local CLI fallback paths.
 
+> **Surface scope:** stable and Forge HTTP clients pin models through the
+> public `agent(model=..., plane=..., fallback_policy=...)` contract. Trusted
+> stdio tools expose additional model-bearing functions. A model appearing in
+> this document or the generated source reference is not proof that it exists
+> on either credential plane; use `grok_mcp_discover_self(include_models=true)`
+> or the live provider catalogs.
+
 ## Model Profiles & Hyperparameters
 
-Profiles are loaded from JSON files inside `.grok/hyperparams/` and control settings like temperature, top_p, thinking mode, and default reasoning effort.
-For example, a model's profile may declare:
+Profiles are loaded from JSON files inside `.grok/hyperparams/` and control
+settings such as temperature, top_p, thinking mode, and the system prompt.
+For example, a current bundled reasoning profile declares:
 ```json
 {
-  "profile": "grok-4.5-reasoning-high",
-  "temperature": 0.3,
+  "temperature": 0.4,
   "top_p": 0.95,
   "thinking_mode": true,
-  "reasoning_effort": "high",
-  "system_prompt_ref": "default-coding.txt"
+  "system_prompt_ref": "grok_adapter.md"
 }
 ```
 
-## API vs CLI Routing Paths
+Current bundled profiles omit `reasoning_effort`, so the normalized value is
+`null` (`none` for guard comparison). Do not infer an effort level from the
+model slug or `thinking_mode`.
 
-### 1. API Plane (Main Path)
+## API and CLI credential planes
+
+### 1. CLI Plane (preferred compatible path)
+
+The local default policy is `UNIGROK_PLANE_POLICY=cli_first`.
+
+- Uses the service's Grok CLI grok.com OAuth session, not `XAI_API_KEY`.
+- Readiness is a bounded, API-key-stripped `grok models` probe.
+- Exact model availability comes from that authenticated catalog.
+- Native CLI session IDs provide continuation for compatible calls.
+- The CLI adapter does not expose every API ReAct/server-tool capability.
+
+### 2. API Plane
 Direct HTTPS connections to the xAI endpoint (`api.x.ai`).
 - Uses `XAI_API_KEY` from the environment.
 - Supports streaming, tool calling, and full structured output (critique JSON schemas).
 
-### 2. CLI Plane (Local Fallback)
-If the server environment lacks an xAI API Key but has a mounted `grok` CLI subscription binary:
-- The router automatically detects the keyless state.
-- Executes prompts through local subshell command calls to the `grok` CLI.
-- Resets conversation context session IDs (`api_thread_id`) to prevent upstream state desynchronization.
+Explicit `plane="cli"` or `plane="api"` requests are strict. Use
+`fallback_policy="same_plane"` when crossing subscription and metered billing
+boundaries is forbidden. `cross_plane` allows only bounded, compatible
+recovery; it does not make a model available on a catalog where it is absent.
 
 ## Live Catalog Discovery & Fallbacks
-If the live xAI endpoint is unreachable or model listing fails, UniGrok falls back to a hardcoded list of supported IDs:
+UniGrok caches live catalog discovery. If API discovery fails, its bundled
+directory supplies routing candidates, but execution still requires the
+selected model to be available on the resolved credential plane. Current
+cold-start capability defaults include:
 - **Premier default**: `grok-4.5`
 - **Default coding**: `grok-build-0.1`
 - **Planning default**: `grok-4.5`
@@ -48,4 +70,6 @@ If the live xAI endpoint is unreachable or model listing fails, UniGrok falls ba
 Auto-routing does not equate "newest" with "best." It filters a bounded
 capability-class candidate list, keeps a stable cold-start default, and only
 lets fresh calibration or mature local telemetry promote a peer by the
-configured quality margin. Explicit pins and environment overrides always win.
+configured quality margin. Explicit pins and environment overrides take
+selection precedence. Strict `plane="cli"` and `plane="api"` requests validate
+against that plane; `plane="auto"` may defer availability checks to execution.

--- a/sites/unigrok-control-center/public/docs/okf/index.md
+++ b/sites/unigrok-control-center/public/docs/okf/index.md
@@ -21,14 +21,30 @@ Welcome, Agent. This is the Open Knowledge Format (OKF) index for UniGrok, a
 local-first gateway for xAI's Grok model family built for the Model Context
 Protocol (MCP).
 
-Use this bundle to discover tool schemas, routing details, reasoning levels, media generation capabilities, and gateway observability.
+Use this bundle for routing, schema, and operational reference. It documents
+more than one execution surface; it is not a substitute for MCP `tools/list`.
+
+## Surface map
+
+- **Stable HTTP (`:4765/mcp`)**: `agent`, `review_pull_request`,
+  `grok_mcp_status`, `grok_mcp_discover_self`, and the disabled-by-default
+  `grok_mcp_restart_container` maintenance helper.
+- **Contributor Forge HTTP (`:4766/mcp`)**: the stable surface plus
+  repository-scoped workspace-memory and Swarm tools.
+- **Trusted stdio**: the full source tool registry, including direct chat,
+  local workspace, media, knowledge, and research tools.
+- **Generated API reference**: documented Python symbols, including internal
+  and surface-specific functions. Presence there never implies MCP exposure.
+
+Deployments can vary by version and mode. Treat their live `tools/list` as
+authoritative.
 
 ## Navigation Map
-- [Agent Entrypoint](agent-tool.md): The unified agent-level execution tool.
-- [Chat & Context Modes](chat-modes.md): Direct text, stateful threads, files, and vision analysis.
-- [Reasoning Guard & Level Enforcement](reasoning-guard.md): Preventing intelligence degradation at the router level.
+- [Agent Entrypoint](agent-tool.md): Stable HTTP and trusted stdio agent contracts.
+- [Chat & Context Modes](chat-modes.md): Trusted-stdio direct text, stateful threads, files, and vision tools.
+- [Reasoning Guard & Level Enforcement](reasoning-guard.md): Trusted-stdio minimum-profile enforcement and its HTTP boundary.
 - [Model Pinning & Profiles](grok-4.5-pinning.md): API vs CLI paths, fallback parameters, and Grok 4.5 capabilities.
-- [Media Generation](media-imagine.md): Image and video generation schemas.
+- [Media Generation](media-imagine.md): Trusted-stdio API-plane image and video schemas.
 - [Observability & Metrics](metrics-tool.md): Aggregated telemetry and status monitoring.
 - [Insider Intelligence Payload Profiles](intelligence-payload-profiles-v1.md): Manifest-closed GNO envelopes, evidenced OptiBench cohorts, direct-Pareto preference pairs, and bounded Needle projections carried beside the immutable Capsule v1 format.
 - [Verified FAQ](faq.md): Curated operational answers that Grok consults only when relevant.

--- a/sites/unigrok-control-center/public/docs/okf/media-imagine.md
+++ b/sites/unigrok-control-center/public/docs/okf/media-imagine.md
@@ -7,7 +7,17 @@ description: "How to generate and edit images and videos using Grok Imagine, wit
 
 # Media Generation
 
-UniGrok integrates xAI's image generation (Grok Imagine) and video generation capabilities into the MCP server.
+UniGrok's full trusted stdio server integrates xAI's image and video generation
+capabilities.
+
+> **Surface scope:** `generate_image`, `generate_video`, and `extend_video` are
+> API-plane tools on trusted stdio only. They are not exposed by stable HTTP at
+> `:4765/mcp`, and contributor Forge does not add them. A caller must confirm
+> live `tools/list` before relying on these names. Local file inputs resolve
+> only within the trusted stdio workspace; URL inputs do not grant filesystem
+> access. In ordinary local trusted stdio, the resolved workspace
+> defaults to the UniGrok service root unless `WORKSPACE_ROOT` is set; it never
+> follows the calling IDE project implicitly.
 
 ## Media Tools Schema Contract
 
@@ -16,7 +26,7 @@ All media tools return `MediaResult` (inheriting from `BaseResult`) to guarantee
 ### `MediaResult` Output Schema
 ```json
 {
-  "response": "Summary text description of generated media...",
+  "response": "https://img.x.ai/image-xyz.png",
   "text": "Human-formatted summary markdown...",
   "finish_reason": "final_answer",
   "cost_usd": 0.05,
@@ -38,7 +48,7 @@ All media tools return `MediaResult` (inheriting from `BaseResult`) to guarantee
 }
 ```
 
-## Available Media Tools
+## Trusted stdio media tools
 
 ### 1. `generate_image`
 Generates new images or edits existing ones using text instructions.

--- a/sites/unigrok-control-center/public/docs/okf/metrics-tool.md
+++ b/sites/unigrok-control-center/public/docs/okf/metrics-tool.md
@@ -9,10 +9,16 @@ description: "UniGrok gateway diagnostics, Prometheus http endpoint, circuit bre
 
 UniGrok is built for zero-trust swarm environments, providing rich operational telemetry, billing budget controls, and circuit breakers.
 
+> **Surface scope:** `grok_mcp_status` is available on stable HTTP, Forge HTTP,
+> and trusted stdio. `/metrics` is an HTTP route, not an MCP tool. Remote
+> access requires the `unigrok:status` OAuth scope or a configured static
+> gateway token; verified local operator access follows the loopback boundary.
+
 ## Telemetry Observability
 
-### 1. Stdio Status Tool (`grok_mcp_status`)
-For stdio MCP hosts, querying gateway metrics can be done directly through the tool:
+### 1. MCP Status Tool (`grok_mcp_status`)
+Query gateway metrics through the MCP tool on any surface where live
+`tools/list` exposes it:
 - `view=text` (default) returns the human-readable operational report.
 - `view=json` returns the stable structured usage ledger consumed by the Control Center: today/lifetime summaries, per-plane/model/caller activity, data coverage, circuit breakers, and billing-source metadata.
 
@@ -32,9 +38,18 @@ failover facts. JSON metrics expose the newest receipts under
 `selection_reasons`. The UI renders these values directly; it never infers why
 a model ran from a model name or dollar amount.
 
-Rows created before v0.5.0 naturally have no receipt. They remain valid for
-cost, latency, success, model, caller, token, and plane aggregates, while
-`data_quality.routing_receipt_rows` states the exact explainability coverage.
+Rows created before routing receipts remain valid for operational fields such
+as cost, latency, model, caller, token, and plane. They do not become explained
+routes retroactively; `data_quality.routing_receipt_rows` states the exact
+coverage.
+
+Outcome truth is tri-state: `success=1` requires an explicit verifier;
+`success=0` records an explicit gateway failure or verifier-established
+failure; and `NULL` means the completion remains unverified. Success rates use
+the non-null outcomes as the denominator and remain `null` when no such outcome
+exists. Schema v14 cleared unsupported historical positive labels, so old
+completion text is never treated as semantic success merely because a
+transport returned normally.
 
 ## Billing Truth
 
@@ -60,10 +75,17 @@ prompts until the notice id changes.
 
 ## Circuit Breakers & Failover
 
-The gateway maintains a circuit breaker status to prevent flooding xAI APIs during outages:
+The gateway maintains per-model circuit breakers to prevent repeated xAI API
+calls during outages:
 - If error rates spike, the circuit trips to **Open** state.
-- During Open state, new calls automatically failover to local CLI execution or return cached fallbacks immediately.
+- During Open state, the selected API model is blocked. A request may use the
+  CLI plane only when its requested plane, model compatibility, and
+  `fallback_policy` permit that crossing; otherwise it fails explicitly.
 - The status resets to **Closed** after error rates recover.
 
 ## Billing Spending Budgets
-Spending limits are enforced per-caller based on client authorization bearer tokens or MCP client info names. Once a caller reaches their daily limit (defined in `UNIGROK_CALLER_BUDGETS`), the gateway throws a budget exceeded exception immediately, protecting operators from run-away agent loops.
+Spending limits are enforced against the authenticated principal: OAuth
+subject remotely, static-key alias for keyed gateways, and MCP client identity
+only as the stdio fallback. `X-Client-ID` remains a reporting/session label and
+cannot change an OAuth subject's budget. Once a matching principal reaches its
+daily `UNIGROK_CALLER_BUDGETS` limit, model work fails before execution.

--- a/sites/unigrok-control-center/public/docs/okf/okf-manifest.json
+++ b/sites/unigrok-control-center/public/docs/okf/okf-manifest.json
@@ -2,7 +2,7 @@
   "okf_version": "0.1",
   "name": "uni-grok-mcp",
   "title": "UniGrok MCP Knowledge Bundle",
-  "description": "Agent-readable documentation for the UniGrok Grok-native Model Context Protocol (MCP) server.",
+  "description": "Surface-scoped documentation for UniGrok stable HTTP, contributor Forge, and trusted stdio capabilities.",
   "root": "index.md",
   "files": [
     "index.md",

--- a/sites/unigrok-control-center/public/docs/okf/reasoning-guard.md
+++ b/sites/unigrok-control-center/public/docs/okf/reasoning-guard.md
@@ -2,27 +2,46 @@
 okf_version: "0.1"
 title: "Reasoning Guard & Level Enforcement"
 type: "topic"
-description: "How UniGrok enforces reasoning effort constraints and prevents intelligence fallback at the routing boundary."
+description: "Trusted-stdio reasoning-effort guard and its boundary from the stable HTTP agent."
 ---
 
 # Reasoning Guard & Level Enforcement
 
-UniGrok includes a model-level **Reasoning Guard** to prevent critical requests from degrading to low-intelligence fallback models during periods of high failover rates or configuration errors.
+UniGrok's trusted stdio tool set includes a model-profile **Reasoning Guard**
+for callers that explicitly request a minimum reasoning effort.
+
+> **Surface scope:** stable HTTP `agent` at `:4765/mcp` does not accept
+> `require_reasoning_level`. Use its `mode`, optional model pin, `plane`, and
+> `fallback_policy` fields. The guard described below belongs to the full
+> trusted stdio `agent` and `chat` signatures. Contributor Forge does not add a
+> second public agent signature.
 
 ## Guard Mechanism
 
-When calling the `agent` or `chat` tools, clients can pass `require_reasoning_level`.
-The gateway performs a pre-execution lookup against the resolved model's configuration profile (from `.grok/hyperparams`). If the chosen model's reasoning effort profile is below the requested threshold, the gateway throws a `ValueError` immediately *before* making the remote API request. This prevents unnecessary cost and latency on an inadequate fallback model.
+When calling the trusted stdio `agent` or `chat` tools, clients can pass `require_reasoning_level`.
+The gateway performs a pre-execution lookup against the resolved model's
+configuration profile (from `.grok/hyperparams`). If the chosen model's
+reasoning effort profile is below the requested threshold, the gateway throws
+a `ValueError` before inference execution. Model-catalog discovery may already
+have contacted a provider, so this is not a guarantee of zero provider traffic.
+It does prevent the requested inference turn and its associated generation
+cost on an inadequate fallback model.
+
+**Current limitation:** the bundled profiles do not declare
+`reasoning_effort`. The loader therefore normalizes every current profile to
+`none`. A trusted-stdio request requiring `low`, `medium`, or `high` currently
+fails closed for every bundled model. A model name, `thinking_mode`, or the
+word `reasoning` in a profile filename does not establish an effort level.
 
 ## Reasoning Level Weights
 Intelligence levels are graded on a strict threshold hierarchy:
 
-| Level | Weight | Description | Typical Target Models |
-|---|---|---|---|
-| `none` | 0 | Fast toolless completions / lightweight utilities | `grok-build-0.1` |
-| `low` | 1 | Standard reasoning with low reflection cycles | Standard API completion fallback profiles |
-| `medium` | 2 | Moderate reasoning limits (e.g. debugging/refactoring) | `grok-4.3` |
-| `high` | 3 | Full cognitive plane execution / planning loops | `grok-4.5`, `grok-4.20-multi-agent` |
+| Level | Weight | Meaning |
+|---|---|---|
+| `none` | 0 | No minimum profile effort required |
+| `low` | 1 | Requires an explicit profile declaration of `low` or higher |
+| `medium` | 2 | Requires an explicit profile declaration of `medium` or higher |
+| `high` | 3 | Requires an explicit profile declaration of `high` |
 
 ## Enforcement Flow Example
 
@@ -31,8 +50,8 @@ graph TD
     A[Client Call with require_reasoning_level='high'] --> B[Router selects/resolves model]
     B --> C[Load Model Hyperparams Profile]
     C --> D{chosen model reasoning >= high?}
-    D -- Yes --> E[Execute Run on target API]
-    D -- No --> F[Raise ValueError & Abort before API call]
+    D -- Yes --> E[Execute Run on resolved provider plane]
+    D -- No --> F[Raise ValueError & Abort before inference execution]
 ```
 
 ## Python Example (Direct Call)
@@ -40,8 +59,13 @@ graph TD
 try:
     res = await agent(
         task="Write a compiler in assembly.",
-        require_reasoning_level="high"
+        require_reasoning_level="low"
     )
 except ValueError as e:
     print(f"Aborted: {e}")
 ```
+
+The Control Center's WebMCP `simulate_reasoning_guard` helper is a static
+inspection of this release's bundled profile state: every listed model reports
+`none`/undeclared. It does not invoke the router and is not evidence that the
+stable HTTP MCP tool accepts this field.

--- a/src/cli.py
+++ b/src/cli.py
@@ -57,7 +57,9 @@ def _write_init_config(stream: TextIO, root: Path) -> None:
     print("Start the shared service", file=stream)
     print(f"  cd {root}", file=stream)
     print("  docker compose up --build -d", file=stream)
-    print("  curl -s http://localhost:4765/healthz", file=stream)
+    print("  curl --fail -s http://localhost:4765/healthz", file=stream)
+    print("After configuring API or CLI credentials", file=stream)
+    print("  curl --fail -s http://localhost:4765/readyz", file=stream)
     print("", file=stream)
     print("VS Code (.vscode/mcp.json or user mcp.json)", file=stream)
     print("""{

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -1071,6 +1071,9 @@ async def readyz(_: Request) -> JSONResponse:
         logger.warning(f"readyz CLI-plane probe failed: {exc}")
         cli_plane = {"ready": False}
     checks: Dict[str, bool] = {
+        # Compatibility note: this public key predates the dual-plane runtime.
+        # API credentials are checked for presence only; the CLI branch is a
+        # live OAuth probe.
         "model_auth": bool(os.environ.get("XAI_API_KEY", "").strip())
         or bool(cli_plane.get("ready")),
         "state_dir_writable": False,
@@ -2199,8 +2202,16 @@ async def webmcp_manifest(_: Request) -> JSONResponse:
         "description": "Agent-callable documentation and verification helper tools for the UniGrok MCP gateway.",
         "tools": [
             {
+                "name": "unigrok_ui_layout_get",
+                "description": "Returns Control Center layout metadata for browser clients."
+            },
+            {
+                "name": "get_result_shape_example",
+                "description": "Returns a non-authoritative example of selected result fields. Live tools/list is authoritative."
+            },
+            {
                 "name": "get_schema",
-                "description": "Returns the Pydantic/JSON schema of a given UniGrok tool."
+                "description": "Deprecated compatibility alias for get_result_shape_example; it returns examples, not authoritative schemas."
             },
             {
                 "name": "example_call",
@@ -2208,7 +2219,7 @@ async def webmcp_manifest(_: Request) -> JSONResponse:
             },
             {
                 "name": "simulate_reasoning_guard",
-                "description": "Simulates checking if a model meets the required reasoning level."
+                "description": "Previews a local reasoning-level check without calling a provider."
             },
             {
                 "name": "fetch_okf_bundle",

--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -1069,7 +1069,7 @@ async def grok_mcp_discover_self(include_models: bool = False) -> SystemResult:
             "For full schemas, reasoning level weights, media generation params, metrics, and verified support answers, ingest these files.\n\n"
             "## WebMCP Manifest\n"
             "- **Path:** `/.well-known/webmcp`\n"
-            "Exposes browser-native callable tools (like `get_schema`, `example_call`, etc.) directly on the console documentation UI."
+            "Exposes browser-native helpers (like `get_result_shape_example`, `example_call`, etc.) directly on the console documentation UI. Result shapes are illustrative; live MCP `tools/list` schemas are authoritative."
         )
 
         return SystemResult(

--- a/src/utils.py
+++ b/src/utils.py
@@ -453,15 +453,32 @@ def local_context_enabled() -> bool:
         return os.environ.get("UNIGROK_ENABLE_LOCAL_CONTEXT", "").lower() in ("1", "true", "yes")
     return True
 
-# Initialize configurations
-root_dir = PathResolver.get_service_root()
-env_path = root_dir / ".env"
-if env_path.exists():
-    load_dotenv(env_path)
-else:
-    load_dotenv(root_dir / "example.env")
+# Initialize configurations. ``example.env`` is distribution documentation,
+# never a runtime fallback: loading it would turn a checked-in placeholder into
+# process configuration for source/stdio launches.
+_PLACEHOLDER_XAI_API_KEY = "your_xai_api_key_here"
 
-XAI_API_KEY = os.getenv("XAI_API_KEY", "")
+
+def _load_service_environment(root_dir: Path) -> None:
+    env_path = root_dir / ".env"
+    if env_path.is_file():
+        load_dotenv(env_path)
+
+
+def _normalize_xai_api_key(value: Optional[str]) -> str:
+    key = str(value or "").strip()
+    return "" if key == _PLACEHOLDER_XAI_API_KEY else key
+
+
+root_dir = PathResolver.get_service_root()
+_load_service_environment(root_dir)
+_raw_xai_api_key = os.getenv("XAI_API_KEY", "")
+XAI_API_KEY = _normalize_xai_api_key(_raw_xai_api_key)
+if _raw_xai_api_key.strip() == _PLACEHOLDER_XAI_API_KEY:
+    # Downstream HTTP readiness and client construction also consult the live
+    # process environment, so remove the sentinel rather than merely hiding it
+    # in the module constant.
+    os.environ.pop("XAI_API_KEY", None)
 
 _LOCAL_EXECUTOR: Optional[concurrent.futures.ThreadPoolExecutor] = None
 
@@ -773,7 +790,7 @@ CLI_MODEL_IDS = tuple(FALLBACK_GROK_CLI_MODELS)
 
 
 def xai_api_key_configured() -> bool:
-    return bool((os.environ.get("XAI_API_KEY") or XAI_API_KEY or "").strip())
+    return bool(_normalize_xai_api_key(os.environ.get("XAI_API_KEY") or XAI_API_KEY))
 
 
 def cli_plane_ready_for_local_runtime() -> bool:

--- a/src/version.py
+++ b/src/version.py
@@ -7,4 +7,4 @@ __version__ = "0.6.0"
 # runtime handshake in app.js).
 # Bump the -rN suffix whenever any /ui asset changes; a pytest asserts every
 # copy of this string agrees so HTML and JS can never skew apart silently.
-UI_ASSET_VERSION = "grok-v0.6.0-r3"
+UI_ASSET_VERSION = "grok-v0.6.0-r4"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,6 +20,8 @@ def test_init_project_copies_example_env_and_prints_ide_configs(tmp_path: Path):
     assert "Claude Code" in out
     assert "Codex" in out
     assert "http://localhost:4765/mcp" in out
+    assert "http://localhost:4765/healthz" in out
+    assert "http://localhost:4765/readyz" in out
 
 
 def test_init_project_leaves_existing_env_unchanged(tmp_path: Path):

--- a/tests/test_generate_okf.py
+++ b/tests/test_generate_okf.py
@@ -77,6 +77,7 @@ def test_render_is_deterministic_and_contains_async_public_tools():
     assert "async def agent(" in first
     assert "async def generate_image(" in first
     assert "### Function: `agent`" in first
+    assert "It is a source-code inventory, not the MCP `tools/list` contract" in first
     assert first.endswith("\n")
 
 

--- a/tests/test_github_review_integration.py
+++ b/tests/test_github_review_integration.py
@@ -357,6 +357,9 @@ def test_chatgpt_github_operator_guide_keeps_credentials_separate():
     assert "There is no switch that permits outside contributors" in guide
     assert "standalone GitHub OAuth control" in guide
     assert "Ed25519 receipt verifier" in guide
+    assert "Opening or updating a PR" in guide
+    assert "does not trigger this workflow" in guide
+    assert "never uses `pull_request` or `pull_request_target`" in guide
 
 
 def test_codex_approval_workflow_is_owner_only_and_exact_head_bound():

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -77,12 +77,21 @@ def test_webmcp_manifest_is_open(monkeypatch):
 
     with TestClient(create_app()) as client:
         res = client.get("/.well-known/webmcp")
+        ui_res = client.get("/ui/.well-known/webmcp")
 
     assert res.status_code == 200
+    assert ui_res.status_code == 200
     manifest = res.json()
+    assert ui_res.json() == manifest
     assert manifest["webmcp_version"] == "0.1"
     assert manifest["name"] == "uni-grok-mcp-docs"
-    assert len(manifest["tools"]) == 4
+    assert len(manifest["tools"]) == 6
+    tools = {tool["name"]: tool for tool in manifest["tools"]}
+    assert "unigrok_ui_layout_get" in tools
+    assert "get_result_shape_example" in tools
+    assert "Deprecated compatibility alias" in tools["get_schema"]["description"]
+    assert "non-authoritative" in tools["get_result_shape_example"]["description"]
+    assert "tools/list" in tools["get_result_shape_example"]["description"]
 
 
 def test_public_discovery_is_sanitized_in_cloudrun(monkeypatch):

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -1,8 +1,13 @@
+import json
 from html.parser import HTMLParser
+from pathlib import Path
 
 from starlette.testclient import TestClient
 
 from src.http_server import create_app
+
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 class _AnchorHrefParser(HTMLParser):
@@ -42,9 +47,9 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert index.status_code == 200
     assert "<title>UniGrok MCP v0.6.0 Control Center</title>" in index.text
     assert '<span class="version-badge">v0.6.0</span>' in index.text
-    assert 'script type="module" src="./app.js?v=grok-v0.6.0-r3"' in index.text
-    assert '<link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r3" />' in index.text
-    assert '<link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r3" />' in index.text
+    assert 'script type="module" src="./app.js?v=grok-v0.6.0-r4"' in index.text
+    assert '<link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r4" />' in index.text
+    assert '<link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r4" />' in index.text
     assert "Control Center" in index.text
     assert "Bearer token" not in index.text
     assert "Agent Playground" in index.text
@@ -60,6 +65,27 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert "/runtimez" in script.text
     assert "grok_mcp_discover_self" in script.text
     assert "simulate_reasoning_guard" in script.text
+    assert "get_result_shape_example" in script.text
+    assert 'name: "get_schema"' in script.text
+    assert "Deprecated compatibility alias" in script.text
+    assert "authoritative: false" in script.text
+    assert "Live MCP tools/list schemas are authoritative" in script.text
+    assert "Result Shape Guide" in index.text
+    assert "startup ingestion is not automatic" in index.text
+    assert "before hitting the API" not in script.text
+    assert "safely route this call" not in script.text
+    assert '"grok-4.3": 0' in script.text
+    assert '"grok-4.5": 0' in script.text
+    assert "no declared reasoning_effort" in script.text
+    assert "Standard / Medium" not in index.text
+    assert "Premier / High" not in index.text
+    assert 'auto: { prompt: "Describe quantum computing."' in script.text
+    profiles = [
+        json.loads(path.read_text(encoding="utf-8"))
+        for path in (ROOT / ".grok" / "hyperparams").glob("*.json")
+    ]
+    assert profiles
+    assert all("reasoning_effort" not in profile for profile in profiles)
     assert "fetch_okf_bundle" in script.text
     assert 'fetch("/docs/okf/okf-manifest.json")' in script.text
     assert "source.files.map" in script.text
@@ -363,7 +389,7 @@ def test_mcp_ui_markdown_renderer_is_shared_and_escape_first():
     assert "\\u000E-\\u001F" in renderer.text
     # app.js imports the shared renderer at the current cache-bust version and
     # no longer defines its own.
-    assert 'from "./markdown.js?v=grok-v0.6.0-r3"' in script.text
+    assert 'from "./markdown.js?v=grok-v0.6.0-r4"' in script.text
     assert "import { parseMarkdown" in script.text
     assert "function parseMarkdown" not in script.text
     assert "renderMarkdownInto" in script.text

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3954,6 +3954,29 @@ class TestCliPlaneV2:
         assert "GROK_API_KEY" not in child_env
         assert child_env["KEEP_ME"] == "yes"
 
+    def test_example_env_is_never_loaded_as_runtime_configuration(
+        self, monkeypatch, tmp_path
+    ):
+        from src import utils
+
+        (tmp_path / "example.env").write_text(
+            "XAI_API_KEY=xai-example-must-not-load\n", encoding="utf-8"
+        )
+        loaded = []
+        monkeypatch.setattr(utils, "load_dotenv", loaded.append)
+
+        utils._load_service_environment(tmp_path)
+
+        assert loaded == []
+
+    def test_xai_placeholder_is_not_a_configured_credential(self, monkeypatch):
+        from src import utils
+
+        monkeypatch.setenv("XAI_API_KEY", "your_xai_api_key_here")
+
+        assert utils._normalize_xai_api_key("your_xai_api_key_here") == ""
+        assert utils.xai_api_key_configured() is False
+
     def test_isolated_cli_runtime_has_empty_workspace_and_durable_oauth_path(
         self, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
## Scope

Corrects stale public/runtime claims without changing the provider architecture: health versus readiness, CLI/API plane behavior, trusted stdio versus stable/Forge HTTP surfaces, model pin validation, reasoning guards, WebMCP result-shape truth, and generated OKF/public mirrors. The legacy `get_schema` WebMCP name remains as a deprecated compatibility alias and explicitly returns non-authoritative examples.

## Evidence

- Exact rebased head: `a15543f88ba8cf7e03a37f58b5aa2c7732c3f9bb`
- Base: merged `origin/main` at PR #78
- Changed path groups: `README.md`, `SECURITY.md`, `Dockerfile`, `.agents/skills/uni-grok-mcp/SKILL.md`, `docs/**`, `mcp_ui/**`, `sites/unigrok-control-center/**`, `scripts/generate_okf.py`, selected `src/**` truth labels, and matching tests
- Independent exact-head review: approved; range-diff confirms the previously approved patch is unchanged after rebase
- Focused final suite: 531 passed
- Rebased full suite: 1,520 passed
- `node --check`, OKF parity, and `git diff --check`: clean
- Ruff reports the same 14 pre-existing findings as origin/main; no new changed-path lint regression was introduced

## Risk

Documentation/UI compatibility only. `/readyz` retains its existing `model_auth` key, and `get_schema` remains available as a deprecated alias.

Human sponsor: David Teli

Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=implementation