### PR TITLE
fix: preserve onboarding consent and LIVE UI truth

### DIFF
--- a/.agents/skills/using-unigrok/SKILL.md
+++ b/.agents/skills/using-unigrok/SKILL.md
@@ -7,8 +7,9 @@ description: How to query xAI Grok through the UniGrok MCP gateway. Activate whe
 
 UniGrok exposes one headline MCP tool: `agent`. It self-routes across Grok
 models and two billing planes, and returns structured metadata with every
-answer. **Primary chat path for every project is IDE → UniGrok MCP**, not a
-browser chat client.
+answer. **Primary chat path for every project is IDE → UniGrok MCP**. The local
+browser UI is an optional trusted-loopback test/control surface whose agent
+playground can invoke providers and spend metered credits.
 
 ## The `agent` tool
 
@@ -83,7 +84,8 @@ not invented subscription cost or remaining provider quota.
 
 The shared gateway runs at `http://localhost:4765/mcp` (Streamable HTTP).
 Health: `GET /healthz`. Optional local Core UI: `http://localhost:4765/ui/`
-(machine-owner loopback status). `X-Client-ID` is a caller-controlled
+(trusted machine-owner test/control surface with a provider-calling agent
+playground). `X-Client-ID` is a caller-controlled
 attribution and session label beneath a server-derived principal; it is not
 authentication. The default unauthenticated loopback service derives the shared
 `http:anon` principal for one local budget/security trust domain, so there is

--- a/.claude/skills/using-unigrok/SKILL.md
+++ b/.claude/skills/using-unigrok/SKILL.md
@@ -90,6 +90,7 @@ configured auth. Because many repositories can reuse
 
 When the user is about to see a multi-step Implementation Plan, prefer calling
 UniGrok `agent` (`thinking` or `reasoning`) for a second opinion, then improve
-the plan before presenting it. Do not silently spend metered API credits without
-consent. Do not invent a second MCP port or Forge workflow for public installs.
-Public path remains `http://localhost:4765/mcp` only.
+the plan before presenting it **only when the user wants a Grok second opinion**
+(including `@grok`). Do not silently spend metered API credits without consent.
+Do not invent a second MCP port or Forge workflow for public installs. Public
+path remains `http://localhost:4765/mcp` only.

--- a/.github/skills/using-unigrok/SKILL.md
+++ b/.github/skills/using-unigrok/SKILL.md
@@ -82,6 +82,7 @@ session namespaces and telemetry remain separated by client.
 
 When the user is about to see a multi-step Implementation Plan, prefer calling
 UniGrok `agent` (`thinking` or `reasoning`) for a second opinion, then improve
-the plan before presenting it. Do not silently spend metered API credits without
-consent. Do not invent a second MCP port or Forge workflow for public installs.
-Public path remains `http://localhost:4765/mcp` only.
+the plan before presenting it **only when the user wants a Grok second opinion**
+(including `@grok`). Do not silently spend metered API credits without consent.
+Do not invent a second MCP port or Forge workflow for public installs. Public
+path remains `http://localhost:4765/mcp` only.

--- a/skills/using-unigrok/SKILL.md
+++ b/skills/using-unigrok/SKILL.md
@@ -7,8 +7,9 @@ description: How to query xAI Grok through the UniGrok MCP gateway. Activate whe
 
 UniGrok exposes one headline MCP tool: `agent`. It self-routes across Grok
 models and two billing planes, and returns structured metadata with every
-answer. **Primary chat path for every project is IDE → UniGrok MCP**, not a
-browser chat client.
+answer. **Primary chat path for every project is IDE → UniGrok MCP**. The local
+browser UI is an optional trusted-loopback test/control surface whose agent
+playground can invoke providers and spend metered credits.
 
 ## The `agent` tool
 
@@ -83,7 +84,8 @@ not invented subscription cost or remaining provider quota.
 
 The shared gateway runs at `http://localhost:4765/mcp` (Streamable HTTP).
 Health: `GET /healthz`. Optional local Core UI: `http://localhost:4765/ui/`
