### PR TITLE
Stabilize MCP sampling capability descriptors

### DIFF
--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -1326,6 +1326,21 @@ legal inside that boundary.  Remote sessions must have an authenticated
 principal.  This object is not accepted from request JSON or headers; a
 future stateful session middleware must inject it into the ASGI scope.
 
+### Class: `TrustedMCPProviderCapability` {#providers-mcp_sampling-trustedmcpprovidercapability}
+
+```python
+class TrustedMCPProviderCapability
+```
+
+**Keywords:** trusted, mcp, provider, capability
+
+Stable provider capability for one authenticated MCP client session.
+
+This contract carries no request, callback, delegation, or effect
+authority.  It can therefore be created before planning and safely expose
+the exact descriptor used by later one-request leases.  Provider branding
+remains an explicit Grok decision; client labels never infer it.
+
 ### Class: `TrustedMCPProviderGrant` {#providers-mcp_sampling-trustedmcpprovidergrant}
 
 ```python

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -1326,6 +1326,21 @@ legal inside that boundary.  Remote sessions must have an authenticated
 principal.  This object is not accepted from request JSON or headers; a
 future stateful session middleware must inject it into the ASGI scope.
 
+### Class: `TrustedMCPProviderCapability` {#providers-mcp_sampling-trustedmcpprovidercapability}
+
+```python
+class TrustedMCPProviderCapability
+```
+
+**Keywords:** trusted, mcp, provider, capability
+
+Stable provider capability for one authenticated MCP client session.
+
+This contract carries no request, callback, delegation, or effect
+authority.  It can therefore be created before planning and safely expose
+the exact descriptor used by later one-request leases.  Provider branding
+remains an explicit Grok decision; client labels never infer it.
+
 ### Class: `TrustedMCPProviderGrant` {#providers-mcp_sampling-trustedmcpprovidergrant}
 
 ```python

