### PR TITLE
docs: insider CONTRIBUTING Core vs Forge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,66 @@
 # Contributing to UniGrok MCP
 
-Thanks for helping improve UniGrok MCP. The project favors small, verified
-changes that keep the shared Grok MCP gateway reliable across IDEs.
+Thanks for helping improve UniGrok. Prefer small, verified changes that keep the
+shared Grok MCP gateway reliable.
 
-## Local Setup
+**Public users** should follow the root [README.md](README.md) only. This file is
+for **insiders**: people developing UniGrok itself (admins and GitHub write+
+collaborators such as Curtis). Product language freeze:
+[docs/design/public-vs-insider-surfaces.md](docs/design/public-vs-insider-surfaces.md).
+
+## Surfaces you must not confuse
+
+| Surface | Port / URL | Who | Purpose |
+|---|---|---|---|
+| **Stable Core** | `http://localhost:4765/mcp` · `/ui/` | Everyone | Public product MCP + machine-owner status UI |
+| **Contributor Forge** | `http://localhost:4766/mcp` (dev compose) | Insiders | UniGrok checkout attach, Swarm, workspace memory |
+| **Cloud control** | `https://control.grokmcp.org` / site `/control` | Insiders (GitHub OAuth) | Repo-facing control; **no** secret proxy, **no** local MCP tunnel |
+| **IDE chat** | Core MCP `agent` | Everyone | **Primary** `@grok` path for public and insiders |
+
+### LIVE vs TARGET (do not over-claim)
+
+| Topic | LIVE today | TARGET |
+|---|---|---|
+| Core UI `/ui/` | Status + optional legacy `agent` playground | Observe + pasteable actions; IDE remains primary chat |
+| Cloud Console entry | GitHub OAuth + live collaborator check (see site code/tests) | Prefer write+ (`write` / `maintain` / `admin`) for privileged views; always fail closed |
+| Swarm | Contributor mode; prefer `dry_run` | Same; never default-apply |
+| Land / merge | Codex/`scripts/land` + required exact-head Codex Approval | Unchanged; Grok review is advisory only |
+
+## Local setup (insider)
 
 ```bash
 uv sync
 uv run python main.py init
 ```
 
-Set `XAI_API_KEY` in `.env` for live API-plane calls, or authenticate the
-container CLI plane with `docker compose run --rm grok-cli-auth` for compatible
-subscription work. Tests should not require either real credential unless they
-are explicitly live tests.
+Set `XAI_API_KEY` in `.env` for API-plane calls, and/or authenticate the CLI
+plane:
 
-## Development Commands
+```bash
+docker compose up --build -d
+docker compose run --rm grok-cli-auth
+```
+
+### Stable Core (always)
+
+```bash
+docker compose up --build -d
+curl -s http://localhost:4765/healthz
+curl -s http://localhost:4765/readyz
+# Optional: http://localhost:4765/ui/
+```
+
+### Contributor Forge (insider only)
+
+```bash
+docker compose -p grok-mcp-dev -f docker-compose.dev.yml up --build -d
+curl -s http://localhost:4766/healthz
+```
+
+Forge mounts the **UniGrok** checkout. Never point it at a random customer app
+as if that were the public product path. Public agents must keep using **4765**.
+
+## Development commands
 
 ```bash
 uv run pytest
@@ -23,14 +68,23 @@ uv run python -m compileall -q src evals main.py
 docker compose config
 ```
 
-For the shared local service:
+## Console / verification culture
 
-```bash
-docker compose up --build -d
-curl -s http://localhost:4765/healthz
-```
+Insiders should **visually** confirm Core health (and Forge when used) before
+asking agents to open draft PRs — even when local tests passed. Prefer:
 
-## Pull Request Guidelines
+1. `/readyz` green on Core
+2. Control Center planes ready
+3. Focused pytest for the change
+4. Draft PR with exact head SHA + attribution trailers
+
+Do **not** build a second daily Grok chat in the browser. Chat is IDE → MCP.
+Cloud control must never receive `XAI_API_KEY` or reverse-proxy local MCP.
+
+Swarm and other power tools: default to dry-run / non-apply until you mean to
+mutate. Pasteable terminal prompts for agents beat multi-step browser forms.
+
+## Pull request guidelines
 
 - Keep changes scoped to one behavior or feature.
 - Open contributions as pull requests; do not push directly to protected
@@ -40,48 +94,38 @@ curl -s http://localhost:4765/healthz
 - Add or update tests for new tool behavior, CLI behavior, and runtime fixes.
 - Keep credentials out of commits. Use `.env`; never commit real API keys.
 - Prefer existing helpers and architecture over new parallel abstractions.
