### PR TITLE
Enforce xAI management authority boundary

### DIFF
--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -3807,13 +3807,13 @@ def get_xai_management_client()
 
 **Keywords:** get, xai, management, client
 
-Return the cached xAI Collections/admin client.
+Return the cached, Collections-only xAI management facade.
 
 The installed SDK requires the inference key alongside the management key
 when constructing its Collections service.  This factory is therefore the
-only place where both credentials may enter one SDK client, and callers are
-restricted to the RAG, knowledge, task-memory, and provider-harvest admin
-surfaces.
+only place where both credentials may enter one SDK client.  The returned
+facade exposes only ``collections`` and ``close`` so that management call
+sites cannot accidentally invoke inference through that raw SDK object.
 
 ### Function: `close_xai_inference_client` {#utils-close_xai_inference_client}
 

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -3807,13 +3807,13 @@ def get_xai_management_client()
 
 **Keywords:** get, xai, management, client
 
-Return the cached xAI Collections/admin client.
+Return the cached, Collections-only xAI management facade.
 
 The installed SDK requires the inference key alongside the management key
 when constructing its Collections service.  This factory is therefore the
-only place where both credentials may enter one SDK client, and callers are
-restricted to the RAG, knowledge, task-memory, and provider-harvest admin
-surfaces.
+only place where both credentials may enter one SDK client.  The returned
+facade exposes only ``collections`` and ``close`` so that management call
+sites cannot accidentally invoke inference through that raw SDK object.
 
 ### Function: `close_xai_inference_client` {#utils-close_xai_inference_client}
 

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -15,6 +15,8 @@ from typing import Any, Dict, List, Optional
 
 import httpx
 
+from .xai_credentials import _resolve_optional_xai_management_key
+
 
 _PROVIDER_CACHE: Dict[str, Any] = {"key": None, "at": 0.0, "value": None}
 _PROVIDER_CACHE_TTL_SEC = 300.0
