### PR TITLE
feat: Core UI honesty + absorb Codex Wave-1 repairs

### DIFF
--- a/.agents/skills/using-unigrok/SKILL.md
+++ b/.agents/skills/using-unigrok/SKILL.md
@@ -7,8 +7,9 @@ description: How to query xAI Grok through the UniGrok MCP gateway. Activate whe
 
 UniGrok exposes one headline MCP tool: `agent`. It self-routes across Grok
 models and two billing planes, and returns structured metadata with every
-answer. **Primary chat path for every project is IDE → UniGrok MCP**, not a
-browser chat client.
+answer. **Primary chat path for every project is IDE → UniGrok MCP**. The local
+browser UI is an optional trusted-loopback test/control surface whose agent
+playground can invoke providers and spend metered credits.
 
 ## The `agent` tool
 
@@ -83,7 +84,8 @@ not invented subscription cost or remaining provider quota.
 
 The shared gateway runs at `http://localhost:4765/mcp` (Streamable HTTP).
 Health: `GET /healthz`. Optional local Core UI: `http://localhost:4765/ui/`
-(machine-owner loopback status). `X-Client-ID` is a caller-controlled
+(trusted machine-owner test/control surface with a provider-calling agent
+playground). `X-Client-ID` is a caller-controlled
 attribution and session label beneath a server-derived principal; it is not
 authentication. The default unauthenticated loopback service derives the shared
 `http:anon` principal for one local budget/security trust domain, so there is

--- a/.claude/skills/using-unigrok/SKILL.md
+++ b/.claude/skills/using-unigrok/SKILL.md
@@ -90,6 +90,7 @@ configured auth. Because many repositories can reuse
 
 When the user is about to see a multi-step Implementation Plan, prefer calling
 UniGrok `agent` (`thinking` or `reasoning`) for a second opinion, then improve
-the plan before presenting it. Do not silently spend metered API credits without
-consent. Do not invent a second MCP port or Forge workflow for public installs.
-Public path remains `http://localhost:4765/mcp` only.
+the plan before presenting it **only when the user wants a Grok second opinion**
+(including `@grok`). Do not silently spend metered API credits without consent.
+Do not invent a second MCP port or Forge workflow for public installs. Public
+path remains `http://localhost:4765/mcp` only.

--- a/.github/skills/using-unigrok/SKILL.md
+++ b/.github/skills/using-unigrok/SKILL.md
@@ -82,6 +82,7 @@ session namespaces and telemetry remain separated by client.
 
 When the user is about to see a multi-step Implementation Plan, prefer calling
 UniGrok `agent` (`thinking` or `reasoning`) for a second opinion, then improve
-the plan before presenting it. Do not silently spend metered API credits without
-consent. Do not invent a second MCP port or Forge workflow for public installs.
-Public path remains `http://localhost:4765/mcp` only.
+the plan before presenting it **only when the user wants a Grok second opinion**
+(including `@grok`). Do not silently spend metered API credits without consent.
+Do not invent a second MCP port or Forge workflow for public installs. Public
+path remains `http://localhost:4765/mcp` only.

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ Configure UniGrok MCP for this machine:
 - Never put XAI_API_KEY in IDE MCP settings; credentials stay in UniGrok's server .env
 - After connecting, call tools/list and grok_mcp_discover_self
 - Prefer the UniGrok agent tool when I say @grok or want a second opinion
+- When I ask for a multi-step Implementation Plan, get a UniGrok second opinion
+  (agent mode thinking or reasoning) and improve the plan before showing it —
+  only if I want that habit; do not silently spend metered API credits
+- Do not invent a second MCP port, Forge, or land workflow for ordinary use
 ```
 
 Detailed multi-IDE notes: [docs/ide-setup.md](docs/ide-setup.md) (public path

--- a/docs/design/public-vs-insider-surfaces.md
+++ b/docs/design/public-vs-insider-surfaces.md
@@ -27,7 +27,7 @@ tool availability.
 |---|---|---|
 | **Audience** | End user / IDE agent | Contributor developing UniGrok |
 | **HTTP surface** | One primary endpoint `http://localhost:4765/mcp` | Stable Core `:4765` + contributor Forge `:4766` |