-- Update `README.md`, `architecture.md`, or `docs/ide-setup.md` when behavior
-  changes user setup, transport, tools, or runtime expectations.
+- Update `README.md` (public) and this file / design docs when behavior changes
+  audience-facing setup.
 - Run `uv run pytest` before opening a PR.
 
-Human contributors and coding agents use the same evidence contract: explain
-the intent, list changed paths, report exact verification commands and results,
-identify the accountable GitHub user and assisting IDE/model, and disclose known
-risks or generated files. Use the canonical `Agent-Assisted-By:` trailer for
-material agent work and `Agent-Reviewed-By:` for advisory review. Use
-`Co-authored-by:` only for a real person's linked GitHub email or an exact bot
-identity in `.github/agent-identities.json`; provider and model names are not
-accounts. See [the attribution policy](docs/agent-attribution.md) for the
-provider/model format and model-evidence rules. Grok review comments are advisory;
-they do not authorize a merge. The Codex/project-admin role reviews the current
-head and owns landing, merge, tag, release, and deployment decisions. That role
-may be performed from Codex Desktop, CLI, GitHub Copilot, or another authorized
-Codex surface. See
-[ADR 0001](docs/adr/0001-cloud-control-plane-governance.md) for the current
-local landing contract and the explicitly not-yet-live remote broker design.
+Human contributors and coding agents use the same evidence contract: intent,
+changed paths, verification commands, human sponsor, agent provenance, risks.
+Use `Agent-Assisted-By:` / `Agent-Reviewed-By:` per
+[docs/agent-attribution.md](docs/agent-attribution.md). Grok review is advisory;
+it does not authorize a merge. The Codex/project-admin role reviews the current
+head and owns landing, merge, tag, release, and deployment. See
+[ADR 0001](docs/adr/0001-cloud-control-plane-governance.md).
 
-Codex approval is enforced as a required commit status bound to the exact PR
-head. Only the repository owner may dispatch `.github/workflows/codex-approval.yml`;
-the workflow re-reads the open PR and refuses a stale SHA or non-`main` target.
-This deterministic check uses no model credits. Any new commit requires a new
-Codex review and approval dispatch.
+Codex approval is a required commit status bound to the exact PR head. Only the
+repository owner may dispatch `.github/workflows/codex-approval.yml`. Any new
+commit requires a new approval dispatch.
 
-Security vulnerabilities should be reported privately as described in
-[SECURITY.md](SECURITY.md), not opened as public issues.
+Security vulnerabilities: [SECURITY.md](SECURITY.md), not public issues.
 
-## Multi-Agent Coordination
+## Multi-agent coordination
 
-This repository is often used from several IDE agents at once. Keep the shared
-checkout on integrated `main`, and do experimental work in an agent-prefixed
-worktree branch such as `codex/my-change`, `claude/my-change`, or
-`gemini/my-change`.
+Keep the shared checkout on integrated `main`. Experimental work lives in
+agent-prefixed worktrees (`codex/…`, `claude/…`, `gemini/…`, `grok/…`).
 
-An agent handoff must include its task branch or PR, full commit SHA, changed
-paths, test evidence, unresolved risks, human sponsor, and agent provenance.
-After local verification, an authorized local IDE agent may push only its own
-agent-prefixed task branch and open or update a draft pull request. If GitHub
-credentials are unavailable, hand the exact commit to an authorized Codex
-session for publication. Contributor agents must not run `scripts/land`, merge,
-push shared `main`, publish releases or deployments, delete shared worktrees,
-or treat an advisory model review as approval unless explicitly acting as the
-Codex/project-admin integration session.
+Handoffs must include branch/PR, full SHA, paths, tests, risks, sponsor, and
+provenance. Contributors may push only their own agent-prefixed branch and open
+or update its draft PR. Do **not** run `scripts/land`, merge, push shared
+`main`, publish releases, or delete others’ worktrees unless you are the
+explicit Codex/project-admin integration session.
+
+## Further reading
+
+- [docs/design/public-vs-insider-surfaces.md](docs/design/public-vs-insider-surfaces.md)
+- [docs/ide-setup.md](docs/ide-setup.md)
+- [architecture.md](architecture.md)
+- [docs/threat-model.md](docs/threat-model.md)


### PR DESCRIPTION
## Summary

Expand CONTRIBUTING for **insiders** (write+ collaborators): 4765 vs 4766 table, LIVE vs TARGET Console/OAuth claims, Swarm dry-run, Codex land rules, no secret tunnels.

## Changed paths

- `CONTRIBUTING.md`

## Depends on

- Design freeze PR (`docs/design/public-vs-insider-surfaces.md`) for the linked freeze doc

## Human sponsor

djtelicloud

Agent-Assisted-By: xAI Grok | model=grok-4.5 | model-source=provider-session | surface=Grok Build | role=documentation