### PR TITLE
Separate xAI inference and management authority

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,8 @@ services:
       - >-
         chown -R 1000:1000 /home/appuser/.grok &&
         exec setpriv --reuid=1000 --regid=1000 --clear-groups
-        env -u XAI_API_KEY -u XAI_MANAGEMENT_API_KEY -u GROK_API_KEY
+        env -u XAI_API_KEY -u XAI_MANAGEMENT_API_KEY -u XAI_MANAGEMENT_KEY
+        -u GROK_API_KEY
         -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u CLAUDE_API_KEY
         -u GEMINI_API_KEY -u GOOGLE_API_KEY
         -u GOOGLE_APPLICATION_CREDENTIALS -u UNIGROK_API_KEYS

--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -1234,7 +1234,7 @@ class TaskMemoryMirror
 Best-effort cloud mirror for task_memory rows.
 
 Modeled on the knowledge collections adapter (find-or-create by name,
-single XAI_API_KEY client, run_blocking offload, warn-once) but with
+role-separated xAI management client, run_blocking offload, warn-once) but with
 instance state instead of module globals, soft-disable with exponential
 backoff instead of unbounded retries, and a token bucket bounding
 remote searches under bursty borderline traffic. Never raises.
@@ -3402,6 +3402,76 @@ async def build_model_catalog(include_cli: bool=True) -> Dict[str, Any]
 **Keywords:** build, model, catalog
 
 Build a structured catalog for API models, local CLI models, and profiles.
+
+### Function: `get_xai_inference_client` {#utils-get_xai_inference_client}
+
+```python
+def get_xai_inference_client()
+```
+
+**Keywords:** get, xai, inference, client
+
+Return the cached inference-only xAI SDK client.
+
+This constructor must never receive ``XAI_MANAGEMENT_API_KEY``.  Keeping
+the privilege boundary at construction time prevents an inference call
+path from gaining Collections/admin authority through the shared cache.
+
+### Function: `get_xai_client` {#utils-get_xai_client}
+
+```python
+def get_xai_client()
+```
+
+**Keywords:** get, xai, client
+
+Compatibility alias for the inference-only xAI client factory.
+
+### Function: `get_xai_management_client` {#utils-get_xai_management_client}
+
+```python
+def get_xai_management_client()
+```
+
+**Keywords:** get, xai, management, client
+
+Return the cached xAI Collections/admin client.
+
+The installed SDK requires the inference key alongside the management key
+when constructing its Collections service.  This factory is therefore the
+only place where both credentials may enter one SDK client, and callers are
+restricted to the RAG, knowledge, task-memory, and provider-harvest admin
+surfaces.
+
+### Function: `close_xai_inference_client` {#utils-close_xai_inference_client}
+
+```python
+def close_xai_inference_client()
+```
+
+**Keywords:** close, xai, inference, client
+
+Close only the inference client cache.
+
+### Function: `close_xai_management_client` {#utils-close_xai_management_client}
+
+```python
+def close_xai_management_client()
+```
+
+**Keywords:** close, xai, management, client
+
+Close only the Collections/admin client cache.
+
+### Function: `close_xai_client` {#utils-close_xai_client}
+
+```python
+def close_xai_client()
+```
+
+**Keywords:** close, xai, client
+
+Compatibility shutdown hook that closes both role-separated caches.
 
 ### Class: `CircuitBreakerOpenError` {#utils-circuitbreakeropenerror}
 

--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -1218,10 +1218,11 @@ def has_management_key() -> bool
 xAI Collections is a MANAGEMENT API: the inference key alone cannot
 create/upload/search collections, and xAI exposes no public embedding
 models to inference keys (/v1/embedding-models returns []). Most users
-therefore run WITHOUT this key — the semantic routing evidence works
-fully locally (task_memory_fts bm25 + recency + per-model success); the
-cloud mirror is an optional boost gated on this check so keyless setups
-never spawn doomed sync work or remote searches.
+therefore run WITHOUT either supported management-key alias — the
+semantic routing evidence works fully locally (task_memory_fts bm25 +
+recency + per-model success); the cloud mirror is an optional boost gated
+on this check so keyless setups never spawn doomed sync work or remote
+searches.
 
 ### Class: `TaskMemoryMirror` {#rag-taskmemorymirror}
 
@@ -3403,6 +3404,16 @@ async def build_model_catalog(include_cli: bool=True) -> Dict[str, Any]
 
 Build a structured catalog for API models, local CLI models, and profiles.
 
+### Function: `xai_management_key_configured` {#utils-xai_management_key_configured}
+
+```python
+def xai_management_key_configured() -> bool
+```
+
+**Keywords:** xai, management, key, configured
+
+Return whether one unambiguous xAI management credential is configured.
+
 ### Function: `get_xai_inference_client` {#utils-get_xai_inference_client}
 
 ```python
@@ -3413,9 +3424,11 @@ def get_xai_inference_client()
 
 Return the cached inference-only xAI SDK client.
 
-This constructor must never receive ``XAI_MANAGEMENT_API_KEY``.  Keeping
-the privilege boundary at construction time prevents an inference call
-path from gaining Collections/admin authority through the shared cache.
+The installed SDK reads ``XAI_MANAGEMENT_KEY`` whenever its management
+argument is falsey.  Pass a fixed, non-provider isolation canary instead of
+mutating process environment, then deny Collections on the returned
+surface.  Real management credentials can therefore never enter this
+client's channel or inference call paths.
 
 ### Function: `get_xai_client` {#utils-get_xai_client}
 

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -1234,7 +1234,7 @@ class TaskMemoryMirror
 Best-effort cloud mirror for task_memory rows.
 
 Modeled on the knowledge collections adapter (find-or-create by name,
-single XAI_API_KEY client, run_blocking offload, warn-once) but with
+role-separated xAI management client, run_blocking offload, warn-once) but with
 instance state instead of module globals, soft-disable with exponential
 backoff instead of unbounded retries, and a token bucket bounding
 remote searches under bursty borderline traffic. Never raises.
@@ -3402,6 +3402,76 @@ async def build_model_catalog(include_cli: bool=True) -> Dict[str, Any]
 **Keywords:** build, model, catalog
 
 Build a structured catalog for API models, local CLI models, and profiles.
+
+### Function: `get_xai_inference_client` {#utils-get_xai_inference_client}
+
+```python
+def get_xai_inference_client()
+```
+
+**Keywords:** get, xai, inference, client
+
+Return the cached inference-only xAI SDK client.
+
+This constructor must never receive ``XAI_MANAGEMENT_API_KEY``.  Keeping
+the privilege boundary at construction time prevents an inference call
+path from gaining Collections/admin authority through the shared cache.
+
+### Function: `get_xai_client` {#utils-get_xai_client}
+
+```python
+def get_xai_client()
+```
+
+**Keywords:** get, xai, client
+
+Compatibility alias for the inference-only xAI client factory.
+
+### Function: `get_xai_management_client` {#utils-get_xai_management_client}
+
+```python
+def get_xai_management_client()
+```
+
+**Keywords:** get, xai, management, client
+
+Return the cached xAI Collections/admin client.
+
+The installed SDK requires the inference key alongside the management key
+when constructing its Collections service.  This factory is therefore the
+only place where both credentials may enter one SDK client, and callers are
+restricted to the RAG, knowledge, task-memory, and provider-harvest admin
+surfaces.
+
+### Function: `close_xai_inference_client` {#utils-close_xai_inference_client}
+
+```python
+def close_xai_inference_client()
+```
+
+**Keywords:** close, xai, inference, client
+
+Close only the inference client cache.
+
+### Function: `close_xai_management_client` {#utils-close_xai_management_client}
+
+```python
+def close_xai_management_client()
+```
+
+**Keywords:** close, xai, management, client
+
+Close only the Collections/admin client cache.
+
+### Function: `close_xai_client` {#utils-close_xai_client}
+
+```python
+def close_xai_client()
+```
+
+**Keywords:** close, xai, client
+
+Compatibility shutdown hook that closes both role-separated caches.
 
 ### Class: `CircuitBreakerOpenError` {#utils-circuitbreakeropenerror}
 

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -1218,10 +1218,11 @@ def has_management_key() -> bool
 xAI Collections is a MANAGEMENT API: the inference key alone cannot
 create/upload/search collections, and xAI exposes no public embedding
 models to inference keys (/v1/embedding-models returns []). Most users
-therefore run WITHOUT this key — the semantic routing evidence works
-fully locally (task_memory_fts bm25 + recency + per-model success); the
-cloud mirror is an optional boost gated on this check so keyless setups
-never spawn doomed sync work or remote searches.
+therefore run WITHOUT either supported management-key alias — the
+semantic routing evidence works fully locally (task_memory_fts bm25 +
+recency + per-model success); the cloud mirror is an optional boost gated
+on this check so keyless setups never spawn doomed sync work or remote
+searches.
 
 ### Class: `TaskMemoryMirror` {#rag-taskmemorymirror}
 
@@ -3403,6 +3404,16 @@ async def build_model_catalog(include_cli: bool=True) -> Dict[str, Any]
 
 Build a structured catalog for API models, local CLI models, and profiles.
 
+### Function: `xai_management_key_configured` {#utils-xai_management_key_configured}
+
+```python
+def xai_management_key_configured() -> bool
+```
+
+**Keywords:** xai, management, key, configured
+
+Return whether one unambiguous xAI management credential is configured.
+
 ### Function: `get_xai_inference_client` {#utils-get_xai_inference_client}
 
 ```python