-(machine-owner loopback status). `X-Client-ID` is a caller-controlled
+(trusted machine-owner test/control surface with a provider-calling agent
+playground). `X-Client-ID` is a caller-controlled
 attribution and session label beneath a server-derived principal; it is not
 authentication. The default unauthenticated loopback service derives the shared
 `http:anon` principal for one local budget/security trust domain, so there is

--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -1061,8 +1061,9 @@ async def grok_mcp_discover_self(include_models: bool = False) -> SystemResult:
 
         doc_text = (
             "# UniGrok MCP Discovery & Self-Description\n\n"
-            "Zero-configuration onboarding for IDE agents. Primary product chat is the UniGrok "
-            "`agent` tool over MCP — not a browser chat client.\n\n"
+            "Zero-configuration onboarding for IDE agents. The primary product chat path is the "
+            "UniGrok `agent` tool over MCP. The trusted-loopback UI is an optional test and control "
+            "surface, not the primary daily chat path.\n\n"
             "## Service and Project Boundary\n"
             "- UniGrok is a standalone MCP service; the caller's project needs no UniGrok namespace files.\n"
             f"- Service mode: `{'contributor' if contributor else 'stable'}`. "
@@ -1071,7 +1072,8 @@ async def grok_mcp_discover_self(include_models: bool = False) -> SystemResult:
             "## Public product path\n"
             "- Canonical endpoint: `http://localhost:4765/mcp` (`4765` spells GROK).\n"
             "- Health: `GET /healthz`. Readiness: `GET /readyz`. Optional local Core UI: "
-            "`http://localhost:4765/ui/` (machine-owner loopback status; not GitHub-gated).\n"
+            "`http://localhost:4765/ui/` (trusted machine-owner test/control surface with an "
+            "agent playground that can invoke providers and spend metered credits; not GitHub-gated).\n"
             f"{dial_extra}"
             "- An explicit `agent.mode` always overrides a dialed-port default.\n\n"
             "## Credential Planes (public-critical)\n"

--- a/tests/test_service_workspace_boundary.py
+++ b/tests/test_service_workspace_boundary.py
@@ -217,6 +217,7 @@ def test_stable_and_contributor_compose_files_are_separate():
     for phoneword_port in (2886, 3278, 7327, 8465, 7724):
         assert str(phoneword_port) in dials
 
+
 @pytest.mark.asyncio
 async def test_stable_discover_self_has_no_forge_connect_recipes(monkeypatch):
     """Public/stable discover prose must not coach Forge 4766 or land workflows."""
@@ -250,3 +251,17 @@ async def test_public_mcp_instructions_prefer_core_endpoint_and_plan_critique():
     assert "4766" not in text
     assert "scripts/land" not in text
 
+
+def test_using_unigrok_skill_variants_preserve_plan_critique_opt_in():
+    variants = (
+        Path("skills/using-unigrok/SKILL.md"),
+        Path(".agents/skills/using-unigrok/SKILL.md"),
+        Path(".claude/skills/using-unigrok/SKILL.md"),
+        Path(".github/skills/using-unigrok/SKILL.md"),
+    )
+
+    for path in variants:
+        text = path.read_text(encoding="utf-8").lower()
+        assert "only when the user wants a grok second opinion" in text or (
+            "when the user wants a grok second opinion" in text
+        ), f"{path} lost the explicit user opt-in condition"


### PR DESCRIPTION
## Summary

Narrow follow-up to the approved Wave-1 onboarding contract:
- keeps IDE MCP as the primary chat path without denying the current legacy loopback playground
- discloses that the current playground can invoke providers and metered credits
- restores explicit user opt-in for Grok plan critique in every distributed skill variant
- adds parity coverage so adapted skills cannot silently broaden calls

The approved unified insider UI remains a later-wave TARGET; this PR does not preserve or redesign the current UI.

## Exact head

`16dd0bbb312337ad85ae9dc310cc7306d6bff2fb`

## Verification

- `git diff --check origin/main...HEAD`
- `uv run pytest -q tests/test_service_workspace_boundary.py tests/test_release_hygiene.py` — 28 passed
- attribution check passed

## Risk

Onboarding prose and skill activation semantics only. No UI implementation, provider call, or credential access.

## Human sponsor

djtelicloud

Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=implementation