### PR TITLE
Add Grok-supervised provider API adapters

### DIFF
--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -745,6 +745,159 @@ async def fetch_provider_api_usage() -> Dict[str, Any]
 
 Optionally fetch today's team-wide API spend from xAI Management API.
 
+## providers/base.py {#providers-base}
+
+### Class: `HTTPProviderAdapter` {#providers-base-httpprovideradapter}
+
+```python
+class HTTPProviderAdapter
+```
+
+**Keywords:** http, provider, adapter
+
+Base for one-shot first-party JSON APIs.
+
+An injected AsyncClient makes every wire interaction deterministic in tests.
+Production clients are short-lived, do not inherit proxy environment state,
+and never follow redirects carrying credentials.
+
+### Method: `HTTPProviderAdapter.complete` {#providers-base-httpprovideradapter-complete}
+
+```python
+async def HTTPProviderAdapter.complete(self, request: ProviderRequest) -> ProviderResponse
+```
+
+**Keywords:** http, provider, adapter, complete
+
+Run the complete worker call under one absolute supervisor deadline.
+
+### Method: `HTTPProviderAdapter.attempt` {#providers-base-httpprovideradapter-attempt}
+
+```python
+async def HTTPProviderAdapter.attempt(self, request: ProviderRequest) -> ProviderAttemptResult
+```
+
+**Keywords:** http, provider, adapter, attempt
+
+Return a complete worker result without granting it semantic authority.
+
+### Function: `opaque_fingerprint` {#providers-base-opaque_fingerprint}
+
+```python
+def opaque_fingerprint(value: str) -> str
+```
+
+**Keywords:** opaque, fingerprint
+
+Identify a non-secret account/project without exposing its raw value.
+
+## providers/config.py {#providers-config}
+
+### Function: `load_model_pins` {#providers-config-load_model_pins}
+
+```python
+def load_model_pins(channel: ProviderChannel, environ: Mapping[str, str]) -> ProviderModelPins
+```
+
+**Keywords:** load, model, pins
+
+Resolve route pin > provider pin > stable first-party default.
+
+Invalid values fail closed while naming only the environment variable, never
+its content.
+
+## providers/contracts.py {#providers-contracts}
+
+### Class: `GrokSupervisorBinding` {#providers-contracts-groksupervisorbinding}
+
+```python
+class GrokSupervisorBinding
+```
+
+**Keywords:** grok, supervisor, binding
+
+Opaque Grok-owned state copied into every worker receipt.
+
+Adapters may bind outputs to this state, but cannot create, extend, route,
+verify, harvest, or finalize it.
+
+### Class: `WorkerAuthority` {#providers-contracts-workerauthority}
+
+```python
+class WorkerAuthority
+```
+
+**Keywords:** worker, authority
+
+Mechanical denial of supervisor authority to external model workers.
+
+### Class: `ProviderFailureReceipt` {#providers-contracts-providerfailurereceipt}
+
+```python
+class ProviderFailureReceipt
+```
+
+**Keywords:** provider, failure, receipt
+
+Bounded, secret-safe failure evidence returned to the Grok supervisor.
+
+### Class: `ProviderAttemptResult` {#providers-contracts-providerattemptresult}
+
+```python
+class ProviderAttemptResult
+```
+
+**Keywords:** provider, attempt, result
+
+One subordinate worker return or failure for Grok synthesis.
+
+### Function: `is_safe_model_id` {#providers-contracts-is_safe_model_id}
+
+```python
+def is_safe_model_id(value: str) -> bool
+```
+
+**Keywords:** is, safe, model, id
+
+Return whether a provider-supplied model ID is safe to put in a receipt.
+
+### Function: `is_safe_response_id` {#providers-contracts-is_safe_response_id}
+
+```python
+def is_safe_response_id(value: str) -> bool
+```
+
+**Keywords:** is, safe, response, id
+
+Return whether an upstream response ID is safe to put in a receipt.
+
+## providers/registry.py {#providers-registry}
+
+### Function: `build_provider_registry` {#providers-registry-build_provider_registry}
+
+```python
+def build_provider_registry(*, environ: Mapping[str, str] | None=None, clients: Mapping[ProviderChannel, httpx.AsyncClient] | None=None, vertex_token_provider: ADCTokenProvider | None=None, clock: Clock | None=None) -> dict[ProviderChannel, ProviderAdapter]
+```
+
+**Keywords:** build, provider, registry
+
+Build adapters without performing discovery or provider calls.
+
+## providers/vertex.py {#providers-vertex}
+
+### Function: `load_google_adc_identity` {#providers-vertex-load_google_adc_identity}
+
+```python
+async def load_google_adc_identity(timeout_seconds: float=60.0) -> ADCIdentity
+```
+
+**Keywords:** load, google, adc, identity
+
+Resolve and refresh ADC off the event loop.
+
+All third-party exception details are suppressed at the adapter boundary so
+credential paths, token fragments, and account identifiers cannot escape.
+
 ## rag.py {#rag}
 
 ### Function: `task_rag_mode` {#rag-task_rag_mode}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
 dependencies = [
     "mcp[cli]>=1.13.1",
     "httpx>=0.28.1",
+    "google-auth[requests]>=2.40,<3",
     "python-dotenv>=1.2.2",
     "pydantic>=2.9.0",
     "pydantic-settings>=2.14.2",

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -745,6 +745,159 @@ async def fetch_provider_api_usage() -> Dict[str, Any]
 
 Optionally fetch today's team-wide API spend from xAI Management API.
 
+## providers/base.py {#providers-base}
+
+### Class: `HTTPProviderAdapter` {#providers-base-httpprovideradapter}
+
+```python
+class HTTPProviderAdapter
+```
+
+**Keywords:** http, provider, adapter
+
+Base for one-shot first-party JSON APIs.
+
+An injected AsyncClient makes every wire interaction deterministic in tests.
+Production clients are short-lived, do not inherit proxy environment state,
+and never follow redirects carrying credentials.
+
+### Method: `HTTPProviderAdapter.complete` {#providers-base-httpprovideradapter-complete}
+
+```python
+async def HTTPProviderAdapter.complete(self, request: ProviderRequest) -> ProviderResponse
+```
+
+**Keywords:** http, provider, adapter, complete
+
+Run the complete worker call under one absolute supervisor deadline.
+
+### Method: `HTTPProviderAdapter.attempt` {#providers-base-httpprovideradapter-attempt}
+
+```python
+async def HTTPProviderAdapter.attempt(self, request: ProviderRequest) -> ProviderAttemptResult
+```
+
+**Keywords:** http, provider, adapter, attempt
+
+Return a complete worker result without granting it semantic authority.
+
+### Function: `opaque_fingerprint` {#providers-base-opaque_fingerprint}
+
+```python
+def opaque_fingerprint(value: str) -> str
+```
+
+**Keywords:** opaque, fingerprint
+
+Identify a non-secret account/project without exposing its raw value.
+
+## providers/config.py {#providers-config}
+
+### Function: `load_model_pins` {#providers-config-load_model_pins}
+
+```python
+def load_model_pins(channel: ProviderChannel, environ: Mapping[str, str]) -> ProviderModelPins
+```
+
+**Keywords:** load, model, pins
+
+Resolve route pin > provider pin > stable first-party default.
+
+Invalid values fail closed while naming only the environment variable, never
+its content.
+
+## providers/contracts.py {#providers-contracts}
+
+### Class: `GrokSupervisorBinding` {#providers-contracts-groksupervisorbinding}
+
+```python
+class GrokSupervisorBinding
+```
+
+**Keywords:** grok, supervisor, binding
+
+Opaque Grok-owned state copied into every worker receipt.
+
+Adapters may bind outputs to this state, but cannot create, extend, route,
+verify, harvest, or finalize it.
+
+### Class: `WorkerAuthority` {#providers-contracts-workerauthority}
+
+```python
+class WorkerAuthority
+```
+
+**Keywords:** worker, authority
+
+Mechanical denial of supervisor authority to external model workers.
+
+### Class: `ProviderFailureReceipt` {#providers-contracts-providerfailurereceipt}
+
+```python
+class ProviderFailureReceipt
+```
+
+**Keywords:** provider, failure, receipt
+
+Bounded, secret-safe failure evidence returned to the Grok supervisor.
+
+### Class: `ProviderAttemptResult` {#providers-contracts-providerattemptresult}
+
+```python
+class ProviderAttemptResult
+```
+
+**Keywords:** provider, attempt, result
+
+One subordinate worker return or failure for Grok synthesis.
+
+### Function: `is_safe_model_id` {#providers-contracts-is_safe_model_id}
+
+```python
+def is_safe_model_id(value: str) -> bool
+```
+
+**Keywords:** is, safe, model, id
+
+Return whether a provider-supplied model ID is safe to put in a receipt.
+
+### Function: `is_safe_response_id` {#providers-contracts-is_safe_response_id}
+
+```python
+def is_safe_response_id(value: str) -> bool
+```
+
+**Keywords:** is, safe, response, id
+
+Return whether an upstream response ID is safe to put in a receipt.
+
+## providers/registry.py {#providers-registry}
+
+### Function: `build_provider_registry` {#providers-registry-build_provider_registry}
+
+```python
+def build_provider_registry(*, environ: Mapping[str, str] | None=None, clients: Mapping[ProviderChannel, httpx.AsyncClient] | None=None, vertex_token_provider: ADCTokenProvider | None=None, clock: Clock | None=None) -> dict[ProviderChannel, ProviderAdapter]
+```
+
+**Keywords:** build, provider, registry
+
+Build adapters without performing discovery or provider calls.
+
+## providers/vertex.py {#providers-vertex}
+
+### Function: `load_google_adc_identity` {#providers-vertex-load_google_adc_identity}
+
+```python
+async def load_google_adc_identity(timeout_seconds: float=60.0) -> ADCIdentity
+```
+
+**Keywords:** load, google, adc, identity
+
+Resolve and refresh ADC off the event loop.
+
+All third-party exception details are suppressed at the adapter boundary so
+credential paths, token fragments, and account identifiers cannot escape.
+
 ## rag.py {#rag}
 
 ### Function: `task_rag_mode` {#rag-task_rag_mode}

--- a/src/providers/__init__.py
+++ b/src/providers/__init__.py
@@ -1,0 +1,68 @@
+"""Provider-neutral semantic inference adapters.
+
+This package is intentionally not wired into ``src.utils`` or the public agent
+yet.  It supplies strict contracts and first-party HTTP transports for the
+future policy broker.
+"""
+
+from .anthropic import AnthropicAdapter
+from .contracts import (
+    CredentialPlane,
+    CredentialState,
+    GrokSupervisorBinding,
+    ProviderAdapter,
+    ProviderAttemptResult,
+    ProviderChannel,
+    ProviderDescriptor,
+    ProviderFailureReceipt,
+    ProviderId,
+    ProviderMessage,
+    ProviderModelPins,
+    ProviderReceipt,
+    ProviderRequest,
+    ProviderResponse,
+    ProviderTokenUsage,
+    RouteClass,
+    WorkerAuthority,
+)
+from .errors import (
+    ProviderConfigurationError,
+    ProviderError,
+    ProviderProtocolError,
+    ProviderTransportError,
+)
+from .gemini import GeminiAdapter
+from .openai import OpenAIAdapter
+from .registry import build_provider_registry
+from .vertex import ADCIdentity, VertexADCAdapter, load_google_adc_identity
+
+__all__ = [
+    "ADCIdentity",
+    "AnthropicAdapter",
+    "CredentialPlane",
+    "CredentialState",
+    "GeminiAdapter",
+    "GrokSupervisorBinding",
+    "OpenAIAdapter",
+    "ProviderAdapter",
+    "ProviderAttemptResult",
+    "ProviderChannel",
+    "ProviderConfigurationError",
+    "ProviderDescriptor",
+    "ProviderError",
+    "ProviderFailureReceipt",
+    "ProviderId",
+    "ProviderMessage",
+    "ProviderModelPins",
+    "ProviderProtocolError",
+    "ProviderReceipt",
+    "ProviderRequest",
+    "ProviderResponse",
+    "ProviderTokenUsage",
+    "ProviderTransportError",
+    "RouteClass",
+    "VertexADCAdapter",
+    "build_provider_registry",
+    "load_google_adc_identity",
+    "WorkerAuthority",
+]

--- a/src/providers/anthropic.py
+++ b/src/providers/anthropic.py
@@ -1,0 +1,146 @@
+"""Anthropic Messages API adapter with server-side key aliases."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import httpx
+
+from .base import Clock, HTTPProviderAdapter
+from .config import load_model_pins
+from .contracts import (
+    CredentialPlane,
+    ProviderChannel,
+    ProviderDescriptor,
+    ProviderId,
+    ProviderRequest,
+    ProviderResponse,
+)
+from .errors import ProviderConfigurationError, ProviderProtocolError
+
+
+ANTHROPIC_ENDPOINT = "https://api.anthropic.com/v1/messages"
+ANTHROPIC_HOST = "api.anthropic.com"
+# Canonical Anthropic name wins; CLAUDE_API_KEY is retained as the user's
+# existing server-side alias.  Neither name or value is sent in receipts.
+ANTHROPIC_KEY_NAMES = ("ANTHROPIC_API_KEY", "CLAUDE_API_KEY")
+
+
+class AnthropicAdapter(HTTPProviderAdapter):
+    provider = ProviderId.ANTHROPIC
+    channel = ProviderChannel.ANTHROPIC_API
+
+    def __init__(
+        self,
+        *,
+        client: httpx.AsyncClient | None = None,
+        environ: Mapping[str, str] | None = None,
+        clock: Clock | None = None,
+    ) -> None:
+        super().__init__(client=client, environ=environ, clock=clock)
+        self._descriptor = ProviderDescriptor(
+            provider=self.provider,
+            channel=self.channel,
+            credential_plane=CredentialPlane.METERED_API,
+            display_name="Anthropic Claude",
+            endpoint_host=ANTHROPIC_HOST,
+            endpoint_kind="first_party_api",
+            credential_kind="api_key",
+            credential_env_names=ANTHROPIC_KEY_NAMES,
+            credential_state=self._credential_state(ANTHROPIC_KEY_NAMES),
+            models=load_model_pins(self.channel, self._environ),
+            max_output_tokens=32_768,
+            max_timeout_seconds=120.0,
+            data_handling="provider_managed",
+            residency="provider_default",
+        )
+
+    @property
+    def descriptor(self) -> ProviderDescriptor:
+        return self._descriptor
+
+    async def _complete(self, request: ProviderRequest) -> ProviderResponse:
+        model = self._model(request)
+        max_tokens, _ = self._limits(request)
+        if request.temperature is not None and model.startswith(
+            ("claude-fable-5", "claude-sonnet-5")
+        ):
+            raise ProviderConfigurationError(self.provider, "temperature_unsupported")
+        key = self._api_key(ANTHROPIC_KEY_NAMES)
+        _, timeout = self._limits(request)
+        model_messages = self._model_messages(request)
+        system_parts = [
+            message.content for message in model_messages if message.role == "system"
+        ]
+        messages = [
+            {"role": message.role, "content": message.content}
+            for message in model_messages
+            if message.role != "system"
+        ]
+        payload: dict[str, Any] = {
+            "model": model,
+            "max_tokens": max_tokens,
+            "messages": messages,
+        }
+        if system_parts:
+            payload["system"] = "\n\n".join(system_parts)
+        if request.temperature is not None:
+            payload["temperature"] = request.temperature
+        data, duration_ms = await self._post_json(
+            url=ANTHROPIC_ENDPOINT,
+            headers={
+                "x-api-key": key.get_secret_value(),
+                "anthropic-version": "2023-06-01",
+                "Content-Type": "application/json",
+            },
+            payload=payload,
+            timeout_seconds=timeout,
+        )
+        content = data.get("content")
+        blocks = content if isinstance(content, list) else []
+        text = "".join(
+            str(block.get("text"))
+            for block in blocks
+            if isinstance(block, dict)
+            and block.get("type") == "text"
+            and isinstance(block.get("text"), str)
+        )
+        stop_reason = str(data.get("stop_reason") or "").lower()
+        if stop_reason == "max_tokens":
+            finish = "length"
+        elif stop_reason == "tool_use":
+            finish = "tool_calls"
+        elif stop_reason in {"refusal", "model_context_window_exceeded"}:
+            finish = "content_filter" if stop_reason == "refusal" else "length"
+        elif stop_reason in {"end_turn", "stop_sequence", "pause_turn"} and text:
+            finish = "stop"
+        else:
+            finish = "unknown"
+        if not text and finish != "content_filter":
+            raise ProviderProtocolError(self.provider, "missing_text")
+        usage_data = data.get("usage") if isinstance(data.get("usage"), dict) else {}
+        usage = self._usage(
+            usage_data.get("input_tokens"),
+            usage_data.get("output_tokens"),
+        )
+        resolved_model, model_source = self._resolved_model(data.get("model"), model)
+        response_id = self._response_id(data.get("id"))
+        receipt = self._receipt(
+            request=request,
+            requested_model=model,
+            resolved_model=resolved_model,
+            model_source=model_source,
+            response_id=response_id,
+            duration_ms=duration_ms,
+            usage=usage,
+            region="provider_default",
+        )
+        return ProviderResponse(
+            provider=self.provider,
+            channel=self.channel,
+            model=resolved_model,
+            text=text,
+            finish_reason=finish,
+            receipt=receipt,
+        )

--- a/src/providers/base.py
+++ b/src/providers/base.py
@@ -1,0 +1,381 @@
+"""Shared bounded HTTP transport for provider adapters."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import time
+from collections.abc import Awaitable, Callable, Mapping
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+import httpx
+from pydantic import SecretStr
+
+from .contracts import (
+    CredentialState,
+    ProviderChannel,
+    ProviderAttemptResult,
+    ProviderDescriptor,
+    ProviderFailureReceipt,
+    ProviderId,
+    ProviderMessage,
+    ProviderReceipt,
+    ProviderRequest,
+    ProviderResponse,
+    ProviderTokenUsage,
+    is_safe_model_id,
+    is_safe_response_id,
+)
+from .errors import (
+    ProviderError,
+    ProviderConfigurationError,
+    ProviderProtocolError,
+    ProviderTransportError,
+)
+
+
+MAX_PROVIDER_RESPONSE_BYTES = 4 * 1024 * 1024
+Clock = Callable[[], datetime]
+FailureKind = Literal["configuration", "transport", "protocol", "internal"]
+
+
+class HTTPProviderAdapter:
+    """Base for one-shot first-party JSON APIs.
+
+    An injected AsyncClient makes every wire interaction deterministic in tests.
+    Production clients are short-lived, do not inherit proxy environment state,
+    and never follow redirects carrying credentials.
+    """
+
+    provider: ProviderId
+    channel: ProviderChannel
+
+    def __init__(
+        self,
+        *,
+        client: httpx.AsyncClient | None = None,
+        environ: Mapping[str, str] | None = None,
+        clock: Clock | None = None,
+    ) -> None:
+        self._client = client
+        self._environ = environ if environ is not None else os.environ
+        self._clock = clock or (lambda: datetime.now(UTC))
+
+    @property
+    def descriptor(self) -> ProviderDescriptor:
+        raise NotImplementedError
+
+    def _credential_state(self, names: tuple[str, ...]) -> CredentialState:
+        return (
+            CredentialState.CONFIGURED
+            if any(str(self._environ.get(name) or "").strip() for name in names)
+            else CredentialState.MISSING
+        )
+
+    def _api_key(self, names: tuple[str, ...]) -> SecretStr:
+        for name in names:
+            value = str(self._environ.get(name) or "").strip()
+            if value:
+                return SecretStr(value)
+        raise ProviderConfigurationError(self.provider, "credential_missing")
+
+    def _model(self, request: ProviderRequest) -> str:
+        if request.route not in self.descriptor.supported_routes:
+            raise ProviderConfigurationError(self.provider, "unsupported_route")
+        model = request.model or self.descriptor.models.for_route(request.route)
+        if not is_safe_model_id(model):
+            raise ProviderConfigurationError(self.provider, "invalid_model")
+        return model
+
+    def _remaining_ttl(self, request: ProviderRequest) -> float:
+        now = self._clock()
+        if now.tzinfo is None:
+            raise ProviderConfigurationError(self.provider, "clock_not_timezone_aware")
+        remaining_ttl = (request.supervision.ttl_expires_at - now).total_seconds()
+        if remaining_ttl <= 0:
+            raise ProviderConfigurationError(self.provider, "ttl_expired")
+        return remaining_ttl
+
+    def _limits(self, request: ProviderRequest) -> tuple[int, float]:
+        remaining_ttl = self._remaining_ttl(request)
+        return (
+            min(request.max_output_tokens, self.descriptor.max_output_tokens),
+            min(
+                request.timeout_seconds,
+                self.descriptor.max_timeout_seconds,
+                remaining_ttl,
+            ),
+        )
+
+    async def complete(self, request: ProviderRequest) -> ProviderResponse:
+        """Run the complete worker call under one absolute supervisor deadline."""
+
+        remaining_ttl = self._remaining_ttl(request)
+        try:
+            async with asyncio.timeout(remaining_ttl):
+                response = await self._complete(request)
+        except TimeoutError:
+            raise ProviderTransportError(self.provider, "ttl_expired") from None
+        # The worker may finish at the deadline boundary. Never emit a late result.
+        self._remaining_ttl(request)
+        return response
+
+    async def _complete(self, request: ProviderRequest) -> ProviderResponse:
+        raise NotImplementedError
+
+    async def _run_with_ttl(
+        self,
+        request: ProviderRequest,
+        operation: Callable[[], Awaitable[Any]],
+    ) -> Any:
+        """Bound a subordinate acquisition to the currently remaining lease."""
+
+        try:
+            async with asyncio.timeout(self._remaining_ttl(request)):
+                return await operation()
+        except TimeoutError:
+            raise ProviderTransportError(self.provider, "ttl_expired") from None
+
+    def _model_messages(self, request: ProviderRequest) -> list[ProviderMessage]:
+        expires = (
+            request.supervision.ttl_expires_at.astimezone(UTC)
+            .isoformat(timespec="seconds")
+            .replace("+00:00", "Z")
+        )
+        ttl_fact = ProviderMessage(
+            role="system",
+            content=f"Supervisor TTL expires at {expires}; do not claim work after it.",
+        )
+        return [ttl_fact, *request.messages]
+
+    async def attempt(self, request: ProviderRequest) -> ProviderAttemptResult:
+        """Return a complete worker result without granting it semantic authority."""
+
+        started = time.monotonic()
+        requested_model = request.model or self.descriptor.models.for_route(request.route)
+        try:
+            response = await self.complete(request)
+        except ProviderError as exc:
+            return ProviderAttemptResult(
+                status="failed",
+                failure=self._failure_receipt(
+                    request=request,
+                    requested_model=requested_model,
+                    error_kind=self._error_kind(exc),
+                    error_code=exc.code,
+                    duration_ms=max(0, round((time.monotonic() - started) * 1000)),
+                ),
+            )
+        except Exception:
+            return ProviderAttemptResult(
+                status="failed",
+                failure=self._failure_receipt(
+                    request=request,
+                    requested_model=requested_model,
+                    error_kind="internal",
+                    error_code="unexpected_error",
+                    duration_ms=max(0, round((time.monotonic() - started) * 1000)),
+                ),
+            )
+        return ProviderAttemptResult(status="returned", response=response)
+
+    def _error_kind(self, error: ProviderError) -> FailureKind:
+        if isinstance(error, ProviderConfigurationError):
+            return "configuration"
+        if isinstance(error, ProviderTransportError):
+            return "transport"
+        if isinstance(error, ProviderProtocolError):
+            return "protocol"
+        return "internal"
+
+    def _failure_receipt(
+        self,
+        *,
+        request: ProviderRequest,
+        requested_model: str,
+        error_kind: FailureKind,
+        error_code: str,
+        duration_ms: int,
+    ) -> ProviderFailureReceipt:
+        return ProviderFailureReceipt(
+            request_id=request.request_id,
+            supervision=request.supervision,
+            provider=self.provider,
+            channel=self.channel,
+            credential_plane=self.descriptor.credential_plane,
+            route=request.route,
+            requested_model=requested_model,
+            endpoint_host=self.descriptor.endpoint_host,
+            error_kind=error_kind,
+            error_code=error_code,
+            duration_ms=duration_ms,
+        )
+
+    async def _post_json(
+        self,
+        *,
+        url: str,
+        headers: dict[str, str],
+        payload: dict[str, Any],
+        timeout_seconds: float,
+    ) -> tuple[dict[str, Any], int]:
+        started = time.monotonic()
+        try:
+            if self._client is None:
+                async with httpx.AsyncClient(
+                    timeout=httpx.Timeout(timeout_seconds),
+                    follow_redirects=False,
+                    trust_env=False,
+                ) as client:
+                    body, status_code = await self._stream_json_body(
+                        client=client,
+                        url=url,
+                        headers=headers,
+                        payload=payload,
+                        timeout_seconds=timeout_seconds,
+                    )
+            else:
+                body, status_code = await self._stream_json_body(
+                    client=self._client,
+                    url=url,
+                    headers=headers,
+                    payload=payload,
+                    timeout_seconds=timeout_seconds,
+                )
+        except httpx.TimeoutException:
+            raise ProviderTransportError(self.provider, "timeout") from None
+        except httpx.HTTPError:
+            raise ProviderTransportError(self.provider, "transport_error") from None
+        duration_ms = max(0, round((time.monotonic() - started) * 1000))
+        if status_code < 200 or status_code >= 300:
+            raise ProviderTransportError(self.provider, f"http_{status_code}")
+        try:
+            value = json.loads(body)
+        except (json.JSONDecodeError, UnicodeError, ValueError):
+            raise ProviderProtocolError(self.provider, "invalid_json") from None
+        if not isinstance(value, dict):
+            raise ProviderProtocolError(self.provider, "invalid_response_shape")
+        return value, duration_ms
+
+    async def _stream_json_body(
+        self,
+        *,
+        client: httpx.AsyncClient,
+        url: str,
+        headers: dict[str, str],
+        payload: dict[str, Any],
+        timeout_seconds: float,
+    ) -> tuple[bytes, int]:
+        body = bytearray()
+        async with client.stream(
+            "POST",
+            url,
+            headers=headers,
+            json=payload,
+            timeout=httpx.Timeout(timeout_seconds),
+            follow_redirects=False,
+        ) as response:
+            status_code = response.status_code
+            if status_code < 200 or status_code >= 300:
+                return b"", status_code
+            async for chunk in response.aiter_bytes():
+                if len(body) + len(chunk) > MAX_PROVIDER_RESPONSE_BYTES:
+                    raise ProviderProtocolError(self.provider, "response_too_large")
+                body.extend(chunk)
+        return bytes(body), status_code
+
+    def _usage(
+        self,
+        input_tokens: Any,
+        output_tokens: Any,
+        total_tokens: Any = None,
+    ) -> ProviderTokenUsage:
+        def bounded_int(value: Any) -> int | None:
+            if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+                return None
+            return min(value, 10**12)
+
+        input_count = bounded_int(input_tokens)
+        output_count = bounded_int(output_tokens)
+        total_count = bounded_int(total_tokens)
+        raw_values = (input_tokens, output_tokens, total_tokens)
+        parsed_values = (input_count, output_count, total_count)
+        invalid_reported = any(
+            raw is not None and parsed is None
+            for raw, parsed in zip(raw_values, parsed_values, strict=True)
+        )
+        if input_count is not None and output_count is not None and not invalid_reported:
+            components_total = input_count + output_count
+            if total_count is None:
+                total_count = components_total
+                source = "derived"
+            elif total_count >= components_total:
+                source = "provider_exact"
+            else:
+                total_count = None
+                source = "partial"
+        elif any(raw is not None for raw in raw_values):
+            source = "partial"
+        else:
+            source = "unavailable"
+        return ProviderTokenUsage(
+            input_tokens=input_count,
+            output_tokens=output_count,
+            total_tokens=total_count,
+            source=source,
+        )
+
+    def _resolved_model(
+        self, value: Any, requested: str
+    ) -> tuple[str, Literal["provider_reported", "requested_fallback"]]:
+        candidate = str(value or "").strip()
+        if is_safe_model_id(candidate):
+            return candidate, "provider_reported"
+        return requested, "requested_fallback"
+
+    def _response_id(self, value: Any) -> str | None:
+        candidate = str(value or "").strip()
+        return candidate if is_safe_response_id(candidate) else None
+
+    def _receipt(
+        self,
+        *,
+        request: ProviderRequest,
+        requested_model: str,
+        resolved_model: str,
+        model_source: Literal["provider_reported", "requested_fallback"],
+        response_id: str | None,
+        duration_ms: int,
+        usage: ProviderTokenUsage,
+        region: str,
+        account_fingerprint: str | None = None,
+    ) -> ProviderReceipt:
+        descriptor = self.descriptor
+        return ProviderReceipt(
+            request_id=request.request_id,
+            supervision=request.supervision,
+            provider=self.provider,
+            channel=self.channel,
+            credential_plane=descriptor.credential_plane,
+            route=request.route,
+            requested_model=requested_model,
+            resolved_model=resolved_model,
+            model_source=model_source,
+            endpoint_host=descriptor.endpoint_host,
+            endpoint_kind=descriptor.endpoint_kind,
+            credential_kind=descriptor.credential_kind,
+            region=region,
+            account_fingerprint=account_fingerprint,
+            response_id=response_id,
+            duration_ms=duration_ms,
+            usage=usage,
+        )
+
+
+def opaque_fingerprint(value: str) -> str:
+    """Identify a non-secret account/project without exposing its raw value."""
+
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()[:12]

--- a/src/providers/config.py
+++ b/src/providers/config.py
@@ -1,0 +1,118 @@
+"""Provider model pins and bounded non-secret configuration."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+
+from pydantic import ValidationError
+
+from .contracts import (
+    ProviderChannel,
+    ProviderId,
+    ProviderModelPins,
+    RouteClass,
+    is_safe_model_id,
+)
+from .errors import ProviderConfigurationError
+
+
+DEFAULT_MODEL_PINS: dict[ProviderChannel, ProviderModelPins] = {
+    ProviderChannel.OPENAI_API: ProviderModelPins(
+        planning="gpt-5.1",
+        coding="gpt-5.1",
+        vision="gpt-5.1",
+        research="gpt-5.1",
+    ),
+    ProviderChannel.ANTHROPIC_API: ProviderModelPins(
+        planning="claude-fable-5",
+        coding="claude-sonnet-5",
+        vision="claude-sonnet-5",
+        research="claude-fable-5",
+    ),
+    ProviderChannel.GEMINI_API_KEY: ProviderModelPins(
+        planning="gemini-3.5-flash",
+        coding="gemini-3.5-flash",
+        vision="gemini-3.5-flash",
+        research="gemini-3.5-flash",
+    ),
+    ProviderChannel.VERTEX_ADC: ProviderModelPins(
+        planning="gemini-3.5-flash",
+        coding="gemini-3.5-flash",
+        vision="gemini-3.5-flash",
+        research="gemini-3.5-flash",
+    ),
+}
+
+_PREFIXES = {
+    ProviderChannel.OPENAI_API: "OPENAI",
+    ProviderChannel.ANTHROPIC_API: "ANTHROPIC",
+    ProviderChannel.GEMINI_API_KEY: "GEMINI",
+    ProviderChannel.VERTEX_ADC: "VERTEX",
+}
+
+_PROVIDERS = {
+    ProviderChannel.OPENAI_API: ProviderId.OPENAI,
+    ProviderChannel.ANTHROPIC_API: ProviderId.ANTHROPIC,
+    ProviderChannel.GEMINI_API_KEY: ProviderId.GOOGLE,
+    ProviderChannel.VERTEX_ADC: ProviderId.GOOGLE,
+}
+
+_PROJECT_RE = re.compile(r"^[a-z][a-z0-9-]{4,61}[a-z0-9]$")
+_LOCATION_RE = re.compile(r"^(?:global|us|eu|[a-z]+-[a-z]+[0-9])$")
+
+
+def _env_value(environ: Mapping[str, str], name: str) -> str | None:
+    value = str(environ.get(name) or "").strip()
+    return value or None
+
+
+def load_model_pins(
+    channel: ProviderChannel,
+    environ: Mapping[str, str],
+) -> ProviderModelPins:
+    """Resolve route pin > provider pin > stable first-party default.
+
+    Invalid values fail closed while naming only the environment variable, never
+    its content.
+    """
+
+    provider = _PROVIDERS[channel]
+    prefix = _PREFIXES[channel]
+    base_name = f"UNIGROK_{prefix}_MODEL"
+    base = _env_value(environ, base_name)
+    defaults = DEFAULT_MODEL_PINS[channel]
+    values: dict[str, str] = {}
+    for route in RouteClass:
+        route_name = f"UNIGROK_{prefix}_{route.value.upper()}_MODEL"
+        value = _env_value(environ, route_name) or base or defaults.for_route(route)
+        if not is_safe_model_id(value):
+            failing_name = route_name if _env_value(environ, route_name) else base_name
+            raise ProviderConfigurationError(provider, f"invalid_model_pin:{failing_name}")
+        values[route.value] = value
+    try:
+        return ProviderModelPins(**values)
+    except ValidationError:  # defensive: the values above are prechecked
+        raise ProviderConfigurationError(provider, "invalid_model_pins") from None
+
+
+def vertex_location(environ: Mapping[str, str]) -> str:
+    location = _env_value(environ, "UNIGROK_VERTEX_LOCATION") or "global"
+    if not _LOCATION_RE.fullmatch(location):
+        raise ProviderConfigurationError(ProviderId.GOOGLE, "invalid_vertex_location")
+    return location
+
+
+def configured_vertex_project(environ: Mapping[str, str]) -> str | None:
+    project = _env_value(environ, "UNIGROK_VERTEX_PROJECT") or _env_value(
+        environ, "GOOGLE_CLOUD_PROJECT"
+    )
+    if project is not None and not _PROJECT_RE.fullmatch(project):
+        raise ProviderConfigurationError(ProviderId.GOOGLE, "invalid_vertex_project")
+    return project
+
+
+def validate_vertex_project(project: str) -> str:
+    if not _PROJECT_RE.fullmatch(str(project or "")):
+        raise ProviderConfigurationError(ProviderId.GOOGLE, "invalid_vertex_project")
+    return project

--- a/src/providers/contracts.py
+++ b/src/providers/contracts.py
@@ -1,0 +1,357 @@
+"""Strict provider-neutral contracts for external semantic model calls.
+
+These types deliberately stop at normalized text inference.  They do not grant
+routing, tool, effect, or verification authority.  Provider adapters translate
+between these contracts and first-party HTTP APIs; the future broker decides
+which adapter may be called.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Annotated, Literal, Protocol, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+MAX_MESSAGE_CHARS = 128_000
+MAX_REQUEST_CHARS = 500_000
+MAX_RESPONSE_CHARS = 1_000_000
+MAX_OUTPUT_TOKENS = 32_768
+MAX_TIMEOUT_SECONDS = 120.0
+
+_SAFE_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_SAFE_MODEL_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/@-]{0,191}$")
+_SAFE_HOST_RE = re.compile(
+    r"^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$"
+)
+
+
+class ProviderId(str, Enum):
+    XAI = "xai"
+    OPENAI = "openai"
+    ANTHROPIC = "anthropic"
+    GOOGLE = "google"
+
+
+class ProviderChannel(str, Enum):
+    XAI_API = "xai_api"
+    GROK_CLI = "grok_cli"
+    OPENAI_API = "openai_api"
+    ANTHROPIC_API = "anthropic_api"
+    GEMINI_API_KEY = "gemini_api_key"
+    VERTEX_ADC = "vertex_adc"
+
+
+class CredentialPlane(str, Enum):
+    METERED_API = "metered_api"
+    SUBSCRIPTION = "subscription"
+
+
+class RouteClass(str, Enum):
+    PLANNING = "planning"
+    CODING = "coding"
+    VISION = "vision"
+    RESEARCH = "research"
+
+
+class CredentialState(str, Enum):
+    CONFIGURED = "configured"
+    MISSING = "missing"
+    DEFERRED = "deferred"
+
+
+class StrictContract(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+
+class GrokSupervisorBinding(StrictContract):
+    """Opaque Grok-owned state copied into every worker receipt.
+
+    Adapters may bind outputs to this state, but cannot create, extend, route,
+    verify, harvest, or finalize it.
+    """
+
+    supervisor: Literal["grok"] = "grok"
+    session_id: Annotated[str, Field(min_length=1, max_length=128)]
+    objective_id: Annotated[str, Field(min_length=1, max_length=128)]
+    route_decision_id: Annotated[str, Field(min_length=1, max_length=128)]
+    ttl_expires_at: datetime
+
+    @model_validator(mode="after")
+    def validate_binding(self) -> "GrokSupervisorBinding":
+        for value in (self.session_id, self.objective_id, self.route_decision_id):
+            if not _SAFE_IDENTIFIER_RE.fullmatch(value):
+                raise ValueError("supervisor identifiers must be opaque and safe")
+        if self.ttl_expires_at.tzinfo is None:
+            raise ValueError("ttl_expires_at must be timezone-aware")
+        return self
+
+
+class WorkerAuthority(StrictContract):
+    """Mechanical denial of supervisor authority to external model workers."""
+
+    role: Literal["subordinate_worker"] = "subordinate_worker"
+    supervisor: Literal["grok"] = "grok"
+    may_route: Literal[False] = False
+    may_verify: Literal[False] = False
+    may_harvest: Literal[False] = False
+    may_finalize: Literal[False] = False
+
+
+class ProviderMessage(StrictContract):
+    role: Literal["system", "user", "assistant"]
+    content: Annotated[str, Field(min_length=1, max_length=MAX_MESSAGE_CHARS)]
+
+
+class ProviderRequest(StrictContract):
+    request_id: Annotated[str, Field(min_length=1, max_length=128)]
+    supervision: GrokSupervisorBinding
+    route: RouteClass
+    messages: Annotated[list[ProviderMessage], Field(min_length=1, max_length=100)]
+    model: Annotated[str, Field(min_length=1, max_length=192)] | None = None
+    max_output_tokens: Annotated[int, Field(ge=1, le=MAX_OUTPUT_TOKENS)] = 4096
+    timeout_seconds: Annotated[float, Field(ge=1.0, le=MAX_TIMEOUT_SECONDS)] = 60.0
+    temperature: Annotated[float, Field(ge=0.0, le=2.0)] | None = None
+
+    @model_validator(mode="after")
+    def validate_semantics(self) -> "ProviderRequest":
+        if not _SAFE_IDENTIFIER_RE.fullmatch(self.request_id):
+            raise ValueError("request_id must be an opaque safe identifier")
+        if self.model is not None and not _SAFE_MODEL_RE.fullmatch(self.model):
+            raise ValueError("model must be a safe provider model identifier")
+        if not any(message.role == "user" for message in self.messages):
+            raise ValueError("messages must contain at least one user turn")
+        if sum(len(message.content) for message in self.messages) > MAX_REQUEST_CHARS:
+            raise ValueError("combined message content exceeds the request bound")
+        return self
+
+
+class ProviderModelPins(StrictContract):
+    planning: Annotated[str, Field(min_length=1, max_length=192)]
+    coding: Annotated[str, Field(min_length=1, max_length=192)]
+    vision: Annotated[str, Field(min_length=1, max_length=192)]
+    research: Annotated[str, Field(min_length=1, max_length=192)]
+
+    @model_validator(mode="after")
+    def validate_model_names(self) -> "ProviderModelPins":
+        for value in (self.planning, self.coding, self.vision, self.research):
+            if not _SAFE_MODEL_RE.fullmatch(value):
+                raise ValueError("model pins must be safe provider identifiers")
+        return self
+
+    def for_route(self, route: RouteClass) -> str:
+        return str(getattr(self, route.value))
+
+
+class ProviderDescriptor(StrictContract):
+    provider: ProviderId
+    channel: ProviderChannel
+    credential_plane: CredentialPlane
+    display_name: Annotated[str, Field(min_length=1, max_length=64)]
+    endpoint_host: Annotated[str, Field(min_length=3, max_length=253)]
+    endpoint_kind: Literal["first_party_api", "vertex_ai"]
+    credential_kind: Literal["api_key", "google_adc"]
+    credential_env_names: tuple[str, ...]
+    credential_state: CredentialState
+    models: ProviderModelPins
+    supported_routes: tuple[RouteClass, ...] = (
+        RouteClass.PLANNING,
+        RouteClass.CODING,
+        RouteClass.RESEARCH,
+    )
+    max_output_tokens: Annotated[int, Field(ge=1, le=MAX_OUTPUT_TOKENS)] = 16_384
+    max_timeout_seconds: Annotated[float, Field(ge=1.0, le=MAX_TIMEOUT_SECONDS)] = 120.0
+    data_handling: Literal["provider_managed", "project_policy"]
+    residency: Annotated[str, Field(min_length=1, max_length=64)]
+    supports_normalized_tools: bool = False
+    authority: WorkerAuthority = WorkerAuthority()
+
+    @model_validator(mode="after")
+    def validate_descriptor(self) -> "ProviderDescriptor":
+        if not _SAFE_HOST_RE.fullmatch(self.endpoint_host):
+            raise ValueError("endpoint_host must be a fixed DNS hostname")
+        if not self.supported_routes or len(set(self.supported_routes)) != len(
+            self.supported_routes
+        ):
+            raise ValueError("supported routes must be nonempty and unique")
+        if len(set(self.credential_env_names)) != len(self.credential_env_names):
+            raise ValueError("credential environment names must be unique")
+        for name in self.credential_env_names:
+            if not re.fullmatch(r"[A-Z][A-Z0-9_]{1,63}", name):
+                raise ValueError("credential environment names must be safe identifiers")
+        return self
+
+
+class ProviderTokenUsage(StrictContract):
+    input_tokens: Annotated[int, Field(ge=0)] | None = None
+    output_tokens: Annotated[int, Field(ge=0)] | None = None
+    total_tokens: Annotated[int, Field(ge=0)] | None = None
+    source: Literal["provider_exact", "derived", "partial", "unavailable"] = (
+        "unavailable"
+    )
+
+    @model_validator(mode="after")
+    def validate_total(self) -> "ProviderTokenUsage":
+        values = (self.input_tokens, self.output_tokens, self.total_tokens)
+        present = tuple(value is not None for value in values)
+        if self.source == "unavailable" and any(present):
+            raise ValueError("unavailable usage cannot contain token counts")
+        if self.source == "provider_exact" and not all(present):
+            raise ValueError("exact usage requires every provider token field")
+        if self.source == "derived" and not (
+            self.input_tokens is not None
+            and self.output_tokens is not None
+            and self.total_tokens == self.input_tokens + self.output_tokens
+        ):
+            raise ValueError("derived usage requires input and output with their sum")
+        if self.source == "partial" and all(present):
+            raise ValueError("partial usage cannot claim every count as valid")
+        if (
+            self.input_tokens is not None
+            and self.output_tokens is not None
+            and self.total_tokens is not None
+            and self.total_tokens < self.input_tokens + self.output_tokens
+        ):
+            raise ValueError("token total cannot be smaller than its components")
+        return self
+
+
+class ProviderReceipt(StrictContract):
+    version: Literal["provider-receipt/v1"] = "provider-receipt/v1"
+    request_id: Annotated[str, Field(min_length=1, max_length=128)]
+    supervision: GrokSupervisorBinding
+    provider: ProviderId
+    channel: ProviderChannel
+    credential_plane: CredentialPlane
+    route: RouteClass
+    requested_model: Annotated[str, Field(min_length=1, max_length=192)]
+    resolved_model: Annotated[str, Field(min_length=1, max_length=192)]
+    model_source: Literal["provider_reported", "requested_fallback"]
+    endpoint_host: Annotated[str, Field(min_length=3, max_length=253)]
+    endpoint_kind: Literal["first_party_api", "vertex_ai"]
+    credential_kind: Literal["api_key", "google_adc"]
+    billing_class: Literal["metered"] = "metered"
+    cost_usd: Annotated[Decimal, Field(ge=0, max_digits=16, decimal_places=8)] | None = None
+    cost_source: Literal["provider_exact", "locally_computed", "unavailable"] = (
+        "unavailable"
+    )
+    region: Annotated[str, Field(min_length=1, max_length=64)]
+    account_fingerprint: Annotated[str, Field(pattern=r"^sha256:[0-9a-f]{12}$")] | None = None
+    response_id: Annotated[str, Field(min_length=1, max_length=128)] | None = None
+    duration_ms: Annotated[int, Field(ge=0, le=3_600_000)]
+    usage: ProviderTokenUsage
+    authority: WorkerAuthority = WorkerAuthority()
+
+    @model_validator(mode="after")
+    def validate_receipt(self) -> "ProviderReceipt":
+        if not _SAFE_IDENTIFIER_RE.fullmatch(self.request_id):
+            raise ValueError("receipt request_id must be a safe identifier")
+        if not _SAFE_MODEL_RE.fullmatch(self.requested_model):
+            raise ValueError("receipt requested_model must be safe")
+        if not _SAFE_MODEL_RE.fullmatch(self.resolved_model):
+            raise ValueError("receipt resolved_model must be safe")
+        if not _SAFE_HOST_RE.fullmatch(self.endpoint_host):
+            raise ValueError("receipt endpoint_host must be a fixed hostname")
+        if self.response_id and not _SAFE_IDENTIFIER_RE.fullmatch(self.response_id):
+            raise ValueError("receipt response_id must be a safe identifier")
+        if (self.cost_usd is None) != (self.cost_source == "unavailable"):
+            raise ValueError("receipt cost and cost source must agree")
+        return self
+
+
+class ProviderResponse(StrictContract):
+    provider: ProviderId
+    channel: ProviderChannel
+    model: Annotated[str, Field(min_length=1, max_length=192)]
+    text: Annotated[str, Field(max_length=MAX_RESPONSE_CHARS)]
+    finish_reason: Literal["stop", "length", "tool_calls", "content_filter", "unknown"]
+    receipt: ProviderReceipt
+    authority: WorkerAuthority = WorkerAuthority()
+
+    @model_validator(mode="after")
+    def bind_receipt(self) -> "ProviderResponse":
+        if self.provider != self.receipt.provider:
+            raise ValueError("response provider does not match its receipt")
+        if self.channel != self.receipt.channel:
+            raise ValueError("response channel does not match its receipt")
+        if self.model != self.receipt.resolved_model:
+            raise ValueError("response model does not match its receipt")
+        return self
+
+
+class ProviderFailureReceipt(StrictContract):
+    """Bounded, secret-safe failure evidence returned to the Grok supervisor."""
+
+    version: Literal["provider-failure/v1"] = "provider-failure/v1"
+    request_id: Annotated[str, Field(min_length=1, max_length=128)]
+    supervision: GrokSupervisorBinding
+    provider: ProviderId
+    channel: ProviderChannel
+    credential_plane: CredentialPlane
+    route: RouteClass
+    requested_model: Annotated[str, Field(min_length=1, max_length=192)]
+    endpoint_host: Annotated[str, Field(min_length=3, max_length=253)]
+    error_kind: Literal["configuration", "transport", "protocol", "internal"]
+    error_code: Annotated[str, Field(pattern=r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")]
+    duration_ms: Annotated[int, Field(ge=0, le=3_600_000)]
+    usage: ProviderTokenUsage = ProviderTokenUsage()
+    cost_usd: Annotated[Decimal, Field(ge=0, max_digits=16, decimal_places=8)] | None = None
+    cost_source: Literal["provider_exact", "locally_computed", "unavailable"] = (
+        "unavailable"
+    )
+    authority: WorkerAuthority = WorkerAuthority()
+
+    @model_validator(mode="after")
+    def validate_failure(self) -> "ProviderFailureReceipt":
+        if not _SAFE_IDENTIFIER_RE.fullmatch(self.request_id):
+            raise ValueError("failure request_id must be safe")
+        if not _SAFE_MODEL_RE.fullmatch(self.requested_model):
+            raise ValueError("failure requested_model must be safe")
+        if not _SAFE_HOST_RE.fullmatch(self.endpoint_host):
+            raise ValueError("failure endpoint_host must be fixed")
+        if (self.cost_usd is None) != (self.cost_source == "unavailable"):
+            raise ValueError("failure cost and cost source must agree")
+        return self
+
+
+class ProviderAttemptResult(StrictContract):
+    """One subordinate worker return or failure for Grok synthesis."""
+
+    version: Literal["provider-attempt/v1"] = "provider-attempt/v1"
+    status: Literal["returned", "failed"]
+    response: ProviderResponse | None = None
+    failure: ProviderFailureReceipt | None = None
+
+    @model_validator(mode="after")
+    def validate_result(self) -> "ProviderAttemptResult":
+        if self.status == "returned" and (self.response is None or self.failure is not None):
+            raise ValueError("returned attempts require only a response")
+        if self.status == "failed" and (self.failure is None or self.response is not None):
+            raise ValueError("failed attempts require only a failure receipt")
+        return self
+
+
+@runtime_checkable
+class ProviderAdapter(Protocol):
+    @property
+    def descriptor(self) -> ProviderDescriptor: ...
+
+    async def complete(self, request: ProviderRequest) -> ProviderResponse: ...
+
+    async def attempt(self, request: ProviderRequest) -> ProviderAttemptResult: ...
+
+
+def is_safe_model_id(value: str) -> bool:
+    """Return whether a provider-supplied model ID is safe to put in a receipt."""
+
+    return bool(_SAFE_MODEL_RE.fullmatch(str(value or "")))
+
+
+def is_safe_response_id(value: str) -> bool:
+    """Return whether an upstream response ID is safe to put in a receipt."""
+
+    return bool(_SAFE_IDENTIFIER_RE.fullmatch(str(value or "")))

--- a/src/providers/errors.py
+++ b/src/providers/errors.py
@@ -1,0 +1,28 @@
+"""Secret-safe provider error taxonomy.
+
+Errors carry bounded machine codes only.  Provider response bodies, request
+URLs, authentication material, and exception text never cross this boundary.
+"""
+
+from __future__ import annotations
+
+from .contracts import ProviderId
+
+
+class ProviderError(RuntimeError):
+    def __init__(self, provider: ProviderId, code: str) -> None:
+        self.provider = provider
+        self.code = code
+        super().__init__(f"{provider.value} provider failed ({code})")
+
+
+class ProviderConfigurationError(ProviderError):
+    pass
+
+
+class ProviderTransportError(ProviderError):
+    pass
+
+
+class ProviderProtocolError(ProviderError):
+    pass

--- a/src/providers/gemini.py
+++ b/src/providers/gemini.py
@@ -1,0 +1,111 @@
+"""Google Gemini API-key adapter using the fixed generateContent endpoint."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from urllib.parse import quote
+
+import httpx
+
+from .base import Clock, HTTPProviderAdapter
+from .config import load_model_pins
+from .contracts import (
+    CredentialPlane,
+    ProviderChannel,
+    ProviderDescriptor,
+    ProviderId,
+    ProviderRequest,
+    ProviderResponse,
+)
+from .google_common import build_generate_content_payload, parse_generate_content_response
+
+
+GEMINI_HOST = "generativelanguage.googleapis.com"
+GEMINI_KEY_NAMES = ("GEMINI_API_KEY",)
+
+
+class GeminiAdapter(HTTPProviderAdapter):
+    provider = ProviderId.GOOGLE
+    channel = ProviderChannel.GEMINI_API_KEY
+
+    def __init__(
+        self,
+        *,
+        client: httpx.AsyncClient | None = None,
+        environ: Mapping[str, str] | None = None,
+        clock: Clock | None = None,
+    ) -> None:
+        super().__init__(client=client, environ=environ, clock=clock)
+        self._descriptor = ProviderDescriptor(
+            provider=self.provider,
+            channel=self.channel,
+            credential_plane=CredentialPlane.METERED_API,
+            display_name="Google Gemini API",
+            endpoint_host=GEMINI_HOST,
+            endpoint_kind="first_party_api",
+            credential_kind="api_key",
+            credential_env_names=GEMINI_KEY_NAMES,
+            credential_state=self._credential_state(GEMINI_KEY_NAMES),
+            models=load_model_pins(self.channel, self._environ),
+            max_output_tokens=32_768,
+            max_timeout_seconds=120.0,
+            data_handling="provider_managed",
+            residency="provider_default",
+        )
+
+    @property
+    def descriptor(self) -> ProviderDescriptor:
+        return self._descriptor
+
+    async def _complete(self, request: ProviderRequest) -> ProviderResponse:
+        model = self._model(request)
+        max_tokens, _ = self._limits(request)
+        key = self._api_key(GEMINI_KEY_NAMES)
+        _, timeout = self._limits(request)
+        endpoint = (
+            f"https://{GEMINI_HOST}/v1beta/models/"
+            f"{quote(model, safe='._-')}:generateContent"
+        )
+        data, duration_ms = await self._post_json(
+            url=endpoint,
+            headers={
+                "x-goog-api-key": key.get_secret_value(),
+                "Content-Type": "application/json",
+            },
+            payload=build_generate_content_payload(
+                request,
+                max_output_tokens=max_tokens,
+                messages=self._model_messages(request),
+            ),
+            timeout_seconds=timeout,
+        )
+        (
+            text,
+            finish,
+            raw_model,
+            raw_response_id,
+            input_tokens,
+            output_tokens,
+            total_tokens,
+        ) = parse_generate_content_response(self.provider, data)
+        usage = self._usage(input_tokens, output_tokens, total_tokens)
+        resolved_model, model_source = self._resolved_model(raw_model, model)
+        response_id = self._response_id(raw_response_id)
+        receipt = self._receipt(
+            request=request,
+            requested_model=model,
+            resolved_model=resolved_model,
+            model_source=model_source,
+            response_id=response_id,
+            duration_ms=duration_ms,
+            usage=usage,
+            region="provider_default",
+        )
+        return ProviderResponse(
+            provider=self.provider,
+            channel=self.channel,
+            model=resolved_model,
+            text=text,
+            finish_reason=finish,
+            receipt=receipt,
+        )

--- a/src/providers/google_common.py
+++ b/src/providers/google_common.py
@@ -1,0 +1,101 @@
+"""Normalized Gemini generateContent request and response helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .contracts import ProviderMessage, ProviderRequest
+from .errors import ProviderProtocolError
+
+
+_FILTER_REASONS = {
+    "SAFETY",
+    "RECITATION",
+    "BLOCKLIST",
+    "PROHIBITED_CONTENT",
+    "SPII",
+    "IMAGE_SAFETY",
+}
+
+
+def build_generate_content_payload(
+    request: ProviderRequest,
+    *,
+    max_output_tokens: int,
+    messages: list[ProviderMessage] | None = None,
+) -> dict[str, Any]:
+    system_parts: list[dict[str, str]] = []
+    contents: list[dict[str, Any]] = []
+    for message in messages if messages is not None else request.messages:
+        if message.role == "system":
+            system_parts.append({"text": message.content})
+            continue
+        contents.append(
+            {
+                "role": "model" if message.role == "assistant" else "user",
+                "parts": [{"text": message.content}],
+            }
+        )
+    payload: dict[str, Any] = {
+        "contents": contents,
+        "generationConfig": {
+            "candidateCount": 1,
+            "maxOutputTokens": max_output_tokens,
+        },
+    }
+    if system_parts:
+        payload["systemInstruction"] = {"parts": system_parts}
+    if request.temperature is not None:
+        payload["generationConfig"]["temperature"] = request.temperature
+    return payload
+
+
+def parse_generate_content_response(
+    provider,
+    data: dict[str, Any],
+) -> tuple[str, str, Any, Any, Any, Any, Any]:
+    candidates = data.get("candidates")
+    candidate = candidates[0] if isinstance(candidates, list) and candidates else None
+    finish_raw = ""
+    parts: list[Any] = []
+    if isinstance(candidate, dict):
+        finish_raw = str(candidate.get("finishReason") or "").upper()
+        content = candidate.get("content")
+        if isinstance(content, dict) and isinstance(content.get("parts"), list):
+            parts = content["parts"]
+    text_parts = [
+        str(part.get("text"))
+        for part in parts
+        if isinstance(part, dict)
+        and isinstance(part.get("text"), str)
+        and not bool(part.get("thought"))
+    ]
+    text = "".join(text_parts)
+    prompt_feedback = data.get("promptFeedback")
+    block_reason = (
+        str(prompt_feedback.get("blockReason") or "").upper()
+        if isinstance(prompt_feedback, dict)
+        else ""
+    )
+    if finish_raw == "MAX_TOKENS":
+        finish = "length"
+    elif finish_raw in _FILTER_REASONS or block_reason:
+        finish = "content_filter"
+    elif finish_raw in {"MALFORMED_FUNCTION_CALL", "UNEXPECTED_TOOL_CALL"}:
+        finish = "tool_calls"
+    elif finish_raw in {"STOP", "FINISH_REASON_UNSPECIFIED"} and text:
+        finish = "stop"
+    else:
+        finish = "unknown"
+    if not text and finish != "content_filter":
+        raise ProviderProtocolError(provider, "missing_text")
+    usage = data.get("usageMetadata") if isinstance(data.get("usageMetadata"), dict) else {}
+    return (
+        text,
+        finish,
+        data.get("modelVersion"),
+        data.get("responseId"),
+        usage.get("promptTokenCount"),
+        usage.get("candidatesTokenCount"),
+        usage.get("totalTokenCount"),
+    )

--- a/src/providers/openai.py
+++ b/src/providers/openai.py
@@ -1,0 +1,145 @@
+"""OpenAI Responses API adapter with a fixed first-party endpoint."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import httpx
+
+from .base import Clock, HTTPProviderAdapter
+from .config import load_model_pins
+from .contracts import (
+    CredentialPlane,
+    ProviderChannel,
+    ProviderDescriptor,
+    ProviderId,
+    ProviderRequest,
+    ProviderResponse,
+)
+from .errors import ProviderProtocolError
+
+
+OPENAI_ENDPOINT = "https://api.openai.com/v1/responses"
+OPENAI_HOST = "api.openai.com"
+OPENAI_KEY_NAMES = ("OPENAI_API_KEY",)
+
+
+class OpenAIAdapter(HTTPProviderAdapter):
+    provider = ProviderId.OPENAI
+    channel = ProviderChannel.OPENAI_API
+
+    def __init__(
+        self,
+        *,
+        client: httpx.AsyncClient | None = None,
+        environ: Mapping[str, str] | None = None,
+        clock: Clock | None = None,
+    ) -> None:
+        super().__init__(client=client, environ=environ, clock=clock)
+        self._descriptor = ProviderDescriptor(
+            provider=self.provider,
+            channel=self.channel,
+            credential_plane=CredentialPlane.METERED_API,
+            display_name="OpenAI",
+            endpoint_host=OPENAI_HOST,
+            endpoint_kind="first_party_api",
+            credential_kind="api_key",
+            credential_env_names=OPENAI_KEY_NAMES,
+            credential_state=self._credential_state(OPENAI_KEY_NAMES),
+            models=load_model_pins(self.channel, self._environ),
+            max_output_tokens=16_384,
+            max_timeout_seconds=120.0,
+            data_handling="provider_managed",
+            residency="provider_default",
+        )
+
+    @property
+    def descriptor(self) -> ProviderDescriptor:
+        return self._descriptor
+
+    async def _complete(self, request: ProviderRequest) -> ProviderResponse:
+        model = self._model(request)
+        max_tokens, _ = self._limits(request)
+        key = self._api_key(OPENAI_KEY_NAMES)
+        _, timeout = self._limits(request)
+        payload: dict[str, Any] = {
+            "model": model,
+            "input": [
+                message.model_dump(mode="json")
+                for message in self._model_messages(request)
+            ],
+            "max_output_tokens": max_tokens,
+            "store": False,
+        }
+        if request.temperature is not None:
+            payload["temperature"] = request.temperature
+        data, duration_ms = await self._post_json(
+            url=OPENAI_ENDPOINT,
+            headers={
+                "Authorization": f"Bearer {key.get_secret_value()}",
+                "Content-Type": "application/json",
+            },
+            payload=payload,
+            timeout_seconds=timeout,
+        )
+        text_parts: list[str] = []
+        refusal_seen = False
+        output = data.get("output")
+        if isinstance(output, list):
+            for item in output:
+                if not isinstance(item, dict) or not isinstance(item.get("content"), list):
+                    continue
+                for part in item["content"]:
+                    if not isinstance(part, dict):
+                        continue
+                    if part.get("type") == "output_text" and isinstance(part.get("text"), str):
+                        text_parts.append(part["text"])
+                    elif part.get("type") == "refusal":
+                        refusal_seen = True
+                        if isinstance(part.get("refusal"), str):
+                            text_parts.append(part["refusal"])
+        text = "".join(text_parts)
+        status = str(data.get("status") or "").lower()
+        incomplete = data.get("incomplete_details")
+        incomplete_reason = (
+            str(incomplete.get("reason") or "").lower()
+            if isinstance(incomplete, dict)
+            else ""
+        )
+        if refusal_seen:
+            finish = "content_filter"
+        elif status == "incomplete" and incomplete_reason == "max_output_tokens":
+            finish = "length"
+        elif status == "completed" and text:
+            finish = "stop"
+        else:
+            finish = "unknown"
+        if not text and finish != "content_filter":
+            raise ProviderProtocolError(self.provider, "missing_text")
+        usage_data = data.get("usage") if isinstance(data.get("usage"), dict) else {}
+        usage = self._usage(
+            usage_data.get("input_tokens"),
+            usage_data.get("output_tokens"),
+            usage_data.get("total_tokens"),
+        )
+        resolved_model, model_source = self._resolved_model(data.get("model"), model)
+        response_id = self._response_id(data.get("id"))
+        receipt = self._receipt(
+            request=request,
+            requested_model=model,
+            resolved_model=resolved_model,
+            model_source=model_source,
+            response_id=response_id,
+            duration_ms=duration_ms,
+            usage=usage,
+            region="provider_default",
+        )
+        return ProviderResponse(
+            provider=self.provider,
+            channel=self.channel,
+            model=resolved_model,
+            text=text,
+            finish_reason=finish,
+            receipt=receipt,
+        )

--- a/src/providers/registry.py
+++ b/src/providers/registry.py
@@ -1,0 +1,49 @@
+"""Construction seam for the provider-neutral API adapter registry."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import httpx
+
+from .anthropic import AnthropicAdapter
+from .base import Clock
+from .contracts import ProviderAdapter, ProviderChannel
+from .gemini import GeminiAdapter
+from .openai import OpenAIAdapter
+from .vertex import ADCTokenProvider, VertexADCAdapter
+
+
+def build_provider_registry(
+    *,
+    environ: Mapping[str, str] | None = None,
+    clients: Mapping[ProviderChannel, httpx.AsyncClient] | None = None,
+    vertex_token_provider: ADCTokenProvider | None = None,
+    clock: Clock | None = None,
+) -> dict[ProviderChannel, ProviderAdapter]:
+    """Build adapters without performing discovery or provider calls."""
+
+    client_map = clients or {}
+    return {
+        ProviderChannel.OPENAI_API: OpenAIAdapter(
+            client=client_map.get(ProviderChannel.OPENAI_API),
+            environ=environ,
+            clock=clock,
+        ),
+        ProviderChannel.ANTHROPIC_API: AnthropicAdapter(
+            client=client_map.get(ProviderChannel.ANTHROPIC_API),
+            environ=environ,
+            clock=clock,
+        ),
+        ProviderChannel.GEMINI_API_KEY: GeminiAdapter(
+            client=client_map.get(ProviderChannel.GEMINI_API_KEY),
+            environ=environ,
+            clock=clock,
+        ),
+        ProviderChannel.VERTEX_ADC: VertexADCAdapter(
+            client=client_map.get(ProviderChannel.VERTEX_ADC),
+            environ=environ,
+            token_provider=vertex_token_provider,
+            clock=clock,
+        ),
+    }

--- a/src/providers/vertex.py
+++ b/src/providers/vertex.py
@@ -1,0 +1,208 @@
+"""Vertex AI Gemini adapter using Google Application Default Credentials."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+from collections.abc import Awaitable, Callable, Mapping
+from urllib.parse import quote
+
+import httpx
+from pydantic import SecretStr
+
+from .base import Clock, HTTPProviderAdapter, opaque_fingerprint
+from .config import (
+    configured_vertex_project,
+    load_model_pins,
+    validate_vertex_project,
+    vertex_location,
+)
+from .contracts import (
+    CredentialPlane,
+    CredentialState,
+    ProviderChannel,
+    ProviderDescriptor,
+    ProviderId,
+    ProviderRequest,
+    ProviderResponse,
+    StrictContract,
+)
+from .errors import ProviderConfigurationError
+from .google_common import build_generate_content_payload, parse_generate_content_response
+
+
+GOOGLE_CLOUD_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
+VERTEX_CREDENTIAL_NAMES = ("GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_CLOUD_PROJECT")
+
+
+class ADCIdentity(StrictContract):
+    access_token: SecretStr
+    project_id: str
+
+
+ADCTokenProvider = Callable[[], Awaitable[ADCIdentity]]
+
+
+async def load_google_adc_identity(timeout_seconds: float = 60.0) -> ADCIdentity:
+    """Resolve and refresh ADC off the event loop.
+
+    All third-party exception details are suppressed at the adapter boundary so
+    credential paths, token fragments, and account identifiers cannot escape.
+    """
+
+    if not math.isfinite(timeout_seconds) or timeout_seconds <= 0:
+        raise ProviderConfigurationError(ProviderId.GOOGLE, "adc_timeout_invalid")
+    bounded_timeout = min(timeout_seconds, 60.0)
+
+    def load() -> ADCIdentity:
+        import google.auth
+        from google.auth.transport.requests import Request
+
+        credentials, project_id = google.auth.default(scopes=[GOOGLE_CLOUD_SCOPE])
+        request = Request()
+
+        def bounded_request(*args, timeout=None, **kwargs):
+            requested_timeout = (
+                float(timeout) if isinstance(timeout, int | float) else bounded_timeout
+            )
+            if not math.isfinite(requested_timeout) or requested_timeout <= 0:
+                requested_timeout = bounded_timeout
+            return request(
+                *args,
+                timeout=min(requested_timeout, bounded_timeout),
+                **kwargs,
+            )
+
+        credentials.refresh(bounded_request)
+        token = str(getattr(credentials, "token", None) or "")
+        return ADCIdentity(access_token=SecretStr(token), project_id=str(project_id or ""))
+
+    try:
+        identity = await asyncio.to_thread(load)
+    except Exception:
+        raise ProviderConfigurationError(ProviderId.GOOGLE, "adc_unavailable") from None
+    if not identity.access_token.get_secret_value():
+        raise ProviderConfigurationError(ProviderId.GOOGLE, "adc_token_missing")
+    return identity
+
+
+class VertexADCAdapter(HTTPProviderAdapter):
+    provider = ProviderId.GOOGLE
+    channel = ProviderChannel.VERTEX_ADC
+
+    def __init__(
+        self,
+        *,
+        client: httpx.AsyncClient | None = None,
+        environ: Mapping[str, str] | None = None,
+        token_provider: ADCTokenProvider | None = None,
+        clock: Clock | None = None,
+    ) -> None:
+        super().__init__(client=client, environ=environ, clock=clock)
+        self._location = vertex_location(self._environ)
+        self._configured_project = configured_vertex_project(self._environ)
+        self._token_provider = token_provider or load_google_adc_identity
+        self._host = (
+            "aiplatform.googleapis.com"
+            if self._location == "global"
+            else f"{self._location}-aiplatform.googleapis.com"
+        )
+        self._descriptor = ProviderDescriptor(
+            provider=self.provider,
+            channel=self.channel,
+            credential_plane=CredentialPlane.METERED_API,
+            display_name="Google Vertex AI",
+            endpoint_host=self._host,
+            endpoint_kind="vertex_ai",
+            credential_kind="google_adc",
+            credential_env_names=VERTEX_CREDENTIAL_NAMES,
+            # ADC may come from a workload identity or metadata server without
+            # any environment variable, so availability is resolved at call time.
+            credential_state=CredentialState.DEFERRED,
+            models=load_model_pins(self.channel, self._environ),
+            max_output_tokens=32_768,
+            max_timeout_seconds=120.0,
+            data_handling="project_policy",
+            residency=self._location,
+        )
+
+    @property
+    def descriptor(self) -> ProviderDescriptor:
+        return self._descriptor
+
+    async def _complete(self, request: ProviderRequest) -> ProviderResponse:
+        model = self._model(request)
+        max_tokens, _ = self._limits(request)
+        try:
+            if self._token_provider is load_google_adc_identity:
+                identity = await self._run_with_ttl(
+                    request,
+                    lambda: load_google_adc_identity(
+                        timeout_seconds=self._remaining_ttl(request),
+                    ),
+                )
+            else:
+                identity = await self._run_with_ttl(
+                    request,
+                    self._token_provider,
+                )
+        except ProviderConfigurationError:
+            raise
+        except Exception:
+            raise ProviderConfigurationError(self.provider, "adc_unavailable") from None
+        token = identity.access_token.get_secret_value()
+        if not token:
+            raise ProviderConfigurationError(self.provider, "adc_token_missing")
+        project = validate_vertex_project(
+            self._configured_project or identity.project_id
+        )
+        _, timeout = self._limits(request)
+        endpoint = (
+            f"https://{self._host}/v1/projects/{quote(project, safe='-')}/"
+            f"locations/{quote(self._location, safe='-')}/publishers/google/models/"
+            f"{quote(model, safe='._-')}:generateContent"
+        )
+        data, duration_ms = await self._post_json(
+            url=endpoint,
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            },
+            payload=build_generate_content_payload(
+                request,
+                max_output_tokens=max_tokens,
+                messages=self._model_messages(request),
+            ),
+            timeout_seconds=timeout,
+        )
+        (
+            text,
+            finish,
+            raw_model,
+            raw_response_id,
+            input_tokens,
+            output_tokens,
+            total_tokens,
+        ) = parse_generate_content_response(self.provider, data)
+        usage = self._usage(input_tokens, output_tokens, total_tokens)
+        resolved_model, model_source = self._resolved_model(raw_model, model)
+        response_id = self._response_id(raw_response_id)
+        receipt = self._receipt(
+            request=request,
+            requested_model=model,
+            resolved_model=resolved_model,
+            model_source=model_source,
+            response_id=response_id,
+            duration_ms=duration_ms,
+            usage=usage,
+            region=self._location,
+            account_fingerprint=opaque_fingerprint(project),
+        )
+        return ProviderResponse(
+            provider=self.provider,
+            channel=self.channel,
+            model=resolved_model,
+            text=text,
+            finish_reason=finish,
+            receipt=receipt,
+        )

--- a/tests/test_provider_adapters.py
+++ b/tests/test_provider_adapters.py
@@ -1,0 +1,1001 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import pytest
+from pydantic import SecretStr, ValidationError
+
+from src.providers import (
+    ADCIdentity,
+    AnthropicAdapter,
+    CredentialState,
+    GeminiAdapter,
+    GrokSupervisorBinding,
+    OpenAIAdapter,
+    ProviderAdapter,
+    ProviderChannel,
+    ProviderConfigurationError,
+    ProviderId,
+    ProviderMessage,
+    ProviderRequest,
+    ProviderTransportError,
+    RouteClass,
+    VertexADCAdapter,
+    build_provider_registry,
+    load_google_adc_identity,
+)
+from src.providers.base import MAX_PROVIDER_RESPONSE_BYTES, opaque_fingerprint
+from src.providers.config import load_model_pins
+from src.providers.errors import ProviderProtocolError
+
+
+def normalized_request(**overrides) -> ProviderRequest:
+    values = {
+        "request_id": "req-provider-1",
+        "supervision": GrokSupervisorBinding(
+            session_id="session-1",
+            objective_id="objective-1",
+            route_decision_id="route-1",
+            ttl_expires_at=datetime(2030, 1, 1, tzinfo=UTC),
+        ),
+        "route": RouteClass.PLANNING,
+        "messages": [
+            ProviderMessage(role="system", content="Be concise."),
+            ProviderMessage(role="user", content="Explain the result."),
+        ],
+        "max_output_tokens": 32_768,
+        "timeout_seconds": 120.0,
+    }
+    values.update(overrides)
+    return ProviderRequest(**values)
+
+
+def supervisor_binding(ttl_expires_at: datetime) -> GrokSupervisorBinding:
+    return GrokSupervisorBinding(
+        session_id="session-1",
+        objective_id="objective-1",
+        route_decision_id="route-1",
+        ttl_expires_at=ttl_expires_at,
+    )
+
+
+def async_client(handler) -> httpx.AsyncClient:
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def test_request_contract_is_strict_and_bounded():
+    with pytest.raises(ValidationError):
+        ProviderRequest(
+            request_id="req-1",
+            supervision=normalized_request().supervision,
+            route=RouteClass.CODING,
+            messages=[ProviderMessage(role="assistant", content="no user")],
+        )
+    with pytest.raises(ValidationError):
+        ProviderMessage(role="tool", content="not normalized")
+    with pytest.raises(ValidationError):
+        ProviderRequest(
+            request_id="req-1",
+            supervision=normalized_request().supervision,
+            route=RouteClass.CODING,
+            messages=[ProviderMessage(role="user", content="hello")],
+            max_output_tokens=32_769,
+        )
+    with pytest.raises(ValidationError):
+        ProviderRequest(
+            request_id="req-1",
+            supervision=normalized_request().supervision,
+            route=RouteClass.CODING,
+            messages=[ProviderMessage(role="user", content="hello")],
+            unexpected=True,
+        )
+
+
+def test_grok_supervisor_binding_and_worker_authority_are_fail_closed():
+    request = normalized_request()
+    assert request.supervision.supervisor == "grok"
+    with pytest.raises(ValidationError):
+        GrokSupervisorBinding(
+            supervisor="openai",
+            session_id="session-1",
+            objective_id="objective-1",
+            route_decision_id="route-1",
+            ttl_expires_at=datetime(2030, 1, 1, tzinfo=UTC),
+        )
+    with pytest.raises(ValidationError):
+        GrokSupervisorBinding(
+            session_id="session-1",
+            objective_id="objective-1",
+            route_decision_id="route-1",
+            ttl_expires_at=datetime(2030, 1, 1),
+        )
+
+
+@pytest.mark.asyncio
+async def test_text_only_adapters_refuse_vision_until_media_contract_exists():
+    result = await GeminiAdapter(environ={"GEMINI_API_KEY": "unused"}).attempt(
+        normalized_request(route=RouteClass.VISION)
+    )
+    assert result.status == "failed"
+    assert result.failure is not None
+    assert result.failure.error_code == "unsupported_route"
+    assert result.failure.provider == ProviderId.GOOGLE
+    assert result.failure.channel == ProviderChannel.GEMINI_API_KEY
+
+
+@pytest.mark.asyncio
+async def test_expired_ttl_blocks_credentials_adc_and_http_effects():
+    now = datetime(2030, 1, 1, tzinfo=UTC)
+    request = normalized_request(supervision=supervisor_binding(now))
+    http_calls = 0
+    adc_calls = 0
+
+    async def http_handler(_: httpx.Request) -> httpx.Response:
+        nonlocal http_calls
+        http_calls += 1
+        raise AssertionError("expired work reached HTTP")
+
+    async def adc_provider() -> ADCIdentity:
+        nonlocal adc_calls
+        adc_calls += 1
+        raise AssertionError("expired work reached ADC")
+
+    client = async_client(http_handler)
+    try:
+        api_result = await OpenAIAdapter(
+            client=client,
+            environ={},
+            clock=lambda: now,
+        ).attempt(request)
+        vertex_result = await VertexADCAdapter(
+            client=client,
+            environ={"UNIGROK_VERTEX_PROJECT": "valid-project"},
+            token_provider=adc_provider,
+            clock=lambda: now,
+        ).attempt(request)
+    finally:
+        await client.aclose()
+
+    assert api_result.status == "failed"
+    assert api_result.failure is not None
+    assert api_result.failure.error_code == "ttl_expired"
+    assert vertex_result.status == "failed"
+    assert vertex_result.failure is not None
+    assert vertex_result.failure.error_code == "ttl_expired"
+    assert http_calls == 0
+    assert adc_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_timeout_is_capped_to_remaining_ttl_and_ttl_is_model_visible():
+    now = datetime(2029, 12, 31, 23, 59, 55, tzinfo=UTC)
+    deadline = now + timedelta(seconds=2.5)
+    observed = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        observed["timeouts"] = request.extensions["timeout"]
+        observed["payload"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "id": "resp_ttl",
+                "model": "gpt-5.1",
+                "status": "completed",
+                "output": [{"content": [{"type": "output_text", "text": "bounded"}]}],
+            },
+        )
+
+    client = async_client(handler)
+    try:
+        await OpenAIAdapter(
+            client=client,
+            environ={"OPENAI_API_KEY": "key"},
+            clock=lambda: now,
+        ).complete(
+            normalized_request(supervision=supervisor_binding(deadline))
+        )
+    finally:
+        await client.aclose()
+
+    numeric_timeouts = [
+        value for value in observed["timeouts"].values() if value is not None
+    ]
+    assert numeric_timeouts
+    assert max(numeric_timeouts) == pytest.approx(2.5)
+    assert observed["payload"]["input"][0] == {
+        "role": "system",
+        "content": (
+            "Supervisor TTL expires at 2029-12-31T23:59:57Z; "
+            "do not claim work after it."
+        ),
+    }
+
+
+@pytest.mark.asyncio
+async def test_ttl_is_rechecked_after_adc_before_inference_http():
+    started = datetime(2030, 1, 1, tzinfo=UTC)
+    current = [started]
+    http_calls = 0
+
+    async def token_provider() -> ADCIdentity:
+        current[0] = started + timedelta(seconds=3)
+        return ADCIdentity(
+            access_token=SecretStr("token-never-sent"),
+            project_id="valid-project",
+        )
+
+    async def handler(_: httpx.Request) -> httpx.Response:
+        nonlocal http_calls
+        http_calls += 1
+        raise AssertionError("expired post-ADC work reached inference HTTP")
+
+    client = async_client(handler)
+    try:
+        result = await VertexADCAdapter(
+            client=client,
+            environ={},
+            token_provider=token_provider,
+            clock=lambda: current[0],
+        ).attempt(
+            normalized_request(
+                supervision=supervisor_binding(started + timedelta(seconds=2))
+            )
+        )
+    finally:
+        await client.aclose()
+    assert result.status == "failed"
+    assert result.failure is not None
+    assert result.failure.error_code == "ttl_expired"
+    assert http_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_stalled_adc_is_cancelled_by_absolute_attempt_deadline():
+    now = datetime(2030, 1, 1, tzinfo=UTC)
+    cancelled = False
+    http_calls = 0
+
+    async def stalled_token_provider() -> ADCIdentity:
+        nonlocal cancelled
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled = True
+        raise AssertionError("unreachable")
+
+    async def handler(_: httpx.Request) -> httpx.Response:
+        nonlocal http_calls
+        http_calls += 1
+        raise AssertionError("stalled ADC reached inference HTTP")
+
+    client = async_client(handler)
+    started = time.monotonic()
+    try:
+        result = await VertexADCAdapter(
+            client=client,
+            environ={},
+            token_provider=stalled_token_provider,
+            clock=lambda: now,
+        ).attempt(
+            normalized_request(
+                supervision=supervisor_binding(now + timedelta(seconds=0.05))
+            )
+        )
+    finally:
+        await client.aclose()
+    assert time.monotonic() - started < 0.5
+    assert result.status == "failed"
+    assert result.failure is not None
+    assert result.failure.error_code == "ttl_expired"
+    assert cancelled is True
+    assert http_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_slow_progress_stream_cannot_extend_absolute_attempt_deadline():
+    now = datetime(2030, 1, 1, tzinfo=UTC)
+    chunks_sent = 0
+
+    class TrickleStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            nonlocal chunks_sent
+            while True:
+                await asyncio.sleep(0.01)
+                chunks_sent += 1
+                yield b" "
+
+    async def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=TrickleStream())
+
+    client = async_client(handler)
+    started = time.monotonic()
+    try:
+        result = await OpenAIAdapter(
+            client=client,
+            environ={"OPENAI_API_KEY": "key"},
+            clock=lambda: now,
+        ).attempt(
+            normalized_request(
+                supervision=supervisor_binding(now + timedelta(seconds=0.06))
+            )
+        )
+    finally:
+        await client.aclose()
+    assert time.monotonic() - started < 0.5
+    assert chunks_sent >= 1
+    assert result.status == "failed"
+    assert result.failure is not None
+    assert result.failure.error_code == "ttl_expired"
+
+
+@pytest.mark.asyncio
+async def test_ttl_is_rechecked_at_response_emission_boundary():
+    started = datetime(2030, 1, 1, tzinfo=UTC)
+    deadline = started + timedelta(seconds=10)
+    current = [started]
+
+    async def handler(_: httpx.Request) -> httpx.Response:
+        current[0] = deadline
+        return httpx.Response(
+            200,
+            json={
+                "id": "late_response",
+                "model": "gpt-5.1",
+                "status": "completed",
+                "output": [{"content": [{"type": "output_text", "text": "late"}]}],
+            },
+        )
+
+    client = async_client(handler)
+    try:
+        result = await OpenAIAdapter(
+            client=client,
+            environ={"OPENAI_API_KEY": "key"},
+            clock=lambda: current[0],
+        ).attempt(
+            normalized_request(supervision=supervisor_binding(deadline))
+        )
+    finally:
+        await client.aclose()
+    assert result.status == "failed"
+    assert result.failure is not None
+    assert result.failure.error_code == "ttl_expired"
+
+
+def test_model_pin_precedence_and_secret_safe_invalid_value():
+    pins = load_model_pins(
+        ProviderChannel.OPENAI_API,
+        {
+            "UNIGROK_OPENAI_MODEL": "gpt-5-mini",
+            "UNIGROK_OPENAI_PLANNING_MODEL": "gpt-5.1",
+        },
+    )
+    assert pins.planning == "gpt-5.1"
+    assert pins.coding == "gpt-5-mini"
+
+    bad = "invalid model fake-secret-value"
+    with pytest.raises(ProviderConfigurationError) as caught:
+        load_model_pins(
+            ProviderChannel.OPENAI_API,
+            {"UNIGROK_OPENAI_CODING_MODEL": bad},
+        )
+    assert bad not in str(caught.value)
+    assert "UNIGROK_OPENAI_CODING_MODEL" in str(caught.value)
+
+
+@pytest.mark.asyncio
+async def test_openai_fixed_endpoint_bounded_payload_and_receipt():
+    observed = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        observed["url"] = str(request.url)
+        observed["authorization"] = request.headers["Authorization"]
+        observed["payload"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "id": "resp_openai_1",
+                "model": "gpt-5.1-2026-01-01",
+                "status": "completed",
+                "output": [
+                    {
+                        "type": "message",
+                        "content": [{"type": "output_text", "text": "OpenAI answer"}],
+                    }
+                ],
+                "usage": {"input_tokens": 12, "output_tokens": 7, "total_tokens": 19},
+            },
+        )
+
+    client = async_client(handler)
+    try:
+        adapter = OpenAIAdapter(
+            client=client,
+            environ={
+                "OPENAI_API_KEY": "openai-test-secret",
+                "OPENAI_BASE_URL": "https://attacker.invalid",
+            },
+        )
+        response = await adapter.complete(normalized_request())
+    finally:
+        await client.aclose()
+
+    assert observed["url"] == "https://api.openai.com/v1/responses"
+    assert observed["authorization"] == "Bearer openai-test-secret"
+    assert observed["payload"]["max_output_tokens"] == 16_384
+    assert observed["payload"]["store"] is False
+    assert response.text == "OpenAI answer"
+    assert response.finish_reason == "stop"
+    assert response.model == "gpt-5.1-2026-01-01"
+    assert response.receipt.usage.total_tokens == 19
+    assert response.receipt.usage.source == "provider_exact"
+    receipt = response.receipt.model_dump_json()
+    assert "openai-test-secret" not in receipt
+    assert "attacker.invalid" not in receipt
+
+
+@pytest.mark.asyncio
+async def test_openai_refusal_and_length_are_normalized():
+    responses = iter(
+        [
+            {
+                "id": "resp_refusal",
+                "model": "gpt-5.1",
+                "status": "completed",
+                "output": [
+                    {"content": [{"type": "refusal", "refusal": "Cannot comply."}]}
+                ],
+            },
+            {
+                "id": "resp_length",
+                "model": "gpt-5.1",
+                "status": "incomplete",
+                "incomplete_details": {"reason": "max_output_tokens"},
+                "output": [
+                    {"content": [{"type": "output_text", "text": "Partial"}]}
+                ],
+            },
+            {
+                "id": "resp_unknown",
+                "model": "gpt-5.1",
+                "status": "unexpected",
+                "output": [
+                    {"content": [{"type": "output_text", "text": "Unverified"}]}
+                ],
+            },
+        ]
+    )
+
+    async def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=next(responses))
+
+    client = async_client(handler)
+    try:
+        adapter = OpenAIAdapter(client=client, environ={"OPENAI_API_KEY": "key"})
+        refusal = await adapter.attempt(normalized_request())
+        length = await adapter.attempt(
+            normalized_request(request_id="req-provider-2")
+        )
+        unknown = await adapter.attempt(
+            normalized_request(request_id="req-provider-3")
+        )
+    finally:
+        await client.aclose()
+    assert refusal.status == "returned"
+    assert refusal.response is not None
+    assert refusal.response.finish_reason == "content_filter"
+    assert length.status == "returned"
+    assert length.response is not None
+    assert length.response.finish_reason == "length"
+    assert unknown.status == "returned"
+    assert unknown.response is not None
+    assert unknown.response.finish_reason == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_missing_or_unsafe_upstream_model_is_explicit_requested_fallback():
+    unsafe_model = "unsafe model with secret-model-fragment"
+
+    async def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "id": "resp_model_fallback",
+                "model": unsafe_model,
+                "status": "completed",
+                "output": [{"content": [{"type": "output_text", "text": "answer"}]}],
+                "usage": {"input_tokens": 2, "total_tokens": 2},
+            },
+        )
+
+    client = async_client(handler)
+    try:
+        response = await OpenAIAdapter(
+            client=client,
+            environ={"OPENAI_API_KEY": "key"},
+        ).complete(normalized_request(model="gpt-5.1"))
+    finally:
+        await client.aclose()
+    assert response.model == "gpt-5.1"
+    assert response.receipt.model_source == "requested_fallback"
+    assert response.receipt.usage.source == "partial"
+    assert response.receipt.usage.output_tokens is None
+    assert unsafe_model not in response.model_dump_json()
+
+
+def test_invalid_usage_metadata_is_explicitly_partial_not_exact():
+    usage = OpenAIAdapter(environ={})._usage(-1, True, "not-a-count")
+    assert usage.source == "partial"
+    assert usage.input_tokens is None
+    assert usage.output_tokens is None
+    assert usage.total_tokens is None
+
+
+@pytest.mark.asyncio
+async def test_attempt_returns_output_or_secret_safe_failure_to_grok():
+    secret = "provider-secret-never-return"
+
+    async def returned_handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "id": "resp_1",
+                "model": "gpt-5.1",
+                "status": "completed",
+                "output": [
+                    {"content": [{"type": "output_text", "text": "worker output"}]}
+                ],
+                "usage": {"input_tokens": 2, "output_tokens": 3, "total_tokens": 5},
+            },
+        )
+
+    returned_client = async_client(returned_handler)
+    try:
+        returned = await OpenAIAdapter(
+            client=returned_client, environ={"OPENAI_API_KEY": secret}
+        ).attempt(normalized_request())
+    finally:
+        await returned_client.aclose()
+    assert returned.status == "returned"
+    assert returned.response is not None
+    assert returned.response.text == "worker output"
+    assert returned.response.receipt.supervision.session_id == "session-1"
+    assert returned.response.authority.may_finalize is False
+    assert returned.response.authority.may_route is False
+    assert returned.response.receipt.cost_usd is None
+    assert returned.response.receipt.cost_source == "unavailable"
+
+    # Missing credentials is the deterministic failure path; no live call occurs.
+    missing = await OpenAIAdapter(environ={}).attempt(normalized_request())
+    assert missing.status == "failed"
+    assert missing.failure is not None
+    assert missing.failure.error_kind == "configuration"
+    assert missing.failure.error_code == "credential_missing"
+    assert missing.failure.supervision.objective_id == "objective-1"
+    assert missing.failure.authority.may_verify is False
+    assert secret not in missing.model_dump_json()
+
+
+@pytest.mark.asyncio
+async def test_anthropic_accepts_both_key_names_with_canonical_precedence():
+    observed = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        observed["url"] = str(request.url)
+        observed["key"] = request.headers["x-api-key"]
+        observed["version"] = request.headers["anthropic-version"]
+        observed["payload"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "id": "msg_claude_1",
+                "model": "claude-fable-5",
+                "stop_reason": "end_turn",
+                "content": [{"type": "text", "text": "Claude answer"}],
+                "usage": {"input_tokens": 8, "output_tokens": 5},
+            },
+        )
+
+    client = async_client(handler)
+    try:
+        adapter = AnthropicAdapter(
+            client=client,
+            environ={
+                "ANTHROPIC_API_KEY": "canonical-key",
+                "CLAUDE_API_KEY": "alias-key",
+                "ANTHROPIC_BASE_URL": "https://attacker.invalid",
+            },
+        )
+        response = await adapter.complete(normalized_request())
+    finally:
+        await client.aclose()
+    assert observed["url"] == "https://api.anthropic.com/v1/messages"
+    assert observed["key"] == "canonical-key"
+    assert observed["version"] == "2023-06-01"
+    assert observed["payload"]["system"] == (
+        "Supervisor TTL expires at 2030-01-01T00:00:00Z; "
+        "do not claim work after it.\n\nBe concise."
+    )
+    assert observed["payload"]["messages"] == [
+        {"role": "user", "content": "Explain the result."}
+    ]
+    assert response.text == "Claude answer"
+    assert response.receipt.usage.total_tokens == 13
+    assert response.receipt.usage.source == "derived"
+
+
+@pytest.mark.asyncio
+async def test_anthropic_claude_key_alias_works_by_itself():
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["x-api-key"] == "claude-alias"
+        return httpx.Response(
+            200,
+            json={
+                "id": "msg_1",
+                "model": "claude-sonnet-5",
+                "stop_reason": "max_tokens",
+                "content": [{"type": "text", "text": "partial"}],
+            },
+        )
+
+    client = async_client(handler)
+    try:
+        adapter = AnthropicAdapter(client=client, environ={"CLAUDE_API_KEY": "claude-alias"})
+        response = await adapter.complete(normalized_request(route=RouteClass.CODING))
+    finally:
+        await client.aclose()
+    assert response.model == "claude-sonnet-5"
+    assert response.finish_reason == "length"
+    assert response.receipt.usage.source == "unavailable"
+    assert response.receipt.usage.input_tokens is None
+
+
+@pytest.mark.asyncio
+async def test_anthropic_rejects_unsupported_temperature_before_http():
+    calls = 0
+
+    async def handler(_: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        raise AssertionError("unsupported temperature reached HTTP")
+
+    client = async_client(handler)
+    try:
+        with pytest.raises(ProviderConfigurationError) as failed:
+            await AnthropicAdapter(
+                client=client,
+                environ={"ANTHROPIC_API_KEY": "key"},
+            ).complete(normalized_request(temperature=0.2))
+    finally:
+        await client.aclose()
+    assert failed.value.code == "temperature_unsupported"
+    assert calls == 0
+
+
+@pytest.mark.asyncio
+async def test_gemini_fixed_endpoint_excludes_thought_parts():
+    observed = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        observed["url"] = str(request.url)
+        observed["key"] = request.headers["x-goog-api-key"]
+        observed["payload"] = json.loads(request.content)
+        return httpx.Response(
+            200,
+            json={
+                "responseId": "gemini_response_1",
+                "modelVersion": "gemini-3.5-flash",
+                "candidates": [
+                    {
+                        "finishReason": "STOP",
+                        "content": {
+                            "parts": [
+                                {"thought": True, "text": "hidden reasoning"},
+                                {"text": "Gemini answer"},
+                            ]
+                        },
+                    }
+                ],
+                "usageMetadata": {
+                    "promptTokenCount": 10,
+                    "candidatesTokenCount": 4,
+                    "totalTokenCount": 14,
+                },
+            },
+        )
+
+    client = async_client(handler)
+    try:
+        adapter = GeminiAdapter(
+            client=client,
+            environ={
+                "GEMINI_API_KEY": "gemini-test-secret",
+                "GEMINI_BASE_URL": "https://attacker.invalid",
+            },
+        )
+        response = await adapter.complete(normalized_request())
+    finally:
+        await client.aclose()
+    assert observed["url"] == (
+        "https://generativelanguage.googleapis.com/v1beta/models/"
+        "gemini-3.5-flash:generateContent"
+    )
+    assert observed["key"] == "gemini-test-secret"
+    assert observed["payload"]["systemInstruction"] == {
+        "parts": [
+            {
+                "text": (
+                    "Supervisor TTL expires at 2030-01-01T00:00:00Z; "
+                    "do not claim work after it."
+                )
+            },
+            {"text": "Be concise."},
+        ]
+    }
+    assert observed["payload"]["generationConfig"]["maxOutputTokens"] == 32_768
+    assert response.text == "Gemini answer"
+    assert "hidden reasoning" not in response.text
+    assert "gemini-test-secret" not in response.receipt.model_dump_json()
+
+
+@pytest.mark.asyncio
+async def test_gemini_safety_block_is_a_valid_empty_filtered_response():
+    async def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "promptFeedback": {"blockReason": "SAFETY"},
+                "usageMetadata": {"promptTokenCount": 3, "totalTokenCount": 3},
+            },
+        )
+
+    client = async_client(handler)
+    try:
+        result = await GeminiAdapter(
+            client=client, environ={"GEMINI_API_KEY": "key"}
+        ).complete(normalized_request())
+    finally:
+        await client.aclose()
+    assert result.text == ""
+    assert result.finish_reason == "content_filter"
+
+
+@pytest.mark.asyncio
+async def test_vertex_adc_uses_fixed_regional_endpoint_and_opaque_project_receipt():
+    observed = {}
+
+    async def token_provider() -> ADCIdentity:
+        return ADCIdentity(
+            access_token=SecretStr("vertex-access-token"),
+            project_id="identity-project",
+        )
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        observed["url"] = str(request.url)
+        observed["authorization"] = request.headers["Authorization"]
+        return httpx.Response(
+            200,
+            json={
+                "responseId": "vertex_response_1",
+                "modelVersion": "gemini-3.5-flash",
+                "candidates": [
+                    {
+                        "finishReason": "STOP",
+                        "content": {"parts": [{"text": "Vertex answer"}]},
+                    }
+                ],
+                "usageMetadata": {
+                    "promptTokenCount": 9,
+                    "candidatesTokenCount": 3,
+                    "totalTokenCount": 12,
+                },
+            },
+        )
+
+    client = async_client(handler)
+    try:
+        adapter = VertexADCAdapter(
+            client=client,
+            environ={
+                "UNIGROK_VERTEX_PROJECT": "configured-project",
+                "UNIGROK_VERTEX_LOCATION": "us-central1",
+                "VERTEX_BASE_URL": "https://attacker.invalid",
+            },
+            token_provider=token_provider,
+        )
+        response = await adapter.complete(normalized_request())
+    finally:
+        await client.aclose()
+    assert observed["url"] == (
+        "https://us-central1-aiplatform.googleapis.com/v1/projects/"
+        "configured-project/locations/us-central1/publishers/google/models/"
+        "gemini-3.5-flash:generateContent"
+    )
+    assert observed["authorization"] == "Bearer vertex-access-token"
+    receipt = response.receipt.model_dump_json()
+    assert "vertex-access-token" not in receipt
+    assert "configured-project" not in receipt
+    assert "identity-project" not in receipt
+    assert response.receipt.account_fingerprint == opaque_fingerprint("configured-project")
+    assert response.receipt.region == "us-central1"
+
+
+@pytest.mark.asyncio
+async def test_vertex_adc_and_project_failures_are_secret_safe():
+    secret = "adc-secret-path-or-token"
+
+    async def broken_provider() -> ADCIdentity:
+        raise RuntimeError(secret)
+
+    adapter = VertexADCAdapter(environ={}, token_provider=broken_provider)
+    with pytest.raises(ProviderConfigurationError) as caught:
+        await adapter.complete(normalized_request())
+    assert secret not in str(caught.value)
+    assert caught.value.code == "adc_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_default_adc_loader_suppresses_third_party_error(monkeypatch):
+    secret = "private-adc-filename-and-token"
+
+    def broken_default(*_args, **_kwargs):
+        raise RuntimeError(secret)
+
+    monkeypatch.setattr("google.auth.default", broken_default)
+    with pytest.raises(ProviderConfigurationError) as caught:
+        await load_google_adc_identity()
+    assert secret not in str(caught.value)
+    assert caught.value.code == "adc_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_default_adc_refresh_caps_google_request_timeout(monkeypatch):
+    observed_timeouts: list[float] = []
+
+    class FakeRequest:
+        def __call__(self, *_args, timeout=None, **_kwargs):
+            observed_timeouts.append(timeout)
+            return object()
+
+    class FakeCredentials:
+        token = "adc-token"
+
+        def refresh(self, request):
+            request("https://metadata.invalid", timeout=99.0)
+
+    monkeypatch.setattr(
+        "google.auth.default",
+        lambda **_kwargs: (FakeCredentials(), "valid-project"),
+    )
+    monkeypatch.setattr("google.auth.transport.requests.Request", FakeRequest)
+    identity = await load_google_adc_identity(timeout_seconds=0.25)
+    assert identity.project_id == "valid-project"
+    assert observed_timeouts == [0.25]
+
+
+@pytest.mark.asyncio
+async def test_missing_key_and_http_error_bodies_never_escape():
+    with pytest.raises(ProviderConfigurationError) as missing:
+        await OpenAIAdapter(environ={}).complete(normalized_request())
+    assert missing.value.code == "credential_missing"
+
+    secret = "upstream-body-secret"
+
+    async def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(401, json={"error": {"message": secret}})
+
+    client = async_client(handler)
+    try:
+        with pytest.raises(ProviderTransportError) as failed:
+            await OpenAIAdapter(client=client, environ={"OPENAI_API_KEY": "key"}).complete(
+                normalized_request()
+            )
+    finally:
+        await client.aclose()
+    assert secret not in str(failed.value)
+    assert failed.value.code == "http_401"
+
+
+@pytest.mark.asyncio
+async def test_transport_exception_is_sanitized_and_redirect_is_not_followed():
+    secret = "transport-secret"
+
+    async def broken(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError(secret, request=request)
+
+    client = async_client(broken)
+    try:
+        with pytest.raises(ProviderTransportError) as failed:
+            await GeminiAdapter(client=client, environ={"GEMINI_API_KEY": "key"}).complete(
+                normalized_request()
+            )
+    finally:
+        await client.aclose()
+    assert secret not in str(failed.value)
+    assert failed.value.code == "transport_error"
+
+    calls = 0
+
+    async def redirect(_: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(307, headers={"Location": "https://attacker.invalid"})
+
+    client = async_client(redirect)
+    try:
+        with pytest.raises(ProviderTransportError) as redirected:
+            await AnthropicAdapter(
+                client=client, environ={"ANTHROPIC_API_KEY": "key"}
+            ).complete(normalized_request())
+    finally:
+        await client.aclose()
+    assert redirected.value.code == "http_307"
+    assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_response_size_and_shape_are_bounded():
+    chunks_requested: list[int] = []
+
+    class OversizedStream(httpx.AsyncByteStream):
+        async def __aiter__(self):
+            chunks_requested.append(MAX_PROVIDER_RESPONSE_BYTES)
+            yield b"x" * MAX_PROVIDER_RESPONSE_BYTES
+            chunks_requested.append(1)
+            yield b"y"
+            raise AssertionError("adapter kept buffering after crossing the cap")
+
+    async def huge(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, stream=OversizedStream())
+
+    client = async_client(huge)
+    try:
+        with pytest.raises(ProviderProtocolError) as failed:
+            await OpenAIAdapter(client=client, environ={"OPENAI_API_KEY": "key"}).complete(
+                normalized_request()
+            )
+    finally:
+        await client.aclose()
+    assert failed.value.code == "response_too_large"
+    assert chunks_requested == [MAX_PROVIDER_RESPONSE_BYTES, 1]
+
+
+def test_registry_is_inert_complete_and_secret_free():
+    secret_values = {
+        "OPENAI_API_KEY": "openai-secret",
+        "CLAUDE_API_KEY": "claude-secret",
+        "GEMINI_API_KEY": "gemini-secret",
+        "GOOGLE_APPLICATION_CREDENTIALS": "/private/adc-secret.json",
+    }
+    registry = build_provider_registry(environ=secret_values)
+    assert set(registry) == {
+        ProviderChannel.OPENAI_API,
+        ProviderChannel.ANTHROPIC_API,
+        ProviderChannel.GEMINI_API_KEY,
+        ProviderChannel.VERTEX_ADC,
+    }
+    assert all(isinstance(adapter, ProviderAdapter) for adapter in registry.values())
+    assert registry[ProviderChannel.OPENAI_API].descriptor.credential_state == CredentialState.CONFIGURED
+    assert registry[ProviderChannel.ANTHROPIC_API].descriptor.credential_state == CredentialState.CONFIGURED
+    assert registry[ProviderChannel.GEMINI_API_KEY].descriptor.credential_state == CredentialState.CONFIGURED
+    assert registry[ProviderChannel.VERTEX_ADC].descriptor.credential_state == CredentialState.DEFERRED
+    assert registry[ProviderChannel.GEMINI_API_KEY].descriptor.provider == ProviderId.GOOGLE
+    assert registry[ProviderChannel.VERTEX_ADC].descriptor.provider == ProviderId.GOOGLE
+    rendered = "\n".join(
+        adapter.descriptor.model_dump_json() for adapter in registry.values()
+    )
+    for value in secret_values.values():
+        assert value not in rendered
+
+
+def test_current_stable_model_defaults_are_route_specific():
+    registry = build_provider_registry(environ={})
+    assert registry[ProviderChannel.OPENAI_API].descriptor.models.planning == "gpt-5.1"
+    assert registry[ProviderChannel.ANTHROPIC_API].descriptor.models.planning == "claude-fable-5"
+    assert registry[ProviderChannel.ANTHROPIC_API].descriptor.models.coding == "claude-sonnet-5"
+    assert registry[ProviderChannel.GEMINI_API_KEY].descriptor.models.coding == "gemini-3.5-flash"
+    assert registry[ProviderChannel.VERTEX_ADC].descriptor.models.research == "gemini-3.5-flash"

--- a/uv.lock
+++ b/uv.lock
@@ -896,6 +896,7 @@ version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
+    { name = "google-auth", extra = ["requests"] },
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
     { name = "pydantic" },
@@ -932,6 +933,7 @@ dev = [
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "coverage", marker = "extra == 'forge'", specifier = ">=7.6" },
+    { name = "google-auth", extras = ["requests"], specifier = ">=2.40,<3" },
     { name = "google-genai", marker = "extra == 'campaign'", specifier = ">=1.25,<2" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.13.1" },


### PR DESCRIPTION
## Scope

Adds the provider-neutral API foundation for subordinate OpenAI, Anthropic, and Google workers. Grok remains the only supervisor: every request is bound to a Grok-owned session/objective/route/TTL envelope, worker authority is mechanically denied, and no adapter is wired to the public router in this PR. Google is one logical provider with Gemini API-key and Vertex ADC channels.

## Safety and truth guarantees

- Absolute end-to-end TTL covers credential acquisition, ADC refresh, streaming, and response emission
- Fixed first-party endpoints, one bounded attempt, streaming 4 MiB body cap, no redirect credential forwarding
- Neutral `returned|failed` transport states; refusal, truncation, or agreement never become semantic success
- Exact/partial/derived/unavailable usage provenance and explicit model provenance
- Secret-safe failures; OpenAI storage disabled; unsupported Claude 5 temperature rejected before network
- No live provider calls and no public router wiring

## Evidence

- Exact head: `48e486025a2b3eab4858cc1bc581091c923a8ef4`
- Changed paths: `src/providers/**`, `tests/test_provider_adapters.py`, `pyproject.toml`, `uv.lock`, and generated OKF API reference mirrors
- Independent exact-head review: approved after two adversarial repair rounds
- Provider-focused tests: 29 passed
- Rebased full suite: 1,549 passed
- Ruff, OKF parity, and `git diff --check`: clean

## Dependency / next gate

Adds `google-auth[requests]` for Vertex ADC. A later, separately reviewed Grok broker will own allowlists, same-provider plane fallback, parallelism, harvesting, and final synthesis.

Human sponsor: David Teli

Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=implementation