--- a/src/providers/__init__.py
+++ b/src/providers/__init__.py
@@ -57,12 +57,14 @@ from .errors import (
 from .gemini import GeminiAdapter
 from .mcp_sampling import (
     MAX_MCP_SAMPLING_EFFECT_CLAIMS,
+    MCP_PROVIDER_CAPABILITIES_SCOPE_KEY,
     MCP_PROVIDER_GRANTS_SCOPE_KEY,
     MCP_SESSION_AUTHORIZATION_SCOPE_KEY,
     MCP_SESSION_RUNTIME_SCOPE_KEY,
     MCPSessionAuthorization,
     MCPSamplingSessionRuntime,
     StatefulMCPSamplingLease,
+    TrustedMCPProviderCapability,
     TrustedMCPProviderGrant,
     create_stateful_mcp_sampling_lease,
 )
@@ -110,6 +112,7 @@ __all__ = [
     "GrokWorkerBrokerResult",
     "GrokWorkerDelegation",
     "GrokWorkerLaneAuthorization",
+    "MCP_PROVIDER_CAPABILITIES_SCOPE_KEY",
     "MCP_PROVIDER_GRANTS_SCOPE_KEY",
     "MCP_SESSION_AUTHORIZATION_SCOPE_KEY",
     "MCP_SESSION_RUNTIME_SCOPE_KEY",
@@ -146,6 +149,7 @@ __all__ = [
     "SamplingModelPreferences",
     "SamplingTextContent",
     "StatefulMCPSamplingLease",
+    "TrustedMCPProviderCapability",
     "TrustedMCPProviderGrant",
     "VertexADCAdapter",
     "build_provider_registry",

--- a/src/providers/mcp_sampling.py
+++ b/src/providers/mcp_sampling.py
@@ -13,11 +13,11 @@ The lease is the lifetime boundary: its callback cannot be cached globally,
 survive the tool request, cross principals or MCP sessions, select a provider,
 use tools, or grant a worker final authority.
 
-This is not yet broker-wirable.  Planning needs a stable session-capability
-descriptor before a deterministic provider request ID exists.  Only after the
-attempt start is durably recorded may later integration mint the exact grant,
-materialize this lease-owned adapter, verify lane conformance, and teach the
-broker's outer timeout to consult ``adapter.effect_claimed()``.
+This remains inert and is not broker-wired.  A trusted provider capability now
+supplies a stable public descriptor before any deterministic provider request
+ID or request grant exists.  Only after an attempt start is durably recorded
+may later integration mint the exact grant and materialize its private,
+lease-owned adapter.
 """
 
 from __future__ import annotations
@@ -37,13 +37,17 @@ from starlette.requests import Request
 from .base import Clock
 from .contracts import (
     MAX_RESPONSE_CHARS,
+    CredentialPlane,
+    CredentialState,
     GrokSupervisorBinding,
     ProviderChannel,
+    ProviderDescriptor,
     ProviderId,
     ProviderModelPins,
     ProviderRequest,
     RouteClass,
     StrictContract,
+    transport_resource_identity,
 )
 from .errors import (
     ProviderAuthorizationInvariantError,
@@ -65,6 +69,7 @@ from .subscription import (
 
 
 MCP_SESSION_AUTHORIZATION_SCOPE_KEY = "unigrok.mcp_sampling.session_authorization"
+MCP_PROVIDER_CAPABILITIES_SCOPE_KEY = "unigrok.mcp_sampling.provider_capabilities"
 MCP_PROVIDER_GRANTS_SCOPE_KEY = "unigrok.mcp_sampling.provider_grants"
 MCP_SESSION_RUNTIME_SCOPE_KEY = "unigrok.mcp_sampling.session_runtime"
 
@@ -159,6 +164,79 @@ class MCPSessionAuthorization(StrictContract):
         )
 
 
+class TrustedMCPProviderCapability(StrictContract):
+    """Stable provider capability for one authenticated MCP client session.
+
+    This contract carries no request, callback, delegation, or effect
+    authority.  It can therefore be created before planning and safely expose
+    the exact descriptor used by later one-request leases.  Provider branding
+    remains an explicit Grok decision; client labels never infer it.
+    """
+
+    version: Literal["trusted-mcp-provider-capability/v1"] = (
+        "trusted-mcp-provider-capability/v1"
+    )
+    issuer: Literal["grok"] = "grok"
+    session_authorization_digest: Annotated[str, Field(pattern=_DIGEST_PATTERN)]
+    provider: ProviderId
+    channel: ProviderChannel
+    models: ProviderModelPins
+    supported_routes: tuple[RouteClass, ...] = (
+        RouteClass.PLANNING,
+        RouteClass.CODING,
+        RouteClass.RESEARCH,
+    )
+    max_output_tokens: Annotated[int, Field(ge=1, le=32_768)] = 32_768
+    max_timeout_seconds: Annotated[float, Field(ge=1.0, le=120.0)] = 120.0
+
+    @model_validator(mode="after")
+    def validate_capability(self) -> "TrustedMCPProviderCapability":
+        if _SAMPLING_CHANNEL_PROVIDERS.get(self.channel) != self.provider:
+            raise ValueError("provider capability channel does not match provider")
+        if not self.supported_routes or len(set(self.supported_routes)) != len(
+            self.supported_routes
+        ):
+            raise ValueError("provider capability routes must be nonempty and unique")
+        # Pydantic's frozen models are shallow: detach the caller's nested
+        # model pins so later mutation of an input object cannot rewrite this
+        # authenticated capability identity.
+        object.__setattr__(self, "models", _snapshot(ProviderModelPins, self.models))
+        return self
+
+    @property
+    def capability_digest(self) -> str:
+        return _canonical_digest(
+            "trusted_mcp_provider_capability",
+            self.model_dump(mode="json"),
+        )
+
+    @property
+    def descriptor(self) -> ProviderDescriptor:
+        digest = self.capability_digest
+        return ProviderDescriptor(
+            provider=self.provider,
+            channel=self.channel,
+            credential_plane=CredentialPlane.SUBSCRIPTION,
+            display_name=f"{self.provider.value} IDE subscription",
+            endpoint_host="mcp-client",
+            endpoint_kind="mcp_client_sampling",
+            credential_kind="mcp_client_subscription",
+            billing_class="subscription",
+            client_identity="mcp-" + digest.removeprefix("sha256:"),
+            transport_resource_identity=transport_resource_identity(
+                "mcp_sampling_capability", digest
+            ),
+            credential_env_names=(),
+            credential_state=CredentialState.DEFERRED,
+            models=_snapshot(ProviderModelPins, self.models),
+            supported_routes=self.supported_routes,
+            max_output_tokens=self.max_output_tokens,
+            max_timeout_seconds=self.max_timeout_seconds,
+            data_handling="provider_managed",
+            residency="client_subscription",
+        )
+
+
 class TrustedMCPProviderGrant(StrictContract):
     """Server-owned provider/model grant bound to one authorized MCP session.
 
@@ -171,6 +249,7 @@ class TrustedMCPProviderGrant(StrictContract):
     issuer: Literal["grok"] = "grok"
     grant_id: Annotated[str, Field(pattern=_SAFE_BINDING_PATTERN)]
     session_authorization_digest: Annotated[str, Field(pattern=_DIGEST_PATTERN)]
+    session_capability_digest: Annotated[str, Field(pattern=_DIGEST_PATTERN)]
     supervision: GrokSupervisorBinding
     provider_request_id: Annotated[str, Field(pattern=_SAFE_BINDING_PATTERN)]
     provider_request_digest: Annotated[str, Field(pattern=_DIGEST_PATTERN)]
@@ -228,13 +307,6 @@ class TrustedMCPProviderGrant(StrictContract):
                 "provider_request_id": self.provider_request_id,
             },
         )
-
-    @property
-    def opaque_client_identity(self) -> str:
-        # Deliberately includes the grant and therefore the authorized session,
-        # principal, physical MCP session, provider, and model pins without
-        # exposing any of those raw values in descriptors or receipts.
-        return "mcp-" + self.grant_digest.removeprefix("sha256:")
 
 
 class MCPSamplingSessionRuntime:
@@ -366,6 +438,8 @@ class StatefulMCPSamplingLease:
         related_request_id: str | int,
         authorization: MCPSessionAuthorization,
         raw_authorization: MCPSessionAuthorization,
+        capability: TrustedMCPProviderCapability,
+        raw_capability: TrustedMCPProviderCapability,
         grant: TrustedMCPProviderGrant,
         raw_grant: TrustedMCPProviderGrant,
         runtime: MCPSamplingSessionRuntime,
@@ -381,6 +455,8 @@ class StatefulMCPSamplingLease:
         self._related_request_id = related_request_id
         self._authorization = authorization
         self._raw_authorization = raw_authorization
+        self._capability = capability
+        self._raw_capability = raw_capability
         self._grant = grant
         self._raw_grant = raw_grant
         self._runtime = runtime
@@ -394,13 +470,14 @@ class StatefulMCPSamplingLease:
         self._revoked = False
         binding = _create_sealed_sampling_client_binding(
             capability=SamplingCapability(
-                client_id=grant.opaque_client_identity,
+                client_id=capability.descriptor.client_identity,
                 sampling=True,
             ),
             callback=self._sample,
             provider=grant.provider,
             channel=grant.channel,
             models=grant.models,
+            descriptor=capability.descriptor,
             binding_digest=grant.grant_digest,
             supervision=grant.supervision,
             provider_request_id=grant.provider_request_id,
@@ -508,6 +585,13 @@ class StatefulMCPSamplingLease:
             item is self._raw_grant for item in grants
         ):
             raise ProviderConfigurationError(self._provider, "sampling_grant_mismatch")
+        capabilities = scope.get(MCP_PROVIDER_CAPABILITIES_SCOPE_KEY)
+        if not isinstance(capabilities, tuple) or not any(
+            item is self._raw_capability for item in capabilities
+        ):
+            raise ProviderConfigurationError(
+                self._provider, "sampling_capability_mismatch"
+            )
         if scope.get(MCP_SESSION_RUNTIME_SCOPE_KEY) is not self._runtime:
             raise ProviderConfigurationError(
                 self._provider, "sampling_session_mismatch"
@@ -515,6 +599,9 @@ class StatefulMCPSamplingLease:
         try:
             current_authorization = _snapshot(
                 MCPSessionAuthorization, self._raw_authorization
+            )
+            current_capability = _snapshot(
+                TrustedMCPProviderCapability, self._raw_capability
             )
             current_grant = _snapshot(TrustedMCPProviderGrant, self._raw_grant)
         except (TypeError, ValueError):
@@ -524,6 +611,10 @@ class StatefulMCPSamplingLease:
         if current_authorization != self._authorization:
             raise ProviderConfigurationError(
                 self._provider, "sampling_authorization_mismatch"
+            )
+        if current_capability != self._capability:
+            raise ProviderConfigurationError(
+                self._provider, "sampling_capability_mismatch"
             )
         if current_grant != self._grant:
             raise ProviderConfigurationError(self._provider, "sampling_grant_mismatch")
@@ -549,6 +640,19 @@ class StatefulMCPSamplingLease:
             self._authorization.authorization_digest
         ):
             raise ProviderConfigurationError(self._provider, "sampling_grant_mismatch")
+        if (
+            self._capability.session_authorization_digest
+            != self._authorization.authorization_digest
+            or self._grant.session_capability_digest
+            != self._capability.capability_digest
+            or self._capability.provider != self._provider
+            or self._capability.channel != self._channel
+            or self._grant.models != self._capability.models
+            or self._grant.route not in self._capability.supported_routes
+        ):
+            raise ProviderConfigurationError(
+                self._provider, "sampling_capability_mismatch"
+            )
         if (
             self._grant.provider != self._provider
             or self._grant.channel != self._channel
@@ -800,8 +904,36 @@ def create_stateful_mcp_sampling_lease(
         grant = _snapshot(TrustedMCPProviderGrant, raw_grant)
     except (TypeError, ValueError):
         raise ProviderConfigurationError(provider, "sampling_grant_missing") from None
+    raw_capabilities = request.scope.get(MCP_PROVIDER_CAPABILITIES_SCOPE_KEY)
+    if not isinstance(raw_capabilities, tuple):
+        raise ProviderConfigurationError(provider, "sampling_capability_missing")
+    matching_capabilities = tuple(
+        item
+        for item in raw_capabilities
+        if isinstance(item, TrustedMCPProviderCapability)
+        and getattr(item, "capability_digest", None) == grant.session_capability_digest
+        and getattr(item, "provider", None) == provider
+        and getattr(item, "channel", None) == channel
+    )
+    if len(matching_capabilities) != 1:
+        raise ProviderConfigurationError(provider, "sampling_capability_mismatch")
+    raw_capability = matching_capabilities[0]
+    try:
+        capability = _snapshot(TrustedMCPProviderCapability, raw_capability)
+    except (TypeError, ValueError):
+        raise ProviderConfigurationError(
+            provider, "sampling_capability_mismatch"
+        ) from None
     if (
         grant.session_authorization_digest != authorization.authorization_digest
+        or capability.session_authorization_digest != authorization.authorization_digest
+        or grant.session_capability_digest != capability.capability_digest
+        or capability.provider != provider
+        or capability.channel != channel
+        or grant.models != capability.models
+        or grant.route not in capability.supported_routes
+        or request_snapshot.max_output_tokens > capability.max_output_tokens
+        or request_snapshot.timeout_seconds > capability.max_timeout_seconds
         or grant.issued_at < authorization.issued_at
         or grant.expires_at > authorization.expires_at
         or grant.mcp_related_request_id != related_request_id
@@ -826,6 +958,8 @@ def create_stateful_mcp_sampling_lease(
         related_request_id=related_request_id,
         authorization=authorization,
         raw_authorization=raw_authorization,
+        capability=capability,
+        raw_capability=raw_capability,
         grant=grant,
         raw_grant=raw_grant,
         runtime=runtime,
@@ -839,6 +973,7 @@ def create_stateful_mcp_sampling_lease(
 
 __all__ = [
     "MAX_MCP_SAMPLING_EFFECT_CLAIMS",
+    "MCP_PROVIDER_CAPABILITIES_SCOPE_KEY",
     "MCP_PROVIDER_GRANTS_SCOPE_KEY",
     "MCP_SESSION_AUTHORIZATION_SCOPE_KEY",
     "MCP_SESSION_RUNTIME_SCOPE_KEY",
@@ -846,5 +981,6 @@ __all__ = [
     "MCPSamplingSessionRuntime",
     "StatefulMCPSamplingLease",
     "TrustedMCPProviderGrant",
+    "TrustedMCPProviderCapability",
     "create_stateful_mcp_sampling_lease",
 ]

--- a/src/providers/subscription.py
+++ b/src/providers/subscription.py
@@ -691,6 +691,43 @@ EffectClaimInspector = Callable[[], bool]
 _SAMPLING_BINDING_FACTORY_SEAL = object()
 
 
+def _snapshot_sampling_capability_descriptor(
+    descriptor: ProviderDescriptor,
+    *,
+    provider: ProviderId,
+    channel: ProviderChannel,
+    capability: SamplingCapability,
+    models: ProviderModelPins,
+    route: RouteClass,
+) -> ProviderDescriptor:
+    try:
+        snapshot = ProviderDescriptor.model_validate_json(
+            descriptor.model_dump_json(warnings="error")
+        )
+    except (AttributeError, TypeError, ValueError, ValidationError):
+        raise ValueError("sampling capability descriptor is invalid") from None
+    if (
+        snapshot.provider != provider
+        or snapshot.channel != channel
+        or snapshot.credential_plane != CredentialPlane.SUBSCRIPTION
+        or snapshot.endpoint_host != MCP_CLIENT_ENDPOINT
+        or snapshot.endpoint_kind != "mcp_client_sampling"
+        or snapshot.credential_kind != "mcp_client_subscription"
+        or snapshot.billing_class != "subscription"
+        or snapshot.client_identity != capability.client_id
+        or snapshot.transport_resource_identity is None
+        or snapshot.credential_env_names
+        or snapshot.credential_state != CredentialState.DEFERRED
+        or snapshot.models != models
+        or route not in snapshot.supported_routes
+        or snapshot.data_handling != "provider_managed"
+        or snapshot.residency != "client_subscription"
+        or snapshot.supports_normalized_tools
+    ):
+        raise ValueError("sampling capability descriptor is invalid")
+    return snapshot
+
+
 @dataclass(frozen=True, slots=True, init=False)
 class SamplingClientBinding:
     capability: SamplingCapability
@@ -698,6 +735,7 @@ class SamplingClientBinding:
     provider: ProviderId
     channel: ProviderChannel
     models: ProviderModelPins
+    descriptor: ProviderDescriptor
     binding_digest: str
     supervision: GrokSupervisorBinding
     provider_request_id: str
@@ -714,6 +752,7 @@ class SamplingClientBinding:
         provider: ProviderId,
         channel: ProviderChannel,
         models: ProviderModelPins,
+        descriptor: ProviderDescriptor,
         binding_digest: str,
         supervision: GrokSupervisorBinding,
         provider_request_id: str,
@@ -728,8 +767,7 @@ class SamplingClientBinding:
             )
         if not re.fullmatch(r"sha256:[0-9a-f]{64}", binding_digest):
             raise ValueError("sampling binding digest must be a SHA-256 identity")
-        expected_client_id = "mcp-" + binding_digest.removeprefix("sha256:")
-        if capability.client_id != expected_client_id or not capability.sampling:
+        if not capability.sampling:
             raise ValueError("sampling capability does not match sealed binding")
         if SAMPLING_CHANNEL_PROVIDERS.get(channel) != provider:
             raise ValueError("sealed sampling provider and channel do not match")
@@ -752,6 +790,14 @@ class SamplingClientBinding:
             raise ValueError("sampling route is invalid")
         if not callable(effect_claimed):
             raise ValueError("sampling effect inspector is invalid")
+        descriptor_snapshot = _snapshot_sampling_capability_descriptor(
+            descriptor,
+            provider=provider,
+            channel=channel,
+            capability=capability,
+            models=models_snapshot,
+            route=route,
+        )
         delegation_digest = _sampling_delegation_digest(
             binding_digest=binding_digest,
             provider=provider,
@@ -767,6 +813,7 @@ class SamplingClientBinding:
         object.__setattr__(self, "provider", provider)
         object.__setattr__(self, "channel", channel)
         object.__setattr__(self, "models", models_snapshot)
+        object.__setattr__(self, "descriptor", descriptor_snapshot)
         object.__setattr__(self, "binding_digest", binding_digest)
         object.__setattr__(self, "supervision", supervision_snapshot)
         object.__setattr__(self, "provider_request_id", provider_request_id)
@@ -810,6 +857,7 @@ def _create_sealed_sampling_client_binding(
     provider: ProviderId,
     channel: ProviderChannel,
     models: ProviderModelPins,
+    descriptor: ProviderDescriptor,
     binding_digest: str,
     supervision: GrokSupervisorBinding,
     provider_request_id: str,
@@ -825,6 +873,7 @@ def _create_sealed_sampling_client_binding(
         provider=provider,
         channel=channel,
         models=models,
+        descriptor=descriptor,
         binding_digest=binding_digest,
         supervision=supervision,
         provider_request_id=provider_request_id,
@@ -947,41 +996,26 @@ class MCPClientSamplingAdapter(HTTPProviderAdapter):
                 route=binding.route,
                 authorized_model=models.for_route(binding.route),
             )
+            descriptor = _snapshot_sampling_capability_descriptor(
+                binding.descriptor,
+                provider=provider,
+                channel=channel,
+                capability=capability,
+                models=models,
+                route=binding.route,
+            )
         except Exception:
             raise ProviderConfigurationError(
                 provider, "sampling_grant_mismatch"
             ) from None
-        expected_client_id = "mcp-" + binding.binding_digest.removeprefix("sha256:")
         if (
             expected_delegation_digest != binding.delegation_digest
-            or capability.client_id != expected_client_id
+            or capability.client_id != binding.descriptor.client_identity
             or not capability.sampling
             or not callable(binding.callback)
             or not callable(binding.effect_claimed)
         ):
             raise ProviderConfigurationError(provider, "sampling_grant_mismatch")
-        descriptor = ProviderDescriptor(
-            provider=provider,
-            channel=channel,
-            credential_plane=CredentialPlane.SUBSCRIPTION,
-            display_name=f"{provider.value} IDE subscription",
-            endpoint_host=MCP_CLIENT_ENDPOINT,
-            endpoint_kind="mcp_client_sampling",
-            credential_kind="mcp_client_subscription",
-            billing_class="subscription",
-            client_identity=capability.client_id,
-            transport_resource_identity=transport_resource_identity(
-                "mcp_sampling_binding", binding.binding_digest
-            ),
-            credential_env_names=(),
-            credential_state=CredentialState.DEFERRED,
-            models=models,
-            supported_routes=(binding.route,),
-            max_output_tokens=32_768,
-            max_timeout_seconds=120.0,
-            data_handling="provider_managed",
-            residency="client_subscription",
-        )
         authority = _SamplingAdapterAuthority(
             provider=provider,
             channel=channel,

--- a/tests/test_mcp_sampling_bridge.py
+++ b/tests/test_mcp_sampling_bridge.py
@@ -13,11 +13,13 @@ from starlette.requests import Request
 from mcp.server.session import ServerSession
 
 from src.providers import (
+    MCP_PROVIDER_CAPABILITIES_SCOPE_KEY,
     MCP_PROVIDER_GRANTS_SCOPE_KEY,
     MCP_SESSION_AUTHORIZATION_SCOPE_KEY,
     MCP_SESSION_RUNTIME_SCOPE_KEY,
     MAX_MCP_SAMPLING_EFFECT_CLAIMS,
     GrokSupervisorBinding,
+    GrokWorkerLaneAuthorization,
     MCPSamplingSessionRuntime,
     MCPSessionAuthorization,
     ProviderAuthorizationInvariantError,
@@ -28,6 +30,7 @@ from src.providers import (
     ProviderModelPins,
     ProviderRequest,
     RouteClass,
+    TrustedMCPProviderCapability,
     TrustedMCPProviderGrant,
     create_stateful_mcp_sampling_lease,
     provider_request_digest,
@@ -69,17 +72,21 @@ class FakeServerSession:
 
 def _authorization(
     *,
+    binding_id: str = "binding-1",
+    mcp_session_id: str = "mcp-session-1",
     principal: str = "http:anon",
+    client_label: str = "antigravity",
+    mcp_client_name: str = "Antigravity",
     trust: str = "verified_local",
     issued_at: datetime = NOW - timedelta(seconds=5),
     expires_at: datetime = NOW + timedelta(minutes=5),
 ) -> MCPSessionAuthorization:
     return MCPSessionAuthorization(
-        binding_id="binding-1",
-        mcp_session_id="mcp-session-1",
+        binding_id=binding_id,
+        mcp_session_id=mcp_session_id,
         principal=principal,
-        client_label="antigravity",
-        mcp_client_name="Antigravity",
+        client_label=client_label,
+        mcp_client_name=mcp_client_name,
         trust=trust,
         issued_at=issued_at,
         expires_at=expires_at,
@@ -92,6 +99,27 @@ def _supervision(*, ttl: datetime | None = None) -> GrokSupervisorBinding:
         objective_id="objective-1",
         route_decision_id="route-1",
         ttl_expires_at=ttl or NOW + timedelta(minutes=2),
+    )
+
+
+def _capability(
+    authorization: MCPSessionAuthorization,
+    *,
+    provider: ProviderId = ProviderId.GOOGLE,
+    channel: ProviderChannel = ProviderChannel.GOOGLE_MCP_SAMPLING,
+    models: ProviderModelPins = MODELS,
+    supported_routes: tuple[RouteClass, ...] = (
+        RouteClass.PLANNING,
+        RouteClass.CODING,
+        RouteClass.RESEARCH,
+    ),
+) -> TrustedMCPProviderCapability:
+    return TrustedMCPProviderCapability(
+        session_authorization_digest=authorization.authorization_digest,
+        provider=provider,
+        channel=channel,
+        models=models,
+        supported_routes=supported_routes,
     )
 
 
@@ -119,6 +147,7 @@ def _provider_request(
 def _grant(
     authorization: MCPSessionAuthorization,
     *,
+    capability: TrustedMCPProviderCapability | None = None,
     supervision: GrokSupervisorBinding | None = None,
     related_request_id: str | int = "tool-request-7",
     provider_request_id: str = "provider-request-1",
@@ -126,6 +155,7 @@ def _grant(
     issued_at: datetime = NOW - timedelta(seconds=2),
     expires_at: datetime = NOW + timedelta(minutes=1),
 ) -> TrustedMCPProviderGrant:
+    capability = capability or _capability(authorization)
     supervision = supervision or _supervision()
     provider_request = _provider_request(
         supervision=supervision,
@@ -135,14 +165,15 @@ def _grant(
     return TrustedMCPProviderGrant(
         grant_id="grant-1",
         session_authorization_digest=authorization.authorization_digest,
+        session_capability_digest=capability.capability_digest,
         supervision=supervision,
         provider_request_id=provider_request_id,
         provider_request_digest=provider_request_digest(provider_request),
         mcp_related_request_id=related_request_id,
-        provider=ProviderId.GOOGLE,
-        channel=ProviderChannel.GOOGLE_MCP_SAMPLING,
+        provider=capability.provider,
+        channel=capability.channel,
         route=RouteClass.PLANNING,
-        models=MODELS,
+        models=capability.models,
         issued_at=issued_at,
         expires_at=expires_at,
     )
@@ -151,6 +182,7 @@ def _grant(
 def _context(
     *,
     authorization: MCPSessionAuthorization | None = None,
+    capability: TrustedMCPProviderCapability | None = None,
     grant: TrustedMCPProviderGrant | None = None,
     runtime: MCPSamplingSessionRuntime | None = None,
     session: FakeServerSession | None = None,
@@ -158,7 +190,12 @@ def _context(
     stateless: bool = False,
 ):
     authorization = authorization or _authorization()
-    grant = grant or _grant(authorization, related_request_id=request_id)
+    capability = capability or _capability(authorization)
+    grant = grant or _grant(
+        authorization,
+        capability=capability,
+        related_request_id=request_id,
+    )
     runtime = runtime or MCPSamplingSessionRuntime(authorization)
     session = session or FakeServerSession()
     scope = {
@@ -170,6 +207,7 @@ def _context(
             (b"x-client-id", authorization.client_label.encode()),
         ],
         MCP_SESSION_AUTHORIZATION_SCOPE_KEY: authorization,
+        MCP_PROVIDER_CAPABILITIES_SCOPE_KEY: (capability,),
         MCP_PROVIDER_GRANTS_SCOPE_KEY: (grant,),
         MCP_SESSION_RUNTIME_SCOPE_KEY: runtime,
     }
@@ -254,6 +292,162 @@ async def test_exact_stateful_session_success_is_text_only_and_request_scoped():
         match="sampling_effect_indeterminate",
     ):
         await adapter.complete(provider_request)
+
+
+@pytest.mark.asyncio
+async def test_request_grants_share_stable_capability_descriptor_without_cross_authority():
+    authorization = _authorization()
+    capability = _capability(authorization)
+    # This exact public lane identity exists before either request grant.
+    pregrant_descriptor = capability.descriptor
+    pregrant_lane = GrokWorkerLaneAuthorization.from_descriptor(pregrant_descriptor)
+    runtime = MCPSamplingSessionRuntime(authorization)
+    session = FakeServerSession()
+    supervision = _supervision()
+    grant1 = _grant(
+        authorization,
+        capability=capability,
+        supervision=supervision,
+        related_request_id="tool-request-1",
+        provider_request_id="provider-request-1",
+    )
+    grant2 = TrustedMCPProviderGrant(
+        **{
+            **_grant(
+                authorization,
+                capability=capability,
+                supervision=supervision,
+                related_request_id="tool-request-2",
+                provider_request_id="provider-request-2",
+            ).model_dump(),
+            "grant_id": "grant-2",
+        }
+    )
+    request1 = _request_for_grant(grant1)
+    request2 = _request_for_grant(grant2)
+    ctx1, *_ = _context(
+        authorization=authorization,
+        capability=capability,
+        grant=grant1,
+        runtime=runtime,
+        session=session,
+        request_id="tool-request-1",
+    )
+    ctx2, *_ = _context(
+        authorization=authorization,
+        capability=capability,
+        grant=grant2,
+        runtime=runtime,
+        session=session,
+        request_id="tool-request-2",
+    )
+
+    async with _lease(ctx1, grant1) as lease1, _lease(ctx2, grant2) as lease2:
+        assert lease1.adapter.descriptor == pregrant_descriptor
+        assert lease2.adapter.descriptor == pregrant_descriptor
+        assert (
+            GrokWorkerLaneAuthorization.from_descriptor(
+                lease1.adapter.descriptor
+            ).contract_digest
+            == pregrant_lane.contract_digest
+            == GrokWorkerLaneAuthorization.from_descriptor(
+                lease2.adapter.descriptor
+            ).contract_digest
+        )
+        authority1 = object.__getattribute__(lease1.adapter, "_sampling_authority")
+        authority2 = object.__getattribute__(lease2.adapter, "_sampling_authority")
+        assert grant1.grant_digest != grant2.grant_digest
+        assert grant1.provider_request_id != grant2.provider_request_id
+        assert grant1.provider_request_digest != grant2.provider_request_digest
+        assert grant1.effect_digest != grant2.effect_digest
+        assert authority1.delegation_digest != authority2.delegation_digest
+        rendered_descriptor = pregrant_descriptor.model_dump_json()
+        for private_identity in (
+            grant1.grant_digest,
+            grant2.grant_digest,
+            grant1.provider_request_id,
+            grant2.provider_request_id,
+            grant1.provider_request_digest,
+            grant2.provider_request_digest,
+            grant1.effect_digest,
+            grant2.effect_digest,
+            authority1.delegation_digest,
+            authority2.delegation_digest,
+        ):
+            assert private_identity not in rendered_descriptor
+
+        crossed1 = await lease1.adapter.attempt(request2)
+        crossed2 = await lease2.adapter.attempt(request1)
+        assert crossed1.failure is not None
+        assert crossed1.failure.error_code == "sampling_grant_mismatch"
+        assert crossed2.failure is not None
+        assert crossed2.failure.error_code == "sampling_grant_mismatch"
+        assert session.calls == []
+
+        first = await lease1.adapter.attempt(request1)
+        second = await lease2.adapter.attempt(request2)
+        replay1 = await lease1.adapter.attempt(request1)
+        replay2 = await lease2.adapter.attempt(request2)
+
+    assert first.status == second.status == "returned"
+    assert replay1.failure is not None
+    assert replay1.failure.error_code == "sampling_effect_already_claimed"
+    assert replay2.failure is not None
+    assert replay2.failure.error_code == "sampling_effect_already_claimed"
+    assert len(session.calls) == 2
+
+
+def test_authenticated_session_client_and_provider_capability_change_descriptor_identity():
+    base_authorization = _authorization()
+    session_authorization = _authorization(
+        binding_id="binding-2",
+        mcp_session_id="mcp-session-2",
+    )
+    client_authorization = _authorization(
+        binding_id="binding-3",
+        mcp_session_id="mcp-session-3",
+        client_label="codex",
+        mcp_client_name="Codex Desktop",
+    )
+    google = _capability(base_authorization)
+    other_session = _capability(session_authorization)
+    other_client = _capability(client_authorization)
+    openai_models = ProviderModelPins(
+        planning="gpt-5.1",
+        coding="gpt-5.1-code",
+        vision="gpt-5.1-vision",
+        research="gpt-5.1-research",
+    )
+    openai = _capability(
+        base_authorization,
+        provider=ProviderId.OPENAI,
+        channel=ProviderChannel.OPENAI_MCP_SAMPLING,
+        models=openai_models,
+    )
+
+    capabilities = (google, other_session, other_client, openai)
+    assert len({item.capability_digest for item in capabilities}) == len(capabilities)
+    descriptors = tuple(item.descriptor for item in capabilities)
+    assert len({item.client_identity for item in descriptors}) == len(descriptors)
+    assert len({item.transport_resource_identity for item in descriptors}) == len(
+        descriptors
+    )
+    exposed_openai = openai.descriptor
+    object.__setattr__(openai_models, "planning", "forged-input-model")
+    object.__setattr__(exposed_openai.models, "planning", "forged-descriptor-model")
+    assert openai.models.planning == "gpt-5.1"
+    assert openai.descriptor.models.planning == "gpt-5.1"
+    rendered = "".join(item.model_dump_json() for item in descriptors)
+    for raw_identity in (
+        base_authorization.principal,
+        base_authorization.mcp_session_id,
+        base_authorization.client_label,
+        base_authorization.mcp_client_name,
+        client_authorization.mcp_session_id,
+        client_authorization.client_label,
+        client_authorization.mcp_client_name,
+    ):
+        assert raw_identity not in rendered
 
 
 @pytest.mark.asyncio
@@ -761,13 +955,30 @@ async def test_future_or_expired_authority_fails_before_effect():
 
 
 @pytest.mark.asyncio
-async def test_auth_and_grant_object_mutation_is_detected_pre_effect():
+async def test_auth_capability_and_grant_object_mutation_is_detected_pre_effect():
     ctx, _, session, authorization, grant, _ = _context()
     lease = _lease(ctx, grant)
     async with lease:
         object.__setattr__(authorization, "principal", "oauth:attacker")
         with pytest.raises(
             ProviderConfigurationError, match="sampling_authorization_mismatch"
+        ):
+            await lease.adapter.complete(_request_for_grant(grant))
+    assert session.calls == []
+
+    ctx, _, session, _, grant, _ = _context()
+    capability = ctx.request_context.request.scope[MCP_PROVIDER_CAPABILITIES_SCOPE_KEY][
+        0
+    ]
+    lease = _lease(ctx, grant)
+    async with lease:
+        object.__setattr__(
+            capability,
+            "supported_routes",
+            (RouteClass.CODING,),
+        )
+        with pytest.raises(
+            ProviderConfigurationError, match="sampling_capability_mismatch"
         ):
             await lease.adapter.complete(_request_for_grant(grant))
     assert session.calls == []

--- a/tests/test_subscription_transports.py
+++ b/tests/test_subscription_transports.py
@@ -24,6 +24,7 @@ from src.providers import (
     ProviderAttemptStart,
     ProviderChannel,
     ProviderConfigurationError,
+    ProviderDescriptor,
     ProviderId,
     ProviderMessage,
     ProviderModelPins,
@@ -183,15 +184,43 @@ def _sampling_binding(
         "test_mcp_sampling_binding",
         f"{provider.value}:{selected_channel.value}:{client_id}:{request.request_id}",
     )
+    capability_digest = transport_resource_identity(
+        "test_mcp_sampling_capability",
+        f"{provider.value}:{selected_channel.value}:{client_id}",
+    )
+    stable_client_identity = "mcp-" + capability_digest.removeprefix("sha256:")
+    descriptor = ProviderDescriptor(
+        provider=provider,
+        channel=selected_channel,
+        credential_plane=CredentialPlane.SUBSCRIPTION,
+        display_name=f"{provider.value} IDE subscription",
+        endpoint_host="mcp-client",
+        endpoint_kind="mcp_client_sampling",
+        credential_kind="mcp_client_subscription",
+        billing_class="subscription",
+        client_identity=stable_client_identity,
+        transport_resource_identity=transport_resource_identity(
+            "mcp_sampling_capability", capability_digest
+        ),
+        credential_env_names=(),
+        credential_state=CredentialState.DEFERRED,
+        models=models,
+        supported_routes=(request.route,),
+        max_output_tokens=32_768,
+        max_timeout_seconds=120.0,
+        data_handling="provider_managed",
+        residency="client_subscription",
+    )
     return _create_sealed_sampling_client_binding(
         capability=SamplingCapability(
-            client_id="mcp-" + binding_digest.removeprefix("sha256:"),
+            client_id=stable_client_identity,
             sampling=sampling,
         ),
         callback=callback,
         provider=provider,
         channel=selected_channel,
         models=models,
+        descriptor=descriptor,
         binding_digest=binding_digest,
         supervision=request.supervision,
         provider_request_id=request.request_id,
@@ -680,6 +709,28 @@ def test_sampling_binding_rejects_bare_callbacks_and_cross_provider_reuse():
         research="gpt-5.1",
     )
     digest = transport_resource_identity("test", "bare-callback")
+    descriptor = ProviderDescriptor(
+        provider=ProviderId.OPENAI,
+        channel=ProviderChannel.OPENAI_MCP_SAMPLING,
+        credential_plane=CredentialPlane.SUBSCRIPTION,
+        display_name="openai IDE subscription",
+        endpoint_host="mcp-client",
+        endpoint_kind="mcp_client_sampling",
+        credential_kind="mcp_client_subscription",
+        billing_class="subscription",
+        client_identity="mcp-" + digest.removeprefix("sha256:"),
+        transport_resource_identity=transport_resource_identity(
+            "mcp_sampling_capability", digest
+        ),
+        credential_env_names=(),
+        credential_state=CredentialState.DEFERRED,
+        models=models,
+        supported_routes=(request.route,),
+        max_output_tokens=32_768,
+        max_timeout_seconds=120.0,
+        data_handling="provider_managed",
+        residency="client_subscription",
+    )
     with pytest.raises(TypeError, match="stateful MCP sampling factory"):
         SamplingClientBinding(
             capability=SamplingCapability(
@@ -690,6 +741,7 @@ def test_sampling_binding_rejects_bare_callbacks_and_cross_provider_reuse():
             provider=ProviderId.OPENAI,
             channel=ProviderChannel.OPENAI_MCP_SAMPLING,
             models=models,
+            descriptor=descriptor,
             binding_digest=digest,
             supervision=request.supervision,
             provider_request_id=request.request_id,


### PR DESCRIPTION
## Scope

Break the descriptor/request-ID cycle before dynamic request-scoped adapter sources are introduced. A trusted MCP provider capability now exposes one stable, opaque lane descriptor before any provider request or grant exists; later request leases must reproduce that descriptor exactly.

## Exact head

`ccf046804fc2e258db667ecf4b76c9a6af6429ac`

## Changed paths

- `src/providers/mcp_sampling.py`
- `src/providers/subscription.py`
- `src/providers/__init__.py`
- `tests/test_mcp_sampling_bridge.py`
- `tests/test_subscription_transports.py`
- deterministic OKF API reference and public mirror

## Safety properties

- The public descriptor is bound to authenticated session capability, provider, models, routes, and limits—not provider request or grant identity.
- Grants, provider request IDs/digests, delegation digests, callbacks, and effect claims remain private and request-scoped.
- Broker descriptor equality can remain exact; no validation is weakened.
- Two grants in one session share the planned descriptor but cannot cross-call, replay, or repeat effects.
- Different session, client, or provider capabilities produce distinct opaque descriptors.
- Capability, grant, request, and context mutation fail before provider effect.
- Nested model pins are deep-detached from caller-owned objects.

## Verification

- Focused sampling suites: 73 passed
- Full repository suite: 1,874 passed
- Ruff, compileall, deterministic OKF, `git diff --check`, and attribution: clean
- Independent exact-tree security review: approved
- xAI Grok 4.5 CLI review: no blocker; requested call-site/lane-digest checks confirmed

## Boundaries

No broker source support, server/runtime wiring, provider calls, credential access, or public worker availability is added. The later wiring PR must keep execution authority grant-route-scoped rather than treating the broader stable capability route set as per-lease authority.

Human-Sponsor: David J. Telicloud

Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=implementation

Agent-Reviewed-By: xAI Grok | model=grok-4.5 | model-source=runtime-receipt | surface=UniGrok CLI | role=code-review | evidence=pr-review:92