### PR TITLE
Unify Swarm under insider control

### DIFF
--- a/sites/unigrok-control-center/app/control-center.tsx
+++ b/sites/unigrok-control-center/app/control-center.tsx
@@ -29,7 +29,7 @@ type IconName =
   | "terminal"
   | "x";
 
-type PanelName = "connection" | "deployments" | "grok-review" | "pull-requests" | "repository" | "review" | "runtime" | "settings" | null;
+type PanelName = "connection" | "deployments" | "grok-review" | "pull-requests" | "repository" | "review" | "runtime" | "settings" | "swarm" | null;
 type WizardMode = "local" | "tunnel";
 
 type ControlCenterProps = {
@@ -51,6 +51,8 @@ type CommandItem = {
 
 const secureTunnelGuide = "https://developers.openai.com/api/docs/guides/secure-mcp-tunnels";
 const sitesGuide = "https://learn.chatgpt.com/docs/sites";
+const localForgeSwarm = "http://127.0.0.1:4766/ui/swarm.html";
+const swarmReviewPrompt = `Open the UniGrok repository in this IDE and use the Contributor Forge Swarm workflow in dry-run mode to inspect the current change. Verify Core and Forge health, run the relevant measured checks, and summarize the evidence. Do not apply changes, open a pull request, or land anything until I approve.`;
 const guardrails = [
   "Identity and fresh project authorization stay separate",
   "Missing, revoked, or public-read-only GitHub access denies control access",
@@ -207,6 +209,7 @@ export default function ControlCenter({ authorization, connection, previewMode =
   const commands: CommandItem[] = [
     { action: () => openPanel("pull-requests", "pull-requests"), detail: "View the explicit PR integration state", icon: "pr", label: "Open pull-request status" },
     { action: () => openPanel("grok-review", "grok-review"), detail: "View the explicit Grok review integration state", icon: "review", label: "Open Grok review results" },
+    { action: () => openPanel("swarm", "swarm"), detail: "Launch a dry-run Swarm review through your local IDE", icon: "spark", label: "Open Swarm workflow" },
     { action: () => openPanel("connection", "connection"), detail: "Choose local development or Secure MCP Tunnel", icon: "cloud", label: "Open connection wizard" },
     { action: () => openPanel("repository", "repository"), detail: "Configure repository metadata without a GitHub token", icon: "github", label: "Review repository setup" },
     { action: () => openPanel("review", "review"), detail: "Inspect control-surface privacy and secret boundaries", icon: "review", label: "View control guardrails" },
@@ -287,6 +290,7 @@ export default function ControlCenter({ authorization, connection, previewMode =
     { id: "overview", label: "Overview", icon: "home", panel: null },
     { id: "pull-requests", label: "Pull requests", icon: "pr", panel: "pull-requests" },
     { id: "grok-review", label: "Grok review", icon: "review", panel: "grok-review" },
+    { id: "swarm", label: "Swarm", icon: "spark", panel: "swarm" },
     { id: "connection", label: "Connection", icon: "cloud", panel: "connection" },
     { id: "runtime", label: "Runtime", icon: "activity", panel: "runtime" },
     { id: "deployments", label: "Deployment", icon: "deploy", panel: "deployments" },
@@ -479,6 +483,7 @@ export default function ControlCenter({ authorization, connection, previewMode =
             {panel === "grok-review" && <GrokReviewDetail snapshot={snapshot} />}
             {panel === "review" && <ReviewDetail />}
             {panel === "runtime" && <RuntimeDetail connection={connection} />}
+            {panel === "swarm" && <SwarmDetail copyText={copyText} />}
             {panel === "deployments" && <DeploymentDetail siteProvisioned={siteProvisioned} snapshot={snapshot} />}
             {panel === "settings" && <SettingsDetail authorization={authorization} displayName={user.displayName} previewMode={previewMode} signOutPath={signOutPath} />}
           </aside>
@@ -586,6 +591,27 @@ function RuntimeDetail({ connection }: { connection: PublicConnectionConfig }) {
       <DrawerHeader icon="activity" eyebrow="Runtime boundary" title="Verification is deliberately local" description="The Site reports configuration metadata only. It does not proxy arbitrary URLs or use a visitor-supplied target." />
       <section className="drawer-section data-list"><h3>Configured metadata</h3><div><span>Mode</span><strong>{connection.connectionMode}</strong></div><div><span>Label</span><strong>{connection.endpointLabel}</strong></div><div><span>Health route</span><strong><code>/healthz</code></strong></div><div><span>MCP route</span><strong><code>/mcp</code></strong></div></section>
       <section className="drawer-section steps-list"><h3>Truthful verification</h3><p><span>1</span><span className="step-copy">For local mode, run the health command on the UniGrok machine.</span></p><p><span>2</span><span className="step-copy">For tunnel mode, run tunnel-client doctor beside UniGrok.</span></p><p><span>3</span><span className="step-copy">Treat this Site as configuration guidance until an approved integration is added.</span></p></section>
+    </div>
+  );
+}
+
+function SwarmDetail({ copyText }: { copyText: (value: string, successMessage: string) => Promise<void> }) {
+  return (
+    <div className="drawer-content">
+      <DrawerHeader icon="spark" eyebrow="Contributor workflow" title="Swarm lives behind the Insider Console" description="Use your IDE agent as the operator. The Console supplies a bounded prompt and the local Forge link; it does not become a second agent chat." />
+      <section className="drawer-section steps-list">
+        <h3>Verified optimization loop</h3>
+        <p><span>1</span><span className="step-copy">Copy the dry-run prompt into the IDE that already has this repository open.</span></p>
+        <p><span>2</span><span className="step-copy">Let the IDE agent call UniGrok and the contributor-only Swarm tools with repository context.</span></p>
+        <p><span>3</span><span className="step-copy">Review measured evidence before allowing apply, PR, or landing actions.</span></p>
+      </section>
+      <section className="drawer-section">
+        <h3>Paste into your IDE agent</h3>
+        <pre className="safe-code"><code>{swarmReviewPrompt}</code></pre>
+        <button className="secondary-action drawer-wide-action" onClick={() => copyText(swarmReviewPrompt, "Swarm review prompt copied")}><Icon name="code" size={17} /> Copy Swarm review prompt</button>
+      </section>
+      <div className="runtime-callout warning"><Icon name="shield" size={21} /><p><strong>Local contributor boundary</strong><span>The Forge view is available only on the contributor runtime on this machine. The public project Site does not expose the Swarm playground.</span></p></div>
+      <a className="external-doc-link" href={localForgeSwarm} target="_blank" rel="noreferrer">Open local Forge Swarm <Icon name="external" size={16} /></a>
     </div>
   );
 }

--- a/sites/unigrok-control-center/app/page.tsx
+++ b/sites/unigrok-control-center/app/page.tsx
@@ -14,7 +14,6 @@ export default function Home() {
         <nav aria-label="Public navigation">
           <a href="#how-it-works">How it works</a>
           <a href="#start">Get started</a>
-          <a href="/swarm/">Swarm Playground</a>
           <a href="/docs/okf/index.md">Knowledge</a>
           <a href="/contribute">Contribute</a>
           <a href={PUBLIC_PROJECT.repository.url}>GitHub</a>
@@ -76,7 +75,7 @@ export default function Home() {
           <article><b>01</b><h3>Shared MCP gateway</h3><p>Connect multiple IDE agents to one stable endpoint with per-client attribution and server-held credentials.</p><code>POST /mcp</code></article>
           <article><b>02</b><h3>Two execution planes</h3><p>The xAI API plane and Grok CLI subscription plane have separate catalogs, sessions, costs, and failover rules.</p><code>api ≠ cli</code></article>
           <article><b>03</b><h3>Supervised collaboration</h3><p>Agents and humans can propose changes while deterministic tests and Codex-owned landing keep main coherent.</p><code>review → verify → land</code></article>
-          <article><b>04</b><h3>Swarm code optimization</h3><p>Paste Python for private browser-side analytics, replay a measured run, then move to local Forge for verified evolutionary search.</p><a href="/swarm/"><code>open playground →</code></a></article>
+          <article><b>04</b><h3>IDE-first collaboration</h3><p>Use UniGrok through the coding agent that already understands your project. Contributor-only optimization tools stay behind the authenticated Console.</p><code>IDE → MCP → Grok</code></article>
         </div>
       </section>
 

--- a/sites/unigrok-control-center/scripts/sync-swarm-playground.mjs
+++ b/sites/unigrok-control-center/scripts/sync-swarm-playground.mjs
@@ -1,34 +1,27 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
-const repositoryRoot = resolve(scriptDir, "../../..");
-const sourceDir = resolve(repositoryRoot, "mcp_ui");
 const targetDir = resolve(scriptDir, "../public/swarm");
 
+await rm(targetDir, { recursive: true, force: true });
 await mkdir(targetDir, { recursive: true });
 
-const html = (await readFile(resolve(sourceDir, "swarm.html"), "utf8"))
-  .replace('href="./index.html"', 'href="/"')
-  .replace("Contributor lab · verified optimization", "Public lab · client-side preview");
+const html = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta http-equiv="refresh" content="0; url=/control" />
+    <title>UniGrok Contributor Control</title>
+  </head>
+  <body>
+    <p>Swarm is an Insider Console workflow. <a href="/control">Continue to GitHub-gated contributor control.</a></p>
+  </body>
+</html>
+`;
 
-await Promise.all([
-  writeFile(resolve(targetDir, "index.html"), html),
-  writeFile(
-    resolve(targetDir, "swarm.js"),
-    await readFile(resolve(sourceDir, "swarm.js"), "utf8"),
-  ),
-  writeFile(
-    resolve(targetDir, "swarm-sample.json"),
-    await readFile(resolve(sourceDir, "swarm-sample.json"), "utf8"),
-  ),
-  // Shared design tokens: the page links ./tokens.css so the public copy
-  // renders with the same UniGrok identity as the local surfaces.
-  writeFile(
-    resolve(targetDir, "tokens.css"),
-    await readFile(resolve(sourceDir, "tokens.css"), "utf8"),
-  ),
-]);
+await writeFile(resolve(targetDir, "index.html"), html);
 
-console.log("Synchronized public Swarm Playground assets.");
+console.log("Synchronized the public Swarm gate to Contributor Control.");

--- a/sites/unigrok-control-center/tests/rendered-html.test.mjs
+++ b/sites/unigrok-control-center/tests/rendered-html.test.mjs
@@ -127,8 +127,9 @@ test("renders the public root without authentication or live-status claims", asy
   assert.match(html, /example · local command session/);
   assert.match(html, /Published route contract · not a live runtime probe/);
   assert.match(html, /Private OAuth · API plane only/);
-  assert.match(html, /Swarm Playground/);
-  assert.match(html, /href="\/swarm\/"/);
+  assert.match(html, /IDE-first collaboration/);
+  assert.match(html, /Contributor-only optimization tools stay behind the authenticated Console/);
+  assert.doesNotMatch(html, /href="\/swarm\/"/);
   assert.match(html, /uv run python main\.py init/);
   assert.match(html, /\/docs\/okf\/index\.md/);
   assert.match(html, /status.*healthy/);

--- a/sites/unigrok-control-center/tests/security-contract.test.mjs
+++ b/sites/unigrok-control-center/tests/security-contract.test.mjs
@@ -61,38 +61,30 @@ test("keeps the connection wizard instructional", async () => {
   assert.doesNotMatch(controlCenter, /localStorage|sessionStorage|dangerouslySetInnerHTML/);
 });
 
-test("publishes Swarm as a client-only showcase", async () => {
+test("keeps Swarm behind contributor control instead of a public showcase", async () => {
   const [
     publicPage,
-    swarmHtml,
-    swarmScript,
+    controlCenter,
     publicSwarmHtml,
-    publicSwarmScript,
     syncScript,
-    versionSource,
   ] = await Promise.all([
     readFile(new URL("../app/page.tsx", import.meta.url), "utf8"),
-    readFile(new URL("../../../mcp_ui/swarm.html", import.meta.url), "utf8"),
-    readFile(new URL("../../../mcp_ui/swarm.js", import.meta.url), "utf8"),
+    readFile(new URL("../app/control-center.tsx", import.meta.url), "utf8"),
     readFile(new URL("../public/swarm/index.html", import.meta.url), "utf8"),
-    readFile(new URL("../public/swarm/swarm.js", import.meta.url), "utf8"),
     readFile(new URL("../scripts/sync-swarm-playground.mjs", import.meta.url), "utf8"),
-    readFile(new URL("../../../src/version.py", import.meta.url), "utf8"),
   ]);
-  const uiVersion = /UI_ASSET_VERSION = "([^"]+)"/.exec(versionSource)?.[1];
-  assert.ok(uiVersion);
 
-  assert.match(publicPage, /href="\/swarm\/"/);
-  assert.match(swarmScript, /state\.runtimeMode === "contributor"/);
-  assert.match(swarmScript, /source was not uploaded/);
-  assert.match(swarmScript, /Public showcase — client-side analysis only/);
-  assert.doesNotMatch(swarmScript, /localStorage|sessionStorage/);
-  assert.match(syncScript, /mcp_ui/);
-  assert.ok(swarmHtml.includes(`src="./swarm.js?v=${uiVersion}"`));
-  assert.ok(swarmScript.includes(`const UI_ASSET_VERSION = "${uiVersion}"`));
-  assert.ok(swarmScript.includes("swarm-sample.json?v=${encodeURIComponent(UI_ASSET_VERSION)}"));
-  assert.ok(publicSwarmHtml.includes(`src="./swarm.js?v=${uiVersion}"`));
-  assert.equal(publicSwarmScript, swarmScript);
+  assert.doesNotMatch(publicPage, /href="\/swarm\/"/);
+  assert.match(publicPage, /Contributor-only optimization tools stay behind the authenticated Console/);
+  assert.match(controlCenter, /id: "swarm", label: "Swarm"/);
+  assert.match(controlCenter, /SwarmDetail/);
+  assert.match(controlCenter, /Copy Swarm review prompt/);
+  assert.match(controlCenter, /http:\/\/127\.0\.0\.1:4766\/ui\/swarm\.html/);
+  assert.match(controlCenter, /does not become a second agent chat/);
+  assert.match(publicSwarmHtml, /http-equiv="refresh" content="0; url=\/control"/);
+  assert.match(publicSwarmHtml, /GitHub-gated contributor control/);
+  assert.match(syncScript, /rm\(targetDir, \{ recursive: true, force: true \}\)/);
+  assert.doesNotMatch(syncScript, /mcp_ui|swarm\.js|swarm-sample/);
 });
 
 test("requires adapters to separate PR review state from release impact", async () => {


### PR DESCRIPTION
## Outcome

Moves Swarm into the authenticated Contributor Control surface and removes the public playground entry, matching the approved public-vs-insider boundary. The Console remains an evidence and action surface; the IDE remains the only agent chat path.

## Exact head

`a1fbb940475fc3094b87ae6df04f737376facf05`

## Changed paths

- `sites/unigrok-control-center/app/control-center.tsx`
- `sites/unigrok-control-center/app/page.tsx`
- `sites/unigrok-control-center/scripts/sync-swarm-playground.mjs`
- `sites/unigrok-control-center/tests/rendered-html.test.mjs`
- `sites/unigrok-control-center/tests/security-contract.test.mjs`

## Verification

- Site suite: 59 passed
- Focused repository suite: 40 passed
- ESLint clean
- TypeScript clean
- vinext production build clean
- deployment-safety and public-asset validation clean
- `git diff --check` clean
- visual review completed for public page and Insider Console navigation

## Risks and remaining work

- The local Forge link works only from the contributor Mac running Forge on `127.0.0.1:4766`; the drawer states that boundary explicitly.
- This is one small UI slice. Demoting the current tunnel-first and form-heavy Console flow remains a separate reviewed PR.

Human sponsor: David

Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=implementation