@@ -261,7 +263,6 @@ def aggregate_telemetry_callers(
 async def fetch_provider_api_usage() -> Dict[str, Any]:
     """Optionally fetch today's team-wide API spend from xAI Management API."""
     enabled = os.environ.get("UNIGROK_PROVIDER_USAGE", "auto").strip().lower()
-    management_key = os.environ.get("XAI_MANAGEMENT_API_KEY", "").strip()
     team_id = os.environ.get("UNIGROK_XAI_TEAM_ID", "").strip()
     base = {
         "scope": "xai_api_team",
@@ -271,6 +272,17 @@ async def fetch_provider_api_usage() -> Dict[str, Any]:
     }
     if enabled in ("0", "false", "off", "disabled"):
         return {**base, "state": "disabled", "detail": "Provider comparison disabled."}
+    try:
+        management_key = _resolve_optional_xai_management_key()
+    except ValueError:
+        return {
+            **base,
+            "state": "error",
+            "detail": (
+                "Management credential aliases conflict; provider comparison "
+                "is blocked until configuration is unambiguous."
+            ),
+        }
     if not management_key or not team_id:
         return {
             **base,

--- a/src/utils.py
+++ b/src/utils.py
@@ -40,6 +40,7 @@ from .credentials import (
     build_credential_plane_contract,
     credential_plane_policy,
 )
+from .xai_credentials import _require_xai_management_key
 from .identity import (
     _ACTIVE_CALLER,
     _ACTIVE_CLIENT_ID,
@@ -1868,8 +1869,8 @@ async def build_model_catalog(include_cli: bool = True) -> Dict[str, Any]:
     }
 
 # Global xAI client connection pools.  The inference client is intentionally
-# incapable of carrying management authority; Collections/admin call sites use
-# the separately named management factory below.
+# incapable of carrying management authority; Collections call sites receive
+# the operation-scoped management facade below.
 _client = None
 _management_client = None
 # Both factories are called from executor threads — guard each check-then-set
@@ -1899,22 +1900,41 @@ class _InferenceOnlyXAIClient:
         self._delegate.close()
 
 
+class _CollectionsOnlyXAIManagementClient:
+    """Expose only the operation-scoped Collections management surface."""
+
+    __slots__ = ("_close_callback", "_collections")
+
+    def __init__(self, delegate: Any) -> None:
+        collections = getattr(delegate, "collections", None)
+        close = getattr(delegate, "close", None)
+        if collections is None or not callable(close):
+            raise RuntimeError("xAI management client interface changed")
+        object.__setattr__(self, "_collections", collections)
+        object.__setattr__(self, "_close_callback", close)
+
+    def __getattribute__(self, name: str) -> Any:
+        if name in {"close", "collections"} or name.startswith("__"):
+            return object.__getattribute__(self, name)
+        raise AttributeError(
+            "xAI management facade exposes only Collections operations"
+        )
+
+    def __dir__(self) -> list[str]:
+        return ["close", "collections"]
+
+    @property
+    def collections(self) -> Any:
+        return object.__getattribute__(self, "_collections")
+
+    def close(self) -> None:
+        object.__getattribute__(self, "_close_callback")()
+
+
 def _resolve_xai_management_key() -> str:
     """Resolve canonical/SDK management-key aliases without exposing a value."""
 
-    canonical = os.getenv("XAI_MANAGEMENT_API_KEY", "").strip()
-    sdk_alias = os.getenv("XAI_MANAGEMENT_KEY", "").strip()
-    if canonical and sdk_alias and canonical != sdk_alias:
-        raise ValueError(
-            "XAI_MANAGEMENT_API_KEY and XAI_MANAGEMENT_KEY are both configured "
-            "with different values."
-        )
-    resolved = canonical or sdk_alias
-    if not resolved:
-        raise ValueError(
-            "XAI_MANAGEMENT_API_KEY or XAI_MANAGEMENT_KEY must be configured."
-        )
-    return resolved
+    return _require_xai_management_key()
 
 
 def xai_management_key_configured() -> bool:
@@ -1965,13 +1985,13 @@ def get_xai_client():
 
 
 def get_xai_management_client():
-    """Return the cached xAI Collections/admin client.
+    """Return the cached, Collections-only xAI management facade.
 
     The installed SDK requires the inference key alongside the management key
     when constructing its Collections service.  This factory is therefore the
-    only place where both credentials may enter one SDK client, and callers are
-    restricted to the RAG, knowledge, task-memory, and provider-harvest admin
-    surfaces.
+    only place where both credentials may enter one SDK client.  The returned
+    facade exposes only ``collections`` and ``close`` so that management call
+    sites cannot accidentally invoke inference through that raw SDK object.
     """
 
     global _management_client
@@ -1985,9 +2005,11 @@ def get_xai_management_client():
                 management_key = _resolve_xai_management_key()
                 from xai_sdk import Client
 
-                _management_client = Client(
-                    api_key=XAI_API_KEY,
-                    management_api_key=management_key,
+                _management_client = _CollectionsOnlyXAIManagementClient(
+                    Client(
+                        api_key=XAI_API_KEY,
+                        management_api_key=management_key,
+                    )
                 )
     return _management_client
 

--- a/src/xai_credentials.py
+++ b/src/xai_credentials.py
@@ -1,0 +1,40 @@
+"""Secret-safe resolution for xAI's distinct management authority.
+
+The canonical UniGrok variable and the xAI SDK alias name the same credential.
+Callers may support either spelling, but conflicting values are ambiguous and
+must fail closed before a management request or SDK client is created.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+
+
+def _resolve_optional_xai_management_key(
+    environ: Mapping[str, str] | None = None,
+) -> str | None:
+    """Return one unambiguous management key without logging its value."""
+
+    source = os.environ if environ is None else environ
+    canonical = str(source.get("XAI_MANAGEMENT_API_KEY", "")).strip()
+    sdk_alias = str(source.get("XAI_MANAGEMENT_KEY", "")).strip()
+    if canonical and sdk_alias and canonical != sdk_alias:
+        raise ValueError(
+            "XAI_MANAGEMENT_API_KEY and XAI_MANAGEMENT_KEY are both configured "
+            "with different values."
+        )
+    return canonical or sdk_alias or None
+
+
+def _require_xai_management_key(
+    environ: Mapping[str, str] | None = None,
+) -> str:
+    """Return the management credential or fail before any remote effect."""
+
+    resolved = _resolve_optional_xai_management_key(environ)
+    if resolved is None:
+        raise ValueError(
+            "XAI_MANAGEMENT_API_KEY or XAI_MANAGEMENT_KEY must be configured."
+        )
+    return resolved

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -179,6 +179,7 @@ def test_semantic_eval_scores_aggregate_and_null_at_zero_rows():
 @pytest.mark.asyncio
 async def test_provider_usage_is_explicitly_not_configured(monkeypatch):
     monkeypatch.delenv("XAI_MANAGEMENT_API_KEY", raising=False)
+    monkeypatch.delenv("XAI_MANAGEMENT_KEY", raising=False)
     monkeypatch.delenv("UNIGROK_XAI_TEAM_ID", raising=False)
     monkeypatch.setenv("UNIGROK_PROVIDER_USAGE", "auto")
 
@@ -187,6 +188,60 @@ async def test_provider_usage_is_explicitly_not_configured(monkeypatch):
     assert result["state"] == "not_configured"
     assert result["usage_usd"] is None
     assert result["scope"] == "xai_api_team"
+
+
+@pytest.mark.asyncio
+async def test_provider_usage_accepts_sdk_management_alias(monkeypatch):
+    captured = {}
+
+    class FakeResponse:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"timeSeries": []}
+
+    class FakeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def post(self, url, *, headers, json):
+            captured.update(url=url, headers=headers, json=json)
+            return FakeResponse()
+
+    monkeypatch.setattr("src.metrics.httpx.AsyncClient", lambda **kwargs: FakeClient())
+    monkeypatch.delenv("XAI_MANAGEMENT_API_KEY", raising=False)
+    monkeypatch.setenv("XAI_MANAGEMENT_KEY", "sdk-management-test-key")
+    monkeypatch.setenv("UNIGROK_XAI_TEAM_ID", "team-test")
+    monkeypatch.setenv("UNIGROK_PROVIDER_USAGE", "auto")
+
+    result = await fetch_provider_api_usage()
+
+    assert result["state"] == "ready"
+    assert captured["headers"] == {
+        "Authorization": "Bearer sdk-management-test-key"
+    }
+
+
+@pytest.mark.asyncio
+async def test_provider_usage_rejects_conflicting_management_aliases(monkeypatch):
+    def forbidden_client(**kwargs):
+        raise AssertionError("conflicting management authority must not make a call")
+
+    monkeypatch.setattr("src.metrics.httpx.AsyncClient", forbidden_client)
+    monkeypatch.setenv("XAI_MANAGEMENT_API_KEY", "canonical-test-key")
+    monkeypatch.setenv("XAI_MANAGEMENT_KEY", "different-sdk-test-key")
+    monkeypatch.setenv("UNIGROK_XAI_TEAM_ID", "team-test")
+    monkeypatch.setenv("UNIGROK_PROVIDER_USAGE", "auto")
+
+    result = await fetch_provider_api_usage()
+
+    assert result["state"] == "error"
+    assert result["usage_usd"] is None
+    assert "conflict" in result["detail"].lower()
 
 
 @pytest.mark.asyncio

--- a/tests/test_provider_harvest.py
+++ b/tests/test_provider_harvest.py
@@ -384,6 +384,7 @@ async def test_missing_credentials_or_client_leave_rows_pending_without_cloud_ca
         raise AssertionError("client must not be constructed without management auth")
 
     monkeypatch.delenv("XAI_MANAGEMENT_API_KEY", raising=False)
+    monkeypatch.delenv("XAI_MANAGEMENT_KEY", raising=False)
     monkeypatch.setattr(provider_utils, "XAI_API_KEY", "xai-inference-test-value")
     missing_management = XAIWorkerEpisodeUploader(client_factory=forbidden_factory)
     result = await ProviderAttemptHarvester(uploader=missing_management).run_once(store)

--- a/tests/test_task_rag.py
+++ b/tests/test_task_rag.py
@@ -1061,6 +1061,8 @@ class TestManagementKeyWiring:
 
         class FakeClient:
             def __init__(self, **kwargs):
+                self.collections = object()
+                self.close = MagicMock()
                 created.append(kwargs)
 
         monkeypatch.setattr("xai_sdk.Client", FakeClient)
@@ -1106,6 +1108,7 @@ class TestKeylessOperation:
     async def test_spawn_skipped_without_management_key(self, monkeypatch):
         monkeypatch.setenv("UNIGROK_TASK_RAG", "mirror")
         monkeypatch.delenv("XAI_MANAGEMENT_API_KEY", raising=False)
+        monkeypatch.delenv("XAI_MANAGEMENT_KEY", raising=False)
         assert rag.spawn_sync_task(None) is None
         assert rag._BG_TASKS == set()
 
@@ -1113,6 +1116,7 @@ class TestKeylessOperation:
     async def test_ready_keyless_reports_reason_without_probe(self, monkeypatch):
         monkeypatch.setenv("UNIGROK_TASK_RAG", "mirror")
         monkeypatch.delenv("XAI_MANAGEMENT_API_KEY", raising=False)
+        monkeypatch.delenv("XAI_MANAGEMENT_KEY", raising=False)
         mirror = get_task_memory_mirror()
         with patch("src.rag.get_xai_management_client") as mock_client:
             assert await mirror.ready() is False
@@ -1126,6 +1130,7 @@ class TestKeylessOperation:
     ):
         monkeypatch.setenv("UNIGROK_TASK_RAG", "shadow")
         monkeypatch.delenv("XAI_MANAGEMENT_API_KEY", raising=False)