-| **Credential plane** | API key **or** SuperGrok CLI (or both) — **public-critical** | Same dual planes + management key for Collections admin |
+| **Provider authority** | Two Grok inference planes: API key **or** SuperGrok CLI (or both) — **public-critical** | The same two inference planes, plus separate optional non-inference management authority for operation-scoped administration such as Collections |
 | **Transport** | Loopback Streamable HTTP MCP primary | Also trusted stdio for full contributor tool surface |
 
 Phoneword mode-dial ports (if enabled) are **aliases of the same Core service**,
@@ -51,10 +51,13 @@ contributor gates — that is not the public product.
 
 **LIVE:**
 
-- MCP `agent`, status, discovery, optional PR review tool
+- MCP `agent`, `grok_mcp_status`, `grok_mcp_discover_self`, and optional
+  `review_pull_request`
 - Workspace-neutral (no automatic browse of the user’s app repo)
-- Loopback Control Center at `/ui/` for **this machine’s** health, cost ledger,
-  and optional playground
+- Trusted-loopback Control Center at `http://localhost:4765/ui/` for **this
+  machine’s** health, cost ledger, and optional agent playground. The
+  playground can invoke providers and spend metered credits; IDE MCP remains
+  the primary chat path.
 - Credentials stay in server env / CLI OAuth volume — never in IDE MCP JSON
 
 **TARGET Console (local Core UI):**
@@ -89,7 +92,7 @@ closed; short cache; never long-lived “is_insider” without recheck.
 Cloud must **never** accept, store, or proxy `XAI_API_KEY`, CLI OAuth material,
 or gateway secrets.
 
-### 4.4 IDE MCP chat — sole primary chat path
+### 4.4 IDE MCP chat — primary chat path
 
 **PRIMARY product chat** for PUBLIC and INSIDER daily work:
 

--- a/mcp_ui/app.js
+++ b/mcp_ui/app.js
@@ -1,9 +1,9 @@
-import { parseMarkdown, sanitizeHref } from "./markdown.js?v=grok-v0.6.0-r4";
+import { parseMarkdown, sanitizeHref } from "./markdown.js?v=grok-v0.6.0-r5";
 
 // Must match the <meta name="unigrok-ui-version"> baked into index.html and
 // src/version.py UI_ASSET_VERSION; a mismatch means the browser paired a
 // cached page with a different script build (the stale-skew failure class).
-const UI_ASSET_VERSION = "grok-v0.6.0-r4";
+const UI_ASSET_VERSION = "grok-v0.6.0-r5";
 
 const LAYOUT_KEY = "unigrok.mcp.console.layout.v2";
 
@@ -744,6 +744,20 @@ function renderRoutingReceipts(receipts) {
   }
 }
 