@@ -3413,9 +3424,11 @@ def get_xai_inference_client()
 
 Return the cached inference-only xAI SDK client.
 
-This constructor must never receive ``XAI_MANAGEMENT_API_KEY``.  Keeping
-the privilege boundary at construction time prevents an inference call
-path from gaining Collections/admin authority through the shared cache.
+The installed SDK reads ``XAI_MANAGEMENT_KEY`` whenever its management
+argument is falsey.  Pass a fixed, non-provider isolation canary instead of
+mutating process environment, then deny Collections on the returned
+surface.  Real management credentials can therefore never enter this
+client's channel or inference call paths.
 
 ### Function: `get_xai_client` {#utils-get_xai_client}
 

--- a/src/credentials.py
+++ b/src/credentials.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, Optional
 UPSTREAM_PROVIDER_SECRET_ENV_NAMES = (
     "XAI_API_KEY",
     "XAI_MANAGEMENT_API_KEY",
+    "XAI_MANAGEMENT_KEY",
     "GROK_API_KEY",
     "OPENAI_API_KEY",
     "ANTHROPIC_API_KEY",

--- a/src/credentials.py
+++ b/src/credentials.py
@@ -11,7 +11,7 @@ import os
 from typing import Any, Dict, Optional
 
 
-SERVER_OWNED_SECRET_ENV_NAMES = (
+UPSTREAM_PROVIDER_SECRET_ENV_NAMES = (
     "XAI_API_KEY",
     "XAI_MANAGEMENT_API_KEY",
     "GROK_API_KEY",
@@ -20,8 +20,17 @@ SERVER_OWNED_SECRET_ENV_NAMES = (
     "CLAUDE_API_KEY",
     "GEMINI_API_KEY",
     "GOOGLE_API_KEY",
+)
+# These server-owned values must be scrubbed from Grok CLI subprocesses, but
+# they are not upstream provider bearer secrets: one is a credential-file path
+# and the other is the gateway's own client-token allowlist.
+NON_BEARER_SERVER_OWNED_ENV_NAMES = (
     "GOOGLE_APPLICATION_CREDENTIALS",
     "UNIGROK_API_KEYS",
+)
+SERVER_OWNED_SECRET_ENV_NAMES = (
+    *UPSTREAM_PROVIDER_SECRET_ENV_NAMES,
+    *NON_BEARER_SERVER_OWNED_ENV_NAMES,
 )
 _CLI_AUTH_ENV_UNSETS = " ".join(
     f"-u {name}" for name in SERVER_OWNED_SECRET_ENV_NAMES

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -28,6 +28,7 @@ from starlette.staticfiles import StaticFiles
 
 from .version import UI_ASSET_VERSION
 
+from .credentials import UPSTREAM_PROVIDER_SECRET_ENV_NAMES
 from .identity import (
     _ACTIVE_CLIENT_ID,
     _ACTIVE_SESSION_ID,
@@ -68,14 +69,6 @@ from .utils import (
 
 UNIGROK_AGENT_MODEL = "unigrok-agent"
 XAI_BASE_URL = "https://api.x.ai/v1"
-_UPSTREAM_PROVIDER_SECRET_ENV_NAMES = (
-    "XAI_API_KEY",
-    "XAI_MANAGEMENT_API_KEY",
-    "OPENAI_API_KEY",
-    "ANTHROPIC_API_KEY",
-    "CLAUDE_API_KEY",
-    "GEMINI_API_KEY",
-)
 FALLBACK_XAI_MODELS = FALLBACK_XAI_LANGUAGE_MODELS
 
 logger = logging.getLogger("GrokMCP")
@@ -360,7 +353,7 @@ def _token_is_allowed(token: Optional[str]) -> bool:
     # Server-owned upstream provider credentials are never valid gateway
     # client credentials.  Reject accidental aliases even when an operator
     # also copied the same value into UNIGROK_API_KEYS.
-    for env_name in _UPSTREAM_PROVIDER_SECRET_ENV_NAMES:
+    for env_name in UPSTREAM_PROVIDER_SECRET_ENV_NAMES:
         upstream_secret = os.environ.get(env_name, "").strip()
         if upstream_secret and _tokens_match(token, upstream_secret):
             return False

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -68,6 +68,14 @@ from .utils import (
 
 UNIGROK_AGENT_MODEL = "unigrok-agent"
 XAI_BASE_URL = "https://api.x.ai/v1"
+_UPSTREAM_PROVIDER_SECRET_ENV_NAMES = (
+    "XAI_API_KEY",
+    "XAI_MANAGEMENT_API_KEY",
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_API_KEY",
+    "GEMINI_API_KEY",
+)
 FALLBACK_XAI_MODELS = FALLBACK_XAI_LANGUAGE_MODELS
 
 logger = logging.getLogger("GrokMCP")
@@ -349,11 +357,13 @@ def _tokens_match(candidate: str, expected: str) -> bool:
 def _token_is_allowed(token: Optional[str]) -> bool:
     if not token:
         return False
-    xai_key = os.environ.get("XAI_API_KEY", "")
-    # The upstream xAI key is never a valid client credential: leaking it into
-    # a client config must not grant gateway access.
-    if xai_key and _tokens_match(token, xai_key):
-        return False
+    # Server-owned upstream provider credentials are never valid gateway
+    # client credentials.  Reject accidental aliases even when an operator
+    # also copied the same value into UNIGROK_API_KEYS.
+    for env_name in _UPSTREAM_PROVIDER_SECRET_ENV_NAMES:
+        upstream_secret = os.environ.get(env_name, "").strip()
+        if upstream_secret and _tokens_match(token, upstream_secret):
+            return False
     return any(_tokens_match(token, key) for key in _api_keys())
 
 

--- a/src/provider_harvest.py
+++ b/src/provider_harvest.py
@@ -356,7 +356,7 @@ class XAIWorkerEpisodeUploader:
     def __init__(
         self,
         *,
-        client_factory: Callable[[], Any] = _utils.get_xai_client,
+        client_factory: Callable[[], Any] = _utils.get_xai_management_client,
         unavailable_reason: Callable[[], str | None] | None = None,
         collection_name: str | None = None,
     ) -> None:
@@ -392,7 +392,7 @@ class XAIWorkerEpisodeUploader:
         try:
             client = self._client_factory()
         except Exception:
-            return None, "inference_client_unavailable"
+            return None, "management_client_unavailable"
         service = getattr(client, "collections", None)
         if service is None or not all(
             callable(getattr(service, name, None))

--- a/src/provider_harvest.py
+++ b/src/provider_harvest.py
@@ -371,7 +371,7 @@ class XAIWorkerEpisodeUploader:
 
     @staticmethod
     def _default_unavailable_reason() -> str | None:
-        if not os.environ.get("XAI_MANAGEMENT_API_KEY", "").strip():
+        if not _utils.xai_management_key_configured():
             return "management_key_missing"
         if not str(_utils.XAI_API_KEY or "").strip():
             return "inference_client_missing"

--- a/src/rag.py
+++ b/src/rag.py
@@ -43,7 +43,7 @@ from .utils import (
     _collections_capable,
     _env_timeout,
     _task_hash,
-    get_xai_client,
+    get_xai_management_client,
     run_blocking,
 )
 
@@ -203,7 +203,7 @@ class TaskMemoryMirror:
     """Best-effort cloud mirror for task_memory rows.
 
     Modeled on the knowledge collections adapter (find-or-create by name,
-    single XAI_API_KEY client, run_blocking offload, warn-once) but with
+    role-separated xAI management client, run_blocking offload, warn-once) but with
     instance state instead of module globals, soft-disable with exponential
     backoff instead of unbounded retries, and a token bucket bounding
     remote searches under bursty borderline traffic. Never raises."""
@@ -340,7 +340,7 @@ class TaskMemoryMirror:
             return False
 
         def _probe():
-            client = get_xai_client()
+            client = get_xai_management_client()
             if not _collections_capable(client):
                 raise RuntimeError("installed xai_sdk lacks the collections service surface")
             if not self._resolve_collection_id(client):
@@ -363,7 +363,7 @@ class TaskMemoryMirror:
             return None
 
         def _upload():
-            client = get_xai_client()
+            client = get_xai_management_client()
             if not _collections_capable(client):
                 raise RuntimeError("installed xai_sdk lacks the collections service surface")
             collection_id = self._resolve_collection_id(client)
@@ -401,7 +401,7 @@ class TaskMemoryMirror:
             return []
 
         def _search():
-            client = get_xai_client()
+            client = get_xai_management_client()
             if not _collections_capable(client):
                 raise RuntimeError("installed xai_sdk lacks the collections service surface")
             collection_id = self._resolve_collection_id(client)

--- a/src/rag.py
+++ b/src/rag.py
@@ -45,6 +45,7 @@ from .utils import (
     _task_hash,
     get_xai_management_client,
     run_blocking,
+    xai_management_key_configured,
 )
 
 _LOGGER = "GrokMCP"
@@ -114,11 +115,12 @@ def has_management_key() -> bool:
     """xAI Collections is a MANAGEMENT API: the inference key alone cannot
     create/upload/search collections, and xAI exposes no public embedding
     models to inference keys (/v1/embedding-models returns []). Most users
-    therefore run WITHOUT this key — the semantic routing evidence works
-    fully locally (task_memory_fts bm25 + recency + per-model success); the
-    cloud mirror is an optional boost gated on this check so keyless setups
-    never spawn doomed sync work or remote searches."""
-    return bool(os.environ.get("XAI_MANAGEMENT_API_KEY", "").strip())
+    therefore run WITHOUT either supported management-key alias — the
+    semantic routing evidence works fully locally (task_memory_fts bm25 +
+    recency + per-model success); the cloud mirror is an optional boost gated
+    on this check so keyless setups never spawn doomed sync work or remote
+    searches."""
+    return xai_management_key_configured()
 
 
 def task_rag_timeout() -> float:
@@ -336,7 +338,7 @@ class TaskMemoryMirror:
             # Not an error: the mirror is an optional boost. Report the
             # reason without burning a probe or tripping failure backoff.
             self.last_known_ready = False
-            self._last_error = "XAI_MANAGEMENT_API_KEY not set (cloud mirror is optional)"
+            self._last_error = "xAI management key not set (cloud mirror is optional)"
             return False
 
         def _probe():
@@ -698,7 +700,7 @@ async def gather_semantic_evidence(
             prompt, context_id=context_id, limit=10, verified_only=True
         )
         local = [row for row in local if row.get("success") in (0, 1)]
-        # Keyless setups (no XAI_MANAGEMENT_API_KEY — the common case) run
+        # Keyless setups (no xAI management key — the common case) run
         # pure local evidence: fusion and the decision signal work the same
         # with an empty remote component.
         remote_hits: List[Dict[str, Any]] = []
@@ -817,10 +819,13 @@ async def _rag_status(store: Any, out: TextIO) -> int:
     elif not has_management_key():
         print(
             "cloud mirror: disabled — optional; set XAI_MANAGEMENT_API_KEY "
-            "(xAI console) to sync/search collections",
+            "(or SDK alias XAI_MANAGEMENT_KEY) to sync/search collections",
             file=out,
         )
-        print("ready: no (XAI_MANAGEMENT_API_KEY not set; cloud mirror is optional)", file=out)
+        print(
+            "ready: no (xAI management key not set; cloud mirror is optional)",
+            file=out,
+        )
     elif await mirror.ready():
         print("cloud mirror: enabled", file=out)
         print("ready: yes", file=out)
@@ -858,9 +863,9 @@ async def _rag_backfill(
     if not has_management_key() and not dry_run:
         # --dry-run stays available keyless (purely local outbox inspection).
         print(
-            "The cloud mirror needs XAI_MANAGEMENT_API_KEY (created in the xAI "
-            "console, separate from the inference key). It is OPTIONAL: local "
-            "semantic routing evidence already works without it.",
+            "The cloud mirror needs XAI_MANAGEMENT_API_KEY (or SDK alias "
+            "XAI_MANAGEMENT_KEY), separate from the inference key. It is "
+            "OPTIONAL: local semantic routing evidence already works without it.",
             file=out,
         )
         return 1

--- a/src/utils.py
+++ b/src/utils.py
@@ -1867,13 +1867,26 @@ async def build_model_catalog(include_cli: bool = True) -> Dict[str, Any]:
         },
     }
 
-# Global Client Connection Pool
+# Global xAI client connection pools.  The inference client is intentionally
+# incapable of carrying management authority; Collections/admin call sites use
+# the separately named management factory below.
 _client = None
-# get_xai_client is called from executor threads — guard the check-then-set so
-# concurrent first calls cannot leak duplicate Client instances.
+_management_client = None
+# Both factories are called from executor threads — guard each check-then-set
+# so concurrent first calls cannot leak duplicate Client instances or cross
+# their credential-authority caches.
 _client_lock = threading.Lock()
+_management_client_lock = threading.Lock()
 
-def get_xai_client():
+
+def get_xai_inference_client():
+    """Return the cached inference-only xAI SDK client.
+
+    This constructor must never receive ``XAI_MANAGEMENT_API_KEY``.  Keeping
+    the privilege boundary at construction time prevents an inference call
+    path from gaining Collections/admin authority through the shared cache.
+    """
+
     global _client
     if _client is None:
         with _client_lock:
@@ -1881,13 +1894,8 @@ def get_xai_client():
                 if not XAI_API_KEY:
                     raise ValueError("XAI_API_KEY is not configured in the environment.")
                 from xai_sdk import Client
-                # Collections (knowledge + task-memory mirrors) require a
-                # SEPARATE management API key on the xAI side — the inference
-                # key alone yields "Please provide a management API key."
-                # Optional: unset keeps inference-only behavior, and the
-                # mirrors fail open with that exact reason in `rag status`.
-                management_key = os.getenv("XAI_MANAGEMENT_API_KEY", "").strip() or None
-                _client = Client(api_key=XAI_API_KEY, management_api_key=management_key)
+
+                _client = Client(api_key=XAI_API_KEY)
     if _eval_record_enabled():
         # Opt-in eval recording tap (UNIGROK_EVAL_RECORD=1): a thin per-call
         # proxy that appends completed responses to a cassette event log.
@@ -1895,7 +1903,48 @@ def get_xai_client():
         return _EvalRecordingClient(_client)
     return _client
 
-def close_xai_client():
+
+def get_xai_client():
+    """Compatibility alias for the inference-only xAI client factory."""
+
+    return get_xai_inference_client()
+
+
+def get_xai_management_client():
+    """Return the cached xAI Collections/admin client.
+
+    The installed SDK requires the inference key alongside the management key
+    when constructing its Collections service.  This factory is therefore the
+    only place where both credentials may enter one SDK client, and callers are
+    restricted to the RAG, knowledge, task-memory, and provider-harvest admin
+    surfaces.
+    """
+
+    global _management_client
+    if _management_client is None:
+        with _management_client_lock:
+            if _management_client is None:
+                if not XAI_API_KEY:
+                    raise ValueError(
+                        "XAI_API_KEY is not configured for the xAI management client."
+                    )
+                management_key = os.getenv("XAI_MANAGEMENT_API_KEY", "").strip()
+                if not management_key:
+                    raise ValueError(
+                        "XAI_MANAGEMENT_API_KEY is not configured in the environment."
+                    )
+                from xai_sdk import Client
+
+                _management_client = Client(
+                    api_key=XAI_API_KEY,
+                    management_api_key=management_key,
+                )
+    return _management_client
+
+
+def close_xai_inference_client():
+    """Close only the inference client cache."""
+
     global _client
     with _client_lock:
         if _client is not None:
@@ -1906,9 +1955,29 @@ def close_xai_client():
             _client = None
 
 
+def close_xai_management_client():
+    """Close only the Collections/admin client cache."""
+
+    global _management_client
+    with _management_client_lock:
+        if _management_client is not None:
+            try:
+                _management_client.close()
+            except Exception:
+                pass
+            _management_client = None
+
+
+def close_xai_client():
+    """Compatibility shutdown hook that closes both role-separated caches."""
+
+    close_xai_inference_client()
+    close_xai_management_client()
+
+
 # ─── Eval Recording Tap (UNIGROK_EVAL_RECORD) ────────────────────────────────
 # OFF by default; zero behavior change while off. With UNIGROK_EVAL_RECORD
-# truthy, get_xai_client() hands back a thin proxy whose chats append one
+# truthy, get_xai_inference_client() hands back a thin proxy whose chats append one
 # JSON line per completed sample()/parse() — (model, prompt-hash, response
 # content/usage/cost) — to UNIGROK_EVAL_RECORD_FILE (default
 # evals/cassettes/recorded.jsonl). Real traffic becomes cassette raw material
@@ -9584,7 +9653,7 @@ async def sync_fact_to_collection(
         return False
 
     def _upload():
-        client = get_xai_client()
+        client = get_xai_management_client()
         if not _collections_capable(client):
             raise RuntimeError("installed xai_sdk lacks the collections service surface")
         collection_id = _resolve_knowledge_collection_id(client)
@@ -9614,7 +9683,7 @@ async def search_knowledge_collection(query: str, limit: int = 5) -> List[Dict[s
         return []
 
     def _search():
-        client = get_xai_client()
+        client = get_xai_management_client()
         if not _collections_capable(client):
             raise RuntimeError("installed xai_sdk lacks the collections service surface")
         collection_id = _resolve_knowledge_collection_id(client)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1877,14 +1877,64 @@ _management_client = None
 # their credential-authority caches.
 _client_lock = threading.Lock()
 _management_client_lock = threading.Lock()
+_XAI_INFERENCE_MANAGEMENT_ISOLATION_KEY = (
+    "unigrok-inference-only-no-management-authority"
+)
+
+
+class _InferenceOnlyXAIClient:
+    """Delegate xAI inference surfaces while denying Collections access."""
+
+    __slots__ = ("_delegate",)
+
+    def __init__(self, delegate: Any) -> None:
+        self._delegate = delegate
+
+    def __getattr__(self, name: str) -> Any:
+        if name == "collections":
+            raise AttributeError("Collections require the xAI management client")
+        return getattr(self._delegate, name)
+
+    def close(self) -> None:
+        self._delegate.close()
+
+
+def _resolve_xai_management_key() -> str:
+    """Resolve canonical/SDK management-key aliases without exposing a value."""
+
+    canonical = os.getenv("XAI_MANAGEMENT_API_KEY", "").strip()
+    sdk_alias = os.getenv("XAI_MANAGEMENT_KEY", "").strip()
+    if canonical and sdk_alias and canonical != sdk_alias:
+        raise ValueError(
+            "XAI_MANAGEMENT_API_KEY and XAI_MANAGEMENT_KEY are both configured "
+            "with different values."
+        )
+    resolved = canonical or sdk_alias
+    if not resolved:
+        raise ValueError(
+            "XAI_MANAGEMENT_API_KEY or XAI_MANAGEMENT_KEY must be configured."
+        )
+    return resolved
+
+
+def xai_management_key_configured() -> bool:
+    """Return whether one unambiguous xAI management credential is configured."""
+
+    try:
+        _resolve_xai_management_key()
+    except ValueError:
+        return False
+    return True
 
 
 def get_xai_inference_client():
     """Return the cached inference-only xAI SDK client.
 
-    This constructor must never receive ``XAI_MANAGEMENT_API_KEY``.  Keeping
-    the privilege boundary at construction time prevents an inference call
-    path from gaining Collections/admin authority through the shared cache.
+    The installed SDK reads ``XAI_MANAGEMENT_KEY`` whenever its management
+    argument is falsey.  Pass a fixed, non-provider isolation canary instead of
+    mutating process environment, then deny Collections on the returned
+    surface.  Real management credentials can therefore never enter this
+    client's channel or inference call paths.
     """
 
     global _client
@@ -1895,7 +1945,11 @@ def get_xai_inference_client():
                     raise ValueError("XAI_API_KEY is not configured in the environment.")
                 from xai_sdk import Client
 
-                _client = Client(api_key=XAI_API_KEY)
+                raw_client = Client(
+                    api_key=XAI_API_KEY,
+                    management_api_key=_XAI_INFERENCE_MANAGEMENT_ISOLATION_KEY,
+                )
+                _client = _InferenceOnlyXAIClient(raw_client)
     if _eval_record_enabled():
         # Opt-in eval recording tap (UNIGROK_EVAL_RECORD=1): a thin per-call
         # proxy that appends completed responses to a cassette event log.
@@ -1928,11 +1982,7 @@ def get_xai_management_client():
                     raise ValueError(
                         "XAI_API_KEY is not configured for the xAI management client."
                     )
-                management_key = os.getenv("XAI_MANAGEMENT_API_KEY", "").strip()
-                if not management_key:
-                    raise ValueError(
-                        "XAI_MANAGEMENT_API_KEY is not configured in the environment."
-                    )
+                management_key = _resolve_xai_management_key()
                 from xai_sdk import Client
 
                 _management_client = Client(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,12 +21,14 @@ def setup_test_env(tmp_path_factory):
 @pytest.fixture(autouse=True)
 def reset_global_client():
     src.utils._client = None
+    src.utils._management_client = None
     src.utils._MODEL_MAX_TOKENS_CACHE.clear()
     src.utils._BREAKER_STATE.clear()
     src.utils._ROUTING_ADVISOR.invalidate()
     src.utils._CALLER_SPEND_CACHE.clear()
     yield
     src.utils._client = None
+    src.utils._management_client = None
     src.utils._MODEL_MAX_TOKENS_CACHE.clear()
     src.utils._BREAKER_STATE.clear()
     src.utils._ROUTING_ADVISOR.invalidate()
@@ -38,4 +40,3 @@ async def cleanup_global_store(setup_test_env):
     yield
     from src.utils import store
     await store.close()
-

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -147,9 +147,8 @@ def test_inference_key_alone_never_satisfies_management_readiness(monkeypatch):
     created = {}
 
     class FakeClient:
-        def __init__(self, api_key=None, management_api_key=None):
-            created["api_key"] = api_key
-            created["management_api_key"] = management_api_key
+        def __init__(self, **kwargs):
+            created.update(kwargs)
 
     monkeypatch.setenv("XAI_API_KEY", "xai-inference-only")
     monkeypatch.delenv("XAI_MANAGEMENT_API_KEY", raising=False)
@@ -160,10 +159,7 @@ def test_inference_key_alone_never_satisfies_management_readiness(monkeypatch):
     assert utils.xai_api_key_configured() is True
     assert rag.has_management_key() is False
     utils.get_xai_client()
-    assert created == {
-        "api_key": "xai-inference-only",
-        "management_api_key": None,
-    }
+    assert created == {"api_key": "xai-inference-only"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
@@ -16,6 +17,17 @@ def test_cli_auth_setup_scrubs_server_credentials_but_keeps_oauth_path():
         assert f"-u {name}" in CLI_AUTH_SETUP_COMMAND
     assert "-u GROK_AUTH_PATH" not in CLI_AUTH_SETUP_COMMAND
     assert "-u GOOGLE_CLOUD_PROJECT" not in CLI_AUTH_SETUP_COMMAND
+
+
+def test_compose_cli_auth_scrubs_every_canonical_server_credential():
+    compose = (Path(__file__).resolve().parents[1] / "docker-compose.yml").read_text(
+        encoding="utf-8"
+    )
+    auth_service = compose.split("  grok-cli-auth:", 1)[1].split("\nvolumes:", 1)[0]
+
+    for name in SERVER_OWNED_SECRET_ENV_NAMES:
+        assert f"-u {name}" in auth_service
+    assert "grok login --device-auth" in auth_service
 
 
 READY_CLI = {
@@ -152,6 +164,7 @@ def test_inference_key_alone_never_satisfies_management_readiness(monkeypatch):
 
     monkeypatch.setenv("XAI_API_KEY", "xai-inference-only")
     monkeypatch.delenv("XAI_MANAGEMENT_API_KEY", raising=False)
+    monkeypatch.delenv("XAI_MANAGEMENT_KEY", raising=False)
     monkeypatch.setattr(utils, "XAI_API_KEY", "xai-inference-only")
     monkeypatch.setattr(utils, "_client", None)
     monkeypatch.setattr("xai_sdk.Client", FakeClient)
@@ -159,7 +172,10 @@ def test_inference_key_alone_never_satisfies_management_readiness(monkeypatch):
     assert utils.xai_api_key_configured() is True
     assert rag.has_management_key() is False
     utils.get_xai_client()
-    assert created == {"api_key": "xai-inference-only"}
+    assert created == {
+        "api_key": "xai-inference-only",
+        "management_api_key": utils._XAI_INFERENCE_MANAGEMENT_ISOLATION_KEY,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -656,6 +656,7 @@ def test_upstream_provider_secret_registry_completely_classifies_server_envs():
     assert set(UPSTREAM_PROVIDER_SECRET_ENV_NAMES) == {
         "XAI_API_KEY",
         "XAI_MANAGEMENT_API_KEY",
+        "XAI_MANAGEMENT_KEY",
         "GROK_API_KEY",
         "OPENAI_API_KEY",
         "ANTHROPIC_API_KEY",

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -6,6 +6,11 @@ import pytest
 from starlette.responses import JSONResponse
 from starlette.testclient import TestClient
 
+from src.credentials import (
+    NON_BEARER_SERVER_OWNED_ENV_NAMES,
+    SERVER_OWNED_SECRET_ENV_NAMES,
+    UPSTREAM_PROVIDER_SECRET_ENV_NAMES,
+)
 from src.http_server import (
     GatewayAuthMiddleware,
     MCPOriginMiddleware,
@@ -632,14 +637,7 @@ def test_readyz_body_stays_boolean_on_failure(monkeypatch):
 
 @pytest.mark.parametrize(
     "secret_env",
-    [
-        "XAI_API_KEY",
-        "XAI_MANAGEMENT_API_KEY",
-        "OPENAI_API_KEY",
-        "ANTHROPIC_API_KEY",
-        "CLAUDE_API_KEY",
-        "GEMINI_API_KEY",
-    ],
+    UPSTREAM_PROVIDER_SECRET_ENV_NAMES,
 )
 def test_upstream_provider_secret_is_not_client_auth(monkeypatch, secret_env):
     monkeypatch.setenv("UNIGROK_RUNTIME", "cloudrun")
@@ -654,18 +652,34 @@ def test_upstream_provider_secret_is_not_client_auth(monkeypatch, secret_env):
     assert res.status_code == 401
 
 
+def test_upstream_provider_secret_registry_completely_classifies_server_envs():
+    assert set(UPSTREAM_PROVIDER_SECRET_ENV_NAMES) == {
+        "XAI_API_KEY",
+        "XAI_MANAGEMENT_API_KEY",
+        "GROK_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "CLAUDE_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+    }
+    assert set(NON_BEARER_SERVER_OWNED_ENV_NAMES) == {
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "UNIGROK_API_KEYS",
+    }
+    assert not (
+        set(UPSTREAM_PROVIDER_SECRET_ENV_NAMES)
+        & set(NON_BEARER_SERVER_OWNED_ENV_NAMES)
+    )
+    assert set(SERVER_OWNED_SECRET_ENV_NAMES) == (
+        set(UPSTREAM_PROVIDER_SECRET_ENV_NAMES)
+        | set(NON_BEARER_SERVER_OWNED_ENV_NAMES)
+    )
+
+
 def test_distinct_gateway_key_remains_valid_with_upstream_secrets(monkeypatch):
     monkeypatch.setenv("UNIGROK_RUNTIME", "cloudrun")
-    for index, env_name in enumerate(
-        (
-            "XAI_API_KEY",
-            "XAI_MANAGEMENT_API_KEY",
-            "OPENAI_API_KEY",
-            "ANTHROPIC_API_KEY",
-            "CLAUDE_API_KEY",
-            "GEMINI_API_KEY",
-        )
-    ):
+    for index, env_name in enumerate(UPSTREAM_PROVIDER_SECRET_ENV_NAMES):
         monkeypatch.setenv(env_name, f"upstream-secret-{index}")
     monkeypatch.setenv("UNIGROK_API_KEYS", "gateway-client-secret")
     monkeypatch.setattr(

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -630,13 +630,67 @@ def test_readyz_body_stays_boolean_on_failure(monkeypatch):
     assert "/secret/container/path" not in res.text
 
 
-def test_xai_key_is_not_client_auth(monkeypatch):
+@pytest.mark.parametrize(
+    "secret_env",
+    [
+        "XAI_API_KEY",
+        "XAI_MANAGEMENT_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "CLAUDE_API_KEY",
+        "GEMINI_API_KEY",
+    ],
+)
+def test_upstream_provider_secret_is_not_client_auth(monkeypatch, secret_env):
     monkeypatch.setenv("UNIGROK_RUNTIME", "cloudrun")
-    monkeypatch.setenv("XAI_API_KEY", "xai-secret")
-    monkeypatch.setenv("UNIGROK_API_KEYS", "client-secret,xai-secret")
+    monkeypatch.setenv(secret_env, "upstream-secret")
+    monkeypatch.setenv("UNIGROK_API_KEYS", "client-secret,upstream-secret")
 
     with TestClient(create_app()) as client:
-        res = client.get("/v1/models", headers={"Authorization": "Bearer xai-secret"})
+        res = client.get(
+            "/v1/models", headers={"Authorization": "Bearer upstream-secret"}
+        )
+
+    assert res.status_code == 401
+
+
+def test_distinct_gateway_key_remains_valid_with_upstream_secrets(monkeypatch):
+    monkeypatch.setenv("UNIGROK_RUNTIME", "cloudrun")
+    for index, env_name in enumerate(
+        (
+            "XAI_API_KEY",
+            "XAI_MANAGEMENT_API_KEY",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+            "CLAUDE_API_KEY",
+            "GEMINI_API_KEY",
+        )
+    ):
+        monkeypatch.setenv(env_name, f"upstream-secret-{index}")
+    monkeypatch.setenv("UNIGROK_API_KEYS", "gateway-client-secret")
+    monkeypatch.setattr(
+        "src.http_server.get_xai_model_ids",
+        AsyncMock(return_value=["unigrok-agent"]),
+    )
+
+    with TestClient(create_app()) as client:
+        res = client.get(
+            "/v1/models",
+            headers={"Authorization": "Bearer gateway-client-secret"},
+        )
+
+    assert res.status_code == 200
+
+
+def test_upstream_secret_alias_rejection_normalizes_provider_whitespace(monkeypatch):
+    monkeypatch.setenv("UNIGROK_RUNTIME", "cloudrun")
+    monkeypatch.setenv("OPENAI_API_KEY", "  upstream-secret  ")
+    monkeypatch.setenv("UNIGROK_API_KEYS", "gateway-client-secret,upstream-secret")
+
+    with TestClient(create_app()) as client:
+        res = client.get(
+            "/v1/models", headers={"Authorization": "Bearer upstream-secret"}
+        )
 
     assert res.status_code == 401
 

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -867,7 +867,7 @@ class TestCollectionsAdapter:
         self, monkeypatch, reset_collections_state
     ):
         monkeypatch.delenv("UNIGROK_COLLECTIONS", raising=False)
-        with patch("src.utils.get_xai_client") as mock_client:
+        with patch("src.utils.get_xai_management_client") as mock_client:
             assert await sync_fact_to_collection(1, "fact") is False
             assert await search_knowledge_collection("query") == []
         mock_client.assert_not_called()
@@ -878,7 +878,7 @@ class TestCollectionsAdapter:
     ):
         monkeypatch.setenv("UNIGROK_COLLECTIONS", "1")
         incapable = MagicMock(spec=["chat"])  # no collections service at all
-        with patch("src.utils.get_xai_client", return_value=incapable):
+        with patch("src.utils.get_xai_management_client", return_value=incapable):
             assert await sync_fact_to_collection(1, "fact") is False
             assert utils_module._COLLECTIONS_WARNED is True
             assert await search_knowledge_collection("query") == []
@@ -890,7 +890,7 @@ class TestCollectionsAdapter:
         monkeypatch.setenv("UNIGROK_COLLECTIONS", "1")
         monkeypatch.setenv("UNIGROK_COLLECTION_NAME", "kb-test")
         client, service = _fake_collections_client()
-        with patch("src.utils.get_xai_client", return_value=client):
+        with patch("src.utils.get_xai_management_client", return_value=client):
             assert await sync_fact_to_collection(7, "durable fact text") is True
             assert await sync_fact_to_collection(8, "another fact") is True
 
@@ -908,7 +908,7 @@ class TestCollectionsAdapter:
         monkeypatch.setenv("UNIGROK_COLLECTION_NAME", "kb-existing")
         existing = SimpleNamespace(collection_id="col-77", collection_name="kb-existing")
         client, service = _fake_collections_client(collections=[existing])
-        with patch("src.utils.get_xai_client", return_value=client):
+        with patch("src.utils.get_xai_management_client", return_value=client):
             assert await sync_fact_to_collection(1, "fact") is True
         service.create.assert_not_called()
         assert service.upload_document.call_args.args[0] == "col-77"
@@ -921,7 +921,7 @@ class TestCollectionsAdapter:
             SimpleNamespace(chunk_content="   ", score=0.5, file_id="f-x"),
         ]
         client, service = _fake_collections_client(search_matches=matches)
-        with patch("src.utils.get_xai_client", return_value=client):
+        with patch("src.utils.get_xai_management_client", return_value=client):
             results = await search_knowledge_collection("remote knowledge", limit=3)
         assert results == [{
             "fact": "remote knowledge chunk",
@@ -938,7 +938,7 @@ class TestCollectionsAdapter:
         monkeypatch.setenv("UNIGROK_COLLECTIONS", "1")
         client, service = _fake_collections_client()
         service.list.side_effect = RuntimeError("collections API down")
-        with patch("src.utils.get_xai_client", return_value=client):
+        with patch("src.utils.get_xai_management_client", return_value=client):
             assert await sync_fact_to_collection(1, "fact") is False
             assert await search_knowledge_collection("q") == []
         assert utils_module._COLLECTIONS_WARNED is True

--- a/tests/test_provider_harvest.py
+++ b/tests/test_provider_harvest.py
@@ -416,7 +416,7 @@ async def test_missing_credentials_or_client_leave_rows_pending_without_cloud_ca
     )
     result = await ProviderAttemptHarvester(uploader=absent_client).run_once(store)
     assert result.status == "unavailable"
-    assert result.reason == "inference_client_unavailable"
+    assert result.reason == "management_client_unavailable"
     assert factory_calls == 1
     row = (await store.list_provider_attempts())[0]
     assert row["harvest_status"] == "pending"

--- a/tests/test_task_rag.py
+++ b/tests/test_task_rag.py
@@ -1065,6 +1065,7 @@ class TestManagementKeyWiring:
 
         monkeypatch.setattr("xai_sdk.Client", FakeClient)
         monkeypatch.setattr(utils_module, "_management_client", None)
+        monkeypatch.delenv("XAI_MANAGEMENT_KEY", raising=False)
         if mgmt_env is None:
             monkeypatch.delenv("XAI_MANAGEMENT_API_KEY", raising=False)
         else:

--- a/tests/test_task_rag.py
+++ b/tests/test_task_rag.py
@@ -40,7 +40,7 @@ def _reset_rag_state():
 
 def _fake_collections_client(collections=None, search_matches=None):
     """Same seam as tests/test_knowledge.py: a MagicMock collections service
-    injected at the get_xai_client boundary (patched at src.rag here)."""
+    injected at the get_xai_management_client boundary (patched at src.rag here)."""
     service = MagicMock()
     service.list.return_value = SimpleNamespace(collections=list(collections or []))
     service.create.return_value = SimpleNamespace(collection_id="col-new")
@@ -364,7 +364,7 @@ class TestTaskMemoryMirror:
     async def test_off_mode_never_touches_client(self, monkeypatch):
         monkeypatch.delenv("UNIGROK_TASK_RAG", raising=False)
         mirror = get_task_memory_mirror()
-        with patch("src.rag.get_xai_client") as mock_client:
+        with patch("src.rag.get_xai_management_client") as mock_client:
             assert await mirror.upload_memory(_memory_row()) is None
             assert await mirror.search("query", 5) == []
             assert await mirror.ready() is False
@@ -376,7 +376,7 @@ class TestTaskMemoryMirror:
         monkeypatch.setenv("UNIGROK_TASK_RAG_COLLECTION", "tm-test")
         client, service = _fake_collections_client()
         mirror = get_task_memory_mirror()
-        with patch("src.rag.get_xai_client", return_value=client):
+        with patch("src.rag.get_xai_management_client", return_value=client):
             fid1 = await mirror.upload_memory(_memory_row(1))
             fid2 = await mirror.upload_memory(_memory_row(2))
 
@@ -403,7 +403,7 @@ class TestTaskMemoryMirror:
         client, service = _fake_collections_client()
         service.upload_document.return_value = SimpleNamespace(file_id="fid-42")
         mirror = get_task_memory_mirror()
-        with patch("src.rag.get_xai_client", return_value=client):
+        with patch("src.rag.get_xai_management_client", return_value=client):
             assert await mirror.upload_memory(_memory_row()) == "fid-42"
 
     @pytest.mark.asyncio
@@ -413,7 +413,7 @@ class TestTaskMemoryMirror:
         existing = SimpleNamespace(collection_id="col-77", collection_name="tm-existing")
         client, service = _fake_collections_client(collections=[existing])
         mirror = get_task_memory_mirror()
-        with patch("src.rag.get_xai_client", return_value=client):
+        with patch("src.rag.get_xai_management_client", return_value=client):
             await mirror.upload_memory(_memory_row())
         service.create.assert_not_called()
         assert service.upload_document.call_args.args[0] == "col-77"
@@ -427,7 +427,7 @@ class TestTaskMemoryMirror:
         ]
         client, service = _fake_collections_client(search_matches=matches)
         mirror = get_task_memory_mirror()
-        with patch("src.rag.get_xai_client", return_value=client):
+        with patch("src.rag.get_xai_management_client", return_value=client):
             results = await mirror.search("query " * 200, 5)
         assert results == [
             {"content": "remote chunk", "score": pytest.approx(0.9), "file_id": "f-1"}
@@ -444,7 +444,7 @@ class TestTaskMemoryMirror:
         client, service = _fake_collections_client()
         service.list.side_effect = RuntimeError("collections API down")
         mirror = get_task_memory_mirror()
-        with patch("src.rag.get_xai_client", return_value=client):
+        with patch("src.rag.get_xai_management_client", return_value=client):
             for _ in range(5):
                 assert await mirror.upload_memory(_memory_row()) is None
             # First trip: ~30s cooldown, calls now short-circuit.
@@ -474,7 +474,7 @@ class TestTaskMemoryMirror:
         mirror = get_task_memory_mirror()
         mirror._bucket_tokens = 0.0
         mirror._bucket_refreshed = time.monotonic()
-        with patch("src.rag.get_xai_client", return_value=client):
+        with patch("src.rag.get_xai_management_client", return_value=client):
             assert await mirror.search("query", 5) == []
         service.search.assert_not_called()
         assert get_task_rag_stats()["rate_limited"] == 1
@@ -486,7 +486,7 @@ class TestTaskMemoryMirror:
         await _save_memory(tstore, "second unsynced task about caching")
         client, service = _fake_collections_client()
         mirror = get_task_memory_mirror()
-        with patch("src.rag.get_xai_client", return_value=client):
+        with patch("src.rag.get_xai_management_client", return_value=client):
             summary = await mirror.sync_pending(tstore, limit=10)
         assert summary == {"synced": 2, "failed": 0}
         assert await tstore.count_unsynced_task_memories() == 0
@@ -511,7 +511,7 @@ class TestTaskMemoryMirror:
         client, service = _fake_collections_client()
         service.upload_document.side_effect = RuntimeError("quota exceeded")
         mirror = get_task_memory_mirror()
-        with patch("src.rag.get_xai_client", return_value=client):
+        with patch("src.rag.get_xai_management_client", return_value=client):
             summary = await mirror.sync_pending(tstore, limit=10)
         assert summary == {"synced": 0, "failed": 1}
         row = (await tstore.list_unsynced_task_memories())[0]
@@ -527,7 +527,7 @@ class TestTaskMemoryMirror:
         client, service = _fake_collections_client()
         mirror = get_task_memory_mirror()
 
-        with patch("src.rag.get_xai_client", return_value=client):
+        with patch("src.rag.get_xai_management_client", return_value=client):
             summary = await mirror.sync_pending(tstore, limit=10)
 
         assert summary == {"synced": 0, "failed": 0}
@@ -685,7 +685,7 @@ class TestGatherSemanticEvidence:
             SimpleNamespace(chunk_content="orphan", score=0.6, file_id="fid-unknown"),
         ]
         client, service = _fake_collections_client(search_matches=matches)
-        with patch("src.rag.get_xai_client", return_value=client):
+        with patch("src.rag.get_xai_management_client", return_value=client):
             verdict = await gather_semantic_evidence(
                 tstore, "plan the migration", None, PLANNING, CODING
             )
@@ -716,7 +716,7 @@ class TestGatherSemanticEvidence:
             SimpleNamespace(chunk_content=header_chunk, score=0.9, file_id="fid-other"),
         ]
         client, _service = _fake_collections_client(search_matches=matches)
-        with patch("src.rag.get_xai_client", return_value=client):
+        with patch("src.rag.get_xai_management_client", return_value=client):
             verdict = await gather_semantic_evidence(
                 tstore, "tune the query planner", None, PLANNING, CODING
             )
@@ -812,7 +812,7 @@ class TestSpawnSyncTask:
             escalated=False, generation="fixed", reflection=None, reasoning=None,
             plane="API", profile="default", latency=0.1, cost_usd=0.0, context_id=None,
         )
-        with patch("src.rag.get_xai_client", return_value=client):
+        with patch("src.rag.get_xai_management_client", return_value=client):
             await utils_module._save_task_memory_safe(
                 tstore, "end to end drain check", layer, CODING, 1
             )
@@ -869,7 +869,7 @@ class TestRagCli:
         _seed_db(db, [])
         client, _service = _fake_collections_client()
         out = io.StringIO()
-        with patch("src.rag.get_xai_client", return_value=client):
+        with patch("src.rag.get_xai_management_client", return_value=client):
             code = rag.rag_cli(
                 ["status"], stream=out, store=GrokSessionStore(db_path=db)
             )
@@ -894,7 +894,7 @@ class TestRagCli:
         db = tmp_path / "cli-dry.db"
         _seed_db(db, ["alpha task", "beta task"])
         out = io.StringIO()
-        with patch("src.rag.get_xai_client") as mock_client:
+        with patch("src.rag.get_xai_management_client") as mock_client:
             code = rag.rag_cli(
                 ["backfill", "--dry-run"], stream=out,
                 store=GrokSessionStore(db_path=db),
@@ -914,7 +914,7 @@ class TestRagCli:
         _seed_db(db, ["alpha task", "beta task", "gamma task"])
         client, service = _fake_collections_client()
         out = io.StringIO()
-        with patch("src.rag.get_xai_client", return_value=client):
+        with patch("src.rag.get_xai_management_client", return_value=client):
             code = rag.rag_cli(
                 ["backfill"], stream=out, store=GrokSessionStore(db_path=db)
             )
@@ -931,7 +931,7 @@ class TestRagCli:
         _seed_db(db, ["alpha task", "beta task", "gamma task"])
         client, service = _fake_collections_client()
         out = io.StringIO()
-        with patch("src.rag.get_xai_client", return_value=client):
+        with patch("src.rag.get_xai_management_client", return_value=client):
             code = rag.rag_cli(
                 ["backfill", "--limit", "1"], stream=out,
                 store=GrokSessionStore(db_path=db),
@@ -961,7 +961,7 @@ class TestRagCli:
         db = tmp_path / "cli-force.db"
         _seed_db(db, ["alpha task"])
         client, service = _fake_collections_client()
-        with patch("src.rag.get_xai_client", return_value=client):
+        with patch("src.rag.get_xai_management_client", return_value=client):
             assert rag.rag_cli(
                 ["backfill"], stream=io.StringIO(),
                 store=GrokSessionStore(db_path=db),
@@ -1006,7 +1006,7 @@ class TestEndToEndIntegration:
         )
 
         client, service = _fake_collections_client()
-        with patch("src.rag.get_xai_client", return_value=client):
+        with patch("src.rag.get_xai_management_client", return_value=client):
             summary = await get_task_memory_mirror().sync_pending(tstore, limit=10)
             assert summary == {"synced": 3, "failed": 0}
 
@@ -1057,34 +1057,39 @@ class TestManagementKeyWiring:
     def _fresh_client(self, monkeypatch, mgmt_env):
         import src.utils as utils_module
 
-        created = {}
+        created = []
 
         class FakeClient:
-            def __init__(self, api_key=None, management_api_key=None):
-                created["api_key"] = api_key
-                created["management_api_key"] = management_api_key
+            def __init__(self, **kwargs):
+                created.append(kwargs)
 
         monkeypatch.setattr("xai_sdk.Client", FakeClient)
-        monkeypatch.setattr(utils_module, "_client", None)
+        monkeypatch.setattr(utils_module, "_management_client", None)
         if mgmt_env is None:
             monkeypatch.delenv("XAI_MANAGEMENT_API_KEY", raising=False)
         else:
             monkeypatch.setenv("XAI_MANAGEMENT_API_KEY", mgmt_env)
-        utils_module.get_xai_client()
+        utils_module.get_xai_management_client()
         return created
 
     def test_management_key_passed_when_set(self, monkeypatch):
+        from src import utils as utils_module
+
         created = self._fresh_client(monkeypatch, "xai-mgmt-test-key")
-        assert created["management_api_key"] == "xai-mgmt-test-key"
-        assert created["api_key"]  # inference key still wired
+        assert created == [
+            {
+                "api_key": utils_module.XAI_API_KEY,
+                "management_api_key": "xai-mgmt-test-key",
+            }
+        ]
 
-    def test_absent_management_key_passes_none(self, monkeypatch):
-        created = self._fresh_client(monkeypatch, None)
-        assert created["management_api_key"] is None
+    def test_absent_management_key_refuses_construction(self, monkeypatch):
+        with pytest.raises(ValueError, match="XAI_MANAGEMENT_API_KEY"):
+            self._fresh_client(monkeypatch, None)
 
-    def test_blank_management_key_passes_none(self, monkeypatch):
-        created = self._fresh_client(monkeypatch, "   ")
-        assert created["management_api_key"] is None
+    def test_blank_management_key_refuses_construction(self, monkeypatch):
+        with pytest.raises(ValueError, match="XAI_MANAGEMENT_API_KEY"):
+            self._fresh_client(monkeypatch, "   ")
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1108,7 +1113,7 @@ class TestKeylessOperation:
         monkeypatch.setenv("UNIGROK_TASK_RAG", "mirror")
         monkeypatch.delenv("XAI_MANAGEMENT_API_KEY", raising=False)
         mirror = get_task_memory_mirror()
-        with patch("src.rag.get_xai_client") as mock_client:
+        with patch("src.rag.get_xai_management_client") as mock_client:
             assert await mirror.ready() is False
         mock_client.assert_not_called()
         assert "optional" in mirror._last_error
@@ -1129,7 +1134,7 @@ class TestKeylessOperation:
         await _save_memory(
             tstore, "plan the sprint backlog grooming", model=CODING, success=0
         )
-        with patch("src.rag.get_xai_client") as mock_client:
+        with patch("src.rag.get_xai_management_client") as mock_client:
             verdict = await gather_semantic_evidence(
                 tstore, "plan the sprint", None, PLANNING, CODING
             )
@@ -1158,7 +1163,7 @@ class TestKeylessOperation:
         db = tmp_path / "keyless-status.db"
         _seed_db(db, ["one task"])
         out = io.StringIO()
-        with patch("src.rag.get_xai_client") as mock_client:
+        with patch("src.rag.get_xai_management_client") as mock_client:
             code = rag.rag_cli(
                 ["status"], stream=out, store=GrokSessionStore(db_path=db)
             )

--- a/tests/test_xai_client_authority.py
+++ b/tests/test_xai_client_authority.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import concurrent.futures
+import inspect
+import time
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from src import utils
+from src.provider_harvest import XAIWorkerEpisodeUploader
+
+
+def test_inference_factory_constructs_with_only_inference_authority(monkeypatch):
+    calls = []
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            calls.append(kwargs)
+
+    monkeypatch.setattr("xai_sdk.Client", FakeClient)
+    monkeypatch.setattr(utils, "XAI_API_KEY", "inference-test-key")
+    monkeypatch.setenv("XAI_MANAGEMENT_API_KEY", "management-test-key")
+    monkeypatch.setattr(utils, "_client", None)
+
+    inference = utils.get_xai_inference_client()
+
+    assert utils.get_xai_client() is inference
+    assert calls == [{"api_key": "inference-test-key"}]
+
+
+def test_management_factory_constructs_with_both_sdk_credentials(monkeypatch):
+    calls = []
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            calls.append(kwargs)
+
+    monkeypatch.setattr("xai_sdk.Client", FakeClient)
+    monkeypatch.setattr(utils, "XAI_API_KEY", "inference-test-key")
+    monkeypatch.setenv("XAI_MANAGEMENT_API_KEY", "management-test-key")
+    monkeypatch.setattr(utils, "_management_client", None)
+
+    management = utils.get_xai_management_client()
+
+    assert management is utils.get_xai_management_client()
+    assert calls == [
+        {
+            "api_key": "inference-test-key",
+            "management_api_key": "management-test-key",
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("inference_key", "management_key", "message"),
+    [
+        ("", "management-test-key", "XAI_API_KEY"),
+        ("inference-test-key", "", "XAI_MANAGEMENT_API_KEY"),
+    ],
+)
+def test_management_factory_requires_both_credentials(
+    monkeypatch, inference_key, management_key, message
+):
+    constructed = False
+
+    class ForbiddenClient:
+        def __init__(self, **kwargs):
+            nonlocal constructed
+            constructed = True
+
+    monkeypatch.setattr("xai_sdk.Client", ForbiddenClient)
+    monkeypatch.setattr(utils, "XAI_API_KEY", inference_key)
+    if management_key:
+        monkeypatch.setenv("XAI_MANAGEMENT_API_KEY", management_key)
+    else:
+        monkeypatch.delenv("XAI_MANAGEMENT_API_KEY", raising=False)
+    monkeypatch.setattr(utils, "_management_client", None)
+
+    with pytest.raises(ValueError, match=message):
+        utils.get_xai_management_client()
+    assert constructed is False
+
+
+def test_eval_recording_wraps_inference_but_never_management(monkeypatch):
+    clients = []
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            clients.append(self)
+
+    monkeypatch.setattr("xai_sdk.Client", FakeClient)
+    monkeypatch.setattr(utils, "XAI_API_KEY", "inference-test-key")
+    monkeypatch.setenv("XAI_MANAGEMENT_API_KEY", "management-test-key")
+    monkeypatch.setenv("UNIGROK_EVAL_RECORD", "1")
+    monkeypatch.setattr(utils, "_client", None)
+    monkeypatch.setattr(utils, "_management_client", None)
+
+    inference = utils.get_xai_inference_client()
+    management = utils.get_xai_management_client()
+
+    assert isinstance(inference, utils._EvalRecordingClient)
+    assert inference._client is clients[0]
+    assert management is clients[1]
+    assert not isinstance(management, utils._EvalRecordingClient)
+
+
+def test_role_specific_close_functions_do_not_cross_caches(monkeypatch):
+    inference = SimpleNamespace(close=MagicMock())
+    management = SimpleNamespace(close=MagicMock())
+    monkeypatch.setattr(utils, "_client", inference)
+    monkeypatch.setattr(utils, "_management_client", management)
+
+    utils.close_xai_inference_client()
+
+    inference.close.assert_called_once_with()
+    management.close.assert_not_called()
+    assert utils._client is None
+    assert utils._management_client is management
+
+    utils.close_xai_management_client()
+
+    management.close.assert_called_once_with()
+    assert utils._management_client is None
+
+
+def test_compatibility_close_hook_closes_both_role_caches(monkeypatch):
+    inference = SimpleNamespace(close=MagicMock())
+    management = SimpleNamespace(close=MagicMock())
+    monkeypatch.setattr(utils, "_client", inference)
+    monkeypatch.setattr(utils, "_management_client", management)
+
+    utils.close_xai_client()
+
+    inference.close.assert_called_once_with()
+    management.close.assert_called_once_with()
+    assert utils._client is None
+    assert utils._management_client is None
+
+
+def test_management_factory_is_thread_safe_and_separate_from_inference(monkeypatch):
+    calls = []
+
+    class SlowClient:
+        def __init__(self, **kwargs):
+            time.sleep(0.01)
+            self.kwargs = kwargs
+            calls.append(self)
+
+    monkeypatch.setattr("xai_sdk.Client", SlowClient)
+    monkeypatch.setattr(utils, "XAI_API_KEY", "inference-test-key")
+    monkeypatch.setenv("XAI_MANAGEMENT_API_KEY", "management-test-key")
+    monkeypatch.setattr(utils, "_client", None)
+    monkeypatch.setattr(utils, "_management_client", None)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        management_clients = list(
+            pool.map(lambda _: utils.get_xai_management_client(), range(8))
+        )
+    inference = utils.get_xai_inference_client()
+
+    assert len(calls) == 2
+    assert all(client is management_clients[0] for client in management_clients)
+    assert management_clients[0].kwargs == {
+        "api_key": "inference-test-key",
+        "management_api_key": "management-test-key",
+    }
+    assert inference.kwargs == {"api_key": "inference-test-key"}
+    assert inference is not management_clients[0]
+
+
+def test_management_factory_is_confined_to_approved_admin_modules():
+    root = Path(__file__).resolve().parents[1]
+    users = {
+        path.relative_to(root).as_posix()
+        for path in (root / "src").rglob("*.py")
+        if "get_xai_management_client" in path.read_text(encoding="utf-8")
+    }
+
+    assert users == {"src/provider_harvest.py", "src/rag.py", "src/utils.py"}
+    assert (
+        inspect.signature(XAIWorkerEpisodeUploader).parameters["client_factory"].default
+        is utils.get_xai_management_client
+    )

--- a/tests/test_xai_client_authority.py
+++ b/tests/test_xai_client_authority.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
+from xai_sdk import Client as SDKClient
 
 from src import utils
 from src.provider_harvest import XAIWorkerEpisodeUploader
@@ -23,12 +24,49 @@ def test_inference_factory_constructs_with_only_inference_authority(monkeypatch)
     monkeypatch.setattr("xai_sdk.Client", FakeClient)
     monkeypatch.setattr(utils, "XAI_API_KEY", "inference-test-key")
     monkeypatch.setenv("XAI_MANAGEMENT_API_KEY", "management-test-key")
+    monkeypatch.setenv("XAI_MANAGEMENT_KEY", "sdk-management-test-key")
     monkeypatch.setattr(utils, "_client", None)
 
     inference = utils.get_xai_inference_client()
 
     assert utils.get_xai_client() is inference
-    assert calls == [{"api_key": "inference-test-key"}]
+    assert calls == [
+        {
+            "api_key": "inference-test-key",
+            "management_api_key": utils._XAI_INFERENCE_MANAGEMENT_ISOLATION_KEY,
+        }
+    ]
+    assert getattr(inference, "collections", None) is None
+
+
+def test_real_sdk_inference_constructor_never_uses_management_environment(
+    monkeypatch,
+):
+    channels = []
+
+    def capture_channel(self, api_key, api_host, *args, **kwargs):
+        channels.append((api_key, api_host))
+        return MagicMock()
+
+    monkeypatch.setattr(SDKClient, "_make_grpc_channel", capture_channel)
+    monkeypatch.setattr(utils, "XAI_API_KEY", "inference-test-key")
+    monkeypatch.setenv("XAI_MANAGEMENT_API_KEY", "canonical-management-test-key")
+    monkeypatch.setenv("XAI_MANAGEMENT_KEY", "sdk-management-test-key")
+    monkeypatch.setattr(utils, "_client", None)
+
+    inference = utils.get_xai_inference_client()
+
+    assert channels == [
+        ("inference-test-key", "api.x.ai"),
+        (
+            utils._XAI_INFERENCE_MANAGEMENT_ISOLATION_KEY,
+            "management-api.x.ai",
+        ),
+    ]
+    assert all(key != "sdk-management-test-key" for key, _ in channels)
+    assert all(key != "canonical-management-test-key" for key, _ in channels)
+    assert getattr(inference, "collections", None) is None
+    utils.close_xai_inference_client()
 
 
 def test_management_factory_constructs_with_both_sdk_credentials(monkeypatch):
@@ -41,6 +79,7 @@ def test_management_factory_constructs_with_both_sdk_credentials(monkeypatch):
     monkeypatch.setattr("xai_sdk.Client", FakeClient)
     monkeypatch.setattr(utils, "XAI_API_KEY", "inference-test-key")
     monkeypatch.setenv("XAI_MANAGEMENT_API_KEY", "management-test-key")
+    monkeypatch.delenv("XAI_MANAGEMENT_KEY", raising=False)
     monkeypatch.setattr(utils, "_management_client", None)
 
     management = utils.get_xai_management_client()
@@ -77,11 +116,61 @@ def test_management_factory_requires_both_credentials(
         monkeypatch.setenv("XAI_MANAGEMENT_API_KEY", management_key)
     else:
         monkeypatch.delenv("XAI_MANAGEMENT_API_KEY", raising=False)
+    monkeypatch.delenv("XAI_MANAGEMENT_KEY", raising=False)
     monkeypatch.setattr(utils, "_management_client", None)
 
     with pytest.raises(ValueError, match=message):
         utils.get_xai_management_client()
     assert constructed is False
+
+
+@pytest.mark.parametrize(
+    ("canonical", "sdk_alias", "expected"),
+    [
+        ("canonical-test-key", "", "canonical-test-key"),
+        ("", "sdk-alias-test-key", "sdk-alias-test-key"),
+        ("shared-test-key", "shared-test-key", "shared-test-key"),
+    ],
+)
+def test_management_factory_resolves_aliases_deterministically(
+    monkeypatch, canonical, sdk_alias, expected
+):
+    calls = []
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            calls.append(kwargs)
+
+    monkeypatch.setattr("xai_sdk.Client", FakeClient)
+    monkeypatch.setattr(utils, "XAI_API_KEY", "inference-test-key")
+    monkeypatch.setenv("XAI_MANAGEMENT_API_KEY", canonical)
+    monkeypatch.setenv("XAI_MANAGEMENT_KEY", sdk_alias)
+    monkeypatch.setattr(utils, "_management_client", None)
+
+    utils.get_xai_management_client()
+
+    assert calls == [
+        {
+            "api_key": "inference-test-key",
+            "management_api_key": expected,
+        }
+    ]
+
+
+def test_management_factory_rejects_conflicting_aliases_before_construction(
+    monkeypatch,
+):
+    constructor = MagicMock()
+    monkeypatch.setattr("xai_sdk.Client", constructor)
+    monkeypatch.setattr(utils, "XAI_API_KEY", "inference-test-key")
+    monkeypatch.setenv("XAI_MANAGEMENT_API_KEY", "canonical-test-key")
+    monkeypatch.setenv("XAI_MANAGEMENT_KEY", "different-sdk-alias-test-key")
+    monkeypatch.setattr(utils, "_management_client", None)
+
+    with pytest.raises(ValueError, match="both configured"):
+        utils.get_xai_management_client()
+
+    constructor.assert_not_called()
 
 
 def test_eval_recording_wraps_inference_but_never_management(monkeypatch):
@@ -95,6 +184,7 @@ def test_eval_recording_wraps_inference_but_never_management(monkeypatch):
     monkeypatch.setattr("xai_sdk.Client", FakeClient)
     monkeypatch.setattr(utils, "XAI_API_KEY", "inference-test-key")
     monkeypatch.setenv("XAI_MANAGEMENT_API_KEY", "management-test-key")
+    monkeypatch.delenv("XAI_MANAGEMENT_KEY", raising=False)
     monkeypatch.setenv("UNIGROK_EVAL_RECORD", "1")
     monkeypatch.setattr(utils, "_client", None)
     monkeypatch.setattr(utils, "_management_client", None)
@@ -103,7 +193,7 @@ def test_eval_recording_wraps_inference_but_never_management(monkeypatch):
     management = utils.get_xai_management_client()
 
     assert isinstance(inference, utils._EvalRecordingClient)
-    assert inference._client is clients[0]
+    assert inference._client._delegate is clients[0]
     assert management is clients[1]
     assert not isinstance(management, utils._EvalRecordingClient)
 
@@ -153,6 +243,7 @@ def test_management_factory_is_thread_safe_and_separate_from_inference(monkeypat
     monkeypatch.setattr("xai_sdk.Client", SlowClient)
     monkeypatch.setattr(utils, "XAI_API_KEY", "inference-test-key")
     monkeypatch.setenv("XAI_MANAGEMENT_API_KEY", "management-test-key")
+    monkeypatch.delenv("XAI_MANAGEMENT_KEY", raising=False)
     monkeypatch.setattr(utils, "_client", None)
     monkeypatch.setattr(utils, "_management_client", None)
 
@@ -168,7 +259,10 @@ def test_management_factory_is_thread_safe_and_separate_from_inference(monkeypat
         "api_key": "inference-test-key",
         "management_api_key": "management-test-key",
     }
-    assert inference.kwargs == {"api_key": "inference-test-key"}
+    assert inference.kwargs == {
+        "api_key": "inference-test-key",
+        "management_api_key": utils._XAI_INFERENCE_MANAGEMENT_ISOLATION_KEY,
+    }
     assert inference is not management_clients[0]
 
 


### PR DESCRIPTION
## Summary

- constructs xAI inference clients without either real management credential and denies Collections on the inference surface
- confines xAI management authority to RAG, knowledge, and worker-harvest administration
- rejects every canonical upstream provider secret as UniGrok gateway authentication, including SDK aliases
- scrubs all server credentials from Grok CLI and Docker device-auth children

## Why

The xAI SDK can implicitly read XAI_MANAGEMENT_KEY when a management argument is omitted. The old shared SDK client could therefore carry more authority than an inference caller needed, and provider keys copied into UNIGROK_API_KEYS could authenticate to the gateway.

## Verification

- reviewed exact head f0ebbf819eee370d9469f4122d97307980b86116
- 1,755 tests passed after rebase onto current main
- installed-SDK channel capture proved real management keys never enter the inference client
- gateway alias, conflict, keyless, cache, close, eval, compose, OKF, Ruff, compile, and diff checks passed
- zero provider calls and zero secret-value disclosure

## Scope and risk

This PR does not add worker routing or change Grok authority. Docker Compose changes require a rebuild at landing. Management clients still require the xAI inference key because the installed SDK requires both channels for Collections.

Human-Sponsor: djtelicloud
Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=implementation and integration