### PR TITLE
Add inert stateful MCP session guard

### DIFF
--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -860,6 +860,99 @@ async def JobManager.wait(self, job_id: str) -> None
 Await a job's in-flight task if this process owns one (used by
 tests and graceful shutdown; a no-op for finished/foreign jobs).
 
+## mcp_session_guard.py {#mcp_session_guard}
+
+### Class: `SessionTransportRegistry` {#mcp_session_guard-sessiontransportregistry}
+
+```python
+class SessionTransportRegistry
+```
+
+**Keywords:** session, transport, registry
+
+Narrow transport ownership used by the guard.
+
+The production implementation below is the only place that knows the
+Python MCP SDK's private stateful-session map and creation lock.
+
+### Class: `SessionRuntimeRevoker` {#mcp_session_guard-sessionruntimerevoker}
+
+```python
+class SessionRuntimeRevoker
+```
+
+**Keywords:** session, runtime, revoker
+
+Revokes all session-owned callback/effect authority before teardown.
+
+### Class: `MCP126SessionTransportRegistry` {#mcp_session_guard-mcp126sessiontransportregistry}
+
+```python
+class MCP126SessionTransportRegistry
+```
+
+**Keywords:** mcp, 126, session, transport, registry
+
+Version-checked adapter over MCP SDK 1.26 private session state.
+
+This adapter is intentionally constructed with one exact session manager;
+it never discovers or mutates a module-global manager.  A future SDK minor
+must receive an explicit compatibility review before this adapter accepts
+it.
+
+### Class: `MCPSessionBinding` {#mcp_session_guard-mcpsessionbinding}
+
+```python
+class MCPSessionBinding
+```
+
+**Keywords:** mcp, session, binding
+
+Immutable server-owned identity for one physical MCP session.
+
+### Class: `StatefulMCPSessionGuard` {#mcp_session_guard-statefulmcpsessionguard}
+
+```python
+class StatefulMCPSessionGuard
+```
+
+**Keywords:** stateful, mcp, session, guard
+
+Admission, binding, expiry, and teardown for stateful MCP HTTP.
+
+Constructing the guard has no network, provider, credential, or transport
+effect.  The current UniGrok HTTP server deliberately does not install it.
+
+### Method: `StatefulMCPSessionGuard.reap_expired` {#mcp_session_guard-statefulmcpsessionguard-reap_expired}
+
+```python
+async def StatefulMCPSessionGuard.reap_expired(self) -> int
+```
+
+**Keywords:** stateful, mcp, session, guard, reap, expired
+
+Hard-revoke max-expired sessions; reap idle sessions when inactive.
+
+### Method: `StatefulMCPSessionGuard.cleanup_session` {#mcp_session_guard-statefulmcpsessionguard-cleanup_session}
+
+```python
+async def StatefulMCPSessionGuard.cleanup_session(self, session_id: str) -> bool
+```
+
+**Keywords:** stateful, mcp, session, guard, cleanup, session
+
+Idempotently revoke authority, then remove and terminate transport.
+
+### Method: `StatefulMCPSessionGuard.shutdown` {#mcp_session_guard-statefulmcpsessionguard-shutdown}
+
+```python
+async def StatefulMCPSessionGuard.shutdown(self) -> None
+```
+
+**Keywords:** stateful, mcp, session, guard, shutdown
+
+Idempotently reject admission and clean every committed session.
+
 ## metrics.py {#metrics}
 
 ### Function: `aggregate_telemetry_planes` {#metrics-aggregate_telemetry_planes}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,9 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "mcp[cli]>=1.13.1",
+    # Stateful session cleanup uses a narrowly isolated, version-checked SDK
+    # 1.26 private registry adapter. Review that adapter before widening this.
+    "mcp[cli]>=1.26,<1.27",
     "httpx>=0.28.1",
     "google-auth[requests]>=2.40,<3",
     "python-dotenv>=1.2.2",

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -860,6 +860,99 @@ async def JobManager.wait(self, job_id: str) -> None
 Await a job's in-flight task if this process owns one (used by
 tests and graceful shutdown; a no-op for finished/foreign jobs).
 
+## mcp_session_guard.py {#mcp_session_guard}
+
+### Class: `SessionTransportRegistry` {#mcp_session_guard-sessiontransportregistry}
+
+```python
+class SessionTransportRegistry
+```
+
+**Keywords:** session, transport, registry
+
+Narrow transport ownership used by the guard.
+
+The production implementation below is the only place that knows the
+Python MCP SDK's private stateful-session map and creation lock.
+
+### Class: `SessionRuntimeRevoker` {#mcp_session_guard-sessionruntimerevoker}
+
+```python
+class SessionRuntimeRevoker
+```
+
+**Keywords:** session, runtime, revoker
+
+Revokes all session-owned callback/effect authority before teardown.
+
+### Class: `MCP126SessionTransportRegistry` {#mcp_session_guard-mcp126sessiontransportregistry}
+
+```python
+class MCP126SessionTransportRegistry
+```
+
+**Keywords:** mcp, 126, session, transport, registry
+
+Version-checked adapter over MCP SDK 1.26 private session state.
+
+This adapter is intentionally constructed with one exact session manager;
+it never discovers or mutates a module-global manager.  A future SDK minor
+must receive an explicit compatibility review before this adapter accepts
+it.
+
+### Class: `MCPSessionBinding` {#mcp_session_guard-mcpsessionbinding}
+
+```python
+class MCPSessionBinding
+```
+
+**Keywords:** mcp, session, binding
+
+Immutable server-owned identity for one physical MCP session.
+
+### Class: `StatefulMCPSessionGuard` {#mcp_session_guard-statefulmcpsessionguard}
+
+```python
+class StatefulMCPSessionGuard
+```
+
+**Keywords:** stateful, mcp, session, guard
+
+Admission, binding, expiry, and teardown for stateful MCP HTTP.
+
+Constructing the guard has no network, provider, credential, or transport
+effect.  The current UniGrok HTTP server deliberately does not install it.
+
+### Method: `StatefulMCPSessionGuard.reap_expired` {#mcp_session_guard-statefulmcpsessionguard-reap_expired}
+
+```python
+async def StatefulMCPSessionGuard.reap_expired(self) -> int
+```
+
+**Keywords:** stateful, mcp, session, guard, reap, expired
+
+Hard-revoke max-expired sessions; reap idle sessions when inactive.
+
+### Method: `StatefulMCPSessionGuard.cleanup_session` {#mcp_session_guard-statefulmcpsessionguard-cleanup_session}
+
+```python
+async def StatefulMCPSessionGuard.cleanup_session(self, session_id: str) -> bool
+```
+
+**Keywords:** stateful, mcp, session, guard, cleanup, session
+
+Idempotently revoke authority, then remove and terminate transport.
+
+### Method: `StatefulMCPSessionGuard.shutdown` {#mcp_session_guard-statefulmcpsessionguard-shutdown}
+
+```python
+async def StatefulMCPSessionGuard.shutdown(self) -> None
+```
+
+**Keywords:** stateful, mcp, session, guard, shutdown
+
+Idempotently reject admission and clean every committed session.
+
 ## metrics.py {#metrics}
 
 ### Function: `aggregate_telemetry_planes` {#metrics-aggregate_telemetry_planes}

