### PR TITLE
fix: hide Forge navigation on Stable Core

### DIFF
--- a/mcp_ui/app.js
+++ b/mcp_ui/app.js
@@ -1,9 +1,9 @@
-import { parseMarkdown, sanitizeHref } from "./markdown.js?v=grok-v0.6.0-r5";
+import { parseMarkdown, sanitizeHref } from "./markdown.js?v=grok-v0.6.0-r6";
 
 // Must match the <meta name="unigrok-ui-version"> baked into index.html and
 // src/version.py UI_ASSET_VERSION; a mismatch means the browser paired a
 // cached page with a different script build (the stale-skew failure class).
-const UI_ASSET_VERSION = "grok-v0.6.0-r5";
+const UI_ASSET_VERSION = "grok-v0.6.0-r6";
 
 const LAYOUT_KEY = "unigrok.mcp.console.layout.v2";
 
@@ -966,11 +966,13 @@ function renderSurfaceModeBadge(data) {
     badge.title = "Public product path. Swarm apply and land workflows are insider-only.";
     badge.dataset.surface = "core";
   }
+  const contributorTitle = $("nav-group-contributor");
   const swarmLink = $("nav-link-swarm");
+  const isForge = badge.dataset.surface === "forge";
+  if (contributorTitle) contributorTitle.hidden = !isForge;
+  if (swarmLink) swarmLink.hidden = !isForge;
   if (swarmLink) {
-    if (badge.dataset.surface === "core") {
-      swarmLink.title = "Swarm Optimizer (best on Contributor Forge :4766; opens local page)";
-    } else {
+    if (isForge) {
       swarmLink.title = "Swarm Optimizer — Pareto Playground";
     }
   }

--- a/mcp_ui/index.html
+++ b/mcp_ui/index.html
@@ -7,9 +7,9 @@
     <meta name="unigrok-ui-regions" content="navigation,workbench,rpc-inspector,rpc-logs,result-facts" />
     <!-- Version handshake: app.js compares this against its own build constant
          and self-heals a stale-cached page with one revalidating reload. -->
-    <meta name="unigrok-ui-version" content="grok-v0.6.0-r5" />
-  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r5" />
-  <link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r5" />
+    <meta name="unigrok-ui-version" content="grok-v0.6.0-r6" />
+  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r6" />
+  <link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r6" />
   </head>
   <body>
     <main class="app-shell">
@@ -78,7 +78,7 @@
           <button id="tab-btn-metrics" type="button" class="nav-btn" data-tab="tab-metrics" role="tab" aria-selected="false" aria-controls="tab-metrics" tabindex="-1" title="Usage &amp; Costs">
             <span class="btn-icon" aria-hidden="true">📊</span><span class="btn-label">Usage &amp; Costs</span>
           </button>
-          <div class="nav-title nav-title-group">Contributor</div>
+          <div id="nav-group-contributor" class="nav-title nav-title-group">Contributor</div>
           <!-- A real page link, deliberately NOT a .nav-btn: the tab router
                and its arrow-key traversal bind .nav-btn only, so this never
                hijacks tab switching or navigates during keyboard cycling. -->
@@ -606,6 +606,6 @@ docker compose up --build -d</code></pre>
 
       </section>
     </main>
-  <script type="module" src="./app.js?v=grok-v0.6.0-r5"></script>
+  <script type="module" src="./app.js?v=grok-v0.6.0-r6"></script>
   </body>
 </html>

--- a/mcp_ui/styles.css
+++ b/mcp_ui/styles.css
@@ -90,6 +90,10 @@ body {
 .surface-mode-badge[data-surface="core"] {
   color: var(--ok, #86efac);
 }
+#nav-group-contributor[hidden],
+#nav-link-swarm[hidden] {
+  display: none;
+}
 .version-badge {
   font-size: 11px;
   font-weight: 500;

--- a/mcp_ui/swarm.html
+++ b/mcp_ui/swarm.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>UniGrok Swarm Optimizer — Pareto Playground</title>
-  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r5" />
+  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r6" />
   <style>
     /* Page vocabulary aliases onto the shared UniGrok tokens (tokens.css) so
        the Swarm Optimizer and the Control Center read as one product. */
@@ -270,6 +270,6 @@
     hidden. "Verified" means: the task's own <code>test_target</code> passed.
   </div>
 
-  <script src="./swarm.js?v=grok-v0.6.0-r5"></script>
+  <script src="./swarm.js?v=grok-v0.6.0-r6"></script>
 </body>
 </html>

--- a/mcp_ui/swarm.js
+++ b/mcp_ui/swarm.js
@@ -10,7 +10,7 @@
 // Must match src/version.py UI_ASSET_VERSION and the query token on the
 // swarm.js reference in swarm.html. The sample uses the same token so a
 // revalidated page cannot pair new logic with a heuristically cached payload.
-const UI_ASSET_VERSION = "grok-v0.6.0-r5";
+const UI_ASSET_VERSION = "grok-v0.6.0-r6";
 
 const $ = (id) => document.getElementById(id);
 const SVG_NS = "http://www.w3.org/2000/svg";

--- a/src/version.py
+++ b/src/version.py
@@ -7,4 +7,4 @@ __version__ = "0.6.0"
 # runtime handshake in app.js).
 # Bump the -rN suffix whenever any /ui asset changes; a pytest asserts every
 # copy of this string agrees so HTML and JS can never skew apart silently.
-UI_ASSET_VERSION = "grok-v0.6.0-r5"
+UI_ASSET_VERSION = "grok-v0.6.0-r6"

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -47,12 +47,16 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert index.status_code == 200
     assert "<title>UniGrok MCP v0.6.0 Control Center</title>" in index.text
     assert '<span class="version-badge">v0.6.0</span>' in index.text
-    assert 'script type="module" src="./app.js?v=grok-v0.6.0-r5"' in index.text
-    assert '<link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r5" />' in index.text
-    assert '<link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r5" />' in index.text
+    assert 'script type="module" src="./app.js?v=grok-v0.6.0-r6"' in index.text
+    assert '<link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r6" />' in index.text
+    assert '<link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r6" />' in index.text
     assert "Control Center" in index.text
     assert 'id="surfaceModeBadge"' in index.text
     assert 'id="metricVerifiedSplit"' in index.text
+    assert 'id="nav-group-contributor"' in index.text
+    assert 'contributorTitle.hidden = !isForge' in script.text
+    assert 'swarmLink.hidden = !isForge' in script.text
+    assert '#nav-link-swarm[hidden]' in styles.text
     assert "Bearer token" not in index.text
     assert "Agent Playground" in index.text
     assert 'id="verifySetupBtn"' in index.text
@@ -391,7 +395,7 @@ def test_mcp_ui_markdown_renderer_is_shared_and_escape_first():
     assert "\\u000E-\\u001F" in renderer.text
     # app.js imports the shared renderer at the current cache-bust version and
     # no longer defines its own.
-    assert 'from "./markdown.js?v=grok-v0.6.0-r5"' in script.text
+    assert 'from "./markdown.js?v=grok-v0.6.0-r6"' in script.text
     assert "import { parseMarkdown" in script.text
     assert "function parseMarkdown" not in script.text
     assert "renderMarkdownInto" in script.text


### PR DESCRIPTION
## Summary

Post-#103 boundary repair found during live visual review:
- hide the Contributor label and Swarm Optimizer link on Stable Core
- retain both on Contributor Forge
- keep the larger unified insider UI redesign in its approved later wave
- bump the UI asset handshake to r6 so browsers cannot pair stale markup/scripts

## Exact head

`6bf4b48c23cb4554bfe873b9fb3958f4f91e67a5`

## Verification

- live isolated stable-mode render: Contributor + Swarm computed display=none
- live isolated contributor-mode render: Contributor + Swarm visible
- `uv run pytest -q tests/test_mcp_ui.py tests/test_service_workspace_boundary.py` — 43 passed
- JavaScript syntax checks passed
- compileall, Ruff, diff hygiene, and attribution checks passed

## Risk

Narrow navigation visibility change. No auth, provider, model, telemetry, or Swarm execution behavior changes.

## Human sponsor

djtelicloud

Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=implementation