### PR TITLE
fix: require write access for Insider Console

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ collaborators such as Curtis). Product language freeze:
 | Topic | LIVE today | TARGET |
 |---|---|---|
 | Core UI `/ui/` | Status + optional legacy `agent` playground | Observe + pasteable actions; IDE remains primary chat |
-| Cloud Console entry | GitHub OAuth + live collaborator check (see site code/tests) | Prefer write+ (`write` / `maintain` / `admin`) for privileged views; always fail closed |
+| Cloud Console entry | GitHub OAuth + live write+ collaborator check (`write` / `maintain` / `admin`) | Same; always fail closed |
 | Swarm | Contributor mode; prefer `dry_run` | Same; never default-apply |
 | Land / merge | Codex/`scripts/land` + required exact-head Codex Approval | Unchanged; Grok review is advisory only |
 

--- a/docs/design/public-vs-insider-surfaces.md
+++ b/docs/design/public-vs-insider-surfaces.md
@@ -85,9 +85,9 @@ Public docs and **stable** `discover_self` prose must **not** instruct agents to
 **LIVE:** GitHub OAuth control plane with live collaborator checks; no provider
 secret forms; no laptop proxy of local MCP.
 
-**TARGET:** Raise privileged Console entry to GitHub permission ∈
-`{write, maintain, admin}` where product requires write-only insiders; fail
-closed; short cache; never long-lived “is_insider” without recheck.
+**LIVE:** Privileged Console entry requires GitHub permission ∈
+`{write, maintain, admin}` and fails closed. Authorization is rechecked on each
+protected request rather than trusting a long-lived “is_insider” claim.
 
 Cloud must **never** accept, store, or proxy `XAI_API_KEY`, CLI OAuth material,
 or gateway secrets.
@@ -139,7 +139,7 @@ public Quick Start.
 | Public README is vibe-only; insider ops in CONTRIBUTING | Wave-1 docs goal |
 | Stable discover prose does not teach Forge connect | Wave-1 onboarding goal |
 | Console is observe+paste only | **TARGET** (legacy chat still LIVE) |
-| GitHub write+ for all cloud Console entry | **TARGET** (verify LIVE gate separately) |
+| GitHub write+ for all cloud Console entry | **LIVE** |
 | Unified single Insider UI (swarm+control+core) | **Deferred** |
 | Silent skill compiler into user repos | **Forbidden** |
 