+        monkeypatch.delenv("XAI_MANAGEMENT_KEY", raising=False)
         await _save_memory(
             tstore, "plan the sprint retro notes", model=PLANNING, success=1
         )
@@ -1148,6 +1153,7 @@ class TestKeylessOperation:
     def test_backfill_keyless_explains_and_exits_1(self, monkeypatch, tmp_path):
         monkeypatch.setenv("UNIGROK_TASK_RAG", "mirror")
         monkeypatch.delenv("XAI_MANAGEMENT_API_KEY", raising=False)
+        monkeypatch.delenv("XAI_MANAGEMENT_KEY", raising=False)
         out = io.StringIO()
         code = rag.rag_cli(
             ["backfill"], stream=out,
@@ -1161,6 +1167,7 @@ class TestKeylessOperation:
     def test_status_keyless_reports_local_first(self, monkeypatch, tmp_path):
         monkeypatch.setenv("UNIGROK_TASK_RAG", "shadow")
         monkeypatch.delenv("XAI_MANAGEMENT_API_KEY", raising=False)
+        monkeypatch.delenv("XAI_MANAGEMENT_KEY", raising=False)
         db = tmp_path / "keyless-status.db"
         _seed_db(db, ["one task"])
         out = io.StringIO()

--- a/tests/test_xai_client_authority.py
+++ b/tests/test_xai_client_authority.py
@@ -19,6 +19,8 @@ def test_inference_factory_constructs_with_only_inference_authority(monkeypatch)
 
     class FakeClient:
         def __init__(self, **kwargs):
+            self.collections = object()
+            self.close = MagicMock()
             calls.append(kwargs)
 
     monkeypatch.setattr("xai_sdk.Client", FakeClient)
@@ -74,6 +76,8 @@ def test_management_factory_constructs_with_both_sdk_credentials(monkeypatch):
 
     class FakeClient:
         def __init__(self, **kwargs):
+            self.collections = object()
+            self.close = MagicMock()
             calls.append(kwargs)
 
     monkeypatch.setattr("xai_sdk.Client", FakeClient)
@@ -139,6 +143,8 @@ def test_management_factory_resolves_aliases_deterministically(
 
     class FakeClient:
         def __init__(self, **kwargs):
+            self.collections = object()
+            self.close = MagicMock()
             calls.append(kwargs)
 
     monkeypatch.setattr("xai_sdk.Client", FakeClient)
@@ -179,6 +185,8 @@ def test_eval_recording_wraps_inference_but_never_management(monkeypatch):
     class FakeClient:
         def __init__(self, **kwargs):
             self.kwargs = kwargs
+            self.collections = object()
+            self.close = MagicMock()
             clients.append(self)
 
     monkeypatch.setattr("xai_sdk.Client", FakeClient)
@@ -194,7 +202,14 @@ def test_eval_recording_wraps_inference_but_never_management(monkeypatch):
 
     assert isinstance(inference, utils._EvalRecordingClient)
     assert inference._client._delegate is clients[0]
-    assert management is clients[1]
+    assert management.collections is clients[1].collections
+    with pytest.raises(AttributeError):
+        management.chat
+    with pytest.raises(AttributeError):
+        management._delegate
+    with pytest.raises(AttributeError):
+        management._close_callback
+    assert dir(management) == ["close", "collections"]
     assert not isinstance(management, utils._EvalRecordingClient)
 
 
@@ -238,6 +253,8 @@ def test_management_factory_is_thread_safe_and_separate_from_inference(monkeypat
         def __init__(self, **kwargs):
             time.sleep(0.01)
             self.kwargs = kwargs
+            self.collections = object()
+            self.close = MagicMock()
             calls.append(self)
 
     monkeypatch.setattr("xai_sdk.Client", SlowClient)
@@ -255,7 +272,7 @@ def test_management_factory_is_thread_safe_and_separate_from_inference(monkeypat
 
     assert len(calls) == 2
     assert all(client is management_clients[0] for client in management_clients)
-    assert management_clients[0].kwargs == {
+    assert calls[0].kwargs == {
         "api_key": "inference-test-key",
         "management_api_key": "management-test-key",
     }
@@ -264,6 +281,10 @@ def test_management_factory_is_thread_safe_and_separate_from_inference(monkeypat
         "management_api_key": utils._XAI_INFERENCE_MANAGEMENT_ISOLATION_KEY,
     }
     assert inference is not management_clients[0]
+    with pytest.raises(AttributeError):
+        management_clients[0].chat
+    with pytest.raises(AttributeError):
+        management_clients[0]._delegate
 
 
 def test_management_factory_is_confined_to_approved_admin_modules():


### PR DESCRIPTION
## Outcome

Keeps UniGrok’s third xAI authority separate from both Grok inference planes. The canonical `XAI_MANAGEMENT_API_KEY` and SDK alias `XAI_MANAGEMENT_KEY` now resolve through one fail-closed boundary; conflicting values stop before any HTTP or SDK effect. The xAI management SDK factory returns a Collections-only facade instead of a raw client with inference surfaces.

## Scope

- centralize canonical/alias management credential resolution
- make optional team-billing telemetry alias-aware and conflict-safe
- expose only `collections` and `close` from the management SDK facade
- make keyless tests hermetic across both supported variable names
- regenerate deterministic OKF mirrors

No routing, model selection, worker activation, training, dataset generation, or deployment behavior is changed.

## Verification

- 134 focused management/metrics/RAG/harvest tests passed
- 1,876 full repository tests passed
- scoped Ruff, compile, OKF check, diff check, and attribution check passed
- independent security review approved the exact patch; network-denied probes confirmed no provider calls

## Risk

Low and bounded to management credential resolution and the Collections factory interface. Existing call sites use only `.collections`; the facade fails closed if the SDK shape changes.

Human-Sponsor: djtelicloud

Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=implementation