+function formatVerifiedSuccess(metrics) {
+  const verified = Number(metrics?.verified_outcomes || 0);
+  if (!verified) return "—";
+  if (metrics.success_rate === null || metrics.success_rate === undefined) return "—";
+  return `${(metrics.success_rate * 100).toFixed(1)}% of ${verified}`;
+}
+
+function formatVerifiedSplit(metrics) {
+  const verified = Number(metrics?.verified_outcomes || 0);
+  const unverified = Number(metrics?.unverified_requests || 0);
+  if (!verified && !unverified && !Number(metrics?.requests || 0)) return "—";
+  return `${verified} / ${unverified}`;
+}
+
 function renderPlaneTable(planes) {
   const body = $("planeBreakdownBody");
   body.replaceChildren();
@@ -760,7 +774,7 @@ function renderPlaneTable(planes) {
   }
   for (const [plane, metrics] of entries) {
     const row = document.createElement("tr");
-    const success = metrics.success_rate === null ? "—" : `${(metrics.success_rate * 100).toFixed(1)}%`;
+    const success = formatVerifiedSuccess(metrics);
     const latency = metrics.avg_latency_sec === null ? "—" : `${metrics.avg_latency_sec.toFixed(2)}s`;
     const cost = plane === "API" ? `$${Number(metrics.api_cost_usd || 0).toFixed(5)}` : "Subscription";
     const values = [plane, metrics.requests, success, latency, formatTokens(metrics.tracked_tokens), cost];
@@ -781,18 +795,28 @@ function renderMetricsSnapshot() {
   const planes = period.planes || {};
   const apiRequests = planeRequests(planes, ["API"]);
   const cliRequests = planeRequests(planes, ["CLI", "CLI-Fallback"]);
+  const verified = Number(summary.verified_outcomes || 0);
+  const unverified = Number(summary.unverified_requests || 0);
 
   $("metricApiCost").innerText = `$${Number(summary.api_cost_usd || 0).toFixed(5)}`;
   $("metricRequests").innerText = Number(summary.requests || 0).toLocaleString();
   $("metricLatency").innerText = formatMetric(summary.avg_latency_sec, (v) => `${v.toFixed(2)}s`);
-  $("metricSuccess").innerText = formatMetric(summary.success_rate, (v) => `${(v * 100).toFixed(1)}%`);
+  $("metricSuccess").innerText = formatVerifiedSuccess(summary);
+  if ($("metricSuccessSub")) {
+    $("metricSuccessSub").innerText = verified
+      ? `Of ${verified} receipt-verified outcome${verified === 1 ? "" : "s"} only`
+      : "No receipt-verified outcomes yet (most stops stay unverified)";
+  }
+  if ($("metricVerifiedSplit")) {
+    $("metricVerifiedSplit").innerText = formatVerifiedSplit(summary);
+  }
   $("metricPlane").innerText = `${apiRequests} / ${cliRequests}`;
   $("metricTokens").innerText = formatTokens(summary.tracked_tokens);
 
   const quality = payload.usage.data_quality;
   const periodLabel = state.metricsPeriod === "today" ? "today" : "across the local ledger";
   $("metricsCoverage").innerText = summary.requests
-    ? `${summary.requests} request${summary.requests === 1 ? "" : "s"} ${periodLabel}. ${summary.routing_receipt_requests || 0} row${summary.routing_receipt_requests === 1 ? "" : "s"} include explainable routing receipts; older rows remain valid for cost, latency, and plane counts.`
+    ? `${summary.requests} request${summary.requests === 1 ? "" : "s"} ${periodLabel} (${verified} verified, ${unverified} unverified). ${summary.routing_receipt_requests || 0} row${summary.routing_receipt_requests === 1 ? "" : "s"} include explainable routing receipts. Success % is never over all requests — only over verified outcomes.`
     : `No model executions ${periodLabel}. Health checks, discovery, and status calls intentionally do not create billable telemetry.`;
 
   const breakerCount = Object.values(payload.circuit_breakers || {}).filter((item) => item?.open).length;
@@ -927,6 +951,31 @@ function renderSetupStatus(data, ready = true, detailText = null) {
   target.replaceChildren(title, document.createElement("br"), detail);
 }
 
+function renderSurfaceModeBadge(data) {
+  const badge = $("surfaceModeBadge");
+  if (!badge) return;
+  const mode = String(data?.service?.mode || "").toLowerCase();
+  const port = window.location.port || "";
+  const isForgePort = port === "4766";
+  if (mode === "contributor" || isForgePort) {
+    badge.textContent = "Surface: Contributor Forge";
+    badge.title = "Forge attaches the UniGrok checkout. Public product path remains Core :4765.";
+    badge.dataset.surface = "forge";
+  } else {
+    badge.textContent = "Surface: Stable Core";
+    badge.title = "Public product path. Swarm apply and land workflows are insider-only.";
+    badge.dataset.surface = "core";
+  }
+  const swarmLink = $("nav-link-swarm");
+  if (swarmLink) {
+    if (badge.dataset.surface === "core") {
+      swarmLink.title = "Swarm Optimizer (best on Contributor Forge :4766; opens local page)";
+    } else {
+      swarmLink.title = "Swarm Optimizer — Pareto Playground";
+    }
+  }
+}
+
 async function fetchRuntimeStatus() {
   try {
     const res = await fetch("/runtimez");
@@ -934,6 +983,7 @@ async function fetchRuntimeStatus() {
     const data = await res.json();
     $("runtimeChip").innerText = `runtime: ${data.runtime || "unknown"}`;
     $("transportChip").innerText = `transport: ${data.transport || "unknown"}`;
+    renderSurfaceModeBadge(data);
     renderCredentialPlanes(data.credential_planes || null);
     // /runtimez is 200 even when not ready, so honor the readiness probe.
     renderSetupStatus(data, gatewayReadiness.ready, gatewayReadiness.detail);
@@ -942,6 +992,7 @@ async function fetchRuntimeStatus() {
     $("runtimeChip").innerText = "runtime: unknown";
     $("transportChip").innerText = "transport: unknown";
     $("planeChip").innerText = "plane: unknown";
+    renderSurfaceModeBadge(null);
     renderSetupStatus(null, false);
     return null;
   }

--- a/mcp_ui/index.html
+++ b/mcp_ui/index.html
@@ -7,9 +7,9 @@
     <meta name="unigrok-ui-regions" content="navigation,workbench,rpc-inspector,rpc-logs,result-facts" />
     <!-- Version handshake: app.js compares this against its own build constant
          and self-heals a stale-cached page with one revalidating reload. -->
-    <meta name="unigrok-ui-version" content="grok-v0.6.0-r4" />
-  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r4" />
-  <link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r4" />
+    <meta name="unigrok-ui-version" content="grok-v0.6.0-r5" />
+  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r5" />
+  <link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r5" />
   </head>
   <body>
     <main class="app-shell">
@@ -39,6 +39,7 @@
         <div class="brand-block">
           <p class="eyebrow">UNIGROK GATEWAY</p>
           <h1>Control Center <span class="version-badge">v0.6.0</span></h1>
+          <p id="surfaceModeBadge" class="surface-mode-badge" title="Stable Core is the public product path">Surface: Core (checking…)</p>
         </div>
         <div class="layout-actions" aria-label="Workspace layout controls">
           <button id="toggleNavBtn" type="button" class="chrome-btn" aria-controls="sidebarNav" aria-expanded="true" aria-pressed="true" title="Show or hide sections (⌘/Ctrl+B)"><span aria-hidden="true">◧</span><span class="chrome-label">Sections</span></button>
@@ -446,9 +447,14 @@
                 <span class="metric-sub">Mean elapsed execution time</span>
               </div>
               <div class="metric-card">
-                <h3>Success Rate</h3>
+                <h3>Verified success</h3>
                 <div id="metricSuccess" class="metric-value">—</div>
-                <span class="metric-sub">Successful completed requests</span>
+                <span id="metricSuccessSub" class="metric-sub">Of receipt-verified outcomes only</span>
+              </div>
+              <div class="metric-card">
+                <h3>Verified / unverified</h3>
+                <div id="metricVerifiedSplit" class="metric-value">—</div>
+                <span class="metric-sub">Most stops stay unverified until a receipt</span>
               </div>
               <div class="metric-card">
                 <h3>API / CLI</h3>
@@ -469,7 +475,7 @@
                 <div class="section-title">Plane Breakdown</div>
                 <div class="usage-table-wrap">
                   <table class="usage-table">
-                    <thead><tr><th>Plane</th><th>Requests</th><th>Success</th><th>Latency</th><th>Tokens</th><th>Cost</th></tr></thead>
+                    <thead><tr><th>Plane</th><th>Requests</th><th>Verified success</th><th>Latency</th><th>Tokens</th><th>Cost</th></tr></thead>
                     <tbody id="planeBreakdownBody"><tr><td colspan="6" class="empty-cell">Loading…</td></tr></tbody>
                   </table>
                 </div>
@@ -600,6 +606,6 @@ docker compose up --build -d</code></pre>
 
       </section>
     </main>
-  <script type="module" src="./app.js?v=grok-v0.6.0-r4"></script>
+  <script type="module" src="./app.js?v=grok-v0.6.0-r5"></script>
   </body>
 </html>

--- a/mcp_ui/styles.css
+++ b/mcp_ui/styles.css
@@ -77,6 +77,19 @@ body {
   letter-spacing: 1.5px;
 }
 
+.surface-mode-badge {
+  margin: 0.2rem 0 0;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--ink-soft, #9aa3b2);
+}
+.surface-mode-badge[data-surface="forge"] {
+  color: var(--accent, #7dd3fc);
+}
+.surface-mode-badge[data-surface="core"] {
+  color: var(--ok, #86efac);
+}
 .version-badge {
   font-size: 11px;
   font-weight: 500;

--- a/mcp_ui/swarm.html
+++ b/mcp_ui/swarm.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>UniGrok Swarm Optimizer — Pareto Playground</title>
-  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r4" />
+  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r5" />
   <style>
     /* Page vocabulary aliases onto the shared UniGrok tokens (tokens.css) so
        the Swarm Optimizer and the Control Center read as one product. */
@@ -270,6 +270,6 @@
     hidden. "Verified" means: the task's own <code>test_target</code> passed.
   </div>
 
-  <script src="./swarm.js?v=grok-v0.6.0-r4"></script>
+  <script src="./swarm.js?v=grok-v0.6.0-r5"></script>
 </body>
 </html>

--- a/mcp_ui/swarm.js
+++ b/mcp_ui/swarm.js
@@ -10,7 +10,7 @@
 // Must match src/version.py UI_ASSET_VERSION and the query token on the
 // swarm.js reference in swarm.html. The sample uses the same token so a
 // revalidated page cannot pair new logic with a heuristically cached payload.
-const UI_ASSET_VERSION = "grok-v0.6.0-r4";
+const UI_ASSET_VERSION = "grok-v0.6.0-r5";
 
 const $ = (id) => document.getElementById(id);
 const SVG_NS = "http://www.w3.org/2000/svg";

--- a/skills/using-unigrok/SKILL.md
+++ b/skills/using-unigrok/SKILL.md
@@ -7,8 +7,9 @@ description: How to query xAI Grok through the UniGrok MCP gateway. Activate whe
 
 UniGrok exposes one headline MCP tool: `agent`. It self-routes across Grok
 models and two billing planes, and returns structured metadata with every
-answer. **Primary chat path for every project is IDE → UniGrok MCP**, not a
-browser chat client.
+answer. **Primary chat path for every project is IDE → UniGrok MCP**. The local
+browser UI is an optional trusted-loopback test/control surface whose agent
+playground can invoke providers and spend metered credits.
 
 ## The `agent` tool
 
@@ -83,7 +84,8 @@ not invented subscription cost or remaining provider quota.
 
 The shared gateway runs at `http://localhost:4765/mcp` (Streamable HTTP).
 Health: `GET /healthz`. Optional local Core UI: `http://localhost:4765/ui/`
-(machine-owner loopback status). `X-Client-ID` is a caller-controlled
+(trusted machine-owner test/control surface with a provider-calling agent
+playground). `X-Client-ID` is a caller-controlled
 attribution and session label beneath a server-derived principal; it is not
 authentication. The default unauthenticated loopback service derives the shared
 `http:anon` principal for one local budget/security trust domain, so there is

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel
 from starlette.applications import Starlette
 from starlette.middleware import Middleware
 from starlette.requests import Request
-from starlette.responses import JSONResponse, Response, StreamingResponse
+from starlette.responses import JSONResponse, RedirectResponse, Response, StreamingResponse
 from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
 
@@ -2284,6 +2284,8 @@ def create_app(*, bound_host: Optional[str] = None) -> Starlette:
                 app=create_docs_app(),
                 name="docs",
             ),
+            # Trailing-slash canonical URL: /ui alone 404s under StaticFiles.
+            Route("/ui", endpoint=lambda _request: RedirectResponse(url="/ui/", status_code=307), methods=["GET"]),
             Mount(
                 "/ui",
                 app=create_ui_app(),

--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -1061,8 +1061,9 @@ async def grok_mcp_discover_self(include_models: bool = False) -> SystemResult:
 
         doc_text = (
             "# UniGrok MCP Discovery & Self-Description\n\n"
-            "Zero-configuration onboarding for IDE agents. Primary product chat is the UniGrok "
-            "`agent` tool over MCP — not a browser chat client.\n\n"
+            "Zero-configuration onboarding for IDE agents. The primary product chat path is the "
+            "UniGrok `agent` tool over MCP. The trusted-loopback UI is an optional test and control "
+            "surface, not the primary daily chat path.\n\n"
             "## Service and Project Boundary\n"
             "- UniGrok is a standalone MCP service; the caller's project needs no UniGrok namespace files.\n"
             f"- Service mode: `{'contributor' if contributor else 'stable'}`. "
@@ -1071,7 +1072,8 @@ async def grok_mcp_discover_self(include_models: bool = False) -> SystemResult:
             "## Public product path\n"
             "- Canonical endpoint: `http://localhost:4765/mcp` (`4765` spells GROK).\n"
             "- Health: `GET /healthz`. Readiness: `GET /readyz`. Optional local Core UI: "
-            "`http://localhost:4765/ui/` (machine-owner loopback status; not GitHub-gated).\n"
+            "`http://localhost:4765/ui/` (trusted machine-owner test/control surface with an "
+            "agent playground that can invoke providers and spend metered credits; not GitHub-gated).\n"
             f"{dial_extra}"
             "- An explicit `agent.mode` always overrides a dialed-port default.\n\n"
             "## Credential Planes (public-critical)\n"

--- a/src/version.py
+++ b/src/version.py
@@ -7,4 +7,4 @@ __version__ = "0.6.0"
 # runtime handshake in app.js).
 # Bump the -rN suffix whenever any /ui asset changes; a pytest asserts every
 # copy of this string agrees so HTML and JS can never skew apart silently.
-UI_ASSET_VERSION = "grok-v0.6.0-r4"
+UI_ASSET_VERSION = "grok-v0.6.0-r5"

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -47,10 +47,12 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert index.status_code == 200
     assert "<title>UniGrok MCP v0.6.0 Control Center</title>" in index.text
     assert '<span class="version-badge">v0.6.0</span>' in index.text
-    assert 'script type="module" src="./app.js?v=grok-v0.6.0-r4"' in index.text
-    assert '<link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r4" />' in index.text
-    assert '<link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r4" />' in index.text
+    assert 'script type="module" src="./app.js?v=grok-v0.6.0-r5"' in index.text
+    assert '<link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r5" />' in index.text
+    assert '<link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r5" />' in index.text
     assert "Control Center" in index.text
+    assert 'id="surfaceModeBadge"' in index.text
+    assert 'id="metricVerifiedSplit"' in index.text
     assert "Bearer token" not in index.text
     assert "Agent Playground" in index.text
     assert 'id="verifySetupBtn"' in index.text
@@ -389,7 +391,7 @@ def test_mcp_ui_markdown_renderer_is_shared_and_escape_first():
     assert "\\u000E-\\u001F" in renderer.text
     # app.js imports the shared renderer at the current cache-bust version and
     # no longer defines its own.
-    assert 'from "./markdown.js?v=grok-v0.6.0-r4"' in script.text
+    assert 'from "./markdown.js?v=grok-v0.6.0-r5"' in script.text
     assert "import { parseMarkdown" in script.text
     assert "function parseMarkdown" not in script.text
     assert "renderMarkdownInto" in script.text
@@ -632,3 +634,12 @@ def test_mcp_ui_reflow_is_container_driven():
     assert "@media (max-width: 768px)" not in styles
     # Fixed sidebar columns became user-resizable with clamps.
     assert "resize: horizontal" in styles
+
+
+def test_ui_root_redirects_to_trailing_slash(monkeypatch):
+    monkeypatch.delenv("UNIGROK_RUNTIME", raising=False)
+    monkeypatch.delenv("UNIGROK_API_KEYS", raising=False)
+    with TestClient(create_app(), base_url="http://localhost:8080") as client:
+        response = client.get("/ui", follow_redirects=False)
+    assert response.status_code in (307, 308)
+    assert response.headers.get("location", "").endswith("/ui/")

--- a/tests/test_service_workspace_boundary.py
+++ b/tests/test_service_workspace_boundary.py
@@ -217,6 +217,7 @@ def test_stable_and_contributor_compose_files_are_separate():
     for phoneword_port in (2886, 3278, 7327, 8465, 7724):
         assert str(phoneword_port) in dials
 
+
 @pytest.mark.asyncio
 async def test_stable_discover_self_has_no_forge_connect_recipes(monkeypatch):
     """Public/stable discover prose must not coach Forge 4766 or land workflows."""
@@ -250,3 +251,17 @@ async def test_public_mcp_instructions_prefer_core_endpoint_and_plan_critique():
     assert "4766" not in text
     assert "scripts/land" not in text
 
+
+def test_using_unigrok_skill_variants_preserve_plan_critique_opt_in():
+    variants = (
+        Path("skills/using-unigrok/SKILL.md"),
+        Path(".agents/skills/using-unigrok/SKILL.md"),
+        Path(".claude/skills/using-unigrok/SKILL.md"),
+        Path(".github/skills/using-unigrok/SKILL.md"),
+    )
+
+    for path in variants:
+        text = path.read_text(encoding="utf-8").lower()
+        assert "only when the user wants a grok second opinion" in text or (
+            "when the user wants a grok second opinion" in text
+        ), f"{path} lost the explicit user opt-in condition"


### PR DESCRIPTION
## Summary

Next-step execution after Wave-1 on main and Codex #94 land:

1. **Absorb valuable Codex repairs** from draft #99/#100 (already largely on main via Wave-1; this keeps their honest wording deltas):
   - Provider authority vs non-inference management language in the freeze doc
   - Exact public MCP tool names
   - Playground can spend metered credits (honest LIVE label)
   - Skill opt-in test coverage
2. **Core UI honesty**
   - Success chip = verified outcomes only, with verified/unverified split
   - Core vs Forge surface badge
   - `/ui` → `/ui/` redirect
   - UI asset version **r5**
3. Public README paste block strengthened for opt-in plan critique

## Exact head

See branch tip after push.

## Tests

- Focused: `test_mcp_ui`, `test_service_workspace_boundary`, readme site phrase test
- Full suite via land / CI

## Codex coordination

- #99 and #100 should close as absorbed/superseded once this lands (Wave-1 content already on main; this carries residual wording fixes + UI honesty)

## Human sponsor

djtelicloud

Agent-Assisted-By: xAI Grok | model=grok-4.5 | model-source=provider-session | surface=Grok Build | role=implementation
Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=integration