### PR TITLE
Add inert MCP subscription sampling lease

### DIFF
--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -1292,6 +1292,154 @@ def is_safe_response_id(value: str) -> bool
 
 Return whether an upstream response ID is safe to put in a receipt.
 
+## providers/errors.py {#providers-errors}
+
+### Class: `ProviderAuthorizationInvariantError` {#providers-errors-providerauthorizationinvarianterror}
+
+```python
+class ProviderAuthorizationInvariantError
+```
+
+**Keywords:** provider, authorization, invariant, error
+
+A server-owned authorization invariant failed after routing.
+
+This is deliberately neither a configuration, transport, nor protocol
+failure.  In particular, a consumed one-shot delegation must never make a
+broker eligible to repeat the effect through an API fallback.
+
+## providers/mcp_sampling.py {#providers-mcp_sampling}
+
+### Class: `MCPSessionAuthorization` {#providers-mcp_sampling-mcpsessionauthorization}
+
+```python
+class MCPSessionAuthorization
+```
+
+**Keywords:** mcp, session, authorization
+
+Gateway-issued authorization for one principal-bound MCP session.
+
+``verified_local`` covers a directly verified loopback request or a
+separately attested loopback-only proxy boundary.  Anonymous HTTP is only
+legal inside that boundary.  Remote sessions must have an authenticated
+principal.  This object is not accepted from request JSON or headers; a
+future stateful session middleware must inject it into the ASGI scope.
+
+### Class: `TrustedMCPProviderGrant` {#providers-mcp_sampling-trustedmcpprovidergrant}
+
+```python
+class TrustedMCPProviderGrant
+```
+
+**Keywords:** trusted, mcp, provider, grant
+
+Server-owned provider/model grant bound to one authorized MCP session.
+
+Client labels and advertised sampling support never imply a provider
+brand.  Only later Grok routing policy may issue this one-delegation grant;
+generic session middleware must never mint it.
+
+### Method: `TrustedMCPProviderGrant.effect_digest` {#providers-mcp_sampling-trustedmcpprovidergrant-effect_digest}
+
+```python
+def TrustedMCPProviderGrant.effect_digest(self) -> str
+```
+
+**Keywords:** trusted, mcp, provider, grant, effect, digest
+
+Stable one-shot identity for the exact broker-authorized effect.
+
+Grant IDs and validity windows are intentionally excluded.  Reissuing
+a grant cannot repeat an indeterminate physical effect; an authorized
+retry requires a new deterministic ``ProviderRequest.request_id``.
+
+### Class: `MCPSamplingSessionRuntime` {#providers-mcp_sampling-mcpsamplingsessionruntime}
+
+```python
+class MCPSamplingSessionRuntime
+```
+
+**Keywords:** mcp, sampling, session, runtime
+
+Mutable session-wide revocation and concurrency gate.
+
+A future authoritative stateful-session registry creates exactly one of
+these objects for one ``MCPSessionAuthorization`` and injects that same
+object into every request scope for the MCP session.  It is intentionally
+not a module global.  Separate request leases therefore share one physical
+sampling slot and one disconnect/revocation state.
+
+### Method: `MCPSamplingSessionRuntime.effect_claimed` {#providers-mcp_sampling-mcpsamplingsessionruntime-effect_claimed}
+
+```python
+def MCPSamplingSessionRuntime.effect_claimed(self, effect_digest: str) -> bool
+```
+
+**Keywords:** mcp, sampling, session, runtime, effect, claimed
+
+Return exact session-owned state for one stable effect identity.
+
+### Method: `MCPSamplingSessionRuntime.claim_effect` {#providers-mcp_sampling-mcpsamplingsessionruntime-claim_effect}
+
+```python
+def MCPSamplingSessionRuntime.claim_effect(self, effect_digest: str) -> bool
+```
+
+**Keywords:** mcp, sampling, session, runtime, claim, effect
+
+Atomically consume one grant before its physical sampling effect.
+
+This runtime belongs to one asyncio session loop.  The synchronous
+check-and-add has no suspension point and is therefore atomic with
+respect to every lease sharing that runtime.  Claims are terminal:
+revocation, timeout, disconnect, and indeterminate provider outcomes
+never remove them.
+
+### Method: `MCPSamplingSessionRuntime.revoke` {#providers-mcp_sampling-mcpsamplingsessionruntime-revoke}
+
+```python
+async def MCPSamplingSessionRuntime.revoke(self, *, drain_timeout_seconds: float=1.0) -> None
+```
+
+**Keywords:** mcp, sampling, session, runtime, revoke
+
+Revoke the whole MCP session and boundedly cancel every sample.
+
+### Class: `StatefulMCPSamplingLease` {#providers-mcp_sampling-statefulmcpsamplinglease}
+
+```python
+class StatefulMCPSamplingLease
+```
+
+**Keywords:** stateful, mcp, sampling, lease
+
+Short-lived callback lease around one exact FastMCP tool request.
+
+### Method: `StatefulMCPSamplingLease.revoke` {#providers-mcp_sampling-statefulmcpsamplinglease-revoke}
+
+```python
+async def StatefulMCPSamplingLease.revoke(self) -> None
+```
+
+**Keywords:** stateful, mcp, sampling, lease, revoke
+
+Revoke the callback, cancel in-flight samples, and bound the drain.
+
+### Function: `create_stateful_mcp_sampling_lease` {#providers-mcp_sampling-create_stateful_mcp_sampling_lease}
+
+```python
+def create_stateful_mcp_sampling_lease(ctx: Any, *, provider: ProviderId, channel: ProviderChannel, provider_request: ProviderRequest, drain_timeout_seconds: Annotated[float, Field(gt=0.0, le=10.0)]=1.0, clock: Clock | None=None) -> StatefulMCPSamplingLease
+```
+
+**Keywords:** create, stateful, mcp, sampling, lease
+
+Validate the current FastMCP request and create an inert sampling lease.
+
+The returned object must be used as an async context manager.  Merely
+constructing it has no provider, process, network, storage, or routing
+effect.
+
 ## providers/registry.py {#providers-registry}
 
 ### Function: `build_provider_registry` {#providers-registry-build_provider_registry}
@@ -1316,6 +1464,16 @@ class ClaudeCLIAdapter
 
 One-shot Claude Code OAuth worker with tools and persistence disabled.
 
+### Function: `provider_request_digest` {#providers-subscription-provider_request_digest}
+
+```python
+def provider_request_digest(request: ProviderRequest) -> str
+```
+
+**Keywords:** provider, request, digest
+
+Canonical secret-safe digest of one complete provider request.
+
 ### Class: `MCPClientSamplingAdapter` {#providers-subscription-mcpclientsamplingadapter}
 
 ```python
@@ -1324,12 +1482,39 @@ class MCPClientSamplingAdapter
 
 **Keywords:** mcp, client, sampling, adapter
 
-One client-advertised MCP sampling lane bound to one trusted provider.
+One lease-owned MCP sampling lane bound to one trusted provider grant.
+
+The private authority state is sealed against ordinary assignment and
+rechecked before and after every await.  Arbitrary code execution inside
+the trusted server process remains outside this object's security boundary.
+
+### Method: `MCPClientSamplingAdapter.effect_claimed` {#providers-subscription-mcpclientsamplingadapter-effect_claimed}
+
+```python
+def MCPClientSamplingAdapter.effect_claimed(self) -> bool
+```
+
+**Keywords:** mcp, client, sampling, adapter, effect, claimed
+
+Return fail-closed one-shot state from the lease-owned runtime.
+
+### Method: `MCPClientSamplingAdapter.complete` {#providers-subscription-mcpclientsamplingadapter-complete}
+
+```python
+async def MCPClientSamplingAdapter.complete(self, request: ProviderRequest) -> ProviderResponse
+```
+
+**Keywords:** mcp, client, sampling, adapter, complete
+
+Preserve post-claim indeterminacy across the base TTL boundary.
+
+The future broker integration must perform the same probe around its
+own outer timeout before this adapter can be wired into runtime.
 
 ### Function: `build_subscription_registry` {#providers-subscription-build_subscription_registry}
 
 ```python
-def build_subscription_registry(*, claude_executable: str='claude', environ: Mapping[str, str] | None=None, claude_runner: CLIProcessRunner | None=None, sampling_clients: Mapping[ProviderChannel, SamplingClientBinding] | None=None, clock: Clock | None=None) -> dict[ProviderChannel, ProviderAdapter]
+def build_subscription_registry(*, claude_executable: str='claude', environ: Mapping[str, str] | None=None, claude_runner: CLIProcessRunner | None=None, clock: Clock | None=None) -> dict[ProviderChannel, ProviderAdapter]
 ```
 
 **Keywords:** build, subscription, registry

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -1292,6 +1292,154 @@ def is_safe_response_id(value: str) -> bool
 
 Return whether an upstream response ID is safe to put in a receipt.
 
+## providers/errors.py {#providers-errors}
+
+### Class: `ProviderAuthorizationInvariantError` {#providers-errors-providerauthorizationinvarianterror}
+
+```python
+class ProviderAuthorizationInvariantError
+```
+
+**Keywords:** provider, authorization, invariant, error
+
+A server-owned authorization invariant failed after routing.
+
+This is deliberately neither a configuration, transport, nor protocol
+failure.  In particular, a consumed one-shot delegation must never make a
+broker eligible to repeat the effect through an API fallback.
+
+## providers/mcp_sampling.py {#providers-mcp_sampling}
+
+### Class: `MCPSessionAuthorization` {#providers-mcp_sampling-mcpsessionauthorization}
+
+```python
+class MCPSessionAuthorization
+```
+
+**Keywords:** mcp, session, authorization
+
+Gateway-issued authorization for one principal-bound MCP session.
+
+``verified_local`` covers a directly verified loopback request or a
+separately attested loopback-only proxy boundary.  Anonymous HTTP is only
+legal inside that boundary.  Remote sessions must have an authenticated
+principal.  This object is not accepted from request JSON or headers; a
+future stateful session middleware must inject it into the ASGI scope.
+
+### Class: `TrustedMCPProviderGrant` {#providers-mcp_sampling-trustedmcpprovidergrant}
+
+```python
+class TrustedMCPProviderGrant
+```
+
+**Keywords:** trusted, mcp, provider, grant
+
+Server-owned provider/model grant bound to one authorized MCP session.
+
+Client labels and advertised sampling support never imply a provider
+brand.  Only later Grok routing policy may issue this one-delegation grant;
+generic session middleware must never mint it.
+
+### Method: `TrustedMCPProviderGrant.effect_digest` {#providers-mcp_sampling-trustedmcpprovidergrant-effect_digest}
+
+```python
+def TrustedMCPProviderGrant.effect_digest(self) -> str
+```
+
+**Keywords:** trusted, mcp, provider, grant, effect, digest
+
+Stable one-shot identity for the exact broker-authorized effect.
+
+Grant IDs and validity windows are intentionally excluded.  Reissuing
+a grant cannot repeat an indeterminate physical effect; an authorized
+retry requires a new deterministic ``ProviderRequest.request_id``.
+
+### Class: `MCPSamplingSessionRuntime` {#providers-mcp_sampling-mcpsamplingsessionruntime}
+
+```python
+class MCPSamplingSessionRuntime
+```
+
+**Keywords:** mcp, sampling, session, runtime
+
+Mutable session-wide revocation and concurrency gate.
+
+A future authoritative stateful-session registry creates exactly one of
+these objects for one ``MCPSessionAuthorization`` and injects that same
+object into every request scope for the MCP session.  It is intentionally
+not a module global.  Separate request leases therefore share one physical
+sampling slot and one disconnect/revocation state.
+
+### Method: `MCPSamplingSessionRuntime.effect_claimed` {#providers-mcp_sampling-mcpsamplingsessionruntime-effect_claimed}
+
+```python
+def MCPSamplingSessionRuntime.effect_claimed(self, effect_digest: str) -> bool
+```
+
+**Keywords:** mcp, sampling, session, runtime, effect, claimed
+
+Return exact session-owned state for one stable effect identity.
+
+### Method: `MCPSamplingSessionRuntime.claim_effect` {#providers-mcp_sampling-mcpsamplingsessionruntime-claim_effect}
+
+```python
+def MCPSamplingSessionRuntime.claim_effect(self, effect_digest: str) -> bool
+```
+
+**Keywords:** mcp, sampling, session, runtime, claim, effect
+
+Atomically consume one grant before its physical sampling effect.
+
+This runtime belongs to one asyncio session loop.  The synchronous
+check-and-add has no suspension point and is therefore atomic with
+respect to every lease sharing that runtime.  Claims are terminal:
+revocation, timeout, disconnect, and indeterminate provider outcomes
+never remove them.
+
+### Method: `MCPSamplingSessionRuntime.revoke` {#providers-mcp_sampling-mcpsamplingsessionruntime-revoke}
+
+```python
+async def MCPSamplingSessionRuntime.revoke(self, *, drain_timeout_seconds: float=1.0) -> None
+```
+
+**Keywords:** mcp, sampling, session, runtime, revoke
+
+Revoke the whole MCP session and boundedly cancel every sample.
+
+### Class: `StatefulMCPSamplingLease` {#providers-mcp_sampling-statefulmcpsamplinglease}
+
+```python
+class StatefulMCPSamplingLease
+```
+
+**Keywords:** stateful, mcp, sampling, lease
+
+Short-lived callback lease around one exact FastMCP tool request.
+
+### Method: `StatefulMCPSamplingLease.revoke` {#providers-mcp_sampling-statefulmcpsamplinglease-revoke}
+
+```python
+async def StatefulMCPSamplingLease.revoke(self) -> None
+```
+
+**Keywords:** stateful, mcp, sampling, lease, revoke
+
+Revoke the callback, cancel in-flight samples, and bound the drain.
+
+### Function: `create_stateful_mcp_sampling_lease` {#providers-mcp_sampling-create_stateful_mcp_sampling_lease}
+
+```python
+def create_stateful_mcp_sampling_lease(ctx: Any, *, provider: ProviderId, channel: ProviderChannel, provider_request: ProviderRequest, drain_timeout_seconds: Annotated[float, Field(gt=0.0, le=10.0)]=1.0, clock: Clock | None=None) -> StatefulMCPSamplingLease
+```
+
+**Keywords:** create, stateful, mcp, sampling, lease
+
+Validate the current FastMCP request and create an inert sampling lease.
+
+The returned object must be used as an async context manager.  Merely
+constructing it has no provider, process, network, storage, or routing
+effect.
+
 ## providers/registry.py {#providers-registry}
 
 ### Function: `build_provider_registry` {#providers-registry-build_provider_registry}
@@ -1316,6 +1464,16 @@ class ClaudeCLIAdapter
 
 One-shot Claude Code OAuth worker with tools and persistence disabled.
 
+### Function: `provider_request_digest` {#providers-subscription-provider_request_digest}
+
+```python
+def provider_request_digest(request: ProviderRequest) -> str
+```
+
+**Keywords:** provider, request, digest
+
+Canonical secret-safe digest of one complete provider request.
+
 ### Class: `MCPClientSamplingAdapter` {#providers-subscription-mcpclientsamplingadapter}
 
 ```python
@@ -1324,12 +1482,39 @@ class MCPClientSamplingAdapter
 
 **Keywords:** mcp, client, sampling, adapter
 
-One client-advertised MCP sampling lane bound to one trusted provider.
+One lease-owned MCP sampling lane bound to one trusted provider grant.
+
+The private authority state is sealed against ordinary assignment and
+rechecked before and after every await.  Arbitrary code execution inside
+the trusted server process remains outside this object's security boundary.
+
+### Method: `MCPClientSamplingAdapter.effect_claimed` {#providers-subscription-mcpclientsamplingadapter-effect_claimed}
+
+```python
+def MCPClientSamplingAdapter.effect_claimed(self) -> bool
+```
+
+**Keywords:** mcp, client, sampling, adapter, effect, claimed
+
+Return fail-closed one-shot state from the lease-owned runtime.
+
+### Method: `MCPClientSamplingAdapter.complete` {#providers-subscription-mcpclientsamplingadapter-complete}
+
+```python
+async def MCPClientSamplingAdapter.complete(self, request: ProviderRequest) -> ProviderResponse
+```
+
+**Keywords:** mcp, client, sampling, adapter, complete
+
+Preserve post-claim indeterminacy across the base TTL boundary.
+
+The future broker integration must perform the same probe around its
+own outer timeout before this adapter can be wired into runtime.
 
 ### Function: `build_subscription_registry` {#providers-subscription-build_subscription_registry}
 
 ```python
-def build_subscription_registry(*, claude_executable: str='claude', environ: Mapping[str, str] | None=None, claude_runner: CLIProcessRunner | None=None, sampling_clients: Mapping[ProviderChannel, SamplingClientBinding] | None=None, clock: Clock | None=None) -> dict[ProviderChannel, ProviderAdapter]
+def build_subscription_registry(*, claude_executable: str='claude', environ: Mapping[str, str] | None=None, claude_runner: CLIProcessRunner | None=None, clock: Clock | None=None) -> dict[ProviderChannel, ProviderAdapter]
 ```
 
 **Keywords:** build, subscription, registry

--- a/src/providers/__init__.py
+++ b/src/providers/__init__.py
@@ -48,12 +48,24 @@ from .contracts import (
     transport_resource_identity,
 )
 from .errors import (
+    ProviderAuthorizationInvariantError,
     ProviderConfigurationError,
     ProviderError,
     ProviderProtocolError,
     ProviderTransportError,
 )
 from .gemini import GeminiAdapter