--- a/sites/unigrok-control-center/app/contribute/page.tsx
+++ b/sites/unigrok-control-center/app/contribute/page.tsx
@@ -21,7 +21,7 @@ export default function ContributePage() {
         <div className="public-capability-grid">
           <article><b>01</b><h3>Learn and run</h3><p>Read the architecture, start the local gateway, and verify your IDE connection without giving this site an xAI key.</p></article>
           <article><b>02</b><h3>Propose work</h3><p>Open an issue or pull request. Codex reviews evidence, tests the exact commit, and owns integration into main.</p></article>
-          <article><b>03</b><h3>Receive access</h3><p>A maintainer grants a GitHub repository role. Control access starts at triage and is rechecked on every protected request.</p></article>
+          <article><b>03</b><h3>Receive access</h3><p>A maintainer grants a GitHub repository role. Control access starts at write and is rechecked on every protected request.</p></article>
         </div>
       </section>
     </main>

--- a/sites/unigrok-control-center/app/control/github-access-denied.tsx
+++ b/sites/unigrok-control-center/app/control/github-access-denied.tsx
@@ -28,7 +28,7 @@ export default function GitHubControlAccessDenied({
         </div>
         <div className="access-notice">
           <strong>Authorization is checked on every request.</strong>
-          <p>Only GitHub roles with triage, write, maintain, or admin access to {PUBLIC_PROJECT.repository.name} qualify. Removing that role revokes control access without waiting for the browser session to expire.</p>
+          <p>Only GitHub roles with write, maintain, or admin access to {PUBLIC_PROJECT.repository.name} qualify. Removing that role revokes control access without waiting for the browser session to expire.</p>
         </div>
         <div className="public-actions">
           <a className="public-primary" href="/auth/github/login?return_to=%2Fcontrol">Sign in with GitHub</a>

--- a/sites/unigrok-control-center/app/control/signed-out.tsx
+++ b/sites/unigrok-control-center/app/control/signed-out.tsx
@@ -23,7 +23,7 @@ export default function ControlSignedOut() {
           <strong>Who gets in, and how it is checked.</strong>
           <p>
             Sign in with GitHub, and every request re-verifies your collaborator role
-            (triage or higher) against the repository — server-side, on each visit.
+            (write, maintain, or admin) against the repository — server-side, on each visit.
             There is nothing to configure and no separate account to create. Public
             project information stays available without any sign-in.
           </p>

--- a/sites/unigrok-control-center/app/forbidden.tsx
+++ b/sites/unigrok-control-center/app/forbidden.tsx
@@ -9,7 +9,7 @@ export default function Forbidden() {
         <p className="public-kicker"><span /> Contributor boundary</p>
         <h1 id="access-title">Contributor access was not confirmed.</h1>
         <p className="access-lede">
-          GitHub did not confirm a current triage, write, maintain, or admin role for this repository.
+          GitHub did not confirm a current write, maintain, or admin role for this repository.
           Public read access is not sufficient.
         </p>
         <div className="access-notice">

--- a/sites/unigrok-control-center/app/lib/github-app.ts
+++ b/sites/unigrok-control-center/app/lib/github-app.ts
@@ -215,14 +215,13 @@ async function readResponseBody(response: Response): Promise<string> {
 function normalizePermission(
   permissionValue: unknown,
   roleNameValue: unknown,
-): "admin" | "maintain" | "triage" | "write" | null {
+): "admin" | "maintain" | "write" | null {
   const candidates = [roleNameValue, permissionValue];
   for (const value of candidates) {
     if (
       value === "admin" ||
       value === "maintain" ||
-      value === "write" ||
-      value === "triage"
+      value === "write"
     ) {
       return value;
     }

--- a/sites/unigrok-control-center/app/lib/public-project.ts
+++ b/sites/unigrok-control-center/app/lib/public-project.ts
@@ -19,7 +19,7 @@ export const PUBLIC_PROJECT = {
     origin: "https://control.grokmcp.org",
     authentication: "github-oauth-app",
     authorization: "fresh-server-side-github-repository-role-check",
-    minimumRole: "triage",
+    minimumRole: "write",
   },
   mcp: {
     localDefault: "http://localhost:4765/mcp",

--- a/sites/unigrok-control-center/tests/github-auth.test.ts
+++ b/sites/unigrok-control-center/tests/github-auth.test.ts
@@ -36,17 +36,19 @@ test("session cookies round trip and reject tampering, duplicates, and expiry", 
   assert.equal(await readGitHubSession(config, pair, now + 3_600_001), null);
 });
 
-test("live authorization accepts triage and above but rejects read and identity mismatch", async () => {
+test("live authorization requires write or stronger and rejects weaker roles or identity mismatch", async () => {
   const config = loadGitHubAuthConfig(environment);
   const identity = { id: 42, login: "contributor" };
   const response = (permission: string, id = 42) => async () => Response.json({
     permission,
     user: { id, login: "contributor" },
   });
-  assert.equal((await authorizeGitHubCollaborator(config, identity, "t".repeat(40), response("triage")))?.role, "contributor");
+  assert.equal((await authorizeGitHubCollaborator(config, identity, "t".repeat(40), response("write")))?.role, "contributor");
+  assert.equal((await authorizeGitHubCollaborator(config, identity, "t".repeat(40), response("maintain")))?.role, "contributor");
   assert.equal((await authorizeGitHubCollaborator(config, identity, "t".repeat(40), response("admin")))?.role, "admin");
+  assert.equal(await authorizeGitHubCollaborator(config, identity, "t".repeat(40), response("triage")), null);
   assert.equal(await authorizeGitHubCollaborator(config, identity, "t".repeat(40), response("read")), null);
-  assert.equal(await authorizeGitHubCollaborator(config, identity, "t".repeat(40), response("triage", 99)), null);
+  assert.equal(await authorizeGitHubCollaborator(config, identity, "t".repeat(40), response("write", 99)), null);
 });
 
 test("a later permission check observes revocation", async () => {

--- a/sites/unigrok-control-center/tests/rendered-html.test.mjs
+++ b/sites/unigrok-control-center/tests/rendered-html.test.mjs
@@ -313,6 +313,7 @@ test("serves public project, discovery, and llms documents anonymously", async (
   assert.equal(project.mcp.remote_status, "private-oauth-api-plane");
   assert.equal(project.mcp.private_remote, "https://mcp.grokmcp.org/mcp");
   assert.equal(project.control.authorization, "fresh-server-side-github-repository-role-check");
+  assert.equal(project.control.minimum_repository_role, "write");
   assert.equal(project.documentation.okf_manifest, "https://grokmcp.org/docs/okf/okf-manifest.json");
 
   const discoveryResponse = await request(worker, "/.well-known/unigrok.json");
@@ -329,6 +330,7 @@ test("serves public project, discovery, and llms documents anonymously", async (
   const llms = await llmsResponse.text();
   assert.match(llms, /# UniGrok/);
   assert.match(llms, /fresh server-side repository role check/);
+  assert.match(llms, /minimum accepted role is write/);
   assert.match(llms, /OKF knowledge bundle/);
   assert.match(llms, /short-lived scoped tokens/);
   assert.doesNotMatch(llms, /xai-[A-Za-z0-9_-]+/i);


### PR DESCRIPTION
## Outcome
Enforces the approved Insider Console boundary: GitHub `write`, `maintain`, or `admin` only. `triage` and `read` now fail closed.

## Exact head
`d0e5deba686d9081408c6491d8861b7ef86ccb01`

## Changed paths
- `sites/unigrok-control-center/app/lib/github-app.ts`
- `sites/unigrok-control-center/app/lib/public-project.ts`
- Console access copy under `sites/unigrok-control-center/app/`
- site authorization/rendered-contract tests
- `CONTRIBUTING.md`
- `docs/design/public-vs-insider-surfaces.md`

## Verification
- Project Site full gate: 59 tests passed; typecheck/build/deployment validation passed
- Site lint: 0 errors; 4 pre-existing generated Swarm warnings
- Focused repository tests: 40 passed
- `git diff --check`: clean

## Risk
Existing triage-only collaborators lose Console access by design. Public project pages remain public; protected Console data remains GitHub-OAuth-gated and rechecked server-side on every request.

Human sponsor: David

Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=implementation