--- a/src/mcp_session_guard.py
+++ b/src/mcp_session_guard.py
@@ -1,0 +1,1097 @@
+"""Inert ASGI guard for a future stateful MCP HTTP transport.
+
+The public HTTP server does not install this module yet.  It exists so the
+stateful activation can later be a small, reviewable wiring change instead of
+mixing admission control, identity binding, expiry, and SDK-private cleanup in
+one step.
+
+The guard deliberately gets the authenticated principal from an injected
+request-scope resolver.  It never reads request context variables: stateful
+MCP server tasks may outlive the request whose context created them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+import re
+import time
+from collections.abc import Callable, Mapping, MutableMapping
+from dataclasses import dataclass, field
+from importlib import metadata
+from typing import Any, Protocol
+
+import anyio
+from mcp.types import InitializeRequest, InitializeResult
+from pydantic import ValidationError
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+
+MCP_SESSION_ID_HEADER = b"mcp-session-id"
+MCP_SESSION_BINDING_SCOPE_KEY = "unigrok.mcp_session.binding"
+
+_SDK_PRIVATE_INTERFACE_MINOR = (1, 26)
+_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._~-]{0,127}$")
+_CLIENT_ID_RE = re.compile(rb"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
+_SINGLETON_SECURITY_HEADERS = frozenset(
+    {
+        b"authorization",
+        b"host",
+        b"mcp-protocol-version",
+        MCP_SESSION_ID_HEADER,
+        b"origin",
+        b"x-client-id",
+    }
+)
+
+
+class SessionTransportRegistry(Protocol):
+    """Narrow transport ownership used by the guard.
+
+    The production implementation below is the only place that knows the
+    Python MCP SDK's private stateful-session map and creation lock.
+    """
+
+    async def contains(self, session_id: str) -> bool: ...
+
+    async def session_ids(self) -> frozenset[str]: ...
+
+    async def remove_and_terminate(self, session_id: str) -> bool: ...
+
+
+class SessionRuntimeRevoker(Protocol):
+    """Revokes all session-owned callback/effect authority before teardown."""
+
+    async def revoke_session(self, session_id: str) -> None: ...
+
+
+class MCP126SessionTransportRegistry:
+    """Version-checked adapter over MCP SDK 1.26 private session state.
+
+    This adapter is intentionally constructed with one exact session manager;
+    it never discovers or mutates a module-global manager.  A future SDK minor
+    must receive an explicit compatibility review before this adapter accepts
+    it.
+    """
+
+    def __init__(self, manager: Any) -> None:
+        sdk_version = metadata.version("mcp")
+        try:
+            major, minor = (int(part) for part in sdk_version.split(".", 2)[:2])
+        except (TypeError, ValueError):
+            raise RuntimeError("unrecognized MCP SDK version") from None
+        if (major, minor) != _SDK_PRIVATE_INTERFACE_MINOR:
+            raise RuntimeError(
+                "MCP private session registry requires an explicit SDK minor review"
+            )
+
+        instances = getattr(manager, "_server_instances", None)
+        creation_lock = getattr(manager, "_session_creation_lock", None)
+        if not isinstance(instances, MutableMapping):
+            raise RuntimeError("MCP SDK session registry shape changed")
+        if not callable(getattr(creation_lock, "__aenter__", None)) or not callable(
+            getattr(creation_lock, "__aexit__", None)
+        ):
+            raise RuntimeError("MCP SDK session creation lock shape changed")
+        self._instances = instances
+        self._creation_lock = creation_lock
+
+    async def contains(self, session_id: str) -> bool:
+        async with self._creation_lock:
+            return session_id in self._instances
+
+    async def session_ids(self) -> frozenset[str]:
+        async with self._creation_lock:
+            return frozenset(self._instances)
+
+    async def remove_and_terminate(self, session_id: str) -> bool:
+        async with self._creation_lock:
+            transport = self._instances.get(session_id)
+        if transport is None:
+            return False
+        terminate = getattr(transport, "terminate", None)
+        if not callable(terminate):
+            raise RuntimeError("MCP SDK transport termination interface changed")
+        await terminate()
+        async with self._creation_lock:
+            current = self._instances.get(session_id)
+            if current is transport:
+                self._instances.pop(session_id, None)
+            elif current is not None:
+                raise RuntimeError("MCP SDK session transport changed during cleanup")
+        return True
+
+
+@dataclass(frozen=True, slots=True)
+class MCPSessionBinding:
+    """Immutable server-owned identity for one physical MCP session."""
+
+    session_id: str
+    principal: str = field(repr=False)
+    client_id: bytes | None = field(repr=False)
+    created_monotonic: float
+
+
+@dataclass(slots=True)
+class _SessionCleanupOutcome:
+    error: BaseException | None = None
+
+
+@dataclass(slots=True)
+class _SessionRecord:
+    binding: MCPSessionBinding
+    last_activity_monotonic: float
+    active_calls: int = 0
+    active_scopes: set[anyio.CancelScope] = field(default_factory=set)
+    closing: bool = False
+    cleanup_retry_required: bool = False
+    cleanup_task: asyncio.Task[_SessionCleanupOutcome] | None = None
+
+
+@dataclass(slots=True)
+class _PendingTransportCleanup:
+    task: asyncio.Task[bool] | None = None
+
+
+class _DuplicateJSONObject(ValueError):
+    pass
+
+
+def _unique_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateJSONObject
+        result[key] = value
+    return result
+
+
+def _reject_json_constant(value: str) -> Any:
+    raise ValueError(f"non-RFC JSON constant: {value}")
+
+
+def _load_strict_json(payload: bytes | str) -> Any:
+    return json.loads(
+        payload,
+        object_pairs_hook=_unique_json_object,
+        parse_constant=_reject_json_constant,
+    )
+
+
+def _parse_exact_initialize(body: bytes) -> str | int | None:
+    try:
+        message = _load_strict_json(body)
+    except (UnicodeDecodeError, ValueError):
+        return None
+    if not isinstance(message, dict) or set(message) != {
+        "jsonrpc",
+        "id",
+        "method",
+        "params",
+    }:
+        return None
+    request_id = message["id"]
+    if (
+        message["jsonrpc"] != "2.0"
+        or message["method"] != "initialize"
+        or isinstance(request_id, bool)
+        or not isinstance(request_id, (str, int))
+        or not isinstance(message["params"], dict)
+    ):
+        return None
+    try:
+        parsed = InitializeRequest.model_validate(
+            {"method": "initialize", "params": message["params"]},
+            strict=True,
+        )
+    except ValidationError:
+        return None
+    client_info = parsed.params.clientInfo
+    if (
+        not client_info.name.strip()
+        or not client_info.version.strip()
+        or any(
+            ord(char) < 32 or ord(char) == 127
+            for char in client_info.name + client_info.version
+        )
+    ):
+        return None
+    return request_id
+
+
+def _response_json_values(
+    *, content_type: bytes | None, body: bytes
+) -> tuple[Any, ...]:
+    try:
+        if content_type is not None and content_type.split(b";", 1)[0].strip().lower() == b"text/event-stream":
+            text = body.decode("utf-8", errors="strict").replace("\r\n", "\n")
+            values: list[Any] = []
+            for event in text.split("\n\n"):
+                data_lines = [
+                    line[5:].lstrip(" ")
+                    for line in event.splitlines()
+                    if line.startswith("data:")
+                ]
+                if data_lines:
+                    values.append(_load_strict_json("\n".join(data_lines)))
+            return tuple(values)
+        return (_load_strict_json(body),)
+    except (UnicodeDecodeError, ValueError):
+        return ()
+
+
+def _is_verified_initialize_response(
+    *,
+    request_id: str | int,
+    content_type: bytes | None,
+    body: bytes,
+) -> bool:
+    matching: list[Mapping[str, Any]] = []
+    for value in _response_json_values(content_type=content_type, body=body):
+        if not isinstance(value, Mapping):
+            continue
+        response_id = value.get("id")
+        if (
+            isinstance(response_id, bool)
+            or type(response_id) is not type(request_id)
+            or response_id != request_id
+        ):
+            continue
+        matching.append(value)
+    if len(matching) != 1:
+        return False
+    response = matching[0]
+    if (
+        response.get("jsonrpc") != "2.0"
+        or "error" in response
+        or set(response) != {"jsonrpc", "id", "result"}
+        or not isinstance(response.get("result"), Mapping)
+    ):
+        return False
+    try:
+        InitializeResult.model_validate(response["result"], strict=True)
+    except ValidationError:
+        return False
+    return True
+
+
+def _header_values(scope: Mapping[str, Any], name: bytes) -> tuple[bytes, ...]:
+    values: list[bytes] = []
+    for raw_name, raw_value in scope.get("headers") or ():
+        try:
+            normalized = raw_name.lower()
+        except AttributeError:
+            continue
+        if normalized == name and isinstance(raw_value, bytes):
+            values.append(raw_value)
+    return tuple(values)
+
+
+def _has_duplicate_security_header(scope: Mapping[str, Any]) -> bool:
+    counts: dict[bytes, int] = {}
+    for raw_name, _ in scope.get("headers") or ():
+        if not isinstance(raw_name, bytes):
+            continue
+        name = raw_name.lower()
+        if name not in _SINGLETON_SECURITY_HEADERS:
+            continue
+        counts[name] = counts.get(name, 0) + 1
+        if counts[name] > 1:
+            return True
+    return False
+
+
+def _valid_principal(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and 0 < len(value) <= 240
+        and all(ord(char) >= 32 and ord(char) != 127 for char in value)
+    )
+
+
+def _valid_client_id(value: bytes | None) -> bool:
+    return value is None or _CLIENT_ID_RE.fullmatch(value) is not None
+
+
+def _parse_session_id(value: bytes) -> str | None:
+    try:
+        decoded = value.decode("ascii")
+    except UnicodeDecodeError:
+        return None
+    return decoded if _SESSION_ID_RE.fullmatch(decoded) else None
+
+
+async def _send_fixed_response(
+    send: Send,
+    *,
+    status: int,
+    body: bytes,
+) -> None:
+    await send(
+        {
+            "type": "http.response.start",
+            "status": status,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(body)).encode("ascii")),
+                (b"cache-control", b"no-store"),
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": body})
+
+
+async def _read_request_body(receive: Receive, *, limit: int) -> bytes | None:
+    chunks: list[bytes] = []
+    length = 0
+    while True:
+        message = await receive()
+        if message["type"] == "http.disconnect":
+            return None
+        if message["type"] != "http.request":
+            return None
+        chunk = message.get("body", b"")
+        if not isinstance(chunk, bytes):
+            return None
+        length += len(chunk)
+        if length > limit:
+            return None
+        chunks.append(chunk)
+        if not message.get("more_body", False):
+            return b"".join(chunks)
+
+
+def _replay_body(body: bytes, original_receive: Receive) -> Receive:
+    delivered = False
+
+    async def receive() -> Message:
+        nonlocal delivered
+        if not delivered:
+            delivered = True
+            return {"type": "http.request", "body": body, "more_body": False}
+        # Stateful SSE transports keep receiving after the request body to
+        # observe the *real* client disconnect.  Inventing a disconnect here
+        # would cancel the initialize response before its first event.
+        return await original_receive()
+
+    return receive
+
+
+class StatefulMCPSessionGuard:
+    """Admission, binding, expiry, and teardown for stateful MCP HTTP.
+
+    Constructing the guard has no network, provider, credential, or transport
+    effect.  The current UniGrok HTTP server deliberately does not install it.
+    """
+
+    _INVALID_REQUEST = b'{"error":"invalid_request"}'
+    _SESSION_NOT_FOUND = b'{"error":"session_not_found"}'
+    _CAPACITY_EXHAUSTED = b'{"error":"session_capacity_exhausted"}'
+    _UNAVAILABLE = b'{"error":"session_guard_unavailable"}'
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        registry: SessionTransportRegistry,
+        runtime_revoker: SessionRuntimeRevoker,
+        principal_resolver: Callable[[Scope], str],
+        max_sessions: int = 64,
+        idle_ttl_seconds: float = 15 * 60,
+        max_ttl_seconds: float = 8 * 60 * 60,
+        max_initialize_body_bytes: int = 1024 * 1024,
+        max_initialize_response_bytes: int = 1024 * 1024,
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
+        if (
+            isinstance(max_sessions, bool)
+            or not isinstance(max_sessions, int)
+            or max_sessions <= 0
+        ):
+            raise ValueError("max_sessions must be a positive integer")
+        for name, value in (
+            ("idle_ttl_seconds", idle_ttl_seconds),
+            ("max_ttl_seconds", max_ttl_seconds),
+        ):
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(float(value))
+                or value <= 0
+            ):
+                raise ValueError(f"{name} must be finite and positive")
+        if max_ttl_seconds < idle_ttl_seconds:
+            raise ValueError("max_ttl_seconds cannot be shorter than idle TTL")
+        for name, value in (
+            ("max_initialize_body_bytes", max_initialize_body_bytes),
+            ("max_initialize_response_bytes", max_initialize_response_bytes),
+        ):
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, int)
+                or value <= 0
+            ):
+                raise ValueError(f"{name} must be positive")
+
+        self._app = app
+        self._registry = registry
+        self._runtime_revoker = runtime_revoker
+        self._principal_resolver = principal_resolver
+        self._max_sessions = max_sessions
+        self._idle_ttl_seconds = float(idle_ttl_seconds)
+        self._max_ttl_seconds = float(max_ttl_seconds)
+        self._max_initialize_body_bytes = max_initialize_body_bytes
+        self._max_initialize_response_bytes = max_initialize_response_bytes
+        self._monotonic = monotonic
+        self._lock = anyio.Lock()
+        # Serializing admission lets a failed SDK initialize be associated
+        # with, and clean up, only the transports created by that initialize.
+        self._initialize_lock = anyio.Lock()
+        self._sessions: dict[str, _SessionRecord] = {}
+        self._pending_transport_cleanup: dict[str, _PendingTransportCleanup] = {}
+        self._reservations: set[int] = set()
+        self._reservations_drained = anyio.Event()
+        self._reservations_drained.set()
+        self._reservation_sequence = 0
+        self._shutting_down = False
+        self._shutdown_task: asyncio.Task[_SessionCleanupOutcome] | None = None
+
+    def _now(self) -> float:
+        now = float(self._monotonic())
+        if not math.isfinite(now):
+            raise RuntimeError("monotonic clock returned a non-finite value")
+        return now
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self._app(scope, receive, send)
+            return
+        if _has_duplicate_security_header(scope):
+            await _send_fixed_response(
+                send, status=400, body=self._INVALID_REQUEST
+            )
+            return
+
+        try:
+            principal = self._principal_resolver(scope)
+        except Exception:
+            principal = None
+        client_values = _header_values(scope, b"x-client-id")
+        client_id = client_values[0] if client_values else None
+        if not _valid_principal(principal) or not _valid_client_id(client_id):
+            await _send_fixed_response(
+                send, status=400, body=self._INVALID_REQUEST
+            )
+            return
+
+        session_values = _header_values(scope, MCP_SESSION_ID_HEADER)
+        if not session_values:
+            await self._handle_sessionless_initialize(
+                scope,
+                receive,
+                send,
+                principal=principal,
+                client_id=client_id,
+            )
+            return
+        session_id = _parse_session_id(session_values[0])
+        if session_id is None:
+            await self._send_session_not_found(send)
+            return
+        await self._handle_existing_session(
+            scope,
+            receive,
+            send,
+            session_id=session_id,
+            principal=principal,
+            client_id=client_id,
+        )
+
+    async def _handle_sessionless_initialize(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+        *,
+        principal: str,
+        client_id: bytes | None,
+    ) -> None:
+        if scope.get("method", "").upper() != "POST":
+            await _send_fixed_response(
+                send, status=400, body=self._INVALID_REQUEST
+            )
+            return
+        body = await _read_request_body(
+            receive, limit=self._max_initialize_body_bytes
+        )
+        request_id = _parse_exact_initialize(body) if body is not None else None
+        if body is None or request_id is None:
+            await _send_fixed_response(
+                send, status=400, body=self._INVALID_REQUEST
+            )
+            return
+
+        reservation = await self._reserve_capacity()
+        if reservation is None:
+            await _send_fixed_response(
+                send, status=503, body=self._CAPACITY_EXHAUSTED
+            )
+            return
+
+        committed_session_id: str | None = None
+        baseline_session_ids: frozenset[str] | None = None
+        buffered_response: list[Message] = []
+        response_started = False
+        response_complete = False
+        response_invalid = False
+        response_body_bytes = 0
+
+        async def buffered_send(message: Message) -> None:
+            nonlocal response_started, response_complete
+            nonlocal response_invalid, response_body_bytes
+            if response_invalid:
+                return
+            message_type = message.get("type")
+            if message_type == "http.response.start":
+                if response_started or response_complete:
+                    response_invalid = True
+                    buffered_response.clear()
+                    return
+                status = message.get("status")
+                headers = message.get("headers", [])
+                if (
+                    isinstance(status, bool)
+                    or not isinstance(status, int)
+                    or not isinstance(headers, (list, tuple))
+                    or any(
+                        not isinstance(item, (list, tuple))
+                        or len(item) != 2
+                        or not isinstance(item[0], bytes)
+                        or not isinstance(item[1], bytes)
+                        for item in headers
+                    )
+                ):
+                    response_invalid = True
+                    buffered_response.clear()
+                    return
+                response_started = True
+                buffered_response.append(
+                    {
+                        "type": "http.response.start",
+                        "status": status,
+                        "headers": list(headers),
+                    }
+                )
+                return
+            if message_type != "http.response.body" or not response_started:
+                response_invalid = True
+                buffered_response.clear()
+                return
+            if response_complete:
+                response_invalid = True
+                buffered_response.clear()
+                return
+            chunk = message.get("body", b"")
+            more_body = message.get("more_body", False)
+            if not isinstance(chunk, bytes) or not isinstance(more_body, bool):
+                response_invalid = True
+                buffered_response.clear()
+                return
+            response_body_bytes += len(chunk)
+            if response_body_bytes > self._max_initialize_response_bytes:
+                response_invalid = True
+                buffered_response.clear()
+                return
+            buffered_response.append(
+                {
+                    "type": "http.response.body",
+                    "body": chunk,
+                    "more_body": more_body,
+                }
+            )
+            response_complete = not more_body
+
+        try:
+            async with self._initialize_lock:
+                baseline_session_ids = await self._registry.session_ids()
+                try:
+                    downstream_failed = False
+                    try:
+                        await self._app(
+                            scope,
+                            _replay_body(body, receive),
+                            buffered_send,
+                        )
+                    except Exception:
+                        downstream_failed = True
+
+                    current_session_ids = await self._registry.session_ids()
+                    new_session_ids = current_session_ids - baseline_session_ids
+                    start = buffered_response[0] if buffered_response else None
+                    status = (
+                        start.get("status")
+                        if isinstance(start, Mapping)
+                        and start.get("type") == "http.response.start"
+                        else None
+                    )
+                    headers = (
+                        start.get("headers", [])
+                        if isinstance(start, Mapping)
+                        else []
+                    )
+                    response_session_values = tuple(
+                        value
+                        for name, value in headers
+                        if name.lower() == MCP_SESSION_ID_HEADER
+                    )
+                    response_session_id = (
+                        _parse_session_id(response_session_values[0])
+                        if len(response_session_values) == 1
+                        else None
+                    )
+                    content_type_values = tuple(
+                        value
+                        for name, value in headers
+                        if name.lower() == b"content-type"
+                    )
+                    content_type = (
+                        content_type_values[0]
+                        if len(content_type_values) == 1
+                        else None
+                    )
+                    response_body = b"".join(
+                        message.get("body", b"")
+                        for message in buffered_response[1:]
+                        if message.get("type") == "http.response.body"
+                    )
+                    response_sequence_valid = (
+                        not downstream_failed
+                        and not response_invalid
+                        and response_started
+                        and response_complete
+                        and isinstance(status, int)
+                    )
+                    initialize_verified = (
+                        response_sequence_valid
+                        and 200 <= status < 300
+                        and response_session_id is not None
+                        and response_session_id in new_session_ids
+                        and _is_verified_initialize_response(
+                            request_id=request_id,
+                            content_type=content_type,
+                            body=response_body,
+                        )
+                    )
+                    if initialize_verified and await self._commit_session(
+                        reservation,
+                        session_id=response_session_id,
+                        new_session_ids=new_session_ids,
+                        principal=principal,
+                        client_id=client_id,
+                    ):
+                        committed_session_id = response_session_id
+
+                    with anyio.CancelScope(shield=True):
+                        unbound_session_ids = set(new_session_ids)
+                        if committed_session_id is not None:
+                            unbound_session_ids.discard(committed_session_id)
+                        for session_id in sorted(unbound_session_ids):
+                            await self._cleanup_unbound_transport(session_id)
+
+                    if committed_session_id is not None:
+                        for message in buffered_response:
+                            await send(message)
+                    elif (
+                        response_sequence_valid
+                        and isinstance(status, int)
+                        and not 200 <= status < 300
+                        and not response_session_values
+                    ):
+                        for message in buffered_response:
+                            await send(message)
+                    else:
+                        await _send_fixed_response(
+                            send, status=503, body=self._UNAVAILABLE
+                        )
+                except BaseException:
+                    with anyio.CancelScope(shield=True):
+                        try:
+                            current_session_ids = await self._registry.session_ids()
+                        except BaseException:
+                            current_session_ids = baseline_session_ids
+                        unbound_session_ids = set(
+                            current_session_ids - baseline_session_ids
+                        )
+                        if committed_session_id is not None:
+                            unbound_session_ids.discard(committed_session_id)
+                            try:
+                                await self.cleanup_session(committed_session_id)
+                            except BaseException:
+                                pass
+                        for session_id in sorted(unbound_session_ids):
+                            await self._cleanup_unbound_transport(session_id)
+                    raise
+        finally:
+            with anyio.CancelScope(shield=True):
+                await self._release_reservation(reservation)
+
+    async def _reserve_capacity(self) -> int | None:
+        async with self._lock:
+            if self._shutting_down:
+                return None
+            if (
+                len(self._sessions)
+                + len(self._reservations)
+                + len(self._pending_transport_cleanup)
+                >= self._max_sessions
+            ):
+                return None
+            self._reservation_sequence += 1
+            reservation = self._reservation_sequence
+            if not self._reservations:
+                self._reservations_drained = anyio.Event()
+            self._reservations.add(reservation)
+            return reservation
+
+    async def _release_reservation(self, reservation: int) -> None:
+        async with self._lock:
+            self._reservations.discard(reservation)
+            if not self._reservations:
+                self._reservations_drained.set()
+
+    async def _commit_session(
+        self,
+        reservation: int,
+        *,
+        session_id: str,
+        new_session_ids: frozenset[str],
+        principal: str,
+        client_id: bytes | None,
+    ) -> bool:
+        if session_id not in new_session_ids or not await self._registry.contains(
+            session_id
+        ):
+            return False
+        now = self._now()
+        async with self._lock:
+            if (
+                self._shutting_down
+                or reservation not in self._reservations
+                or session_id in self._sessions
+                or session_id in self._pending_transport_cleanup
+            ):
+                return False
+            self._reservations.remove(reservation)
+            self._sessions[session_id] = _SessionRecord(
+                binding=MCPSessionBinding(
+                    session_id=session_id,
+                    principal=principal,
+                    client_id=client_id,
+                    created_monotonic=now,
+                ),
+                last_activity_monotonic=now,
+            )
+            return True
+
+    async def _handle_existing_session(
+        self,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+        *,
+        session_id: str,
+        principal: str,
+        client_id: bytes | None,
+    ) -> None:
+        method = scope.get("method", "").upper()
+        call_scope = anyio.CancelScope()
+        binding, should_cleanup = await self._enter_session(
+            session_id,
+            principal=principal,
+            client_id=client_id,
+            enter_call=method != "DELETE",
+            call_scope=call_scope,
+        )
+        if binding is None:
+            if should_cleanup:
+                try:
+                    await self.cleanup_session(session_id)
+                except BaseException:
+                    # Expiry must remain indistinguishable from an unknown or
+                    # identity-mismatched session. The closing record remains
+                    # retryable when cleanup fails.
+                    pass
+            await self._send_session_not_found(send)
+            return
+
+        if method == "DELETE":
+            try:
+                await self.cleanup_session(session_id)
+            except BaseException:
+                await _send_fixed_response(
+                    send, status=503, body=self._UNAVAILABLE
+                )
+            else:
+                await _send_fixed_response(send, status=204, body=b"")
+            return
+
+        request_scope = dict(scope)
+        request_scope[MCP_SESSION_BINDING_SCOPE_KEY] = binding
+        response_started = False
+
+        async def tracked_send(message: Message) -> None:
+            nonlocal response_started
+            if message.get("type") == "http.response.start":
+                response_started = True
+            await send(message)
+
+        try:
+            with call_scope:
+                await self._app(request_scope, receive, tracked_send)
+            if call_scope.cancel_called and not response_started:
+                await self._send_session_not_found(send)
+        finally:
+            with anyio.CancelScope(shield=True):
+                if await self._leave_session(session_id, call_scope=call_scope):
+                    try:
+                        await self.cleanup_session(session_id)
+                    except BaseException:
+                        pass
+
+    async def _enter_session(
+        self,
+        session_id: str,
+        *,
+        principal: str,
+        client_id: bytes | None,
+        enter_call: bool,
+        call_scope: anyio.CancelScope,
+    ) -> tuple[MCPSessionBinding | None, bool]:
+        now = self._now()
+        async with self._lock:
+            record = self._sessions.get(session_id)
+            if record is None or self._shutting_down:
+                return None, False
+            binding = record.binding
+            if binding.principal != principal or binding.client_id != client_id:
+                return None, False
+            max_expired = now - binding.created_monotonic >= self._max_ttl_seconds
+            idle_expired = (
+                record.active_calls == 0
+                and now - record.last_activity_monotonic >= self._idle_ttl_seconds
+            )
+            if record.closing or max_expired or idle_expired:
+                record.closing = True
+                return None, max_expired or record.active_calls == 0
+            if enter_call:
+                record.active_calls += 1
+                record.active_scopes.add(call_scope)
+                record.last_activity_monotonic = now
+            else:
+                record.closing = True
+            return binding, False
+
+    async def _leave_session(
+        self, session_id: str, *, call_scope: anyio.CancelScope
+    ) -> bool:
+        now = self._now()
+        async with self._lock:
+            record = self._sessions.get(session_id)
+            if record is None:
+                return False
+            if call_scope in record.active_scopes:
+                record.active_scopes.remove(call_scope)
+                record.active_calls -= 1
+            max_expired = (
+                now - record.binding.created_monotonic >= self._max_ttl_seconds
+            )
+            if not record.closing:
+                if max_expired:
+                    record.closing = True
+                else:
+                    record.last_activity_monotonic = now
+            return (
+                record.closing
+                and (max_expired or record.active_calls == 0)
+                and record.cleanup_task is None
+                and not record.cleanup_retry_required
+            )
+
+    async def reap_expired(self) -> int:
+        """Hard-revoke max-expired sessions; reap idle sessions when inactive."""
+
+        now = self._now()
+        cleanup: list[str] = []
+        async with self._lock:
+            for session_id, record in self._sessions.items():
+                max_expired = (
+                    now - record.binding.created_monotonic
+                    >= self._max_ttl_seconds
+                )
+                idle_expired = (
+                    record.active_calls == 0
+                    and now - record.last_activity_monotonic
+                    >= self._idle_ttl_seconds
+                )
+                if max_expired or idle_expired:
+                    record.closing = True
+                if max_expired or (record.closing and record.active_calls == 0):
+                    cleanup.append(session_id)
+        first_error: BaseException | None = None
+        for session_id in cleanup:
+            try:
+                await self.cleanup_session(session_id)
+            except BaseException as exc:
+                if first_error is None:
+                    first_error = exc
+        if first_error is not None:
+            raise first_error
+        return len(cleanup)
+
+    async def cleanup_session(self, session_id: str) -> bool:
+        """Idempotently revoke authority, then remove and terminate transport."""
+
+        async with self._lock:
+            record = self._sessions.get(session_id)
+            if record is None:
+                return False
+            record.closing = True
+            if record.cleanup_task is None:
+                record.cleanup_retry_required = False
+                record.cleanup_task = asyncio.create_task(
+                    self._run_session_cleanup(session_id, record)
+                )
+            cleanup_task = record.cleanup_task
+        outcome = await asyncio.shield(cleanup_task)
+        if outcome.error is not None:
+            raise outcome.error
+        return True
+
+    async def _run_session_cleanup(
+        self,
+        session_id: str,
+        record: _SessionRecord,
+    ) -> _SessionCleanupOutcome:
+        error: BaseException | None = None
+        try:
+            try:
+                await self._runtime_revoker.revoke_session(session_id)
+            except BaseException as exc:
+                error = exc
+            async with self._lock:
+                current = self._sessions.get(session_id)
+                active_scopes = (
+                    tuple(record.active_scopes) if current is record else ()
+                )
+            for active_scope in active_scopes:
+                active_scope.cancel()
+            if error is None:
+                await self._registry.remove_and_terminate(session_id)
+        except BaseException as exc:
+            if error is None:
+                error = exc
+        finally:
+            async with self._lock:
+                current = self._sessions.get(session_id)
+                if current is record and error is None:
+                    self._sessions.pop(session_id, None)
+                elif current is record:
+                    record.cleanup_retry_required = True
+                    record.cleanup_task = None
+        return _SessionCleanupOutcome(error=error)
+
+    async def _cleanup_unbound_transport(
+        self, session_id: str, *, register: bool = True
+    ) -> bool:
+        async with self._lock:
+            pending = self._pending_transport_cleanup.get(session_id)
+            if pending is None:
+                if not register:
+                    return True
+                pending = _PendingTransportCleanup()
+                self._pending_transport_cleanup[session_id] = pending
+            if pending.task is None:
+                pending.task = asyncio.create_task(
+                    self._run_unbound_transport_cleanup(session_id, pending)
+                )
+            cleanup_task = pending.task
+        return await asyncio.shield(cleanup_task)
+
+    async def _run_unbound_transport_cleanup(
+        self,
+        session_id: str,
+        pending: _PendingTransportCleanup,
+    ) -> bool:
+        succeeded = False
+        try:
+            await self._runtime_revoker.revoke_session(session_id)
+            await self._registry.remove_and_terminate(session_id)
+            succeeded = True
+        except BaseException:
+            succeeded = False
+        finally:
+            async with self._lock:
+                current = self._pending_transport_cleanup.get(session_id)
+                if current is pending:
+                    if succeeded:
+                        self._pending_transport_cleanup.pop(session_id, None)
+                    else:
+                        pending.task = None
+        return succeeded
+
+    async def shutdown(self) -> None:
+        """Idempotently reject admission and clean every committed session."""
+
+        async with self._lock:
+            self._shutting_down = True
+            for record in self._sessions.values():
+                record.closing = True
+            if self._shutdown_task is None:
+                self._shutdown_task = asyncio.create_task(self._run_shutdown())
+            shutdown_task = self._shutdown_task
+        outcome = await asyncio.shield(shutdown_task)
+        if outcome.error is not None:
+            raise outcome.error
+
+    async def _run_shutdown(self) -> _SessionCleanupOutcome:
+        """Own the complete shutdown independently of any individual waiter."""
+
+        first_error: BaseException | None = None
+        try:
+            async with self._lock:
+                reservations_drained = self._reservations_drained
+            await reservations_drained.wait()
+            async with self._lock:
+                session_ids = tuple(self._sessions)
+                pending_transport_ids = tuple(self._pending_transport_cleanup)
+                for record in self._sessions.values():
+                    record.closing = True
+            for session_id in session_ids:
+                try:
+                    await self.cleanup_session(session_id)
+                except BaseException as exc:
+                    if first_error is None:
+                        first_error = exc
+            for session_id in pending_transport_ids:
+                if not await self._cleanup_unbound_transport(
+                    session_id, register=False
+                ):
+                    if first_error is None:
+                        first_error = RuntimeError(
+                            "stateful MCP transport cleanup remains pending"
+                        )
+        except BaseException as exc:
+            if first_error is None:
+                first_error = exc
+        finally:
+            if first_error is not None:
+                async with self._lock:
+                    if self._shutdown_task is asyncio.current_task():
+                        self._shutdown_task = None
+        return _SessionCleanupOutcome(error=first_error)
+
+    async def _send_session_not_found(self, send: Send) -> None:
+        await _send_fixed_response(
+            send, status=404, body=self._SESSION_NOT_FOUND
+        )

--- a/tests/test_mcp_session_guard.py
+++ b/tests/test_mcp_session_guard.py
@@ -1,0 +1,1325 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Mapping
+from typing import Any
+
+import httpx
+import pytest
+
+from src.mcp_session_guard import (
+    MCP_SESSION_BINDING_SCOPE_KEY,
+    MCP126SessionTransportRegistry,
+    MCPSessionBinding,
+    StatefulMCPSessionGuard,
+)
+
+
+def initialize_payload(*, request_id: str | int = 1) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-11-25",
+            "capabilities": {"sampling": {}},
+            "clientInfo": {"name": "guard-test", "version": "1.0"},
+        },
+    }
+
+
+def header(scope: Mapping[str, Any], name: bytes) -> bytes | None:
+    for key, value in scope.get("headers") or ():
+        if key.lower() == name:
+            return value
+    return None
+
+
+def principal_from_scope(scope: Mapping[str, Any]) -> str:
+    authorization = header(scope, b"authorization")
+    suffix = authorization.decode("ascii") if authorization is not None else "anon"
+    return f"server:{suffix}"
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.value = 0.0
+
+    def __call__(self) -> float:
+        return self.value
+
+    def advance(self, seconds: float) -> None:
+        self.value += seconds
+
+
+class FakeTransport:
+    def __init__(self, session_id: str, events: list[str]) -> None:
+        self.session_id = session_id
+        self.events = events
+        self.terminated = False
+
+    async def terminate(self) -> None:
+        self.events.append(f"terminate:{self.session_id}")
+        self.terminated = True
+
+
+class FakeRegistry:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+        self.transports: dict[str, FakeTransport] = {}
+
+    def add(self, session_id: str) -> None:
+        self.transports[session_id] = FakeTransport(session_id, self.events)
+
+    async def contains(self, session_id: str) -> bool:
+        return session_id in self.transports
+
+    async def session_ids(self) -> frozenset[str]:
+        return frozenset(self.transports)
+
+    async def remove_and_terminate(self, session_id: str) -> bool:
+        self.events.append(f"remove:{session_id}")
+        transport = self.transports.pop(session_id, None)
+        if transport is None:
+            return False
+        await transport.terminate()
+        return True
+
+
+class BlockingSnapshotRegistry(FakeRegistry):
+    def __init__(self, events: list[str], *, block_call: int) -> None:
+        super().__init__(events)
+        self.block_call = block_call
+        self.snapshot_calls = 0
+        self.blocked = asyncio.Event()
+
+    async def session_ids(self) -> frozenset[str]:
+        self.snapshot_calls += 1
+        if self.snapshot_calls == self.block_call:
+            self.blocked.set()
+            await asyncio.Event().wait()
+        return await super().session_ids()
+
+
+class FakeRevoker:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+
+    async def revoke_session(self, session_id: str) -> None:
+        self.events.append(f"revoke:{session_id}")
+
+
+class FlakyRevoker(FakeRevoker):
+    def __init__(self, events: list[str]) -> None:
+        super().__init__(events)
+        self.failures = 1
+
+    async def revoke_session(self, session_id: str) -> None:
+        self.events.append(f"revoke:{session_id}")
+        if self.failures:
+            self.failures -= 1
+            raise RuntimeError("revocation failed")
+
+
+class PendingThenBlockingRevoker(FakeRevoker):
+    def __init__(self, events: list[str]) -> None:
+        super().__init__(events)
+        self.calls = 0
+        self.concurrent = 0
+        self.max_concurrent = 0
+        self.retry_started = asyncio.Event()
+        self.retry_release = asyncio.Event()
+
+    async def revoke_session(self, session_id: str) -> None:
+        self.calls += 1
+        self.events.append(f"revoke:{session_id}")
+        if self.calls == 1:
+            raise RuntimeError("initial revocation failed")
+        self.concurrent += 1
+        self.max_concurrent = max(self.max_concurrent, self.concurrent)
+        self.retry_started.set()
+        await self.retry_release.wait()
+        self.concurrent -= 1
+
+
+class BlockingCommittedRevoker(FakeRevoker):
+    def __init__(self, events: list[str]) -> None:
+        super().__init__(events)
+        self.calls = 0
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def revoke_session(self, session_id: str) -> None:
+        self.calls += 1
+        self.events.append(f"revoke:{session_id}")
+        self.started.set()
+        await self.release.wait()
+
+
+class FakeStatefulApp:
+    def __init__(self, registry: FakeRegistry) -> None:
+        self.registry = registry
+        self.calls = 0
+        self.initializations = 0
+        self.bindings: list[MCPSessionBinding] = []
+        self.response_session_headers: list[tuple[bytes, bytes]] | None = None
+        self.initialize_response_payload: dict[str, Any] | None = None
+        self.initialize_status = 200
+
+    async def __call__(self, scope, receive, send) -> None:
+        self.calls += 1
+        if header(scope, b"mcp-session-id") is None:
+            self.initializations += 1
+            # Exercise the guard's request-body replay, not only its parser.
+            request = await receive()
+            assert request["type"] == "http.request"
+            initialize_request = json.loads(request["body"])
+            assert initialize_request["method"] == "initialize"
+            session_id = f"session-{self.initializations}"
+            self.registry.add(session_id)
+            response_headers = self.response_session_headers
+            if response_headers is None:
+                response_headers = [(b"mcp-session-id", session_id.encode())]
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": self.initialize_status,
+                    "headers": response_headers,
+                }
+            )
+            response = self.initialize_response_payload or {
+                "jsonrpc": "2.0",
+                "id": initialize_request["id"],
+                "result": {
+                    "protocolVersion": initialize_request["params"][
+                        "protocolVersion"
+                    ],
+                    "capabilities": {},
+                    "serverInfo": {"name": "guard-test", "version": "1.0"},
+                },
+            }
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": json.dumps(response).encode(),
+                }
+            )
+            return
+
+        binding = scope.get(MCP_SESSION_BINDING_SCOPE_KEY)
+        assert isinstance(binding, MCPSessionBinding)
+        self.bindings.append(binding)
+        await send(
+            {"type": "http.response.start", "status": 200, "headers": []}
+        )
+        await send({"type": "http.response.body", "body": b"{}"})
+
+
+class BlockingStatefulApp(FakeStatefulApp):
+    def __init__(self, registry: FakeRegistry) -> None:
+        super().__init__(registry)
+        self.started = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def __call__(self, scope, receive, send) -> None:
+        if (
+            header(scope, b"mcp-session-id") is not None
+            and scope.get("path") == "/block"
+        ):
+            self.calls += 1
+            binding = scope.get(MCP_SESSION_BINDING_SCOPE_KEY)
+            assert isinstance(binding, MCPSessionBinding)
+            self.bindings.append(binding)
+            self.started.set()
+            await self.release.wait()
+            await send(
+                {"type": "http.response.start", "status": 200, "headers": []}
+            )
+            await send({"type": "http.response.body", "body": b"{}"})
+            return
+        await super().__call__(scope, receive, send)
+
+
+class BlockingInitializeApp(FakeStatefulApp):
+    def __init__(self, registry: FakeRegistry) -> None:
+        super().__init__(registry)
+        self.initialize_started = asyncio.Event()
+        self.initialize_release = asyncio.Event()
+
+    async def __call__(self, scope, receive, send) -> None:
+        if header(scope, b"mcp-session-id") is None:
+            self.initialize_started.set()
+            await self.initialize_release.wait()
+        await super().__call__(scope, receive, send)
+
+
+class NoResponseInitializeApp(FakeStatefulApp):
+    async def __call__(self, scope, receive, send) -> None:
+        if header(scope, b"mcp-session-id") is not None:
+            await super().__call__(scope, receive, send)
+            return
+        self.calls += 1
+        self.initializations += 1
+        await receive()
+        self.registry.add(f"session-{self.initializations}")
+
+
+class BodyFirstInitializeApp(FakeStatefulApp):
+    async def __call__(self, scope, receive, send) -> None:
+        if header(scope, b"mcp-session-id") is not None:
+            await super().__call__(scope, receive, send)
+            return
+        self.calls += 1
+        self.initializations += 1
+        await receive()
+        self.registry.add(f"session-{self.initializations}")
+        await send({"type": "http.response.body", "body": b"{}"})
+
+
+def build_guard(
+    *,
+    max_sessions: int = 4,
+    idle_ttl_seconds: float = 10,
+    max_ttl_seconds: float = 100,
+    clock: FakeClock | None = None,
+    app_type=FakeStatefulApp,
+    revoker_type=FakeRevoker,
+):
+    events: list[str] = []
+    registry = FakeRegistry(events)
+    app = app_type(registry)
+    clock = clock or FakeClock()
+    guard = StatefulMCPSessionGuard(
+        app,
+        registry=registry,
+        runtime_revoker=revoker_type(events),
+        principal_resolver=principal_from_scope,
+        max_sessions=max_sessions,
+        idle_ttl_seconds=idle_ttl_seconds,
+        max_ttl_seconds=max_ttl_seconds,
+        monotonic=clock,
+    )
+    return guard, app, registry, events, clock
+
+
+def build_guard_with_registry(registry: FakeRegistry):
+    app = FakeStatefulApp(registry)
+    clock = FakeClock()
+    guard = StatefulMCPSessionGuard(
+        app,
+        registry=registry,
+        runtime_revoker=FakeRevoker(registry.events),
+        principal_resolver=principal_from_scope,
+        max_sessions=2,
+        idle_ttl_seconds=10,
+        max_ttl_seconds=100,
+        monotonic=clock,
+    )
+    return guard, app
+
+
+async def initialize(
+    client: httpx.AsyncClient,
+    *,
+    headers: list[tuple[str, str]] | dict[str, str] | None = None,
+) -> httpx.Response:
+    return await client.post("/mcp", json=initialize_payload(), headers=headers)
+
+
+@pytest.mark.asyncio
+async def test_exact_initialize_is_only_sessionless_request_reaching_downstream():
+    guard, app, registry, _, _ = build_guard()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        response = await initialize(client, headers={"X-Client-ID": "codex"})
+
+    assert response.status_code == 200
+    assert response.headers["mcp-session-id"] == "session-1"
+    assert app.calls == 1
+    assert set(registry.transports) == {"session-1"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("method", "content"),
+    [
+        ("GET", None),
+        ("POST", {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}),
+        ("POST", [initialize_payload()]),
+        ("POST", {"jsonrpc": "2.0", "id": 1, "method": "initialize"}),
+    ],
+)
+async def test_sessionless_non_initialize_malformed_and_batch_are_rejected(
+    method: str, content: Any
+):
+    guard, app, registry, _, _ = build_guard()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        response = await client.request(method, "/mcp", json=content)
+
+    assert response.status_code == 400
+    assert response.json() == {"error": "invalid_request"}
+    assert app.calls == 0
+    assert registry.transports == {}
+
+
+@pytest.mark.asyncio
+async def test_duplicate_json_keys_are_rejected_before_downstream_allocation():
+    guard, app, registry, _, _ = build_guard()
+    body = (
+        b'{"jsonrpc":"2.0","id":1,"id":2,"method":"initialize",'
+        b'"params":{"protocolVersion":"x","capabilities":{},'
+        b'"clientInfo":{"name":"n","version":"v"}}}'
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        response = await client.post("/mcp", content=body)
+
+    assert response.status_code == 400
+    assert app.calls == 0
+    assert registry.transports == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "body",
+    [
+        b'{"jsonrpc":"2.0","id":1,"method":"initialize",'
+        b'"params":{"protocolVersion":"x","capabilities":{"x":NaN},'
+        b'"clientInfo":{"name":"n","version":"v"}}}',
+        json.dumps(
+            {
+                **initialize_payload(),
+                "params": {
+                    **initialize_payload()["params"],
+                    "capabilities": {
+                        "roots": {"listChanged": "not-a-boolean"}
+                    },
+                },
+            }
+        ).encode(),
+    ],
+)
+async def test_non_rfc_json_and_nested_invalid_initialize_are_rejected(body):
+    guard, app, registry, _, _ = build_guard()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        response = await client.post("/mcp", content=body)
+
+    assert response.status_code == 400
+    assert app.calls == 0
+    assert registry.transports == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("client_id", ["", "   ", "codex/other"])
+async def test_present_client_id_must_be_nonempty_safe_identity(client_id):
+    guard, app, registry, _, _ = build_guard()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        response = await initialize(client, headers={"X-Client-ID": client_id})
+
+    assert response.status_code == 400
+    assert app.calls == 0
+    assert registry.transports == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "headers",
+    [
+        [("Authorization", "one"), ("authorization", "two")],
+        [("X-Client-ID", "codex"), ("x-client-id", "other")],
+        [("Mcp-Session-Id", "session-1"), ("mcp-session-id", "session-2")],
+    ],
+)
+async def test_duplicate_security_headers_are_rejected(headers):
+    guard, app, registry, _, _ = build_guard()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/mcp", json=initialize_payload(), headers=headers
+        )
+
+    assert response.status_code == 400
+    assert app.calls == 0
+    assert registry.transports == {}
+
+
+@pytest.mark.asyncio
+async def test_capacity_reservation_prevents_second_transport_allocation():
+    guard, app, registry, _, _ = build_guard(max_sessions=1)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        first = await initialize(client)
+        second = await initialize(client)
+
+    assert first.status_code == 200
+    assert second.status_code == 503
+    assert second.json() == {"error": "session_capacity_exhausted"}
+    assert app.initializations == 1
+    assert set(registry.transports) == {"session-1"}
+
+
+@pytest.mark.asyncio
+async def test_inflight_reservation_closes_concurrent_capacity_race():
+    guard, app, registry, _, _ = build_guard(
+        max_sessions=1, app_type=BlockingInitializeApp
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        first_task = asyncio.create_task(initialize(client))
+        await asyncio.wait_for(app.initialize_started.wait(), timeout=1)
+        second = await initialize(client)
+        assert second.status_code == 503
+        assert app.initializations == 0
+        assert registry.transports == {}
+        app.initialize_release.set()
+        first = await asyncio.wait_for(first_task, timeout=1)
+
+    assert first.status_code == 200
+    assert app.initializations == 1
+    assert set(registry.transports) == {"session-1"}
+
+
+@pytest.mark.asyncio
+async def test_cancel_while_queued_for_initialize_lock_releases_reservation():
+    guard, app, registry, _, _ = build_guard(max_sessions=2)
+    await guard._initialize_lock.acquire()
+    try:
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=guard), base_url="http://test"
+        ) as client:
+            request = asyncio.create_task(initialize(client))
+            for _ in range(100):
+                if guard._reservations:
+                    break
+                await asyncio.sleep(0)
+            assert len(guard._reservations) == 1
+            request.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await request
+    finally:
+        guard._initialize_lock.release()
+
+    assert guard._reservations == set()
+    assert app.calls == 0
+    assert registry.transports == {}
+    await asyncio.wait_for(guard.shutdown(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_baseline_snapshot_releases_without_dispatch():
+    events: list[str] = []
+    registry = BlockingSnapshotRegistry(events, block_call=1)
+    guard, app = build_guard_with_registry(registry)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        request = asyncio.create_task(initialize(client))
+        await asyncio.wait_for(registry.blocked.wait(), timeout=1)
+        request.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await request
+
+    assert guard._reservations == set()
+    assert app.calls == 0
+    assert registry.transports == {}
+    assert events == []
+    await asyncio.wait_for(guard.shutdown(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_post_allocation_snapshot_cleans_before_reraise():
+    events: list[str] = []
+    registry = BlockingSnapshotRegistry(events, block_call=2)
+    guard, app = build_guard_with_registry(registry)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        request = asyncio.create_task(initialize(client))
+        await asyncio.wait_for(registry.blocked.wait(), timeout=1)
+        assert app.initializations == 1
+        assert set(registry.transports) == {"session-1"}
+        request.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await request
+
+    assert guard._reservations == set()
+    assert registry.transports == {}
+    assert guard._pending_transport_cleanup == {}
+    assert events == [
+        "revoke:session-1",
+        "remove:session-1",
+        "terminate:session-1",
+    ]
+    await asyncio.wait_for(guard.shutdown(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_failed_initialize_releases_reservation_and_cleans_sdk_transport():
+    guard, app, registry, events, _ = build_guard(max_sessions=1)
+    app.initialize_status = 400
+    app.response_session_headers = []
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        first = await initialize(client)
+        second = await initialize(client)
+
+    assert first.status_code == 400
+    assert second.status_code == 400
+    assert app.initializations == 2
+    assert registry.transports == {}
+    assert events == [
+        "revoke:session-1",
+        "remove:session-1",
+        "terminate:session-1",
+        "revoke:session-2",
+        "remove:session-2",
+        "terminate:session-2",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_success_without_one_valid_session_header_fails_closed_and_cleans():
+    guard, app, registry, events, _ = build_guard()
+    app.response_session_headers = []
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        response = await initialize(client)
+
+    assert response.status_code == 503
+    assert registry.transports == {}
+    assert events == [
+        "revoke:session-1",
+        "remove:session-1",
+        "terminate:session-1",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("app_type", [NoResponseInitializeApp, BodyFirstInitializeApp])
+async def test_missing_or_body_first_initialize_response_is_explicit_503_and_cleaned(
+    app_type,
+):
+    guard, app, registry, events, _ = build_guard(app_type=app_type)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        response = await initialize(client)
+
+    assert response.status_code == 503
+    assert response.json() == {"error": "session_guard_unavailable"}
+    assert app.initializations == 1
+    assert registry.transports == {}
+    assert events == [
+        "revoke:session-1",
+        "remove:session-1",
+        "terminate:session-1",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_jsonrpc_initialize_error_is_never_committed_despite_2xx_header():
+    guard, app, registry, events, _ = build_guard()
+    app.initialize_response_payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "error": {"code": -32602, "message": "invalid params"},
+    }
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        response = await initialize(client)
+        followup = await client.post(
+            "/mcp", headers={"Mcp-Session-Id": "session-1"}
+        )
+
+    assert response.status_code == 503
+    assert followup.status_code == 404
+    assert registry.transports == {}
+    assert events == [
+        "revoke:session-1",
+        "remove:session-1",
+        "terminate:session-1",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_initialize_cannot_claim_a_preexisting_registry_transport():
+    guard, app, registry, events, _ = build_guard()
+    registry.add("preexisting")
+    app.response_session_headers = [(b"mcp-session-id", b"preexisting")]
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        response = await initialize(client)
+        followup = await client.post(
+            "/mcp", headers={"Mcp-Session-Id": "preexisting"}
+        )
+
+    assert response.status_code == 503
+    assert followup.status_code == 404
+    assert set(registry.transports) == {"preexisting"}
+    assert events == [
+        "revoke:session-1",
+        "remove:session-1",
+        "terminate:session-1",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_failed_unbound_cleanup_is_pending_and_shutdown_retries_it():
+    guard, app, registry, events, _ = build_guard(
+        max_sessions=1,
+        app_type=NoResponseInitializeApp,
+        revoker_type=FlakyRevoker,
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        response = await initialize(client)
+        capacity_blocked = await initialize(client)
+        assert response.status_code == 503
+        assert capacity_blocked.status_code == 503
+        assert app.initializations == 1
+        assert set(registry.transports) == {"session-1"}
+        assert set(guard._pending_transport_cleanup) == {"session-1"}
+        await guard.shutdown()
+
+    assert registry.transports == {}
+    assert guard._pending_transport_cleanup == {}
+    assert events == [
+        "revoke:session-1",
+        "revoke:session-1",
+        "remove:session-1",
+        "terminate:session-1",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_shutdowns_deduplicate_pending_transport_cleanup():
+    guard, _, registry, events, _ = build_guard(
+        max_sessions=1,
+        app_type=NoResponseInitializeApp,
+        revoker_type=PendingThenBlockingRevoker,
+    )
+    revoker = guard._runtime_revoker
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        assert (await initialize(client)).status_code == 503
+    assert set(guard._pending_transport_cleanup) == {"session-1"}
+
+    first = asyncio.create_task(guard.shutdown())
+    second = asyncio.create_task(guard.shutdown())
+    await asyncio.wait_for(revoker.retry_started.wait(), timeout=1)
+    await asyncio.sleep(0)
+    assert revoker.calls == 2
+    assert revoker.max_concurrent == 1
+    revoker.retry_release.set()
+    await asyncio.wait_for(asyncio.gather(first, second), timeout=1)
+
+    assert registry.transports == {}
+    assert guard._pending_transport_cleanup == {}
+    assert events == [
+        "revoke:session-1",
+        "revoke:session-1",
+        "remove:session-1",
+        "terminate:session-1",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_shutdown_does_not_cancel_claimed_pending_cleanup():
+    guard, _, registry, events, _ = build_guard(
+        max_sessions=1,
+        app_type=NoResponseInitializeApp,
+        revoker_type=PendingThenBlockingRevoker,
+    )
+    revoker = guard._runtime_revoker
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        assert (await initialize(client)).status_code == 503
+
+    shutdown = asyncio.create_task(guard.shutdown())
+    await asyncio.wait_for(revoker.retry_started.wait(), timeout=1)
+    shutdown.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await shutdown
+    revoker.retry_release.set()
+    for _ in range(100):
+        if not guard._pending_transport_cleanup:
+            break
+        await asyncio.sleep(0)
+
+    assert guard._pending_transport_cleanup == {}
+    assert registry.transports == {}
+    assert revoker.calls == 2
+    assert revoker.max_concurrent == 1
+    await guard.shutdown()
+    assert events == [
+        "revoke:session-1",
+        "revoke:session-1",
+        "remove:session-1",
+        "terminate:session-1",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_session_binding_uses_exact_server_principal_and_client_id():
+    guard, app, _, _, _ = build_guard()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        initialized = await initialize(
+            client,
+            headers={"Authorization": "principal-a", "X-Client-ID": "Codex"},
+        )
+        session_id = initialized.headers["mcp-session-id"]
+        accepted = await client.post(
+            "/mcp",
+            headers={
+                "Authorization": "principal-a",
+                "X-Client-ID": "Codex",
+                "Mcp-Session-Id": session_id,
+            },
+            json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+        )
+        wrong_case = await client.post(
+            "/mcp",
+            headers={
+                "Authorization": "principal-a",
+                "X-Client-ID": "codex",
+                "Mcp-Session-Id": session_id,
+            },
+            json={"jsonrpc": "2.0", "id": 3, "method": "tools/list"},
+        )
+
+    assert accepted.status_code == 200
+    assert wrong_case.status_code == 404
+    assert app.bindings[0].principal == "server:principal-a"
+    assert app.bindings[0].client_id == b"Codex"
+
+
+@pytest.mark.asyncio
+async def test_absent_client_id_is_distinct_from_present_client_id():
+    guard, _, _, _, _ = build_guard()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        initialized = await initialize(client)
+        response = await client.post(
+            "/mcp",
+            headers={
+                "X-Client-ID": "codex",
+                "Mcp-Session-Id": initialized.headers["mcp-session-id"],
+            },
+            json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+        )
+
+    assert response.status_code == 404
+    assert response.json() == {"error": "session_not_found"}
+
+
+@pytest.mark.asyncio
+async def test_unknown_expired_and_identity_mismatch_share_generic_404():
+    clock = FakeClock()
+    guard, _, _, _, _ = build_guard(
+        clock=clock, idle_ttl_seconds=5, max_ttl_seconds=100
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        initialized = await initialize(client, headers={"Authorization": "a"})
+        session_id = initialized.headers["mcp-session-id"]
+        unknown = await client.post(
+            "/mcp",
+            headers={"Authorization": "a", "Mcp-Session-Id": "unknown"},
+        )
+        mismatch = await client.post(
+            "/mcp",
+            headers={"Authorization": "b", "Mcp-Session-Id": session_id},
+        )
+        clock.advance(5)
+        expired = await client.post(
+            "/mcp",
+            headers={"Authorization": "a", "Mcp-Session-Id": session_id},
+        )
+
+    assert {unknown.status_code, mismatch.status_code, expired.status_code} == {404}
+    assert unknown.content == mismatch.content == expired.content
+
+
+@pytest.mark.asyncio
+async def test_expired_cleanup_failure_still_matches_generic_404_and_is_retryable():
+    clock = FakeClock()
+    guard, _, registry, events, _ = build_guard(
+        clock=clock,
+        idle_ttl_seconds=5,
+        max_ttl_seconds=100,
+        revoker_type=FlakyRevoker,
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        initialized = await initialize(client, headers={"Authorization": "a"})
+        session_id = initialized.headers["mcp-session-id"]
+        unknown = await client.post(
+            "/mcp",
+            headers={"Authorization": "a", "Mcp-Session-Id": "unknown"},
+        )
+        mismatch = await client.post(
+            "/mcp",
+            headers={"Authorization": "b", "Mcp-Session-Id": session_id},
+        )
+        clock.advance(5)
+        expired = await client.post(
+            "/mcp",
+            headers={"Authorization": "a", "Mcp-Session-Id": session_id},
+        )
+        assert session_id in registry.transports
+        await guard.shutdown()
+
+    assert {unknown.status_code, mismatch.status_code, expired.status_code} == {404}
+    assert unknown.content == mismatch.content == expired.content
+    assert registry.transports == {}
+    assert events == [
+        f"revoke:{session_id}",
+        f"revoke:{session_id}",
+        f"remove:{session_id}",
+        f"terminate:{session_id}",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_idle_ttl_uses_completion_activity_and_reaper_cleanup_order():
+    clock = FakeClock()
+    guard, _, registry, events, _ = build_guard(
+        clock=clock, idle_ttl_seconds=10, max_ttl_seconds=100
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        initialized = await initialize(client)
+        session_id = initialized.headers["mcp-session-id"]
+        clock.advance(5)
+        active = await client.post(
+            "/mcp",
+            headers={"Mcp-Session-Id": session_id},
+            json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+        )
+        clock.advance(9)
+        assert await guard.reap_expired() == 0
+        clock.advance(1)
+        assert await guard.reap_expired() == 1
+
+    assert active.status_code == 200
+    assert registry.transports == {}
+    assert events == [
+        f"revoke:{session_id}",
+        f"remove:{session_id}",
+        f"terminate:{session_id}",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_max_ttl_hard_revokes_and_cancels_active_call_at_deadline():
+    clock = FakeClock()
+    guard, app, registry, events, _ = build_guard(
+        clock=clock,
+        idle_ttl_seconds=5,
+        max_ttl_seconds=10,
+        app_type=BlockingStatefulApp,
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        initialized = await initialize(client)
+        session_id = initialized.headers["mcp-session-id"]
+        blocked = asyncio.create_task(
+            client.post(
+                "/block",
+                headers={"Mcp-Session-Id": session_id},
+                json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+            )
+        )
+        await asyncio.wait_for(app.started.wait(), timeout=1)
+        clock.advance(10)
+        assert await guard.reap_expired() == 1
+        completed = await asyncio.wait_for(blocked, timeout=1)
+
+    assert completed.status_code == 404
+    assert registry.transports == {}
+    assert events == [
+        f"revoke:{session_id}",
+        f"remove:{session_id}",
+        f"terminate:{session_id}",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_max_ttl_cancels_active_call_when_revocation_needs_retry():
+    clock = FakeClock()
+    guard, app, registry, events, _ = build_guard(
+        clock=clock,
+        idle_ttl_seconds=5,
+        max_ttl_seconds=10,
+        app_type=BlockingStatefulApp,
+        revoker_type=FlakyRevoker,
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        initialized = await initialize(client)
+        session_id = initialized.headers["mcp-session-id"]
+        blocked = asyncio.create_task(
+            client.post(
+                "/block",
+                headers={"Mcp-Session-Id": session_id},
+                json={"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+            )
+        )
+        await asyncio.wait_for(app.started.wait(), timeout=1)
+        clock.advance(10)
+
+        with pytest.raises(RuntimeError, match="revocation failed"):
+            await guard.reap_expired()
+        completed = await asyncio.wait_for(blocked, timeout=1)
+
+        assert completed.status_code == 404
+        assert session_id in registry.transports
+        assert events == [f"revoke:{session_id}"]
+        assert await guard.cleanup_session(session_id) is True
+
+    assert registry.transports == {}
+    assert events == [
+        f"revoke:{session_id}",
+        f"revoke:{session_id}",
+        f"remove:{session_id}",
+        f"terminate:{session_id}",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_delete_and_direct_cleanup_are_idempotent_and_revoke_first():
+    guard, _, registry, events, _ = build_guard()
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        initialized = await initialize(client)
+        session_id = initialized.headers["mcp-session-id"]
+        deleted = await client.delete(
+            "/mcp", headers={"Mcp-Session-Id": session_id}
+        )
+        repeated = await client.delete(
+            "/mcp", headers={"Mcp-Session-Id": session_id}
+        )
+        assert await guard.cleanup_session(session_id) is False
+
+    assert deleted.status_code == 204
+    assert repeated.status_code == 404
+    assert registry.transports == {}
+    assert events == [
+        f"revoke:{session_id}",
+        f"remove:{session_id}",
+        f"terminate:{session_id}",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_delete_cleanup_failure_returns_503_and_retains_retryable_tombstone():
+    guard, _, registry, events, _ = build_guard(revoker_type=FlakyRevoker)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        initialized = await initialize(client)
+        session_id = initialized.headers["mcp-session-id"]
+        failed = await client.delete(
+            "/mcp", headers={"Mcp-Session-Id": session_id}
+        )
+        assert failed.status_code == 503
+        assert session_id in registry.transports
+        retry = await client.delete(
+            "/mcp", headers={"Mcp-Session-Id": session_id}
+        )
+
+    assert retry.status_code == 404
+    assert registry.transports == {}
+    assert events == [
+        f"revoke:{session_id}",
+        f"revoke:{session_id}",
+        f"remove:{session_id}",
+        f"terminate:{session_id}",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_failed_revocation_blocks_transport_removal_and_can_be_retried():
+    guard, _, registry, events, _ = build_guard(revoker_type=FlakyRevoker)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        initialized = await initialize(client)
+        session_id = initialized.headers["mcp-session-id"]
+        with pytest.raises(RuntimeError, match="revocation failed"):
+            await guard.cleanup_session(session_id)
+        assert session_id in registry.transports
+        assert events == [f"revoke:{session_id}"]
+        assert await guard.cleanup_session(session_id) is True
+
+    assert registry.transports == {}
+    assert events == [
+        f"revoke:{session_id}",
+        f"revoke:{session_id}",
+        f"remove:{session_id}",
+        f"terminate:{session_id}",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cancelling_cleanup_waiter_does_not_cancel_committed_cleanup_effect():
+    guard, _, registry, events, _ = build_guard(
+        revoker_type=BlockingCommittedRevoker
+    )
+    revoker = guard._runtime_revoker
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        initialized = await initialize(client)
+    session_id = initialized.headers["mcp-session-id"]
+
+    waiter = asyncio.create_task(guard.cleanup_session(session_id))
+    await asyncio.wait_for(revoker.started.wait(), timeout=1)
+    waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await waiter
+    revoker.release.set()
+    for _ in range(100):
+        if session_id not in registry.transports:
+            break
+        await asyncio.sleep(0)
+
+    assert session_id not in registry.transports
+    assert revoker.calls == 1
+    assert await guard.cleanup_session(session_id) is False
+    assert events == [
+        f"revoke:{session_id}",
+        f"remove:{session_id}",
+        f"terminate:{session_id}",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cancelling_shutdown_waiter_does_not_cancel_committed_cleanup():
+    guard, _, registry, events, _ = build_guard(
+        revoker_type=BlockingCommittedRevoker
+    )
+    revoker = guard._runtime_revoker
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        initialized = await initialize(client)
+    session_id = initialized.headers["mcp-session-id"]
+
+    shutdown = asyncio.create_task(guard.shutdown())
+    await asyncio.wait_for(revoker.started.wait(), timeout=1)
+    shutdown.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await shutdown
+    revoker.release.set()
+    for _ in range(100):
+        if session_id not in registry.transports:
+            break
+        await asyncio.sleep(0)
+
+    assert session_id not in registry.transports
+    assert revoker.calls == 1
+    await guard.shutdown()
+    assert events == [
+        f"revoke:{session_id}",
+        f"remove:{session_id}",
+        f"terminate:{session_id}",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_shutdown_still_cleans_all_sessions_without_retry():
+    guard, _, registry, events, _ = build_guard(
+        max_sessions=2, revoker_type=BlockingCommittedRevoker
+    )
+    revoker = guard._runtime_revoker
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        first = await initialize(client)
+        second = await initialize(client)
+    session_ids = (
+        first.headers["mcp-session-id"],
+        second.headers["mcp-session-id"],
+    )
+
+    shutdown_waiter = asyncio.create_task(guard.shutdown())
+    await asyncio.wait_for(revoker.started.wait(), timeout=1)
+    master_cleanup = guard._shutdown_task
+    assert master_cleanup is not None
+    assert revoker.calls == 1
+    shutdown_waiter.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await shutdown_waiter
+
+    revoker.release.set()
+    outcome = await asyncio.wait_for(
+        asyncio.shield(master_cleanup), timeout=1
+    )
+
+    assert outcome.error is None
+    assert registry.transports == {}
+    assert revoker.calls == 2
+    assert events == [
+        f"revoke:{session_ids[0]}",
+        f"remove:{session_ids[0]}",
+        f"terminate:{session_ids[0]}",
+        f"revoke:{session_ids[1]}",
+        f"remove:{session_ids[1]}",
+        f"terminate:{session_ids[1]}",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_shutdown_is_idempotent_and_cleans_every_session():
+    guard, app, registry, events, _ = build_guard(max_sessions=2)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        assert (await initialize(client)).status_code == 200
+        assert (await initialize(client)).status_code == 200
+        await guard.shutdown()
+        await guard.shutdown()
+        refused = await initialize(client)
+
+    assert refused.status_code == 503
+    assert app.initializations == 2
+    assert registry.transports == {}
+    assert events == [
+        "revoke:session-1",
+        "remove:session-1",
+        "terminate:session-1",
+        "revoke:session-2",
+        "remove:session-2",
+        "terminate:session-2",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_shutdown_waits_for_inflight_initialize_to_fail_closed_and_cleanup():
+    guard, app, registry, events, _ = build_guard(
+        max_sessions=1, app_type=BlockingInitializeApp
+    )
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=guard), base_url="http://test"
+    ) as client:
+        initialize_task = asyncio.create_task(initialize(client))
+        await asyncio.wait_for(app.initialize_started.wait(), timeout=1)
+        shutdown_task = asyncio.create_task(guard.shutdown())
+        await asyncio.sleep(0)
+        assert shutdown_task.done() is False
+        app.initialize_release.set()
+        response = await asyncio.wait_for(initialize_task, timeout=1)
+        await asyncio.wait_for(shutdown_task, timeout=1)
+
+    assert response.status_code == 503
+    assert registry.transports == {}
+    assert events == [
+        "revoke:session-1",
+        "remove:session-1",
+        "terminate:session-1",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sdk_private_registry_is_instance_scoped_and_terminates_after_removal():
+    from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+
+    events: list[str] = []
+    manager = StreamableHTTPSessionManager(app=object())
+    transport = FakeTransport("session-a", events)
+    manager._server_instances["session-a"] = transport
+    registry = MCP126SessionTransportRegistry(manager)
+
+    assert await registry.session_ids() == frozenset({"session-a"})
+    assert await registry.contains("session-a") is True
+    assert await registry.remove_and_terminate("session-a") is True
+    assert manager._server_instances == {}
+    assert events == ["terminate:session-a"]
+
+
+@pytest.mark.asyncio
+async def test_guard_interoperates_with_real_mcp_126_stateful_asgi():
+    from mcp.server.fastmcp import FastMCP
+
+    events: list[str] = []
+    mcp = FastMCP("guard-integration", stateless_http=False)
+    mcp_app = mcp.streamable_http_app()
+    registry = MCP126SessionTransportRegistry(mcp.session_manager)
+    guard = StatefulMCPSessionGuard(
+        mcp_app,
+        registry=registry,
+        runtime_revoker=FakeRevoker(events),
+        principal_resolver=principal_from_scope,
+    )
+
+    async with mcp_app.router.lifespan_context(mcp_app):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=guard),
+            base_url="http://127.0.0.1:8000",
+        ) as client:
+            invalid_payload = initialize_payload()
+            invalid_payload["params"]["capabilities"] = {
+                "roots": {"listChanged": "not-a-boolean"}
+            }
+            invalid = await client.post(
+                "/mcp",
+                json=invalid_payload,
+                headers={"Accept": "application/json, text/event-stream"},
+            )
+            assert invalid.status_code == 400
+            assert await registry.session_ids() == frozenset()
+            async with asyncio.timeout(5):
+                initialized = await initialize(
+                    client,
+                    headers={"Accept": "application/json, text/event-stream"},
+                )
+            session_id = initialized.headers["mcp-session-id"]
+            assert initialized.status_code == 200
+            assert session_id in await registry.session_ids()
+            async with asyncio.timeout(5):
+                deleted = await client.delete(
+                    "/mcp", headers={"Mcp-Session-Id": session_id}
+                )
+
+    assert deleted.status_code == 204
+    assert await registry.session_ids() == frozenset()
+    assert events == [f"revoke:{session_id}"]
+
+
+def test_sdk_private_registry_rejects_unreviewed_minor(monkeypatch):
+    from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+
+    monkeypatch.setattr("src.mcp_session_guard.metadata.version", lambda _: "1.27.0")
+    manager = StreamableHTTPSessionManager(app=object())
+
+    with pytest.raises(RuntimeError, match="explicit SDK minor review"):
+        MCP126SessionTransportRegistry(manager)

--- a/uv.lock
+++ b/uv.lock
@@ -938,7 +938,7 @@ requires-dist = [
     { name = "google-genai", marker = "extra == 'campaign'", specifier = ">=1.25,<2" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "jsonschema", specifier = ">=4.23,<5" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.13.1" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.26,<1.27" },
     { name = "pydantic", specifier = ">=2.9.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pytest", marker = "extra == 'forge'", specifier = ">=9.1.1" },


### PR DESCRIPTION
## Outcome

Adds the inert admission, identity binding, expiry, and teardown core required before UniGrok can safely activate stateful MCP HTTP sessions. This PR does **not** install the guard into `src/http_server.py`, flip FastMCP statefulness, expose UI controls, wire providers, or make any provider/network call.

## Scope

- strict full MCP initialize validation before SDK allocation
- verified InitializeResult/SSE buffering before session commit
- exact principal + `X-Client-ID` session binding
- capacity reservations and new-transport-only binding
- idle TTL and hard maximum TTL with active-call cancellation
- revoke-before-remove teardown with retryable tombstones
- cancellation-safe, deduplicated cleanup and shared shutdown
- version-checked MCP SDK 1.26 private registry adapter
- real FastMCP ASGI and bounded race/failure regressions

## Verification

- exact head `973c08e787b84b2ea88ec8987689f93b86499536`
- 46 focused guard tests passed
- 1,922 full repository tests passed
- scoped Ruff, compileall, deterministic OKF, diff integrity, and attribution checks passed
- independent exact-head review approved with no P1/P0 blockers

## Safety posture

No runtime activation, UI/server wiring, provider adapters, sampling grants, credential access, provider calls, dataset generation, training, or sealed evaluation. Activation remains a later atomic PR.

Human-Sponsor: djtelicloud

Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=implementation