+from .mcp_sampling import (
+    MAX_MCP_SAMPLING_EFFECT_CLAIMS,
+    MCP_PROVIDER_GRANTS_SCOPE_KEY,
+    MCP_SESSION_AUTHORIZATION_SCOPE_KEY,
+    MCP_SESSION_RUNTIME_SCOPE_KEY,
+    MCPSessionAuthorization,
+    MCPSamplingSessionRuntime,
+    StatefulMCPSamplingLease,
+    TrustedMCPProviderGrant,
+    create_stateful_mcp_sampling_lease,
+)
 from .openai import OpenAIAdapter
 from .registry import build_provider_registry
 from .subscription import (
@@ -64,14 +76,13 @@ from .subscription import (
     ClientSamplingRequest,
     ClientSamplingResult,
     MCPClientSamplingAdapter,
-    SamplingCallback,
     SamplingCapability,
-    SamplingClientBinding,
     SamplingMessage,
     SamplingModelHint,
     SamplingModelPreferences,
     SamplingTextContent,
     build_subscription_registry,
+    provider_request_digest,
 )
 from .vertex import ADCIdentity, VertexADCAdapter, load_google_adc_identity
 
@@ -99,9 +110,16 @@ __all__ = [
     "GrokWorkerBrokerResult",
     "GrokWorkerDelegation",
     "GrokWorkerLaneAuthorization",
+    "MCP_PROVIDER_GRANTS_SCOPE_KEY",
+    "MCP_SESSION_AUTHORIZATION_SCOPE_KEY",
+    "MCP_SESSION_RUNTIME_SCOPE_KEY",
+    "MAX_MCP_SAMPLING_EFFECT_CLAIMS",
+    "MCPSessionAuthorization",
+    "MCPSamplingSessionRuntime",
     "OpenAIAdapter",
     "MCPClientSamplingAdapter",
     "ProviderAdapter",
+    "ProviderAuthorizationInvariantError",
     "ProviderAttemptHarvestTrigger",
     "ProviderAttemptResult",
     "ProviderAttemptStart",
@@ -122,20 +140,22 @@ __all__ = [
     "ProviderTokenUsage",
     "ProviderTransportError",
     "RouteClass",
-    "SamplingCallback",
     "SamplingCapability",
-    "SamplingClientBinding",
     "SamplingMessage",
     "SamplingModelHint",
     "SamplingModelPreferences",
     "SamplingTextContent",
+    "StatefulMCPSamplingLease",
+    "TrustedMCPProviderGrant",
     "VertexADCAdapter",
     "build_provider_registry",
     "build_subscription_registry",
+    "create_stateful_mcp_sampling_lease",
     "DISABLED_SUBSCRIPTION_SURFACES",
     "load_google_adc_identity",
     "model_visible_messages",
     "provider_result_matches_start",
+    "provider_request_digest",
     "transport_resource_identity",
     "WorkerAuthority",
     "WorkerFallbackPolicy",

--- a/src/providers/errors.py
+++ b/src/providers/errors.py
@@ -26,3 +26,14 @@ class ProviderTransportError(ProviderError):
 
 class ProviderProtocolError(ProviderError):
     pass
+
+
+class ProviderAuthorizationInvariantError(ProviderError):
+    """A server-owned authorization invariant failed after routing.
+
+    This is deliberately neither a configuration, transport, nor protocol
+    failure.  In particular, a consumed one-shot delegation must never make a
+    broker eligible to repeat the effect through an API fallback.
+    """
+
+    pass

--- a/src/providers/mcp_sampling.py
+++ b/src/providers/mcp_sampling.py
@@ -1,0 +1,850 @@
+"""Authenticated, request-scoped MCP client-sampling bridge.
+
+This module is deliberately inert.  It does not register a tool, change the
+HTTP server to stateful mode, construct a broker, or discover subscription
+providers.  A future stateful HTTP integration injects only an immutable
+session authorization and shared runtime gate.  Later, Grok policy may mint a
+one-delegation provider/model grant for the exact supervisor, provider request,
+route, and MCP tool request and place it in the current Starlette request
+scope.  Only then can a tool handler open a short-lived lease around the exact
+FastMCP request context.
+
+The lease is the lifetime boundary: its callback cannot be cached globally,
+survive the tool request, cross principals or MCP sessions, select a provider,
+use tools, or grant a worker final authority.
+
+This is not yet broker-wirable.  Planning needs a stable session-capability
+descriptor before a deterministic provider request ID exists.  Only after the
+attempt start is durably recorded may later integration mint the exact grant,
+materialize this lease-owned adapter, verify lane conformance, and teach the
+broker's outer timeout to consult ``adapter.effect_claimed()``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import math
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Annotated, Any, Literal
+
+import mcp.types as mcp_types
+from pydantic import Field, field_validator, model_validator
+from starlette.requests import Request
+
+from .base import Clock
+from .contracts import (
+    MAX_RESPONSE_CHARS,
+    GrokSupervisorBinding,
+    ProviderChannel,
+    ProviderId,
+    ProviderModelPins,
+    ProviderRequest,
+    RouteClass,
+    StrictContract,
+)
+from .errors import (
+    ProviderAuthorizationInvariantError,
+    ProviderConfigurationError,
+    ProviderError,
+    ProviderProtocolError,
+    ProviderTransportError,
+)
+from .subscription import (
+    ClientSamplingRequest,
+    ClientSamplingResult,
+    MCPClientSamplingAdapter,
+    SamplingCapability,
+    SamplingTextContent,
+    _create_sealed_mcp_sampling_adapter,
+    _create_sealed_sampling_client_binding,
+    provider_request_digest,
+)
+
+
+MCP_SESSION_AUTHORIZATION_SCOPE_KEY = "unigrok.mcp_sampling.session_authorization"
+MCP_PROVIDER_GRANTS_SCOPE_KEY = "unigrok.mcp_sampling.provider_grants"
+MCP_SESSION_RUNTIME_SCOPE_KEY = "unigrok.mcp_sampling.session_runtime"
+
+_SAFE_BINDING_PATTERN = r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$"
+_DIGEST_PATTERN = r"^sha256:[0-9a-f]{64}$"
+_SAMPLING_CHANNEL_PROVIDERS: dict[ProviderChannel, ProviderId] = {
+    ProviderChannel.OPENAI_MCP_SAMPLING: ProviderId.OPENAI,
+    ProviderChannel.ANTHROPIC_MCP_SAMPLING: ProviderId.ANTHROPIC,
+    ProviderChannel.GOOGLE_MCP_SAMPLING: ProviderId.GOOGLE,
+}
+MAX_MCP_SAMPLING_EFFECT_CLAIMS = 1024
+
+
+def _canonical_digest(namespace: str, payload: Mapping[str, Any]) -> str:
+    material = json.dumps(
+        {"namespace": namespace, "payload": payload},
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8", errors="strict")
+    return "sha256:" + hashlib.sha256(material).hexdigest()
+
+
+def _snapshot(model_type, value):
+    """Revalidate even objects made with Pydantic's non-validating helpers."""
+
+    if not isinstance(value, model_type):
+        raise TypeError(f"expected {model_type.__name__}")
+    return model_type.model_validate_json(value.model_dump_json())
+
+
+def _validate_visible_identity(value: str) -> str:
+    if any(ord(char) < 32 or ord(char) == 127 for char in value):
+        raise ValueError("identity fields cannot contain control characters")
+    return value
+
+
+def _scope_header(scope: Mapping[str, Any], name: bytes) -> str | None:
+    for key, value in scope.get("headers") or ():
+        if key.lower() == name:
+            try:
+                return value.decode("latin-1")
+            except (AttributeError, UnicodeError):
+                return None
+    return None
+
+
+class MCPSessionAuthorization(StrictContract):
+    """Gateway-issued authorization for one principal-bound MCP session.
+
+    ``verified_local`` covers a directly verified loopback request or a
+    separately attested loopback-only proxy boundary.  Anonymous HTTP is only
+    legal inside that boundary.  Remote sessions must have an authenticated
+    principal.  This object is not accepted from request JSON or headers; a
+    future stateful session middleware must inject it into the ASGI scope.
+    """
+
+    version: Literal["mcp-sampling-session-authorization/v1"] = (
+        "mcp-sampling-session-authorization/v1"
+    )
+    binding_id: Annotated[str, Field(pattern=_SAFE_BINDING_PATTERN)]
+    mcp_session_id: Annotated[str, Field(pattern=_SAFE_BINDING_PATTERN)]
+    principal: Annotated[str, Field(min_length=1, max_length=240, repr=False)]
+    client_label: Annotated[str, Field(min_length=1, max_length=128, repr=False)]
+    mcp_client_name: Annotated[str, Field(min_length=1, max_length=128, repr=False)]
+    trust: Literal["verified_local", "authenticated_remote"]
+    issued_at: datetime
+    expires_at: datetime
+
+    @field_validator("principal", "client_label", "mcp_client_name")
+    @classmethod
+    def reject_control_characters(cls, value: str) -> str:
+        return _validate_visible_identity(value)
+
+    @model_validator(mode="after")
+    def validate_authorization(self) -> "MCPSessionAuthorization":
+        if self.issued_at.tzinfo is None or self.expires_at.tzinfo is None:
+            raise ValueError("session authorization timestamps must be timezone-aware")
+        if self.issued_at >= self.expires_at:
+            raise ValueError("session authorization must expire after issuance")
+        if self.principal == "http:anon" and self.trust != "verified_local":
+            raise ValueError("anonymous MCP sampling requires verified local trust")
+        if self.trust == "authenticated_remote" and self.principal == "http:anon":
+            raise ValueError("remote MCP sampling requires an authenticated principal")
+        return self
+
+    @property
+    def authorization_digest(self) -> str:
+        return _canonical_digest(
+            "mcp_sampling_session_authorization",
+            self.model_dump(mode="json"),
+        )
+
+
+class TrustedMCPProviderGrant(StrictContract):
+    """Server-owned provider/model grant bound to one authorized MCP session.
+
+    Client labels and advertised sampling support never imply a provider
+    brand.  Only later Grok routing policy may issue this one-delegation grant;
+    generic session middleware must never mint it.
+    """
+
+    version: Literal["trusted-mcp-provider-grant/v1"] = "trusted-mcp-provider-grant/v1"
+    issuer: Literal["grok"] = "grok"
+    grant_id: Annotated[str, Field(pattern=_SAFE_BINDING_PATTERN)]
+    session_authorization_digest: Annotated[str, Field(pattern=_DIGEST_PATTERN)]
+    supervision: GrokSupervisorBinding
+    provider_request_id: Annotated[str, Field(pattern=_SAFE_BINDING_PATTERN)]
+    provider_request_digest: Annotated[str, Field(pattern=_DIGEST_PATTERN)]
+    mcp_related_request_id: str | int
+    provider: ProviderId
+    channel: ProviderChannel
+    route: RouteClass
+    models: ProviderModelPins
+    issued_at: datetime
+    expires_at: datetime
+
+    @model_validator(mode="after")
+    def validate_grant(self) -> "TrustedMCPProviderGrant":
+        if self.issued_at.tzinfo is None or self.expires_at.tzinfo is None:
+            raise ValueError("provider grant timestamps must be timezone-aware")
+        if self.issued_at >= self.expires_at:
+            raise ValueError("provider grant must expire after issuance")
+        if _SAMPLING_CHANNEL_PROVIDERS.get(self.channel) != self.provider:
+            raise ValueError("provider grant channel does not match provider")
+        if isinstance(self.mcp_related_request_id, str):
+            if (
+                not self.mcp_related_request_id
+                or len(self.mcp_related_request_id) > 128
+            ):
+                raise ValueError("MCP related request id must be bounded")
+            _validate_visible_identity(self.mcp_related_request_id)
+        elif isinstance(self.mcp_related_request_id, bool):
+            raise ValueError("MCP related request id cannot be boolean")
+        if self.expires_at > self.supervision.ttl_expires_at:
+            raise ValueError("provider grant cannot outlive Grok supervision")
+        return self
+
+    @property
+    def grant_digest(self) -> str:
+        return _canonical_digest(
+            "trusted_mcp_provider_grant",
+            self.model_dump(mode="json"),
+        )
+
+    @property
+    def effect_digest(self) -> str:
+        """Stable one-shot identity for the exact broker-authorized effect.
+
+        Grant IDs and validity windows are intentionally excluded.  Reissuing
+        a grant cannot repeat an indeterminate physical effect; an authorized
+        retry requires a new deterministic ``ProviderRequest.request_id``.
+        """
+
+        return _canonical_digest(
+            "trusted_mcp_sampling_effect",
+            {
+                "session_authorization_digest": self.session_authorization_digest,
+                "provider": self.provider.value,
+                "channel": self.channel.value,
+                "provider_request_id": self.provider_request_id,
+            },
+        )
+
+    @property
+    def opaque_client_identity(self) -> str:
+        # Deliberately includes the grant and therefore the authorized session,
+        # principal, physical MCP session, provider, and model pins without
+        # exposing any of those raw values in descriptors or receipts.
+        return "mcp-" + self.grant_digest.removeprefix("sha256:")
+
+
+class MCPSamplingSessionRuntime:
+    """Mutable session-wide revocation and concurrency gate.
+
+    A future authoritative stateful-session registry creates exactly one of
+    these objects for one ``MCPSessionAuthorization`` and injects that same
+    object into every request scope for the MCP session.  It is intentionally
+    not a module global.  Separate request leases therefore share one physical
+    sampling slot and one disconnect/revocation state.
+    """
+
+    def __init__(self, authorization: MCPSessionAuthorization) -> None:
+        snapshot = _snapshot(MCPSessionAuthorization, authorization)
+        self._authorization_digest = snapshot.authorization_digest
+        self._mcp_session_id = snapshot.mcp_session_id
+        self._binding_id = snapshot.binding_id
+        self._semaphore = asyncio.Semaphore(1)
+        self._active_tasks: set[asyncio.Task[Any]] = set()
+        self._claimed_effects: set[str] = set()
+        self._revoked = False
+
+    @property
+    def authorization_digest(self) -> str:
+        return self._authorization_digest
+
+    @property
+    def mcp_session_id(self) -> str:
+        return self._mcp_session_id
+
+    @property
+    def binding_id(self) -> str:
+        return self._binding_id
+
+    @property
+    def revoked(self) -> bool:
+        return self._revoked
+
+    def register(self, task: asyncio.Task[Any]) -> None:
+        if self._revoked:
+            raise RuntimeError("session runtime is revoked")
+        self._active_tasks.add(task)
+
+    def unregister(self, task: asyncio.Task[Any]) -> None:
+        self._active_tasks.discard(task)
+
+    def sampling_slot(self) -> asyncio.Semaphore:
+        return self._semaphore
+
+    @staticmethod
+    def _validate_effect_digest(effect_digest: str) -> None:
+        if (
+            not isinstance(effect_digest, str)
+            or len(effect_digest) != 71
+            or not effect_digest.startswith("sha256:")
+            or any(char not in "0123456789abcdef" for char in effect_digest[7:])
+        ):
+            raise ValueError("sampling effect digest must be a SHA-256 identity")
+
+    def effect_claimed(self, effect_digest: str) -> bool:
+        """Return exact session-owned state for one stable effect identity."""
+
+        self._validate_effect_digest(effect_digest)
+        return effect_digest in self._claimed_effects
+
+    def claim_effect(self, effect_digest: str) -> bool:
+        """Atomically consume one grant before its physical sampling effect.
+
+        This runtime belongs to one asyncio session loop.  The synchronous
+        check-and-add has no suspension point and is therefore atomic with
+        respect to every lease sharing that runtime.  Claims are terminal:
+        revocation, timeout, disconnect, and indeterminate provider outcomes
+        never remove them.
+        """
+
+        self._validate_effect_digest(effect_digest)
+        if self._revoked:
+            raise RuntimeError("session runtime is revoked")
+        if effect_digest in self._claimed_effects:
+            return False
+        if len(self._claimed_effects) >= MAX_MCP_SAMPLING_EFFECT_CLAIMS:
+            # Never evict: eviction would re-enable replay.  Revoke this
+            # session before insertion and fail the new pre-effect claim.
+            self._revoked = True
+            try:
+                current = asyncio.current_task()
+            except RuntimeError:
+                current = None
+            for task in tuple(self._active_tasks):
+                if task is not current:
+                    task.cancel()
+            raise RuntimeError("session runtime effect claim capacity exhausted")
+        self._claimed_effects.add(effect_digest)
+        return True
+
+    async def revoke(self, *, drain_timeout_seconds: float = 1.0) -> None:
+        """Revoke the whole MCP session and boundedly cancel every sample."""
+
+        if (
+            not isinstance(drain_timeout_seconds, (int, float))
+            or isinstance(drain_timeout_seconds, bool)
+            or not math.isfinite(float(drain_timeout_seconds))
+            or drain_timeout_seconds <= 0
+            or drain_timeout_seconds > 10
+        ):
+            raise ValueError("session runtime drain timeout must be in (0, 10]")
+        self._revoked = True
+        current = asyncio.current_task()
+        tasks = tuple(task for task in self._active_tasks if task is not current)
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            try:
+                async with asyncio.timeout(drain_timeout_seconds):
+                    await asyncio.gather(*tasks, return_exceptions=True)
+            except TimeoutError:
+                pass
+
+
+class StatefulMCPSamplingLease:
+    """Short-lived callback lease around one exact FastMCP tool request."""
+
+    def __init__(
+        self,
+        *,
+        ctx: Any,
+        request: Request,
+        session: Any,
+        related_request_id: str | int,
+        authorization: MCPSessionAuthorization,
+        raw_authorization: MCPSessionAuthorization,
+        grant: TrustedMCPProviderGrant,
+        raw_grant: TrustedMCPProviderGrant,
+        runtime: MCPSamplingSessionRuntime,
+        provider: ProviderId,
+        channel: ProviderChannel,
+        deadline: datetime,
+        drain_timeout_seconds: float,
+        clock: Clock,
+    ) -> None:
+        self._ctx = ctx
+        self._request = request
+        self._session = session
+        self._related_request_id = related_request_id
+        self._authorization = authorization
+        self._raw_authorization = raw_authorization
+        self._grant = grant
+        self._raw_grant = raw_grant
+        self._runtime = runtime
+        self._provider = provider
+        self._channel = channel
+        self._deadline = deadline
+        self._clock = clock
+        self._drain_timeout_seconds = drain_timeout_seconds
+        self._active_tasks: set[asyncio.Task[Any]] = set()
+        self._entered = False
+        self._revoked = False
+        binding = _create_sealed_sampling_client_binding(
+            capability=SamplingCapability(
+                client_id=grant.opaque_client_identity,
+                sampling=True,
+            ),
+            callback=self._sample,
+            provider=grant.provider,
+            channel=grant.channel,
+            models=grant.models,
+            binding_digest=grant.grant_digest,
+            supervision=grant.supervision,
+            provider_request_id=grant.provider_request_id,
+            provider_request_digest=grant.provider_request_digest,
+            route=grant.route,
+            effect_claimed=lambda: runtime.effect_claimed(grant.effect_digest),
+        )
+        # Construct and snapshot the authoritative adapter before the internal
+        # callback-bearing binding can escape.  Runtime callers receive only
+        # this lease-owned adapter while the lease is active.
+        self._adapter = _create_sealed_mcp_sampling_adapter(
+            provider=provider,
+            channel=channel,
+            binding=binding,
+            clock=clock,
+        )
+
+    async def __aenter__(self) -> "StatefulMCPSamplingLease":
+        if self._entered or self._revoked:
+            raise ProviderConfigurationError(self._provider, "sampling_lease_inactive")
+        self._validate_live_binding()
+        self._remaining_seconds()
+        self._entered = True
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback) -> None:
+        await self.revoke()
+
+    @property
+    def adapter(self) -> MCPClientSamplingAdapter:
+        if not self._entered or self._revoked:
+            raise ProviderConfigurationError(self._provider, "sampling_lease_inactive")
+        return self._adapter
+
+    async def revoke(self) -> None:
+        """Revoke the callback, cancel in-flight samples, and bound the drain."""
+
+        if self._revoked:
+            return
+        self._revoked = True
+        current = asyncio.current_task()
+        tasks = tuple(task for task in self._active_tasks if task is not current)
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            try:
+                async with asyncio.timeout(self._drain_timeout_seconds):
+                    await asyncio.gather(*tasks, return_exceptions=True)
+            except TimeoutError:
+                # The lease remains revoked even if a non-cooperative client
+                # transport ignores cancellation.  No result can be accepted.
+                pass
+        self._entered = False
+
+    def _remaining_seconds(self) -> float:
+        now = self._clock()
+        if now.tzinfo is None:
+            raise ProviderConfigurationError(self._provider, "clock_not_timezone_aware")
+        effective_deadline = min(
+            self._deadline,
+            self._authorization.expires_at,
+            self._grant.expires_at,
+        )
+        if now < self._authorization.issued_at or now < self._grant.issued_at:
+            raise ProviderConfigurationError(
+                self._provider, "sampling_authority_not_yet_valid"
+            )
+        remaining = (effective_deadline - now).total_seconds()
+        if remaining <= 0:
+            raise ProviderConfigurationError(self._provider, "ttl_expired")
+        return remaining
+
+    def _validate_live_binding(self) -> None:
+        if not self._entered and self._revoked:
+            raise ProviderConfigurationError(self._provider, "sampling_lease_inactive")
+        try:
+            request_context = self._ctx.request_context
+            current_request = request_context.request
+            current_session = request_context.session
+            current_request_id = request_context.request_id
+            exposed_session = self._ctx.session
+        except Exception:
+            raise ProviderConfigurationError(
+                self._provider, "sampling_context_unavailable"
+            ) from None
+        if (
+            current_request is not self._request
+            or current_session is not self._session
+            or exposed_session is not self._session
+            or current_request_id != self._related_request_id
+        ):
+            raise ProviderConfigurationError(
+                self._provider, "sampling_session_mismatch"
+            )
+        scope = self._request.scope
+        if (
+            scope.get(MCP_SESSION_AUTHORIZATION_SCOPE_KEY)
+            is not self._raw_authorization
+        ):
+            raise ProviderConfigurationError(
+                self._provider, "sampling_authorization_mismatch"
+            )
+        grants = scope.get(MCP_PROVIDER_GRANTS_SCOPE_KEY)
+        if not isinstance(grants, tuple) or not any(
+            item is self._raw_grant for item in grants
+        ):
+            raise ProviderConfigurationError(self._provider, "sampling_grant_mismatch")
+        if scope.get(MCP_SESSION_RUNTIME_SCOPE_KEY) is not self._runtime:
+            raise ProviderConfigurationError(
+                self._provider, "sampling_session_mismatch"
+            )
+        try:
+            current_authorization = _snapshot(
+                MCPSessionAuthorization, self._raw_authorization
+            )
+            current_grant = _snapshot(TrustedMCPProviderGrant, self._raw_grant)
+        except (TypeError, ValueError):
+            raise ProviderConfigurationError(
+                self._provider, "sampling_authorization_mismatch"
+            ) from None
+        if current_authorization != self._authorization:
+            raise ProviderConfigurationError(
+                self._provider, "sampling_authorization_mismatch"
+            )
+        if current_grant != self._grant:
+            raise ProviderConfigurationError(self._provider, "sampling_grant_mismatch")
+        if (
+            _scope_header(scope, b"mcp-session-id")
+            != self._authorization.mcp_session_id
+        ):
+            raise ProviderConfigurationError(
+                self._provider, "sampling_session_mismatch"
+            )
+        if _scope_header(scope, b"x-client-id") != self._authorization.client_label:
+            raise ProviderConfigurationError(self._provider, "sampling_client_mismatch")
+        client_params = getattr(self._session, "client_params", None)
+        capabilities = getattr(client_params, "capabilities", None)
+        if client_params is None or getattr(capabilities, "sampling", None) is None:
+            raise ProviderConfigurationError(
+                self._provider, "sampling_capability_unavailable"
+            )
+        client_info = getattr(client_params, "clientInfo", None)
+        if getattr(client_info, "name", None) != self._authorization.mcp_client_name:
+            raise ProviderConfigurationError(self._provider, "sampling_client_mismatch")
+        if self._grant.session_authorization_digest != (
+            self._authorization.authorization_digest
+        ):
+            raise ProviderConfigurationError(self._provider, "sampling_grant_mismatch")
+        if (
+            self._grant.provider != self._provider
+            or self._grant.channel != self._channel
+        ):
+            raise ProviderConfigurationError(self._provider, "sampling_grant_mismatch")
+        if (
+            self._runtime.revoked
+            or self._runtime.authorization_digest
+            != self._authorization.authorization_digest
+            or self._runtime.mcp_session_id != self._authorization.mcp_session_id
+            or self._runtime.binding_id != self._authorization.binding_id
+        ):
+            raise ProviderConfigurationError(
+                self._provider, "sampling_session_disconnected"
+            )
+
+    def _sdk_request(self, request: ClientSamplingRequest) -> dict[str, Any]:
+        requested_models = tuple(hint.name for hint in request.model_preferences.hints)
+        granted_model = self._grant.models.for_route(self._grant.route)
+        if not requested_models or any(
+            model != granted_model for model in requested_models
+        ):
+            raise ProviderConfigurationError(
+                self._provider, "sampling_model_not_granted"
+            )
+        return {
+            "messages": [
+                mcp_types.SamplingMessage(
+                    role=message.role,
+                    content=mcp_types.TextContent(
+                        type="text",
+                        text=message.content.text,
+                    ),
+                )
+                for message in request.messages
+            ],
+            "max_tokens": request.max_tokens,
+            "system_prompt": request.system_prompt,
+            "include_context": "none",
+            "temperature": request.temperature,
+            "model_preferences": mcp_types.ModelPreferences(
+                hints=[mcp_types.ModelHint(name=model) for model in requested_models],
+                intelligencePriority=request.model_preferences.intelligence_priority,
+                speedPriority=request.model_preferences.speed_priority,
+                costPriority=request.model_preferences.cost_priority,
+            ),
+            "tools": None,
+            "related_request_id": self._related_request_id,
+        }
+
+    def _translate_result(self, result: Any) -> ClientSamplingResult:
+        if not isinstance(result, mcp_types.CreateMessageResult):
+            raise ProviderProtocolError(self._provider, "invalid_sampling_result")
+        try:
+            result = mcp_types.CreateMessageResult.model_validate_json(
+                result.model_dump_json(warnings="error")
+            )
+        except Exception:
+            raise ProviderProtocolError(
+                self._provider, "invalid_sampling_result"
+            ) from None
+        if result.role != "assistant" or not isinstance(
+            result.content, mcp_types.TextContent
+        ):
+            raise ProviderProtocolError(self._provider, "invalid_sampling_result")
+        text = result.content.text
+        if not text or len(text) > MAX_RESPONSE_CHARS:
+            raise ProviderProtocolError(self._provider, "invalid_sampling_result")
+        if result.model != self._grant.models.for_route(self._grant.route):
+            raise ProviderProtocolError(self._provider, "provider_model_mismatch")
+        stop_reason = result.stopReason or "endTurn"
+        if stop_reason not in {
+            "endTurn",
+            "stopSequence",
+            "maxTokens",
+            "contentFilter",
+        }:
+            raise ProviderProtocolError(self._provider, "invalid_sampling_result")
+        return ClientSamplingResult(
+            role="assistant",
+            content=SamplingTextContent(type="text", text=text),
+            model=result.model,
+            stop_reason=stop_reason,
+        )
+
+    async def _sample(self, request: ClientSamplingRequest) -> ClientSamplingResult:
+        if not self._entered or self._revoked:
+            raise ProviderConfigurationError(self._provider, "sampling_lease_inactive")
+        task = asyncio.current_task()
+        if task is None:
+            raise ProviderConfigurationError(
+                self._provider, "sampling_context_unavailable"
+            )
+        self._active_tasks.add(task)
+        effect_claimed = False
+        try:
+            try:
+                self._runtime.register(task)
+            except RuntimeError:
+                raise ProviderConfigurationError(
+                    self._provider, "sampling_session_disconnected"
+                ) from None
+            remaining = self._remaining_seconds()
+            try:
+                async with asyncio.timeout(remaining):
+                    async with self._runtime.sampling_slot():
+                        # Waiting for a lane consumes the same absolute lease.
+                        self._remaining_seconds()
+                        self._validate_live_binding()
+                        sdk_request = self._sdk_request(request)
+                        self._remaining_seconds()
+                        try:
+                            claimed = self._runtime.claim_effect(
+                                self._grant.effect_digest
+                            )
+                        except RuntimeError:
+                            raise ProviderConfigurationError(
+                                self._provider, "sampling_session_disconnected"
+                            ) from None
+                        if not claimed:
+                            raise ProviderAuthorizationInvariantError(
+                                self._provider, "sampling_effect_already_claimed"
+                            )
+                        effect_claimed = True
+                        # No suspension is permitted between the terminal
+                        # effect claim and invocation of the physical MCP
+                        # sampling operation.
+                        raw_result = await self._session.create_message(**sdk_request)
+                        self._remaining_seconds()
+                        self._validate_live_binding()
+                        if self._revoked:
+                            raise ProviderConfigurationError(
+                                self._provider, "sampling_lease_inactive"
+                            )
+                        return self._translate_result(raw_result)
+            except TimeoutError:
+                raise ProviderTransportError(self._provider, "ttl_expired") from None
+        except asyncio.CancelledError:
+            if effect_claimed:
+                raise ProviderAuthorizationInvariantError(
+                    self._provider, "sampling_effect_indeterminate"
+                ) from None
+            raise
+        except ProviderError as exc:
+            if effect_claimed and not isinstance(
+                exc, ProviderAuthorizationInvariantError
+            ):
+                raise ProviderAuthorizationInvariantError(
+                    self._provider, "sampling_effect_indeterminate"
+                ) from None
+            raise
+        except Exception:
+            if effect_claimed:
+                raise ProviderAuthorizationInvariantError(
+                    self._provider, "sampling_effect_indeterminate"
+                ) from None
+            raise ProviderTransportError(
+                self._provider, "sampling_session_disconnected"
+            ) from None
+        finally:
+            self._active_tasks.discard(task)
+            self._runtime.unregister(task)
+
+
+def create_stateful_mcp_sampling_lease(
+    ctx: Any,
+    *,
+    provider: ProviderId,
+    channel: ProviderChannel,
+    provider_request: ProviderRequest,
+    drain_timeout_seconds: Annotated[float, Field(gt=0.0, le=10.0)] = 1.0,
+    clock: Clock | None = None,
+) -> StatefulMCPSamplingLease:
+    """Validate the current FastMCP request and create an inert sampling lease.
+
+    The returned object must be used as an async context manager.  Merely
+    constructing it has no provider, process, network, storage, or routing
+    effect.
+    """
+
+    if _SAMPLING_CHANNEL_PROVIDERS.get(channel) != provider:
+        raise ProviderConfigurationError(provider, "sampling_channel_mismatch")
+    try:
+        request_snapshot = _snapshot(ProviderRequest, provider_request)
+        request_digest = provider_request_digest(request_snapshot)
+    except (TypeError, ValueError):
+        raise ProviderConfigurationError(
+            provider, "sampling_provider_request_invalid"
+        ) from None
+    deadline = request_snapshot.supervision.ttl_expires_at
+    if (
+        not isinstance(drain_timeout_seconds, (int, float))
+        or isinstance(drain_timeout_seconds, bool)
+        or not math.isfinite(float(drain_timeout_seconds))
+        or drain_timeout_seconds <= 0
+        or drain_timeout_seconds > 10
+    ):
+        raise ProviderConfigurationError(provider, "sampling_drain_timeout_invalid")
+    try:
+        if getattr(getattr(ctx, "fastmcp"), "settings").stateless_http is not False:
+            raise ProviderConfigurationError(provider, "stateful_sampling_required")
+        request_context = ctx.request_context
+        request = request_context.request
+        session = request_context.session
+        related_request_id = request_context.request_id
+        if ctx.session is not session:
+            raise ProviderConfigurationError(provider, "sampling_session_mismatch")
+    except ProviderConfigurationError:
+        raise
+    except Exception:
+        raise ProviderConfigurationError(
+            provider, "sampling_context_unavailable"
+        ) from None
+    if not isinstance(request, Request) or request.scope.get("type") != "http":
+        raise ProviderConfigurationError(provider, "sampling_context_unavailable")
+    if related_request_id is None or not isinstance(related_request_id, (str, int)):
+        raise ProviderConfigurationError(provider, "sampling_context_unavailable")
+
+    raw_authorization = request.scope.get(MCP_SESSION_AUTHORIZATION_SCOPE_KEY)
+    try:
+        authorization = _snapshot(MCPSessionAuthorization, raw_authorization)
+    except (TypeError, ValueError):
+        raise ProviderConfigurationError(
+            provider, "sampling_authorization_missing"
+        ) from None
+    raw_grants = request.scope.get(MCP_PROVIDER_GRANTS_SCOPE_KEY)
+    if not isinstance(raw_grants, tuple):
+        raise ProviderConfigurationError(provider, "sampling_grant_missing")
+    provider_raw = tuple(
+        item
+        for item in raw_grants
+        if isinstance(item, TrustedMCPProviderGrant)
+        and getattr(item, "provider", None) == provider
+        and getattr(item, "channel", None) == channel
+    )
+    if not provider_raw:
+        raise ProviderConfigurationError(provider, "sampling_grant_missing")
+    matching_raw = tuple(
+        item
+        for item in provider_raw
+        if getattr(item, "provider_request_id", None) == request_snapshot.request_id
+        and getattr(item, "provider_request_digest", None) == request_digest
+        and getattr(item, "mcp_related_request_id", None) == related_request_id
+    )
+    if len(matching_raw) != 1:
+        raise ProviderConfigurationError(provider, "sampling_grant_mismatch")
+    raw_grant = matching_raw[0]
+    try:
+        grant = _snapshot(TrustedMCPProviderGrant, raw_grant)
+    except (TypeError, ValueError):
+        raise ProviderConfigurationError(provider, "sampling_grant_missing") from None
+    if (
+        grant.session_authorization_digest != authorization.authorization_digest
+        or grant.issued_at < authorization.issued_at
+        or grant.expires_at > authorization.expires_at
+        or grant.mcp_related_request_id != related_request_id
+        or grant.supervision != request_snapshot.supervision
+        or grant.provider_request_id != request_snapshot.request_id
+        or grant.provider_request_digest != request_digest
+        or grant.route != request_snapshot.route
+        or (
+            request_snapshot.model is not None
+            and request_snapshot.model != grant.models.for_route(grant.route)
+        )
+    ):
+        raise ProviderConfigurationError(provider, "sampling_grant_mismatch")
+    runtime = request.scope.get(MCP_SESSION_RUNTIME_SCOPE_KEY)
+    if not isinstance(runtime, MCPSamplingSessionRuntime):
+        raise ProviderConfigurationError(provider, "sampling_session_runtime_missing")
+
+    return StatefulMCPSamplingLease(
+        ctx=ctx,
+        request=request,
+        session=session,
+        related_request_id=related_request_id,
+        authorization=authorization,
+        raw_authorization=raw_authorization,
+        grant=grant,
+        raw_grant=raw_grant,
+        runtime=runtime,
+        provider=provider,
+        channel=channel,
+        deadline=deadline.astimezone(UTC),
+        drain_timeout_seconds=float(drain_timeout_seconds),
+        clock=clock or (lambda: datetime.now(UTC)),
+    )
+
+
+__all__ = [
+    "MAX_MCP_SAMPLING_EFFECT_CLAIMS",
+    "MCP_PROVIDER_GRANTS_SCOPE_KEY",
+    "MCP_SESSION_AUTHORIZATION_SCOPE_KEY",
+    "MCP_SESSION_RUNTIME_SCOPE_KEY",
+    "MCPSessionAuthorization",
+    "MCPSamplingSessionRuntime",
+    "StatefulMCPSamplingLease",
+    "TrustedMCPProviderGrant",
+    "create_stateful_mcp_sampling_lease",
+]

--- a/src/providers/subscription.py
+++ b/src/providers/subscription.py
@@ -8,6 +8,7 @@ files, copy credentials, route work, or grant a worker completion authority.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import os
 import re
@@ -29,20 +30,26 @@ from .contracts import (
     MAX_RESPONSE_CHARS,
     CredentialPlane,
     CredentialState,
+    GrokSupervisorBinding,
     ProviderAdapter,
+    ProviderAttemptResult,
     ProviderChannel,
     ProviderDescriptor,
+    ProviderFailureReceipt,
     ProviderId,
     ProviderModelPins,
     ProviderReceipt,
     ProviderRequest,
     ProviderResponse,
     ProviderTokenUsage,
+    RouteClass,
     is_safe_model_id,
     transport_resource_identity,
 )
 from .errors import (
+    ProviderAuthorizationInvariantError,
     ProviderConfigurationError,
+    ProviderError,
     ProviderProtocolError,
     ProviderTransportError,
 )
@@ -59,12 +66,6 @@ CLAUDE_WORKER_SYSTEM_PROMPT = (
 )
 
 CLAUDE_SUBSCRIPTION_MODELS = DEFAULT_MODEL_PINS[ProviderChannel.ANTHROPIC_API]
-
-SAMPLING_DEFAULT_MODELS: dict[ProviderId, ProviderModelPins] = {
-    ProviderId.OPENAI: DEFAULT_MODEL_PINS[ProviderChannel.OPENAI_API],
-    ProviderId.ANTHROPIC: CLAUDE_SUBSCRIPTION_MODELS,
-    ProviderId.GOOGLE: DEFAULT_MODEL_PINS[ProviderChannel.GEMINI_API_KEY],
-}
 
 SAMPLING_CHANNEL_PROVIDERS: dict[ProviderChannel, ProviderId] = {
     ProviderChannel.OPENAI_MCP_SAMPLING: ProviderId.OPENAI,
@@ -684,26 +685,229 @@ SamplingCallback = Callable[
     [ClientSamplingRequest],
     Awaitable[ClientSamplingResult | Mapping[str, Any]],
 ]
+EffectClaimInspector = Callable[[], bool]
 
 
-@dataclass(frozen=True, slots=True)
+_SAMPLING_BINDING_FACTORY_SEAL = object()
+
+
+@dataclass(frozen=True, slots=True, init=False)
 class SamplingClientBinding:
     capability: SamplingCapability
     callback: SamplingCallback
-    models: ProviderModelPins | None = None
+    provider: ProviderId
+    channel: ProviderChannel
+    models: ProviderModelPins
+    binding_digest: str
+    supervision: GrokSupervisorBinding
+    provider_request_id: str
+    provider_request_digest: str
+    route: RouteClass
+    effect_claimed: EffectClaimInspector
+    delegation_digest: str
+
+    def __init__(
+        self,
+        *,
+        capability: SamplingCapability,
+        callback: SamplingCallback,
+        provider: ProviderId,
+        channel: ProviderChannel,
+        models: ProviderModelPins,
+        binding_digest: str,
+        supervision: GrokSupervisorBinding,
+        provider_request_id: str,
+        provider_request_digest: str,
+        route: RouteClass,
+        effect_claimed: EffectClaimInspector,
+        _factory_seal: object | None = None,
+    ) -> None:
+        if _factory_seal is not _SAMPLING_BINDING_FACTORY_SEAL:
+            raise TypeError(
+                "SamplingClientBinding must be created by the stateful MCP sampling factory"
+            )
+        if not re.fullmatch(r"sha256:[0-9a-f]{64}", binding_digest):
+            raise ValueError("sampling binding digest must be a SHA-256 identity")
+        expected_client_id = "mcp-" + binding_digest.removeprefix("sha256:")
+        if capability.client_id != expected_client_id or not capability.sampling:
+            raise ValueError("sampling capability does not match sealed binding")
+        if SAMPLING_CHANNEL_PROVIDERS.get(channel) != provider:
+            raise ValueError("sealed sampling provider and channel do not match")
+        try:
+            supervision_snapshot = GrokSupervisorBinding.model_validate_json(
+                supervision.model_dump_json()
+            )
+            models_snapshot = ProviderModelPins.model_validate_json(
+                models.model_dump_json()
+            )
+        except (AttributeError, TypeError, ValueError, ValidationError):
+            raise ValueError("sampling grant binding is invalid") from None
+        if not isinstance(supervision_snapshot, GrokSupervisorBinding):
+            raise ValueError("sampling supervision binding is invalid")
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,127}", provider_request_id):
+            raise ValueError("sampling provider request id is invalid")
+        if not re.fullmatch(r"sha256:[0-9a-f]{64}", provider_request_digest):
+            raise ValueError("sampling provider request digest is invalid")
+        if not isinstance(route, RouteClass):
+            raise ValueError("sampling route is invalid")
+        if not callable(effect_claimed):
+            raise ValueError("sampling effect inspector is invalid")
+        delegation_digest = _sampling_delegation_digest(
+            binding_digest=binding_digest,
+            provider=provider,
+            channel=channel,
+            supervision=supervision_snapshot,
+            provider_request_id=provider_request_id,
+            provider_request_digest=provider_request_digest,
+            route=route,
+            authorized_model=models_snapshot.for_route(route),
+        )
+        object.__setattr__(self, "capability", capability)
+        object.__setattr__(self, "callback", callback)
+        object.__setattr__(self, "provider", provider)
+        object.__setattr__(self, "channel", channel)
+        object.__setattr__(self, "models", models_snapshot)
+        object.__setattr__(self, "binding_digest", binding_digest)
+        object.__setattr__(self, "supervision", supervision_snapshot)
+        object.__setattr__(self, "provider_request_id", provider_request_id)
+        object.__setattr__(self, "provider_request_digest", provider_request_digest)
+        object.__setattr__(self, "route", route)
+        object.__setattr__(self, "effect_claimed", effect_claimed)
+        object.__setattr__(self, "delegation_digest", delegation_digest)
 
 
-def _provider_model_matches(provider: ProviderId, model: str) -> bool:
-    prefixes = {
-        ProviderId.OPENAI: ("gpt-", "o1", "o3", "o4", "codex-", "chatgpt-"),
-        ProviderId.ANTHROPIC: ("claude-",),
-        ProviderId.GOOGLE: ("gemini-",),
+def _sampling_delegation_digest(
+    *,
+    binding_digest: str,
+    provider: ProviderId,
+    channel: ProviderChannel,
+    supervision: GrokSupervisorBinding,
+    provider_request_id: str,
+    provider_request_digest: str,
+    route: RouteClass,
+    authorized_model: str,
+) -> str:
+    payload = {
+        "binding_digest": binding_digest,
+        "provider": provider.value,
+        "channel": channel.value,
+        "supervision": supervision.model_dump(mode="json"),
+        "provider_request_id": provider_request_id,
+        "provider_request_digest": provider_request_digest,
+        "route": route.value,
+        "authorized_model": authorized_model,
     }
-    return provider in prefixes and model.startswith(prefixes[provider])
+    material = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8", errors="strict")
+    return "sha256:" + hashlib.sha256(material).hexdigest()
+
+
+def _create_sealed_sampling_client_binding(
+    *,
+    capability: SamplingCapability,
+    callback: SamplingCallback,
+    provider: ProviderId,
+    channel: ProviderChannel,
+    models: ProviderModelPins,
+    binding_digest: str,
+    supervision: GrokSupervisorBinding,
+    provider_request_id: str,
+    provider_request_digest: str,
+    route: RouteClass,
+    effect_claimed: EffectClaimInspector,
+) -> SamplingClientBinding:
+    """Internal constructor used only by the stateful request lease."""
+
+    return SamplingClientBinding(
+        capability=capability,
+        callback=callback,
+        provider=provider,
+        channel=channel,
+        models=models,
+        binding_digest=binding_digest,
+        supervision=supervision,
+        provider_request_id=provider_request_id,
+        provider_request_digest=provider_request_digest,
+        route=route,
+        effect_claimed=effect_claimed,
+        _factory_seal=_SAMPLING_BINDING_FACTORY_SEAL,
+    )
+
+
+def provider_request_digest(request: ProviderRequest) -> str:
+    """Canonical secret-safe digest of one complete provider request."""
+
+    snapshot = ProviderRequest.model_validate_json(
+        request.model_dump_json(warnings="error")
+    )
+    material = json.dumps(
+        snapshot.model_dump(mode="json"),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8", errors="strict")
+    return "sha256:" + hashlib.sha256(material).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class _SamplingAdapterAuthority:
+    provider: ProviderId
+    channel: ProviderChannel
+    capability: SamplingCapability
+    callback: SamplingCallback
+    effect_claimed: EffectClaimInspector
+    models: ProviderModelPins
+    binding_digest: str
+    supervision: GrokSupervisorBinding
+    provider_request_id: str
+    provider_request_digest: str
+    route: RouteClass
+    delegation_digest: str
+    descriptor: ProviderDescriptor
+    clock: Clock
+
+
+def _sampling_adapter_authority_digest(authority: _SamplingAdapterAuthority) -> str:
+    payload = {
+        "provider": authority.provider.value,
+        "channel": authority.channel.value,
+        "capability": authority.capability.model_dump(mode="json"),
+        "callback_identity": id(authority.callback),
+        "effect_claimed_identity": id(authority.effect_claimed),
+        "models": authority.models.model_dump(mode="json"),
+        "binding_digest": authority.binding_digest,
+        "supervision": authority.supervision.model_dump(mode="json"),
+        "provider_request_id": authority.provider_request_id,
+        "provider_request_digest": authority.provider_request_digest,
+        "route": authority.route.value,
+        "delegation_digest": authority.delegation_digest,
+        "descriptor": authority.descriptor.model_dump(mode="json"),
+        "clock_identity": id(authority.clock),
+    }
+    material = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8", errors="strict")
+    return "sha256:" + hashlib.sha256(material).hexdigest()
 
 
 class MCPClientSamplingAdapter(HTTPProviderAdapter):
-    """One client-advertised MCP sampling lane bound to one trusted provider."""
+    """One lease-owned MCP sampling lane bound to one trusted provider grant.
+
+    The private authority state is sealed against ordinary assignment and
+    rechecked before and after every await.  Arbitrary code execution inside
+    the trusted server process remains outside this object's security boundary.
+    """
+
+    _PROTECTED_AUTHORITY_ATTRIBUTES = frozenset({"provider", "channel", "_clock"})
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if getattr(self, "_sampling_adapter_sealed", False) and (
+            name in self._PROTECTED_AUTHORITY_ATTRIBUTES
+            or name.startswith("_sampling_")
+        ):
+            raise AttributeError("sealed MCP sampling authority cannot be mutated")
+        object.__setattr__(self, name, value)
 
     def __init__(
         self,
@@ -712,15 +916,51 @@ class MCPClientSamplingAdapter(HTTPProviderAdapter):
         channel: ProviderChannel,
         binding: SamplingClientBinding,
         clock: Clock | None = None,
+        _factory_seal: object | None = None,
     ) -> None:
+        if _factory_seal is not _MCP_SAMPLING_ADAPTER_FACTORY_SEAL:
+            raise TypeError(
+                "MCPClientSamplingAdapter must be created by the stateful MCP sampling lease"
+            )
         super().__init__(environ={}, clock=clock)
         if SAMPLING_CHANNEL_PROVIDERS.get(channel) != provider:
             raise ProviderConfigurationError(provider, "sampling_channel_mismatch")
-        self.provider = provider
-        self.channel = channel
-        self._binding = binding
-        models = binding.models or SAMPLING_DEFAULT_MODELS[provider]
-        self._descriptor = ProviderDescriptor(
+        if binding.provider != provider or binding.channel != channel:
+            raise ProviderConfigurationError(provider, "sampling_grant_mismatch")
+        try:
+            capability = SamplingCapability.model_validate_json(
+                binding.capability.model_dump_json(warnings="error")
+            )
+            models = ProviderModelPins.model_validate_json(
+                binding.models.model_dump_json(warnings="error")
+            )
+            supervision = GrokSupervisorBinding.model_validate_json(
+                binding.supervision.model_dump_json(warnings="error")
+            )
+            expected_delegation_digest = _sampling_delegation_digest(
+                binding_digest=binding.binding_digest,
+                provider=binding.provider,
+                channel=binding.channel,
+                supervision=supervision,
+                provider_request_id=binding.provider_request_id,
+                provider_request_digest=binding.provider_request_digest,
+                route=binding.route,
+                authorized_model=models.for_route(binding.route),
+            )
+        except Exception:
+            raise ProviderConfigurationError(
+                provider, "sampling_grant_mismatch"
+            ) from None
+        expected_client_id = "mcp-" + binding.binding_digest.removeprefix("sha256:")
+        if (
+            expected_delegation_digest != binding.delegation_digest
+            or capability.client_id != expected_client_id
+            or not capability.sampling
+            or not callable(binding.callback)
+            or not callable(binding.effect_claimed)
+        ):
+            raise ProviderConfigurationError(provider, "sampling_grant_mismatch")
+        descriptor = ProviderDescriptor(
             provider=provider,
             channel=channel,
             credential_plane=CredentialPlane.SUBSCRIPTION,
@@ -729,27 +969,209 @@ class MCPClientSamplingAdapter(HTTPProviderAdapter):
             endpoint_kind="mcp_client_sampling",
             credential_kind="mcp_client_subscription",
             billing_class="subscription",
-            client_identity=binding.capability.client_id,
+            client_identity=capability.client_id,
             transport_resource_identity=transport_resource_identity(
-                "mcp_sampling_client",
-                binding.capability.client_id,
+                "mcp_sampling_binding", binding.binding_digest
             ),
             credential_env_names=(),
-            credential_state=(
-                CredentialState.DEFERRED
-                if binding.capability.sampling
-                else CredentialState.MISSING
-            ),
+            credential_state=CredentialState.DEFERRED,
             models=models,
+            supported_routes=(binding.route,),
             max_output_tokens=32_768,
             max_timeout_seconds=120.0,
             data_handling="provider_managed",
             residency="client_subscription",
         )
+        authority = _SamplingAdapterAuthority(
+            provider=provider,
+            channel=channel,
+            capability=capability,
+            callback=binding.callback,
+            effect_claimed=binding.effect_claimed,
+            models=models,
+            binding_digest=str(binding.binding_digest),
+            supervision=supervision,
+            provider_request_id=str(binding.provider_request_id),
+            provider_request_digest=str(binding.provider_request_digest),
+            route=binding.route,
+            delegation_digest=str(binding.delegation_digest),
+            descriptor=descriptor,
+            clock=self._clock,
+        )
+        self.provider = provider
+        self.channel = channel
+        self._sampling_authority = authority
+        self._sampling_authority_identity = id(authority)
+        self._sampling_authority_digest = _sampling_adapter_authority_digest(authority)
+        self._sampling_adapter_sealed = True
+
+    def _validated_authority(self) -> _SamplingAdapterAuthority:
+        try:
+            authority = object.__getattribute__(self, "_sampling_authority")
+            valid = (
+                isinstance(authority, _SamplingAdapterAuthority)
+                and id(authority)
+                == object.__getattribute__(self, "_sampling_authority_identity")
+                and _sampling_adapter_authority_digest(authority)
+                == object.__getattribute__(self, "_sampling_authority_digest")
+                and object.__getattribute__(self, "provider") == authority.provider
+                and object.__getattribute__(self, "channel") == authority.channel
+                and object.__getattribute__(self, "_clock") is authority.clock
+            )
+        except Exception:
+            valid = False
+            authority = None
+        if not valid or authority is None:
+            provider = getattr(self, "provider", ProviderId.XAI)
+            if not isinstance(provider, ProviderId):
+                provider = ProviderId.XAI
+            raise ProviderAuthorizationInvariantError(
+                provider, "sampling_adapter_authority_mutated"
+            )
+        return authority
+
+    @staticmethod
+    def _claimed(authority: _SamplingAdapterAuthority) -> bool:
+        try:
+            claimed = authority.effect_claimed()
+        except Exception:
+            return True
+        return claimed if isinstance(claimed, bool) else True
+
+    @staticmethod
+    def _snapshot_request(
+        request: ProviderRequest, provider: ProviderId
+    ) -> ProviderRequest:
+        try:
+            if not isinstance(request, ProviderRequest):
+                raise TypeError
+            return ProviderRequest.model_validate_json(
+                request.model_dump_json(warnings="error")
+            )
+        except Exception:
+            raise ProviderConfigurationError(
+                provider, "sampling_provider_request_invalid"
+            ) from None
 
     @property
     def descriptor(self) -> ProviderDescriptor:
-        return self._descriptor
+        authority = self._validated_authority()
+        return ProviderDescriptor.model_validate_json(
+            authority.descriptor.model_dump_json(warnings="error")
+        )
+
+    def effect_claimed(self) -> bool:
+        """Return fail-closed one-shot state from the lease-owned runtime."""
+
+        try:
+            authority = self._validated_authority()
+        except ProviderAuthorizationInvariantError:
+            return True
+        return self._claimed(authority)
+
+    async def attempt(self, request: ProviderRequest) -> ProviderAttemptResult:
+        authority = self._validated_authority()
+        request_snapshot = self._snapshot_request(request, authority.provider)
+        receipt_descriptor = ProviderDescriptor.model_validate_json(
+            authority.descriptor.model_dump_json(warnings="error")
+        )
+        receipt_provider = authority.provider
+        receipt_channel = authority.channel
+        started = time.monotonic()
+        requested_model = request_snapshot.model or authority.models.for_route(
+            request_snapshot.route
+        )
+        try:
+            response = await self.complete(request_snapshot)
+        except ProviderError as exc:
+            return ProviderAttemptResult(
+                status="failed",
+                failure=self._sampling_failure_receipt(
+                    request=request_snapshot,
+                    requested_model=requested_model,
+                    provider=receipt_provider,
+                    channel=receipt_channel,
+                    descriptor=receipt_descriptor,
+                    error_kind=self._error_kind(exc),
+                    error_code=exc.code,
+                    duration_ms=max(0, round((time.monotonic() - started) * 1000)),
+                ),
+            )
+        except Exception:
+            return ProviderAttemptResult(
+                status="failed",
+                failure=self._sampling_failure_receipt(
+                    request=request_snapshot,
+                    requested_model=requested_model,
+                    provider=receipt_provider,
+                    channel=receipt_channel,
+                    descriptor=receipt_descriptor,
+                    error_kind="internal",
+                    error_code="unexpected_error",
+                    duration_ms=max(0, round((time.monotonic() - started) * 1000)),
+                ),
+            )
+        return ProviderAttemptResult(status="returned", response=response)
+
+    @staticmethod
+    def _sampling_failure_receipt(
+        *,
+        request: ProviderRequest,
+        requested_model: str,
+        provider: ProviderId,
+        channel: ProviderChannel,
+        descriptor: ProviderDescriptor,
+        error_kind: Literal["configuration", "transport", "protocol", "internal"],
+        error_code: str,
+        duration_ms: int,
+    ) -> ProviderFailureReceipt:
+        return ProviderFailureReceipt(
+            request_id=request.request_id,
+            supervision=request.supervision,
+            provider=provider,
+            channel=channel,
+            credential_plane=descriptor.credential_plane,
+            route=request.route,
+            requested_model=requested_model,
+            endpoint_host=descriptor.endpoint_host,
+            endpoint_kind=descriptor.endpoint_kind,
+            credential_kind=descriptor.credential_kind,
+            billing_class=descriptor.billing_class,
+            client_identity=descriptor.client_identity,
+            error_kind=error_kind,
+            error_code=error_code,
+            duration_ms=duration_ms,
+        )
+
+    async def complete(self, request: ProviderRequest) -> ProviderResponse:
+        """Preserve post-claim indeterminacy across the base TTL boundary.
+
+        The future broker integration must perform the same probe around its
+        own outer timeout before this adapter can be wired into runtime.
+        """
+
+        authority = self._validated_authority()
+        request_snapshot = self._snapshot_request(request, authority.provider)
+        try:
+            response = await super().complete(request_snapshot)
+            self._validated_authority()
+            return response
+        except asyncio.CancelledError:
+            # Only pre-claim cancellation can reach this boundary.  The lease
+            # converts every post-claim cancellation source to an internal,
+            # indeterminate effect failure before it reaches the adapter.
+            raise
+        except (
+            ProviderConfigurationError,
+            ProviderProtocolError,
+            ProviderTransportError,
+        ):
+            self._validated_authority()
+            if self._claimed(authority):
+                raise ProviderAuthorizationInvariantError(
+                    authority.provider, "sampling_effect_indeterminate"
+                ) from None
+            raise
 
     def _sampling_request(
         self,
@@ -782,8 +1204,44 @@ class MCPClientSamplingAdapter(HTTPProviderAdapter):
         )
 
     async def _complete(self, request: ProviderRequest) -> ProviderResponse:
-        if not self._binding.capability.sampling:
-            raise ProviderConfigurationError(self.provider, "sampling_unavailable")
+        authority = self._validated_authority()
+        request = self._snapshot_request(request, authority.provider)
+        callback = authority.callback
+        descriptor = ProviderDescriptor.model_validate_json(
+            authority.descriptor.model_dump_json(warnings="error")
+        )
+        models = ProviderModelPins.model_validate_json(
+            authority.models.model_dump_json(warnings="error")
+        )
+        if not authority.capability.sampling:
+            raise ProviderConfigurationError(authority.provider, "sampling_unavailable")
+        try:
+            current_digest = _sampling_delegation_digest(
+                binding_digest=authority.binding_digest,
+                provider=authority.provider,
+                channel=authority.channel,
+                supervision=authority.supervision,
+                provider_request_id=authority.provider_request_id,
+                provider_request_digest=authority.provider_request_digest,
+                route=authority.route,
+                authorized_model=models.for_route(authority.route),
+            )
+            requested_model = request.model or models.for_route(request.route)
+            matches_request = (
+                current_digest == authority.delegation_digest
+                and request.supervision == authority.supervision
+                and request.request_id == authority.provider_request_id
+                and provider_request_digest(request)
+                == authority.provider_request_digest
+                and request.route == authority.route
+                and requested_model == models.for_route(authority.route)
+            )
+        except Exception:
+            matches_request = False
+        if not matches_request:
+            raise ProviderConfigurationError(
+                authority.provider, "sampling_grant_mismatch"
+            )
         model = self._model(request)
         max_tokens, timeout = self._limits(request)
         sampling_request = self._sampling_request(
@@ -791,34 +1249,51 @@ class MCPClientSamplingAdapter(HTTPProviderAdapter):
             model=model,
             max_tokens=max_tokens,
         )
+        self._validated_authority()
         started = time.monotonic()
+        adapter_timeout: asyncio.Timeout | None = None
         try:
-            async with asyncio.timeout(timeout):
-                raw_result = await self._binding.callback(sampling_request)
+            async with asyncio.timeout(timeout) as adapter_timeout:
+                raw_result = await callback(sampling_request)
         except TimeoutError:
-            raise ProviderTransportError(self.provider, "timeout") from None
-        except (
-            ProviderConfigurationError,
-            ProviderProtocolError,
-            ProviderTransportError,
-        ):
+            self._validated_authority()
+            if self._claimed(authority):
+                raise ProviderAuthorizationInvariantError(
+                    authority.provider, "sampling_effect_indeterminate"
+                ) from None
+            raise ProviderTransportError(authority.provider, "timeout") from None
+        except ProviderError:
+            self._validated_authority()
             raise
         except Exception:
-            raise ProviderTransportError(self.provider, "sampling_failed") from None
+            self._validated_authority()
+            raise ProviderTransportError(
+                authority.provider, "sampling_failed"
+            ) from None
+        self._validated_authority()
+        if adapter_timeout is not None and adapter_timeout.expired():
+            if self._claimed(authority):
+                raise ProviderAuthorizationInvariantError(
+                    authority.provider, "sampling_effect_indeterminate"
+                )
+            raise ProviderTransportError(authority.provider, "timeout")
         try:
             result = (
-                raw_result
+                ClientSamplingResult.model_validate_json(
+                    raw_result.model_dump_json(warnings="error")
+                )
                 if isinstance(raw_result, ClientSamplingResult)
                 else ClientSamplingResult.model_validate(raw_result)
             )
-        except (ValidationError, ValueError, TypeError):
-            raise ProviderProtocolError(
-                self.provider, "invalid_sampling_result"
+        except Exception:
+            raise ProviderAuthorizationInvariantError(
+                authority.provider, "sampling_effect_indeterminate"
             ) from None
-        if not is_safe_model_id(result.model) or not _provider_model_matches(
-            self.provider, result.model
-        ):
-            raise ProviderProtocolError(self.provider, "provider_model_mismatch")
+        granted_model = models.for_route(authority.route)
+        if not is_safe_model_id(result.model) or result.model != granted_model:
+            raise ProviderAuthorizationInvariantError(
+                authority.provider, "sampling_effect_indeterminate"
+            )
         finish_reason = {
             "endTurn": "stop",
             "stopSequence": "stop",
@@ -826,34 +1301,31 @@ class MCPClientSamplingAdapter(HTTPProviderAdapter):
             "contentFilter": "content_filter",
         }[result.stop_reason]
         duration_ms = max(0, round((time.monotonic() - started) * 1000))
-        descriptor = self.descriptor
         receipt = ProviderReceipt(
             request_id=request.request_id,
             supervision=request.supervision,
-            provider=self.provider,
-            channel=self.channel,
+            provider=authority.provider,
+            channel=authority.channel,
             credential_plane=descriptor.credential_plane,
             route=request.route,
             requested_model=model,
             resolved_model=result.model,
-            model_source="provider_reported",
+            model_source="requested_fallback",
             endpoint_host=descriptor.endpoint_host,
             endpoint_kind=descriptor.endpoint_kind,
             credential_kind=descriptor.credential_kind,
             billing_class=descriptor.billing_class,
             client_identity=descriptor.client_identity,
-            cost_usd=result.cost_usd,
-            cost_source="provider_exact"
-            if result.cost_usd is not None
-            else "unavailable",
+            cost_usd=None,
+            cost_source="unavailable",
             region="client_subscription",
-            response_id=result.response_id,
+            response_id=None,
             duration_ms=duration_ms,
-            usage=result.usage,
+            usage=ProviderTokenUsage(),
         )
         return ProviderResponse(
-            provider=self.provider,
-            channel=self.channel,
+            provider=authority.provider,
+            channel=authority.channel,
             model=result.model,
             text=result.content.text,
             finish_reason=finish_reason,
@@ -861,12 +1333,32 @@ class MCPClientSamplingAdapter(HTTPProviderAdapter):
         )
 
 
+_MCP_SAMPLING_ADAPTER_FACTORY_SEAL = object()
+
+
+def _create_sealed_mcp_sampling_adapter(
+    *,
+    provider: ProviderId,
+    channel: ProviderChannel,
+    binding: SamplingClientBinding,
+    clock: Clock | None = None,
+) -> MCPClientSamplingAdapter:
+    """Internal bridge from a live lease callback to one bounded adapter."""
+
+    return MCPClientSamplingAdapter(
+        provider=provider,
+        channel=channel,
+        binding=binding,
+        clock=clock,
+        _factory_seal=_MCP_SAMPLING_ADAPTER_FACTORY_SEAL,
+    )
+
+
 def build_subscription_registry(
     *,
     claude_executable: str = "claude",
     environ: Mapping[str, str] | None = None,
     claude_runner: CLIProcessRunner | None = None,
-    sampling_clients: Mapping[ProviderChannel, SamplingClientBinding] | None = None,
     clock: Clock | None = None,
 ) -> dict[ProviderChannel, ProviderAdapter]:
     """Construct request-scoped subscription adapters without any effect."""
@@ -879,14 +1371,4 @@ def build_subscription_registry(
             clock=clock,
         )
     }
-    for channel, binding in (sampling_clients or {}).items():
-        provider = SAMPLING_CHANNEL_PROVIDERS.get(channel)
-        if provider is None:
-            raise ValueError("unsupported sampling channel")
-        registry[channel] = MCPClientSamplingAdapter(
-            provider=provider,
-            channel=channel,
-            binding=binding,
-            clock=clock,
-        )
     return registry

--- a/tests/test_mcp_sampling_bridge.py
+++ b/tests/test_mcp_sampling_bridge.py
@@ -1,0 +1,1168 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import mcp.types as mcp_types
+import pytest
+from pydantic import ValidationError
+from starlette.requests import Request
+from mcp.server.session import ServerSession
+
+from src.providers import (
+    MCP_PROVIDER_GRANTS_SCOPE_KEY,
+    MCP_SESSION_AUTHORIZATION_SCOPE_KEY,
+    MCP_SESSION_RUNTIME_SCOPE_KEY,
+    MAX_MCP_SAMPLING_EFFECT_CLAIMS,
+    GrokSupervisorBinding,
+    MCPSamplingSessionRuntime,
+    MCPSessionAuthorization,
+    ProviderAuthorizationInvariantError,
+    ProviderChannel,
+    ProviderConfigurationError,
+    ProviderId,
+    ProviderMessage,
+    ProviderModelPins,
+    ProviderRequest,
+    RouteClass,
+    TrustedMCPProviderGrant,
+    create_stateful_mcp_sampling_lease,
+    provider_request_digest,
+)
+
+
+NOW = datetime(2035, 1, 1, tzinfo=UTC)
+MODELS = ProviderModelPins(
+    planning="gemini-3.5-pro",
+    coding="gemini-3.5-code",
+    vision="gemini-3.5-vision",
+    research="gemini-3.5-research",
+)
+
+
+class FakeServerSession:
+    def __init__(self, handler=None, *, sampling: bool = True) -> None:
+        self.calls: list[dict] = []
+        self._handler = handler
+        self.client_params = SimpleNamespace(
+            capabilities=SimpleNamespace(sampling=object() if sampling else None),
+            clientInfo=SimpleNamespace(name="Antigravity"),
+        )
+
+    async def create_message(self, **kwargs):
+        self.calls.append(kwargs)
+        if self._handler is not None:
+            result = self._handler(kwargs)
+            if hasattr(result, "__await__"):
+                return await result
+            return result
+        return mcp_types.CreateMessageResult(
+            role="assistant",
+            content=mcp_types.TextContent(type="text", text="Bound observation."),
+            model=MODELS.planning,
+            stopReason="endTurn",
+        )
+
+
+def _authorization(
+    *,
+    principal: str = "http:anon",
+    trust: str = "verified_local",
+    issued_at: datetime = NOW - timedelta(seconds=5),
+    expires_at: datetime = NOW + timedelta(minutes=5),
+) -> MCPSessionAuthorization:
+    return MCPSessionAuthorization(
+        binding_id="binding-1",
+        mcp_session_id="mcp-session-1",
+        principal=principal,
+        client_label="antigravity",
+        mcp_client_name="Antigravity",
+        trust=trust,
+        issued_at=issued_at,
+        expires_at=expires_at,
+    )
+
+
+def _supervision(*, ttl: datetime | None = None) -> GrokSupervisorBinding:
+    return GrokSupervisorBinding(
+        session_id="grok-session-1",
+        objective_id="objective-1",
+        route_decision_id="route-1",
+        ttl_expires_at=ttl or NOW + timedelta(minutes=2),
+    )
+
+
+def _provider_request(
+    *,
+    supervision: GrokSupervisorBinding | None = None,
+    request_id: str = "provider-request-1",
+    timeout_seconds: float = 60.0,
+) -> ProviderRequest:
+    return ProviderRequest(
+        request_id=request_id,
+        supervision=supervision or _supervision(),
+        route=RouteClass.PLANNING,
+        messages=(
+            ProviderMessage(role="system", content="Return one bounded observation."),
+            ProviderMessage(role="user", content="Compare these."),
+        ),
+        model=MODELS.planning,
+        max_output_tokens=512,
+        timeout_seconds=timeout_seconds,
+        temperature=0.1,
+    )
+
+
+def _grant(
+    authorization: MCPSessionAuthorization,
+    *,
+    supervision: GrokSupervisorBinding | None = None,
+    related_request_id: str | int = "tool-request-7",
+    provider_request_id: str = "provider-request-1",
+    timeout_seconds: float = 60.0,
+    issued_at: datetime = NOW - timedelta(seconds=2),
+    expires_at: datetime = NOW + timedelta(minutes=1),
+) -> TrustedMCPProviderGrant:
+    supervision = supervision or _supervision()
+    provider_request = _provider_request(
+        supervision=supervision,
+        request_id=provider_request_id,
+        timeout_seconds=timeout_seconds,
+    )
+    return TrustedMCPProviderGrant(
+        grant_id="grant-1",
+        session_authorization_digest=authorization.authorization_digest,
+        supervision=supervision,
+        provider_request_id=provider_request_id,
+        provider_request_digest=provider_request_digest(provider_request),
+        mcp_related_request_id=related_request_id,
+        provider=ProviderId.GOOGLE,
+        channel=ProviderChannel.GOOGLE_MCP_SAMPLING,
+        route=RouteClass.PLANNING,
+        models=MODELS,
+        issued_at=issued_at,
+        expires_at=expires_at,
+    )
+
+
+def _context(
+    *,
+    authorization: MCPSessionAuthorization | None = None,
+    grant: TrustedMCPProviderGrant | None = None,
+    runtime: MCPSamplingSessionRuntime | None = None,
+    session: FakeServerSession | None = None,
+    request_id: str | int = "tool-request-7",
+    stateless: bool = False,
+):
+    authorization = authorization or _authorization()
+    grant = grant or _grant(authorization, related_request_id=request_id)
+    runtime = runtime or MCPSamplingSessionRuntime(authorization)
+    session = session or FakeServerSession()
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/mcp",
+        "headers": [
+            (b"mcp-session-id", authorization.mcp_session_id.encode()),
+            (b"x-client-id", authorization.client_label.encode()),
+        ],
+        MCP_SESSION_AUTHORIZATION_SCOPE_KEY: authorization,
+        MCP_PROVIDER_GRANTS_SCOPE_KEY: (grant,),
+        MCP_SESSION_RUNTIME_SCOPE_KEY: runtime,
+    }
+    request = Request(scope)
+    request_context = SimpleNamespace(
+        request=request,
+        session=session,
+        request_id=request_id,
+    )
+    ctx = SimpleNamespace(
+        fastmcp=SimpleNamespace(settings=SimpleNamespace(stateless_http=stateless)),
+        request_context=request_context,
+        session=session,
+    )
+    return ctx, request, session, authorization, grant, runtime
+
+
+def _request_for_grant(grant: TrustedMCPProviderGrant) -> ProviderRequest:
+    return _provider_request(
+        supervision=grant.supervision,
+        request_id=grant.provider_request_id,
+    )
+
+
+def _lease(ctx, grant: TrustedMCPProviderGrant | None = None, **kwargs):
+    if grant is None:
+        grant = ctx.request_context.request.scope[MCP_PROVIDER_GRANTS_SCOPE_KEY][0]
+    provider_request = kwargs.pop(
+        "provider_request",
+        _request_for_grant(grant),
+    )
+    clock = kwargs.pop("clock", lambda: NOW)
+    return create_stateful_mcp_sampling_lease(
+        ctx,
+        provider=grant.provider,
+        channel=grant.channel,
+        provider_request=provider_request,
+        clock=clock,
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_exact_stateful_session_success_is_text_only_and_request_scoped():
+    ctx, _, session, authorization, grant, _ = _context()
+    lease = _lease(ctx, grant)
+    provider_request = _request_for_grant(grant)
+
+    async with lease:
+        adapter = lease.adapter
+        assert not hasattr(lease, "binding")
+        result = await adapter.complete(provider_request)
+        assert result.text == "Bound observation."
+        assert result.model == MODELS.planning
+        assert result.receipt.usage.source == "unavailable"
+        assert result.receipt.cost_usd is None
+        assert result.receipt.response_id is None
+        assert result.receipt.supervision == grant.supervision
+        assert result.receipt.request_id == grant.provider_request_id
+        assert result.receipt.route == grant.route
+        assert adapter.descriptor.client_identity.startswith("mcp-")
+        rendered = (
+            adapter.descriptor.client_identity
+            + adapter.descriptor.transport_resource_identity
+        )
+        for raw in (
+            authorization.principal,
+            authorization.mcp_session_id,
+            authorization.client_label,
+            authorization.mcp_client_name,
+        ):
+            assert raw not in rendered
+
+    assert len(session.calls) == 1
+    call = session.calls[0]
+    assert call["include_context"] == "none"
+    assert call["tools"] is None
+    assert call["related_request_id"] == grant.mcp_related_request_id
+    assert call["messages"][0].content.type == "text"
+    with pytest.raises(
+        ProviderAuthorizationInvariantError,
+        match="sampling_effect_indeterminate",
+    ):
+        await adapter.complete(provider_request)
+
+
+@pytest.mark.asyncio
+async def test_lease_owned_adapter_authority_rejects_callback_and_state_mutation():
+    async def forged_callback(_request):
+        return {
+            "role": "assistant",
+            "content": {"type": "text", "text": "forged"},
+            "model": MODELS.planning,
+            "stopReason": "endTurn",
+        }
+
+    ctx, _, session, _, grant, _ = _context()
+    request = _request_for_grant(grant)
+    async with _lease(ctx, grant) as lease:
+        adapter = lease.adapter
+        authority = object.__getattribute__(adapter, "_sampling_authority")
+        with pytest.raises(AttributeError, match="cannot be mutated"):
+            adapter._sampling_callback = forged_callback
+        with pytest.raises(AttributeError, match="cannot be mutated"):
+            adapter.provider = ProviderId.OPENAI
+        with pytest.raises(AttributeError, match="cannot be mutated"):
+            adapter._sampling_authority = replace(authority, callback=forged_callback)
+
+        # The historical mutable attribute name is no longer consumed.  Even
+        # object-level injection cannot redirect the sealed callback.
+        object.__setattr__(adapter, "_sampling_callback", forged_callback)
+        result = await adapter.complete(request)
+
+    assert result.text == "Bound observation."
+    assert len(session.calls) == 1
+
+    ctx, _, session, _, grant, _ = _context()
+    request = _request_for_grant(grant)
+    async with _lease(ctx, grant) as lease:
+        adapter = lease.adapter
+        authority = object.__getattribute__(adapter, "_sampling_authority")
+        object.__setattr__(
+            adapter,
+            "_sampling_authority",
+            replace(authority, callback=forged_callback),
+        )
+        with pytest.raises(
+            ProviderAuthorizationInvariantError,
+            match="sampling_adapter_authority_mutated",
+        ):
+            await adapter.complete(request)
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "mutation",
+    ["request_id", "supervision", "route", "messages", "ttl"],
+)
+async def test_inflight_provider_request_mutation_cannot_forge_effect_or_receipt(
+    mutation,
+):
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def handler(_kwargs):
+        started.set()
+        await release.wait()
+        return mcp_types.CreateMessageResult(
+            role="assistant",
+            content=mcp_types.TextContent(type="text", text="snapshotted"),
+            model=MODELS.planning,
+            stopReason="endTurn",
+        )
+
+    ctx, _, session, _, grant, _ = _context(session=FakeServerSession(handler))
+    supervision = GrokSupervisorBinding.model_validate_json(
+        grant.supervision.model_dump_json()
+    )
+    request = _provider_request(
+        supervision=supervision,
+        request_id=grant.provider_request_id,
+    )
+    expected = ProviderRequest.model_validate_json(request.model_dump_json())
+    async with _lease(ctx, grant, provider_request=request) as lease:
+        task = asyncio.create_task(lease.adapter.attempt(request))
+        await started.wait()
+        if mutation == "request_id":
+            object.__setattr__(request, "request_id", "forged-request")
+        elif mutation == "supervision":
+            object.__setattr__(
+                request,
+                "supervision",
+                request.supervision.model_copy(
+                    update={"objective_id": "forged-objective"}
+                ),
+            )
+        elif mutation == "route":
+            object.__setattr__(request, "route", RouteClass.CODING)
+        elif mutation == "messages":
+            object.__setattr__(
+                request,
+                "messages",
+                (ProviderMessage(role="user", content="forged payload"),),
+            )
+        else:
+            object.__setattr__(
+                request.supervision,
+                "ttl_expires_at",
+                NOW + timedelta(hours=4),
+            )
+        release.set()
+        result = await task
+
+    assert result.response is not None
+    receipt = result.response.receipt
+    assert receipt.request_id == expected.request_id
+    assert receipt.supervision == expected.supervision
+    assert receipt.route == expected.route
+    assert result.response.text == "snapshotted"
+    assert len(session.calls) == 1
+    assert session.calls[0]["messages"][-1].content.text == "Compare these."
+
+
+@pytest.mark.asyncio
+async def test_exposed_descriptor_is_a_copy_and_cannot_forge_inflight_receipt():
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def handler(_kwargs):
+        started.set()
+        await release.wait()
+        return mcp_types.CreateMessageResult(
+            role="assistant",
+            content=mcp_types.TextContent(type="text", text="descriptor safe"),
+            model=MODELS.planning,
+            stopReason="endTurn",
+        )
+
+    ctx, _, session, _, grant, _ = _context(session=FakeServerSession(handler))
+    request = _request_for_grant(grant)
+    async with _lease(ctx, grant) as lease:
+        exposed = lease.adapter.descriptor
+        expected_identity = exposed.client_identity
+        task = asyncio.create_task(lease.adapter.attempt(request))
+        await started.wait()
+        object.__setattr__(exposed, "client_identity", "forged-client")
+        release.set()
+        result = await task
+
+    assert result.response is not None
+    assert result.response.receipt.client_identity == expected_identity
+    assert result.response.receipt.client_identity != "forged-client"
+    assert len(session.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_same_adapter_grant_is_one_shot_and_replay_is_internal():
+    ctx, _, session, _, grant, _ = _context()
+    request = _request_for_grant(grant)
+    async with _lease(ctx, grant) as lease:
+        first = await lease.adapter.attempt(request)
+        replay = await lease.adapter.attempt(request)
+
+    assert first.status == "returned"
+    assert replay.failure is not None
+    assert replay.failure.error_kind == "internal"
+    assert replay.failure.error_code == "sampling_effect_already_claimed"
+    assert replay.failure.error_kind not in {
+        "configuration",
+        "transport",
+        "protocol",
+    }
+    assert len(session.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_same_adapter_replay_executes_exactly_one_effect():
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def handler(_kwargs):
+        started.set()
+        await release.wait()
+        return mcp_types.CreateMessageResult(
+            role="assistant",
+            content=mcp_types.TextContent(type="text", text="one effect"),
+            model=MODELS.planning,
+            stopReason="endTurn",
+        )
+
+    ctx, _, session, _, grant, _ = _context(session=FakeServerSession(handler))
+    request = _request_for_grant(grant)
+    async with _lease(ctx, grant) as lease:
+        first_task = asyncio.create_task(lease.adapter.attempt(request))
+        await started.wait()
+        replay_task = asyncio.create_task(lease.adapter.attempt(request))
+        await asyncio.sleep(0)
+        assert len(session.calls) == 1
+        release.set()
+        first, replay = await asyncio.gather(first_task, replay_task)
+
+    assert first.status == "returned"
+    assert replay.failure is not None
+    assert replay.failure.error_kind == "internal"
+    assert replay.failure.error_code == "sampling_effect_already_claimed"
+    assert len(session.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_reissued_grant_across_leases_cannot_replay_same_effect():
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def handler(_kwargs):
+        started.set()
+        await release.wait()
+        return mcp_types.CreateMessageResult(
+            role="assistant",
+            content=mcp_types.TextContent(type="text", text="one effect"),
+            model=MODELS.planning,
+            stopReason="endTurn",
+        )
+
+    authorization = _authorization()
+    runtime = MCPSamplingSessionRuntime(authorization)
+    session = FakeServerSession(handler)
+    grant1 = _grant(authorization)
+    grant2 = TrustedMCPProviderGrant(**{**grant1.model_dump(), "grant_id": "grant-2"})
+    assert grant1.grant_digest != grant2.grant_digest
+    assert grant1.effect_digest == grant2.effect_digest
+    ctx1, *_ = _context(
+        authorization=authorization,
+        grant=grant1,
+        runtime=runtime,
+        session=session,
+    )
+    ctx2, *_ = _context(
+        authorization=authorization,
+        grant=grant2,
+        runtime=runtime,
+        session=session,
+    )
+    request = _request_for_grant(grant1)
+    async with _lease(ctx1, grant1) as lease1, _lease(ctx2, grant2) as lease2:
+        first_task = asyncio.create_task(lease1.adapter.attempt(request))
+        await started.wait()
+        replay_task = asyncio.create_task(lease2.adapter.attempt(request))
+        await asyncio.sleep(0)
+        assert len(session.calls) == 1
+        release.set()
+        first, replay = await asyncio.gather(first_task, replay_task)
+
+    assert first.status == "returned"
+    assert replay.failure is not None
+    assert replay.failure.error_kind == "internal"
+    assert replay.failure.error_code == "sampling_effect_already_claimed"
+    assert len(session.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_same_request_id_with_different_payload_digest_is_still_one_shot():
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def handler(_kwargs):
+        started.set()
+        await release.wait()
+        return mcp_types.CreateMessageResult(
+            role="assistant",
+            content=mcp_types.TextContent(type="text", text="one effect"),
+            model=MODELS.planning,
+            stopReason="endTurn",
+        )
+
+    authorization = _authorization()
+    runtime = MCPSamplingSessionRuntime(authorization)
+    session = FakeServerSession(handler)
+    grant1 = _grant(authorization)
+    request1 = _request_for_grant(grant1)
+    request2 = ProviderRequest.model_validate(
+        {
+            **request1.model_dump(),
+            "messages": (
+                ProviderMessage(
+                    role="system", content="Return one bounded observation."
+                ),
+                ProviderMessage(role="user", content="Different payload."),
+            ),
+        }
+    )
+    grant2 = TrustedMCPProviderGrant(
+        **{
+            **grant1.model_dump(),
+            "grant_id": "grant-2",
+            "provider_request_digest": provider_request_digest(request2),
+        }
+    )
+    assert grant1.provider_request_digest != grant2.provider_request_digest
+    assert grant1.effect_digest == grant2.effect_digest
+    ctx1, *_ = _context(
+        authorization=authorization,
+        grant=grant1,
+        runtime=runtime,
+        session=session,
+    )
+    ctx2, *_ = _context(
+        authorization=authorization,
+        grant=grant2,
+        runtime=runtime,
+        session=session,
+    )
+    async with (
+        _lease(ctx1, grant1, provider_request=request1) as lease1,
+        _lease(ctx2, grant2, provider_request=request2) as lease2,
+    ):
+        first_task = asyncio.create_task(lease1.adapter.attempt(request1))
+        await started.wait()
+        replay_task = asyncio.create_task(lease2.adapter.attempt(request2))
+        release.set()
+        first, replay = await asyncio.gather(first_task, replay_task)
+
+    assert first.status == "returned"
+    assert replay.failure is not None
+    assert replay.failure.error_kind == "internal"
+    assert replay.failure.error_code == "sampling_effect_already_claimed"
+    assert len(session.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_stateless_global_uninitialized_and_capability_absent_fail_closed():
+    ctx, *_ = _context(stateless=True)
+    with pytest.raises(ProviderConfigurationError, match="stateful_sampling_required"):
+        _lease(ctx)
+
+    ctx, _, _, _, grant, _ = _context()
+    ctx.request_context.request = SimpleNamespace(scope={})
+    with pytest.raises(
+        ProviderConfigurationError, match="sampling_context_unavailable"
+    ):
+        _lease(ctx, grant)
+
+    session = FakeServerSession()
+    session.client_params = None
+    ctx, *_ = _context(session=session)
+    with pytest.raises(
+        ProviderConfigurationError, match="sampling_capability_unavailable"
+    ):
+        async with _lease(ctx):
+            pass
+
+    ctx, *_ = _context(session=FakeServerSession(sampling=False))
+    with pytest.raises(
+        ProviderConfigurationError, match="sampling_capability_unavailable"
+    ):
+        async with _lease(ctx):
+            pass
+
+
+def test_installed_mcp_sdk_supports_exact_sampling_bridge_keywords():
+    parameters = inspect.signature(ServerSession.create_message).parameters
+    for name in (
+        "messages",
+        "max_tokens",
+        "system_prompt",
+        "include_context",
+        "temperature",
+        "model_preferences",
+        "tools",
+        "related_request_id",
+    ):
+        assert name in parameters
+    assert parameters["tools"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameters["related_request_id"].kind is inspect.Parameter.KEYWORD_ONLY
+    assert parameters["tools"].default is None
+    assert parameters["related_request_id"].default is None
+
+
+@pytest.mark.asyncio
+async def test_session_effect_claim_ceiling_revokes_without_evicting_claims():
+    runtime = MCPSamplingSessionRuntime(_authorization())
+    first_digest = "sha256:" + f"{0:064x}"
+    for index in range(MAX_MCP_SAMPLING_EFFECT_CLAIMS):
+        assert runtime.claim_effect("sha256:" + f"{index:064x}") is True
+
+    assert runtime.effect_claimed(first_digest) is True
+    with pytest.raises(RuntimeError, match="capacity exhausted"):
+        runtime.claim_effect("sha256:" + f"{MAX_MCP_SAMPLING_EFFECT_CLAIMS:064x}")
+    assert runtime.revoked is True
+    assert runtime.effect_claimed(first_digest) is True
+
+
+@pytest.mark.asyncio
+async def test_nan_drain_timeouts_fail_closed():
+    runtime = MCPSamplingSessionRuntime(_authorization())
+    with pytest.raises(ValueError, match="drain timeout"):
+        await runtime.revoke(drain_timeout_seconds=float("nan"))
+
+    ctx, *_ = _context()
+    with pytest.raises(
+        ProviderConfigurationError,
+        match="sampling_drain_timeout_invalid",
+    ):
+        _lease(ctx, drain_timeout_seconds=float("nan"))
+
+
+def test_anonymous_remote_and_non_grok_provider_grants_are_rejected():
+    with pytest.raises(ValidationError, match="anonymous MCP sampling"):
+        _authorization(trust="authenticated_remote")
+
+    authorization = _authorization(
+        principal="oauth:user-1", trust="authenticated_remote"
+    )
+    grant = _grant(authorization)
+    with pytest.raises(ValidationError):
+        TrustedMCPProviderGrant.model_validate(
+            {**grant.model_dump(), "issuer": "client"}
+        )
+
+
+@pytest.mark.asyncio
+async def test_client_labels_never_infer_provider_or_model_authority():
+    authorization = _authorization()
+    object.__setattr__(authorization, "client_label", "openai-looking-client")
+    # Rebuild a valid authorization after demonstrating that the label itself
+    # carries no provider semantics.
+    authorization = MCPSessionAuthorization(
+        **{
+            **_authorization().model_dump(),
+            "client_label": "openai-looking-client",
+        }
+    )
+    grant = _grant(authorization)
+    ctx, request, session, *_ = _context(authorization=authorization, grant=grant)
+    request.scope["headers"] = [
+        (b"mcp-session-id", b"mcp-session-1"),
+        (b"x-client-id", b"openai-looking-client"),
+    ]
+    lease = _lease(ctx, grant)
+    async with lease:
+        with pytest.raises(ProviderConfigurationError, match="sampling_grant_mismatch"):
+            await lease.adapter.complete(
+                _request_for_grant(grant).model_copy(
+                    update={"model": "gpt-9-client-claim"}
+                )
+            )
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+async def test_grant_is_bound_to_authorization_supervision_and_mcp_request():
+    ctx, _, session, authorization, grant, _ = _context()
+    forged = grant.model_copy(
+        update={"session_authorization_digest": "sha256:" + ("0" * 64)}
+    )
+    ctx.request_context.request.scope[MCP_PROVIDER_GRANTS_SCOPE_KEY] = (forged,)
+    with pytest.raises(ProviderConfigurationError, match="sampling_grant_mismatch"):
+        _lease(ctx, forged)
+
+    ctx, *_ = _context()
+    ctx.request_context.request_id = "other-tool-request"
+    with pytest.raises(ProviderConfigurationError, match="sampling_grant_mismatch"):
+        _lease(ctx)
+
+    # The grant model itself rejects outliving Grok supervision.
+    with pytest.raises(ValidationError, match="cannot outlive Grok supervision"):
+        TrustedMCPProviderGrant.model_validate(
+            {
+                **grant.model_dump(),
+                "expires_at": grant.supervision.ttl_expires_at + timedelta(seconds=1),
+            }
+        )
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+async def test_future_or_expired_authority_fails_before_effect():
+    future_auth = _authorization(
+        issued_at=NOW + timedelta(seconds=1),
+        expires_at=NOW + timedelta(minutes=5),
+    )
+    future_grant = _grant(
+        future_auth,
+        issued_at=NOW + timedelta(seconds=2),
+        expires_at=NOW + timedelta(minutes=1),
+    )
+    ctx, _, session, *_ = _context(
+        authorization=future_auth,
+        grant=future_grant,
+    )
+    with pytest.raises(
+        ProviderConfigurationError, match="sampling_authority_not_yet_valid"
+    ):
+        async with _lease(ctx, future_grant):
+            pass
+    assert session.calls == []
+
+    ctx, _, session, _, grant, _ = _context()
+    with pytest.raises(ProviderConfigurationError, match="ttl_expired"):
+        async with create_stateful_mcp_sampling_lease(
+            ctx,
+            provider=grant.provider,
+            channel=grant.channel,
+            provider_request=_request_for_grant(grant),
+            clock=lambda: grant.expires_at,
+        ):
+            pass
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+async def test_auth_and_grant_object_mutation_is_detected_pre_effect():
+    ctx, _, session, authorization, grant, _ = _context()
+    lease = _lease(ctx, grant)
+    async with lease:
+        object.__setattr__(authorization, "principal", "oauth:attacker")
+        with pytest.raises(
+            ProviderConfigurationError, match="sampling_authorization_mismatch"
+        ):
+            await lease.adapter.complete(_request_for_grant(grant))
+    assert session.calls == []
+
+    ctx, _, session, _, grant, _ = _context()
+    lease = _lease(ctx, grant)
+    async with lease:
+        object.__setattr__(grant, "provider_request_id", "forged-request")
+        with pytest.raises(ProviderConfigurationError, match="sampling_grant_mismatch"):
+            await lease.adapter.complete(
+                _provider_request(request_id="provider-request-1")
+            )
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+async def test_exact_context_session_header_client_and_request_id_are_rechecked():
+    ctx, request, session, _, grant, _ = _context()
+    lease = _lease(ctx, grant)
+    async with lease:
+        ctx.request_context.session = FakeServerSession()
+        with pytest.raises(
+            ProviderConfigurationError, match="sampling_session_mismatch"
+        ):
+            await lease.adapter.complete(_request_for_grant(grant))
+    assert session.calls == []
+
+    ctx, request, session, _, grant, _ = _context()
+    lease = _lease(ctx, grant)
+    async with lease:
+        request.scope["headers"] = [
+            (b"mcp-session-id", b"other-session"),
+            (b"x-client-id", b"antigravity"),
+        ]
+        with pytest.raises(
+            ProviderConfigurationError, match="sampling_session_mismatch"
+        ):
+            await lease.adapter.complete(_request_for_grant(grant))
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+async def test_two_distinct_request_leases_share_one_session_concurrency_slot():
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    active = 0
+    max_active = 0
+
+    async def handler(_kwargs):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        try:
+            if len(session.calls) == 1:
+                first_started.set()
+                await release_first.wait()
+            return mcp_types.CreateMessageResult(
+                role="assistant",
+                content=mcp_types.TextContent(type="text", text="serialized"),
+                model=MODELS.planning,
+                stopReason="endTurn",
+            )
+        finally:
+            active -= 1
+
+    authorization = _authorization()
+    supervision = _supervision()
+    runtime = MCPSamplingSessionRuntime(authorization)
+    session = FakeServerSession(handler)
+    grant1 = _grant(
+        authorization,
+        supervision=supervision,
+        related_request_id="tool-request-1",
+        provider_request_id="provider-request-1",
+    )
+    grant2 = TrustedMCPProviderGrant(
+        **{
+            **_grant(
+                authorization,
+                supervision=supervision,
+                related_request_id="tool-request-2",
+                provider_request_id="provider-request-2",
+            ).model_dump(),
+            "grant_id": "grant-2",
+        }
+    )
+    ctx1, *_ = _context(
+        authorization=authorization,
+        grant=grant1,
+        runtime=runtime,
+        session=session,
+        request_id="tool-request-1",
+    )
+    ctx2, *_ = _context(
+        authorization=authorization,
+        grant=grant2,
+        runtime=runtime,
+        session=session,
+        request_id="tool-request-2",
+    )
+    async with _lease(ctx1, grant1) as lease1, _lease(ctx2, grant2) as lease2:
+        task1 = asyncio.create_task(lease1.adapter.complete(_request_for_grant(grant1)))
+        await first_started.wait()
+        task2 = asyncio.create_task(lease2.adapter.complete(_request_for_grant(grant2)))
+        await asyncio.sleep(0)
+        assert len(session.calls) == 1
+        release_first.set()
+        await asyncio.gather(task1, task2)
+
+    assert len(session.calls) == 2
+    assert max_active == 1
+
+
+@pytest.mark.asyncio
+async def test_lease_and_session_revocation_cancel_and_drain_active_calls():
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def handler(_kwargs):
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    ctx, _, _, _, grant, runtime = _context(session=FakeServerSession(handler))
+    lease = _lease(ctx, grant)
+    await lease.__aenter__()
+    adapter = lease.adapter
+    task = asyncio.create_task(adapter.complete(_request_for_grant(grant)))
+    await started.wait()
+    await lease.revoke()
+    assert cancelled.is_set()
+    with pytest.raises(
+        ProviderAuthorizationInvariantError,
+        match="sampling_effect_indeterminate",
+    ):
+        await task
+    with pytest.raises(
+        ProviderAuthorizationInvariantError,
+        match="sampling_effect_indeterminate",
+    ):
+        await adapter.complete(_request_for_grant(grant))
+
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+    ctx, _, _, _, grant, runtime = _context(session=FakeServerSession(handler))
+    lease = _lease(ctx, grant)
+    await lease.__aenter__()
+    task = asyncio.create_task(lease.adapter.complete(_request_for_grant(grant)))
+    await started.wait()
+    await runtime.revoke()
+    with pytest.raises(
+        ProviderAuthorizationInvariantError,
+        match="sampling_effect_indeterminate",
+    ):
+        await task
+    with pytest.raises(
+        ProviderAuthorizationInvariantError,
+        match="sampling_effect_indeterminate",
+    ):
+        await lease.adapter.complete(_request_for_grant(grant))
+    await lease.revoke()
+
+
+@pytest.mark.asyncio
+async def test_outer_task_cancellation_after_claim_is_internal_indeterminate():
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def handler(_kwargs):
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    ctx, _, session, _, grant, _ = _context(session=FakeServerSession(handler))
+    async with _lease(ctx, grant) as lease:
+        task = asyncio.create_task(lease.adapter.complete(_request_for_grant(grant)))
+        await started.wait()
+        assert lease.adapter.effect_claimed() is True
+        task.cancel()
+        with pytest.raises(
+            ProviderAuthorizationInvariantError,
+            match="sampling_effect_indeterminate",
+        ):
+            await task
+
+    assert cancelled.is_set()
+    assert task.cancelled() is False
+    assert len(session.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_outer_task_cancellation_before_claim_preserves_cancellation():
+    ctx, _, session, _, grant, runtime = _context()
+    semaphore = runtime.sampling_slot()
+    await semaphore.acquire()
+    try:
+        async with _lease(ctx, grant) as lease:
+            task = asyncio.create_task(
+                lease.adapter.complete(_request_for_grant(grant))
+            )
+            for _ in range(10):
+                await asyncio.sleep(0)
+                if task in runtime._active_tasks:
+                    break
+            assert task in runtime._active_tasks
+            assert task.done() is False
+            assert lease.adapter.effect_claimed() is False
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+            assert lease.adapter.effect_claimed() is False
+    finally:
+        semaphore.release()
+
+    assert task.cancelled() is True
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+async def test_disconnect_and_callback_errors_are_secret_safe():
+    secret = "private-session-transport-token"
+
+    async def handler(_kwargs):
+        raise RuntimeError(secret)
+
+    ctx, _, _, _, grant, _ = _context(session=FakeServerSession(handler))
+    async with _lease(ctx, grant) as lease:
+        with pytest.raises(ProviderAuthorizationInvariantError) as exc_info:
+            await lease.adapter.complete(_request_for_grant(grant))
+    assert exc_info.value.code == "sampling_effect_indeterminate"
+    assert secret not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "case",
+    ["timeout", "disconnect", "protocol", "late_result", "auth_changed"],
+)
+async def test_every_post_claim_failure_is_internal_and_not_fallback_eligible(case):
+    current = NOW
+    authorization = _authorization()
+    grant = _grant(authorization)
+
+    async def handler(_kwargs):
+        nonlocal current
+        if case == "timeout":
+            raise TimeoutError
+        if case == "disconnect":
+            raise RuntimeError("private disconnect detail")
+        if case == "protocol":
+            return mcp_types.CreateMessageResult(
+                role="user",
+                content=mcp_types.TextContent(type="text", text="wrong role"),
+                model=MODELS.planning,
+                stopReason="endTurn",
+            )
+        if case == "late_result":
+            current = grant.expires_at
+        if case == "auth_changed":
+            object.__setattr__(authorization, "principal", "oauth:changed")
+        return mcp_types.CreateMessageResult(
+            role="assistant",
+            content=mcp_types.TextContent(type="text", text="late or changed"),
+            model=MODELS.planning,
+            stopReason="endTurn",
+        )
+
+    session = FakeServerSession(handler)
+    ctx, *_ = _context(
+        authorization=authorization,
+        grant=grant,
+        session=session,
+    )
+    async with _lease(ctx, grant, clock=lambda: current) as lease:
+        assert lease.adapter.effect_claimed() is False
+        result = await lease.adapter.attempt(_request_for_grant(grant))
+        assert lease.adapter.effect_claimed() is True
+
+    assert result.failure is not None
+    assert result.failure.error_kind == "internal"
+    assert result.failure.error_code == "sampling_effect_indeterminate"
+    assert result.failure.error_kind not in {
+        "configuration",
+        "transport",
+        "protocol",
+    }
+    assert len(session.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_real_adapter_timeout_after_dispatch_is_internal():
+    cancelled = asyncio.Event()
+
+    async def handler(_kwargs):
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    authorization = _authorization()
+    supervision = _supervision()
+    request = _provider_request(
+        supervision=supervision,
+        timeout_seconds=1.0,
+    )
+    grant = _grant(
+        authorization,
+        supervision=supervision,
+        timeout_seconds=1.0,
+    )
+    session = FakeServerSession(handler)
+    ctx, *_ = _context(
+        authorization=authorization,
+        grant=grant,
+        session=session,
+    )
+    async with _lease(ctx, grant, provider_request=request) as lease:
+        result = await lease.adapter.attempt(request)
+        assert lease.adapter.effect_claimed() is True
+
+    assert cancelled.is_set()
+    assert len(session.calls) == 1
+    assert result.failure is not None
+    assert result.failure.error_kind == "internal"
+    assert result.failure.error_code == "sampling_effect_indeterminate"
+
+
+@pytest.mark.asyncio
+async def test_preclaim_context_failure_remains_fallback_eligible_configuration():
+    ctx, request_scope, session, _, grant, _ = _context()
+    async with _lease(ctx, grant) as lease:
+        request_scope.scope["headers"] = [
+            (b"mcp-session-id", b"wrong-session"),
+            (b"x-client-id", b"antigravity"),
+        ]
+        assert lease.adapter.effect_claimed() is False
+        result = await lease.adapter.attempt(_request_for_grant(grant))
+        assert lease.adapter.effect_claimed() is False
+
+    assert result.failure is not None
+    assert result.failure.error_kind == "configuration"
+    assert result.failure.error_code == "sampling_session_mismatch"
+    assert session.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", ["image", "user", "tool", "model", "constructed"])
+async def test_sdk_results_are_revalidated_and_strictly_text_only(case):
+    def handler(_kwargs):
+        if case == "image":
+            return mcp_types.CreateMessageResult(
+                role="assistant",
+                content=mcp_types.ImageContent(
+                    type="image", data="AA==", mimeType="image/png"
+                ),
+                model=MODELS.planning,
+                stopReason="endTurn",
+            )
+        if case == "user":
+            return mcp_types.CreateMessageResult(
+                role="user",
+                content=mcp_types.TextContent(type="text", text="wrong role"),
+                model=MODELS.planning,
+                stopReason="endTurn",
+            )
+        if case == "tool":
+            return mcp_types.CreateMessageResult(
+                role="assistant",
+                content=mcp_types.TextContent(type="text", text="tool requested"),
+                model=MODELS.planning,
+                stopReason="toolUse",
+            )
+        if case == "model":
+            return mcp_types.CreateMessageResult(
+                role="assistant",
+                content=mcp_types.TextContent(type="text", text="wrong model"),
+                model=MODELS.coding,
+                stopReason="endTurn",
+            )
+        return mcp_types.CreateMessageResult.model_construct(
+            role="assistant",
+            content={"type": "tool_use", "name": "forbidden"},
+            model=MODELS.planning,
+            stopReason="endTurn",
+        )
+
+    ctx, _, _, _, grant, _ = _context(session=FakeServerSession(handler))
+    async with _lease(ctx, grant) as lease:
+        with pytest.raises(ProviderAuthorizationInvariantError) as exc_info:
+            await lease.adapter.complete(_request_for_grant(grant))
+    assert exc_info.value.code == "sampling_effect_indeterminate"

--- a/tests/test_subscription_transports.py
+++ b/tests/test_subscription_transports.py
@@ -26,20 +26,25 @@ from src.providers import (
     ProviderConfigurationError,
     ProviderId,
     ProviderMessage,
+    ProviderModelPins,
     ProviderReceipt,
     ProviderRequest,
     ProviderTokenUsage,
     RouteClass,
     SamplingCapability,
-    SamplingClientBinding,
     SamplingTextContent,
     build_subscription_registry,
+    provider_request_digest,
+    transport_resource_identity,
 )
 from src.providers.subscription import (
     MAX_CLI_STDERR_BYTES,
     MAX_CLI_STDOUT_BYTES,
     _ProcessOutputLimit,
     _ProcessTimeout,
+    SamplingClientBinding,
+    _create_sealed_mcp_sampling_adapter,
+    _create_sealed_sampling_client_binding,
     _claude_subscription_environment,
     _run_bounded_process,
 )
@@ -147,12 +152,87 @@ class CapturingRunner:
 def _sampling_binding(
     callback,
     *,
+    request: ProviderRequest,
+    provider: ProviderId = ProviderId.OPENAI,
+    channel: ProviderChannel | None = None,
     client_id: str = "codex-desktop",
     sampling: bool = True,
+    effect_claimed=None,
 ) -> SamplingClientBinding:
-    return SamplingClientBinding(
-        capability=SamplingCapability(client_id=client_id, sampling=sampling),
+    channels = {
+        ProviderId.OPENAI: ProviderChannel.OPENAI_MCP_SAMPLING,
+        ProviderId.ANTHROPIC: ProviderChannel.ANTHROPIC_MCP_SAMPLING,
+        ProviderId.GOOGLE: ProviderChannel.GOOGLE_MCP_SAMPLING,
+    }
+    selected_channel = channel or channels[provider]
+    model = (
+        request.model
+        or {
+            ProviderId.OPENAI: "gpt-5.1",
+            ProviderId.ANTHROPIC: "claude-fable-5",
+            ProviderId.GOOGLE: "gemini-3.5-flash",
+        }[provider]
+    )
+    models = ProviderModelPins(
+        planning=model,
+        coding=model,
+        vision=model,
+        research=model,
+    )
+    binding_digest = transport_resource_identity(
+        "test_mcp_sampling_binding",
+        f"{provider.value}:{selected_channel.value}:{client_id}:{request.request_id}",
+    )
+    return _create_sealed_sampling_client_binding(
+        capability=SamplingCapability(
+            client_id="mcp-" + binding_digest.removeprefix("sha256:"),
+            sampling=sampling,
+        ),
         callback=callback,
+        provider=provider,
+        channel=selected_channel,
+        models=models,
+        binding_digest=binding_digest,
+        supervision=request.supervision,
+        provider_request_id=request.request_id,
+        provider_request_digest=provider_request_digest(request),
+        route=request.route,
+        effect_claimed=effect_claimed or (lambda: False),
+    )
+
+
+def _sampling_adapter(
+    callback,
+    *,
+    request: ProviderRequest,
+    provider: ProviderId = ProviderId.OPENAI,
+    channel: ProviderChannel | None = None,
+    client_id: str = "codex-desktop",
+    sampling: bool = True,
+    effect_claimed=None,
+    clock=None,
+) -> MCPClientSamplingAdapter:
+    selected_channel = (
+        channel
+        or {
+            ProviderId.OPENAI: ProviderChannel.OPENAI_MCP_SAMPLING,
+            ProviderId.ANTHROPIC: ProviderChannel.ANTHROPIC_MCP_SAMPLING,
+            ProviderId.GOOGLE: ProviderChannel.GOOGLE_MCP_SAMPLING,
+        }[provider]
+    )
+    return _create_sealed_mcp_sampling_adapter(
+        provider=provider,
+        channel=selected_channel,
+        binding=_sampling_binding(
+            callback,
+            request=request,
+            provider=provider,
+            channel=selected_channel,
+            client_id=client_id,
+            sampling=sampling,
+            effect_claimed=effect_claimed,
+        ),
+        clock=clock,
     )
 
 
@@ -576,16 +656,141 @@ async def test_sampling_requires_advertised_capability_and_never_calls_when_abse
         calls += 1
         raise AssertionError("capability-absent client was called")
 
-    adapter = MCPClientSamplingAdapter(
-        provider=ProviderId.GOOGLE,
-        channel=ProviderChannel.GOOGLE_MCP_SAMPLING,
-        binding=_sampling_binding(callback, client_id="antigravity", sampling=False),
-    )
-    assert adapter.descriptor.credential_state == CredentialState.MISSING
-    result = await adapter.attempt(_request(model="gemini-3.5-flash"))
-    assert result.failure is not None
-    assert result.failure.error_code == "sampling_unavailable"
+    request = _request(model="gemini-3.5-flash")
+    with pytest.raises(ValueError, match="sealed binding"):
+        _sampling_binding(
+            callback,
+            request=request,
+            provider=ProviderId.GOOGLE,
+            client_id="antigravity",
+            sampling=False,
+        )
     assert calls == 0
+
+
+def test_sampling_binding_rejects_bare_callbacks_and_cross_provider_reuse():
+    async def callback(_request):
+        raise AssertionError("construction must stay inert")
+
+    request = _request(model="gpt-5.1")
+    models = ProviderModelPins(
+        planning="gpt-5.1",
+        coding="gpt-5.1",
+        vision="gpt-5.1",
+        research="gpt-5.1",
+    )
+    digest = transport_resource_identity("test", "bare-callback")
+    with pytest.raises(TypeError, match="stateful MCP sampling factory"):
+        SamplingClientBinding(
+            capability=SamplingCapability(
+                client_id="mcp-" + digest.removeprefix("sha256:"),
+                sampling=True,
+            ),
+            callback=callback,
+            provider=ProviderId.OPENAI,
+            channel=ProviderChannel.OPENAI_MCP_SAMPLING,
+            models=models,
+            binding_digest=digest,
+            supervision=request.supervision,
+            provider_request_id=request.request_id,
+            provider_request_digest=provider_request_digest(request),
+            route=request.route,
+            effect_claimed=lambda: False,
+        )
+
+    binding = _sampling_binding(callback, request=request)
+    with pytest.raises(ProviderConfigurationError, match="sampling_grant_mismatch"):
+        _create_sealed_mcp_sampling_adapter(
+            provider=ProviderId.ANTHROPIC,
+            channel=ProviderChannel.ANTHROPIC_MCP_SAMPLING,
+            binding=binding,
+        )
+    with pytest.raises(TypeError, match="stateful MCP sampling lease"):
+        MCPClientSamplingAdapter(
+            provider=ProviderId.OPENAI,
+            channel=ProviderChannel.OPENAI_MCP_SAMPLING,
+            binding=binding,
+        )
+
+    google_request = _request(model="gemini-3.5-flash")
+    relabeled = _sampling_binding(
+        callback,
+        request=google_request,
+        provider=ProviderId.GOOGLE,
+    )
+    object.__setattr__(relabeled, "provider", ProviderId.OPENAI)
+    object.__setattr__(relabeled, "channel", ProviderChannel.OPENAI_MCP_SAMPLING)
+    with pytest.raises(ProviderConfigurationError, match="sampling_grant_mismatch"):
+        _create_sealed_mcp_sampling_adapter(
+            provider=ProviderId.OPENAI,
+            channel=ProviderChannel.OPENAI_MCP_SAMPLING,
+            binding=relabeled,
+        )
+
+    wrong_identity = _sampling_binding(callback, request=request)
+    object.__setattr__(wrong_identity.capability, "client_id", "mcp-" + ("0" * 64))
+    with pytest.raises(ProviderConfigurationError, match="sampling_grant_mismatch"):
+        _create_sealed_mcp_sampling_adapter(
+            provider=ProviderId.OPENAI,
+            channel=ProviderChannel.OPENAI_MCP_SAMPLING,
+            binding=wrong_identity,
+        )
+
+
+@pytest.mark.asyncio
+async def test_sampling_grant_matches_exact_supervision_request_route_and_model_pre_effect():
+    calls = 0
+
+    async def callback(_request):
+        nonlocal calls
+        calls += 1
+        return ClientSamplingResult(
+            content=SamplingTextContent(type="text", text="unreachable"),
+            model="gpt-5.1",
+            stop_reason="endTurn",
+        )
+
+    request = _request(model="gpt-5.1")
+    adapter = _sampling_adapter(callback, request=request)
+    other_supervision = request.supervision.model_copy(
+        update={"objective_id": "objective-2"}
+    )
+    altered = (
+        request.model_copy(update={"supervision": other_supervision}),
+        request.model_copy(update={"request_id": "provider-request-2"}),
+        request.model_copy(update={"route": RouteClass.CODING}),
+        request.model_copy(update={"model": "gpt-5.2"}),
+        request.model_copy(
+            update={
+                "messages": (ProviderMessage(role="user", content="Changed content."),)
+            }
+        ),
+        request.model_copy(update={"max_output_tokens": 2048}),
+        request.model_copy(update={"timeout_seconds": 12.0}),
+        request.model_copy(update={"temperature": 0.8}),
+    )
+    for candidate in altered:
+        result = await adapter.attempt(candidate)
+        assert result.failure is not None
+        assert result.failure.error_code == "sampling_grant_mismatch"
+    assert calls == 0
+
+
+@pytest.mark.asyncio
+async def test_constructed_client_sampling_result_is_revalidated():
+    async def callback(_request):
+        return ClientSamplingResult.model_construct(
+            role="assistant",
+            content={"type": "tool_use", "text": "forbidden"},
+            model="gpt-5.1",
+            stop_reason="endTurn",
+        )
+
+    request = _request(model="gpt-5.1")
+    result = await _sampling_adapter(callback, request=request).attempt(request)
+    assert result.failure is not None
+    assert result.failure.error_kind == "internal"
+    assert result.failure.error_code == "sampling_effect_indeterminate"
 
 
 @pytest.mark.asyncio
@@ -596,18 +801,20 @@ async def test_sampling_request_has_no_context_tools_or_implicit_model_and_recei
         observed.append(request)
         return ClientSamplingResult(
             content=SamplingTextContent(type="text", text="IDE subscription answer."),
-            model="gpt-5.1-20260701",
+            model="gpt-5.1",
             stop_reason="endTurn",
             response_id="sampling-response-1",
         )
 
-    adapter = MCPClientSamplingAdapter(
+    provider_request = _request(model="gpt-5.1", max_output_tokens=9000)
+    binding = _sampling_binding(callback, request=provider_request)
+    adapter = _create_sealed_mcp_sampling_adapter(
         provider=ProviderId.OPENAI,
         channel=ProviderChannel.OPENAI_MCP_SAMPLING,
-        binding=_sampling_binding(callback),
+        binding=binding,
     )
     assert adapter.descriptor.credential_state == CredentialState.DEFERRED
-    response = await adapter.complete(_request(model="gpt-5.1", max_output_tokens=9000))
+    response = await adapter.complete(provider_request)
     assert len(observed) == 1
     request = observed[0]
     assert request.method == "sampling/createMessage"
@@ -625,9 +832,10 @@ async def test_sampling_request_has_no_context_tools_or_implicit_model_and_recei
     assert wire_request["messages"][0]["content"]["type"] == "text"
     assert response.receipt.provider == ProviderId.OPENAI
     assert response.receipt.channel == ProviderChannel.OPENAI_MCP_SAMPLING
-    assert response.receipt.client_identity == "codex-desktop"
-    assert response.receipt.resolved_model == "gpt-5.1-20260701"
-    assert response.receipt.model_source == "provider_reported"
+    assert response.receipt.client_identity == binding.capability.client_id
+    assert response.receipt.resolved_model == "gpt-5.1"
+    assert response.receipt.response_id is None
+    assert response.receipt.model_source == "requested_fallback"
     assert response.receipt.billing_class == "subscription"
     assert response.receipt.usage.source == "unavailable"
     assert response.receipt.cost_usd is None
@@ -638,6 +846,8 @@ async def test_sampling_request_has_no_context_tools_or_implicit_model_and_recei
 
 @pytest.mark.asyncio
 async def test_sampling_rejects_provider_spoofing_model_spoofing_and_malformed_content():
+    request = _request(model="gpt-5.1")
+
     async def wrong_model(_request):
         return {
             "content": {"type": "text", "text": "spoofed"},
@@ -646,14 +856,11 @@ async def test_sampling_rejects_provider_spoofing_model_spoofing_and_malformed_c
             "stopReason": "endTurn",
         }
 
-    adapter = MCPClientSamplingAdapter(
-        provider=ProviderId.OPENAI,
-        channel=ProviderChannel.OPENAI_MCP_SAMPLING,
-        binding=_sampling_binding(wrong_model),
-    )
-    result = await adapter.attempt(_request(model="gpt-5.1"))
+    adapter = _sampling_adapter(wrong_model, request=request)
+    result = await adapter.attempt(request)
     assert result.failure is not None
-    assert result.failure.error_code == "provider_model_mismatch"
+    assert result.failure.error_kind == "internal"
+    assert result.failure.error_code == "sampling_effect_indeterminate"
 
     async def spoofed_provider(_request):
         return {
@@ -663,14 +870,11 @@ async def test_sampling_rejects_provider_spoofing_model_spoofing_and_malformed_c
             "stop_reason": "endTurn",
         }
 
-    adapter = MCPClientSamplingAdapter(
-        provider=ProviderId.OPENAI,
-        channel=ProviderChannel.OPENAI_MCP_SAMPLING,
-        binding=_sampling_binding(spoofed_provider),
-    )
-    result = await adapter.attempt(_request(model="gpt-5.1"))
+    adapter = _sampling_adapter(spoofed_provider, request=request)
+    result = await adapter.attempt(request)
     assert result.failure is not None
-    assert result.failure.error_code == "invalid_sampling_result"
+    assert result.failure.error_kind == "internal"
+    assert result.failure.error_code == "sampling_effect_indeterminate"
 
     async def tool_content(_request):
         return {
@@ -680,20 +884,17 @@ async def test_sampling_rejects_provider_spoofing_model_spoofing_and_malformed_c
             "stopReason": "endTurn",
         }
 
-    adapter = MCPClientSamplingAdapter(
-        provider=ProviderId.OPENAI,
-        channel=ProviderChannel.OPENAI_MCP_SAMPLING,
-        binding=_sampling_binding(tool_content),
-    )
-    result = await adapter.attempt(_request(model="gpt-5.1"))
+    adapter = _sampling_adapter(tool_content, request=request)
+    result = await adapter.attempt(request)
     assert result.failure is not None
-    assert result.failure.error_code == "invalid_sampling_result"
+    assert result.failure.error_kind == "internal"
+    assert result.failure.error_code == "sampling_effect_indeterminate"
 
     with pytest.raises(ProviderConfigurationError, match="sampling_channel_mismatch"):
-        MCPClientSamplingAdapter(
+        _create_sealed_mcp_sampling_adapter(
             provider=ProviderId.ANTHROPIC,
             channel=ProviderChannel.OPENAI_MCP_SAMPLING,
-            binding=_sampling_binding(spoofed_provider),
+            binding=_sampling_binding(spoofed_provider, request=request),
         )
 
 
@@ -704,11 +905,13 @@ async def test_sampling_callback_errors_are_secret_safe():
     async def callback(_request):
         raise RuntimeError(secret)
 
-    result = await MCPClientSamplingAdapter(
+    request = _request(model="gemini-3.5-flash")
+    result = await _sampling_adapter(
+        callback,
+        request=request,
         provider=ProviderId.GOOGLE,
-        channel=ProviderChannel.GOOGLE_MCP_SAMPLING,
-        binding=_sampling_binding(callback, client_id="antigravity"),
-    ).attempt(_request(model="gemini-3.5-flash"))
+        client_id="antigravity",
+    ).attempt(request)
     assert result.failure is not None
     assert result.failure.error_code == "sampling_failed"
     assert secret not in result.failure.model_dump_json()
@@ -725,33 +928,68 @@ async def test_sampling_ttl_expiry_and_callback_timeout_are_bounded():
         await asyncio.sleep(5)
         raise AssertionError("unreachable")
 
-    adapter = MCPClientSamplingAdapter(
+    expired_request = _request(now=now, ttl_seconds=-1, model="gemini-3.5-flash")
+    adapter = _sampling_adapter(
+        callback,
+        request=expired_request,
         provider=ProviderId.GOOGLE,
-        channel=ProviderChannel.GOOGLE_MCP_SAMPLING,
-        binding=_sampling_binding(callback, client_id="antigravity"),
+        client_id="antigravity",
         clock=lambda: now,
     )
-    expired = await adapter.attempt(
-        _request(now=now, ttl_seconds=-1, model="gemini-3.5-flash")
-    )
+    expired = await adapter.attempt(expired_request)
     assert expired.failure is not None
     assert expired.failure.error_code == "ttl_expired"
     assert calls == 0
 
     # The absolute completion guard is independently tested with a real clock.
-    timed = MCPClientSamplingAdapter(
+    timed_request = _request(ttl_seconds=0.02, model="gemini-3.5-flash")
+    timed = _sampling_adapter(
+        callback,
+        request=timed_request,
         provider=ProviderId.GOOGLE,
-        channel=ProviderChannel.GOOGLE_MCP_SAMPLING,
-        binding=_sampling_binding(callback, client_id="antigravity"),
+        client_id="antigravity",
     )
-    timeout = await timed.attempt(_request(ttl_seconds=0.02, model="gemini-3.5-flash"))
+    timeout = await timed.attempt(timed_request)
     assert timeout.failure is not None
     assert timeout.failure.error_code == "ttl_expired"
     assert calls == 1
 
 
 @pytest.mark.asyncio
-async def test_sampling_records_only_actually_returned_usage_and_cost():
+async def test_sampling_base_ttl_boundary_after_claim_is_internal():
+    now = datetime(2030, 1, 1, tzinfo=UTC)
+    current = now
+    claimed = False
+    request = _request(
+        now=now,
+        ttl_seconds=10.0,
+        model="gemini-3.5-flash",
+    )
+
+    async def callback(_request):
+        nonlocal claimed, current
+        claimed = True
+        current = request.supervision.ttl_expires_at
+        return ClientSamplingResult(
+            content=SamplingTextContent(type="text", text="boundary result"),
+            model="gemini-3.5-flash",
+            stop_reason="endTurn",
+        )
+
+    result = await _sampling_adapter(
+        callback,
+        request=request,
+        provider=ProviderId.GOOGLE,
+        effect_claimed=lambda: claimed,
+        clock=lambda: current,
+    ).attempt(request)
+    assert result.failure is not None
+    assert result.failure.error_kind == "internal"
+    assert result.failure.error_code == "sampling_effect_indeterminate"
+
+
+@pytest.mark.asyncio
+async def test_sampling_client_usage_cost_and_response_id_are_not_receipt_authority():
     async def callback(_request):
         return ClientSamplingResult(
             content=SamplingTextContent(type="text", text="Measured answer."),
@@ -764,21 +1002,25 @@ async def test_sampling_records_only_actually_returned_usage_and_cost():
                 source="provider_exact",
             ),
             cost_usd=Decimal("0.00120000"),
+            response_id="client-claimed-response",
         )
 
-    response = await MCPClientSamplingAdapter(
+    request = _request(model="claude-fable-5")
+    response = await _sampling_adapter(
+        callback,
+        request=request,
         provider=ProviderId.ANTHROPIC,
-        channel=ProviderChannel.ANTHROPIC_MCP_SAMPLING,
-        binding=_sampling_binding(callback, client_id="claude-code"),
-    ).complete(_request(model="claude-fable-5"))
+        client_id="claude-code",
+    ).complete(request)
     assert response.finish_reason == "length"
-    assert response.receipt.usage.total_tokens == 14
-    assert response.receipt.usage.source == "provider_exact"
-    assert response.receipt.cost_usd == Decimal("0.00120000")
-    assert response.receipt.cost_source == "provider_exact"
+    assert response.receipt.usage.total_tokens is None
+    assert response.receipt.usage.source == "unavailable"
+    assert response.receipt.cost_usd is None
+    assert response.receipt.cost_source == "unavailable"
+    assert response.receipt.response_id is None
 
 
-def test_subscription_registry_is_inert_request_scoped_and_has_no_codex_cli():
+def test_subscription_registry_is_inert_and_sampling_requires_live_lease():
     effects = 0
 
     async def runner(**_kwargs):
@@ -786,25 +1028,11 @@ def test_subscription_registry_is_inert_request_scoped_and_has_no_codex_cli():
         effects += 1
         raise AssertionError("registry construction executed Claude")
 
-    async def callback(_request):
-        nonlocal effects
-        effects += 1
-        raise AssertionError("registry construction sampled an IDE")
-
     registry = build_subscription_registry(
         environ={"OPENAI_API_KEY": "must-not-be-read"},
         claude_runner=runner,
-        sampling_clients={
-            ProviderChannel.GOOGLE_MCP_SAMPLING: _sampling_binding(
-                callback,
-                client_id="antigravity",
-            )
-        },
     )
-    assert set(registry) == {
-        ProviderChannel.CLAUDE_CLI,
-        ProviderChannel.GOOGLE_MCP_SAMPLING,
-    }
+    assert set(registry) == {ProviderChannel.CLAUDE_CLI}
     assert effects == 0
     assert all(
         adapter.descriptor.credential_plane == CredentialPlane.SUBSCRIPTION
@@ -820,14 +1048,6 @@ def test_subscription_registry_is_inert_request_scoped_and_has_no_codex_cli():
         descriptor.credential_kind
         for descriptor in (adapter.descriptor for adapter in registry.values())
     )
-    with pytest.raises(ValueError, match="unsupported sampling channel"):
-        build_subscription_registry(
-            environ={},
-            claude_runner=runner,
-            sampling_clients={
-                ProviderChannel.OPENAI_API: _sampling_binding(callback),
-            },
-        )
     assert effects == 0
 
 
@@ -881,10 +1101,18 @@ def test_subscription_lane_identities_are_pinned_without_exposing_paths():
         ),
     )
     for provider, channel, client_id in sampling:
-        descriptor = MCPClientSamplingAdapter(
+        descriptor = _sampling_adapter(
+            callback,
+            request=_request(
+                model={
+                    ProviderId.OPENAI: "gpt-5.1",
+                    ProviderId.ANTHROPIC: "claude-fable-5",
+                    ProviderId.GOOGLE: "gemini-3.5-flash",
+                }[provider]
+            ),
             provider=provider,
             channel=channel,
-            binding=_sampling_binding(callback, client_id=client_id),
+            client_id=client_id,
         ).descriptor
         assert descriptor.transport_resource_identity is not None
         assert GrokWorkerLaneAuthorization.from_descriptor(descriptor).contract_digest


### PR DESCRIPTION
## Outcome

Adds an inert, request-scoped MCP client-sampling lease for subordinate OpenAI, Anthropic, and Google subscription workers. Grok remains the sole supervisor/finalizer. Nothing is wired into the public MCP server or broker yet.

## Exact head

`4f9fec1b5e0c5668836d925e12f058d4e47683c8`

## Scope

- `src/providers/mcp_sampling.py`: principal/session authorization, exact Grok provider grant, TTL-bound lease, shared one-shot session runtime
- `src/providers/subscription.py`: sealed sampling adapter, full request binding, client-claim-safe receipts
- `src/providers/errors.py`, `src/providers/__init__.py`: internal authorization invariant and exports
- focused adversarial tests plus generated OKF mirrors

## Verification

- focused bridge/provider/OKF: 76 passed
- broad provider tests: 211 passed
- full repository: 1,853 passed
- Ruff, compileall, generated OKF, diff, and attribution checks clean
- independent exact-diff review: no remaining P0/P1/P2 findings before the cancellation amendment; amended head is under exact-head re-review
- Grok review finding resolved: every post-claim cancellation is internal/indeterminate; preclaim cancellation remains effect-free

## Boundaries / dependencies

- zero live provider calls, training, routing, server, or credential changes
- not broker-wirable until two separate follow-ups land:
  1. broker consults claimed-effect state around its own post-adapter checks
  2. stable pre-plan session capability plus post-durable-start grant/adapter materialization
- xAI Grok CLI OAuth, `XAI_API_KEY`, and xAI business-management credentials remain separate and untouched

Human-Sponsor: djtelicloud

Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=implementation

Agent-Reviewed-By: xAI Grok | model=grok-4.5 | model-source=runtime-receipt | surface=UniGrok CLI | role=architecture-review | evidence=pr-review:89
