### PR TITLE
feat(ui): one-page Health glass (P2 readiness console)

### DIFF
--- a/mcp_ui/app.js
+++ b/mcp_ui/app.js
@@ -1,9 +1,9 @@
-import { parseMarkdown, sanitizeHref } from "./markdown.js?v=grok-v0.6.0-r7";
+import { parseMarkdown, sanitizeHref } from "./markdown.js?v=grok-v0.6.0-r8";
 
 // Must match the <meta name="unigrok-ui-version"> baked into index.html and
 // src/version.py UI_ASSET_VERSION; a mismatch means the browser paired a
 // cached page with a different script build (the stale-skew failure class).
-const UI_ASSET_VERSION = "grok-v0.6.0-r7";
+const UI_ASSET_VERSION = "grok-v0.6.0-r8";
 
 const LAYOUT_KEY = "unigrok.mcp.console.layout.v2";
 
@@ -28,7 +28,7 @@ const LAYOUT_LIMITS = {
 const defaultLayout = {
   navPresence: "show",
   inspectorPresence: "hide",
-  navWidth: 200,
+  navWidth: 168,
   inspectorWidth: 280,
   density: "auto",
 };
@@ -630,6 +630,7 @@ async function fetchLiveMetrics() {
     }
     state.metricsSnapshot = payload;
     renderMetricsSnapshot();
+    renderSpendGlance(payload);
   } catch (err) {
     setText("rawMetricsReport", `Failed to fetch telemetry report: ${err.message}`);
     setText("metricsStatus", "Metrics unavailable — the MCP status call failed.");
@@ -924,27 +925,155 @@ async function runStartupCheck() {
   return false;
 }
 
+function resolveMcpEndpoint() {
+  // Public product endpoint for pasteable IDE config. Loopback UI always
+  // advertises Core :4765/mcp even when the browser preview is on another port
+  // (e.g. TestClient :8080 or a reverse proxy). Non-loopback keeps the host
+  // that served this page so cloud/deploy previews stay accurate.
+  try {
+    const u = new URL(window.location.href);
+    const host = u.hostname || "localhost";
+    const loopback = host === "localhost" || host === "127.0.0.1";
+    if (loopback) {
+      return `${u.protocol}//${host}:4765/mcp`;
+    }
+    u.pathname = "/mcp";
+    u.search = "";
+    u.hash = "";
+    return u.toString().replace(/\/$/, "");
+  } catch {
+    return "http://localhost:4765/mcp";
+  }
+}
+
+function genericMcpJson(endpoint) {
+  return JSON.stringify({
+    mcpServers: {
+      unigrok: {
+        url: endpoint,
+        headers: { "X-Client-ID": "ide" },
+      },
+    },
+  }, null, 2);
+}
+
+function agentSetupPrompt(endpoint) {
+  return [
+    "Configure UniGrok MCP for this machine:",
+    `- Streamable HTTP URL: ${endpoint}`,
+    "- Send a stable X-Client-ID header for this IDE (e.g. cursor, claude-code, vscode, codex)",
+    "- Never put XAI_API_KEY in IDE MCP settings; credentials stay in UniGrok's server .env",
+    "- After connecting, call tools/list and grok_mcp_discover_self",
+    "- Prefer the UniGrok agent tool when I say @grok or want a second opinion",
+    "- When I ask for a multi-step Implementation Plan, get a UniGrok second opinion",
+    "  (agent mode thinking or reasoning) and improve the plan before showing it —",
+    "  only if I want that habit; do not silently spend metered API credits",
+    "- Do not invent a second MCP port, Forge, or land workflow for ordinary use",
+  ].join("\n");
+}
+
+function renderConnectSnippets() {
+  const endpoint = resolveMcpEndpoint();
+  if ($("mcpEndpointDisplay")) $("mcpEndpointDisplay").textContent = endpoint;
+  if ($("mcpJsonSnippet")) $("mcpJsonSnippet").textContent = genericMcpJson(endpoint);
+  return endpoint;
+}
+
+function renderPlaneCards(contract) {
+  const cli = contract?.cli || {};
+  const api = contract?.api || {};
+  const setChip = (id, available, label) => {
+    const el = $(id);
+    if (!el) return;
+    el.textContent = available ? "ready" : (label || "not ready");
+    el.className = `state-chip ${available ? "ready" : ""}`;
+  };
+  setChip("cliPlaneState", Boolean(cli.available), cli.state || "unavailable");
+  setChip("apiPlaneState", Boolean(api.available), api.state || "unavailable");
+  if ($("cliPlaneDetail")) {
+    $("cliPlaneDetail").textContent = cli.available
+      ? "Subscription plane ready. Local request tracking only — provider quota is not exposed."
+      : (cli.state === "needs_auth" || cli.auth === "needs_auth")
+        ? "CLI OAuth not verified. Use device login on the gateway host, then recheck."
+        : "CLI plane unavailable on this machine.";
+  }
+  if ($("apiPlaneDetail")) {
+    $("apiPlaneDetail").textContent = api.available
+      ? "Metered developer API key present. Exact response cost tracked when the provider returns it."
+      : "No usable XAI_API_KEY in the gateway environment.";
+  }
+}
+
+function renderSpendGlance(payload) {
+  if (!payload?.usage) return;
+  const period = payload.usage.today || payload.usage.lifetime || {};
+  const summary = period.summary || {};
+  const planes = period.planes || {};
+  const api = planes.API || {};
+  const cli = planes.CLI || {};
+  const cliFb = planes["CLI-Fallback"] || {};
+  const cliReqs = Number(cli.requests || 0) + Number(cliFb.requests || 0);
+  if ($("spendApiToday")) {
+    $("spendApiToday").textContent = `$${Number(summary.api_cost_usd || api.api_cost_usd || api.total_cost_usd || 0).toFixed(4)}`;
+  }
+  if ($("spendCliRequests")) $("spendCliRequests").textContent = String(cliReqs);
+  const verified = Number(summary.verified_outcomes || 0);
+  const unverified = Number(summary.unverified_requests || 0);
+  if ($("spendVerifiedSplit")) $("spendVerifiedSplit").textContent = `${verified} / ${unverified}`;
+  if ($("spendHonesty")) {
+    $("spendHonesty").textContent = verified
+      ? `Verified success is of ${verified} receipt-verified outcome${verified === 1 ? "" : "s"} only — not of all requests.`
+      : "No receipt-verified outcomes yet. Most provider stops stay unverified until a receipt.";
+  }
+}
+
 function renderSetupStatus(data, ready = true, detailText = null) {
-  // The quick-start card is the onboarding action for a machine where the
-  // gateway is NOT REACHABLE. A reachable gateway failing a readiness check
-  // (detailText names it) is already installed and running — reinstall
-  // instructions would be the wrong remedy, so the card stays hidden and the
-  // named failing checks plus the credential alert carry the fix.
+  // Offline → show install card. Ready-but-degraded → named checks + credential alert.
   $("quickStartCard")?.classList.toggle("hidden", Boolean(ready) || Boolean(detailText));
   const target = $("setupStatusSummary");
-  if (!target) return;
   const contract = data?.credential_planes || {};
   const effective = contract.effective_plane || "none";
   const runtime = data?.runtime || "unknown";
+  const tools = $("toolCountChip")?.innerText?.replace(/^tools:\s*/i, "") || "…";
   const notices = (contract.notices || []).filter((notice) => notice.prompt_user);
   const attention = notices.map((notice) => notice.message).join(" ");
-  const title = document.createElement("strong");
-  title.textContent = ready ? "Gateway is live." : "Gateway needs attention.";
-  const detail = document.createElement("span");
-  detail.textContent = ready
-    ? `Runtime: ${runtime} · active credential plane: ${effective}.${attention ? ` ${attention}` : ""}`
-    : detailText || "The live readiness check failed. Restart or inspect the runtime before running a task.";
-  target.replaceChildren(title, document.createElement("br"), detail);
+
+  const hero = $("readinessHero");
+  const title = $("readinessTitle");
+  const detail = $("readinessDetail");
+  if (hero && title && detail) {
+    hero.classList.remove("state-checking", "state-ready", "state-attention", "state-offline");
+    if (ready) {
+      hero.classList.add("state-ready");
+      title.textContent = "Gateway is live";
+      detail.textContent = `Runtime ${runtime} · effective plane ${effective} · ${tools}.${attention ? ` ${attention}` : ""}`;
+    } else if (detailText) {
+      hero.classList.add("state-attention");
+      title.textContent = "Gateway needs attention";
+      detail.textContent = detailText;
+    } else {
+      hero.classList.add("state-offline");
+      title.textContent = "Gateway offline";
+      detail.textContent = "Cannot reach /readyz. Start the service, then recheck.";
+    }
+  }
+
+  if ($("probeAge")) {
+    $("probeAge").textContent = `probed ${new Date().toLocaleTimeString()}`;
+  }
+
+  renderPlaneCards(contract);
+  renderConnectSnippets();
+
+  if (target) {
+    const t = document.createElement("strong");
+    t.textContent = ready ? "Gateway is live." : "Gateway needs attention.";
+    const d = document.createElement("span");
+    d.textContent = ready
+      ? ` Runtime: ${runtime} · active credential plane: ${effective}.${attention ? ` ${attention}` : ""}`
+      : ` ${detailText || "The live readiness check failed. Restart or inspect the runtime before running a task."}`;
+    target.replaceChildren(t, d);
+  }
 }
 
 function renderSurfaceModeBadge(data) {
@@ -2214,6 +2343,25 @@ function init() {
   $("copyQuickStartBtn")?.addEventListener("click", function () {
     copyTextToClipboard($("quickStartCommands")?.innerText || "", this);
   });
+  $("copyEndpointBtn")?.addEventListener("click", function () {
+    copyTextToClipboard(resolveMcpEndpoint(), this);
+  });
+  $("copyMcpJsonBtn")?.addEventListener("click", function () {
+    copyTextToClipboard(genericMcpJson(resolveMcpEndpoint()), this);
+  });
+  $("copyAgentPromptBtn")?.addEventListener("click", function () {
+    copyTextToClipboard(agentSetupPrompt(resolveMcpEndpoint()), this);
+  });
+  $("copyPrimaryActionBtn")?.addEventListener("click", function () {
+    // Ready → IDE config; offline → install commands when visible
+    if (!$("quickStartCard")?.classList.contains("hidden")) {
+      copyTextToClipboard($("quickStartCommands")?.innerText || "", this);
+      return;
+    }
+    copyTextToClipboard(genericMcpJson(resolveMcpEndpoint()), this);
+  });
+  $("refreshSpendBtn")?.addEventListener("click", fetchLiveMetrics);
+  renderConnectSnippets();
   $("setupRecheckBtn")?.addEventListener("click", async () => {
     const ready = await runStartupCheck();
     const runtime = await fetchRuntimeStatus();
@@ -2247,6 +2395,7 @@ function init() {
     await loadModelsList();
     await loadPlaneModelCatalog();
     await fetchMcpListTools();
+    await fetchLiveMetrics();
     // WebMCP browser registration is optional/experimental; skip on Core glass.
   }, 100);
 }

--- a/mcp_ui/index.html
+++ b/mcp_ui/index.html
@@ -7,9 +7,9 @@
     <meta name="unigrok-ui-regions" content="navigation,workbench,rpc-inspector,rpc-logs,result-facts" />
     <!-- Version handshake: app.js compares this against its own build constant
          and self-heals a stale-cached page with one revalidating reload. -->
-    <meta name="unigrok-ui-version" content="grok-v0.6.0-r7" />
-  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r7" />
-  <link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r7" />
+    <meta name="unigrok-ui-version" content="grok-v0.6.0-r8" />
+  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r8" />
+  <link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r8" />
   </head>
   <body>
     <main class="app-shell">
@@ -43,8 +43,8 @@
           <p class="product-law">Chat lives in your IDE. This page is health, credentials, and connect snippets.</p>
         </div>
         <div class="layout-actions" aria-label="Workspace layout controls">
-          <button id="toggleNavBtn" type="button" class="chrome-btn" aria-controls="sidebarNav" aria-expanded="true" aria-pressed="true" title="Show or hide sections (⌘/Ctrl+B)"><span aria-hidden="true">◧</span><span class="chrome-label">Sections</span></button>
-          <button id="toggleInspectorBtn" type="button" class="chrome-btn" aria-controls="inspector" aria-expanded="false" aria-pressed="false" title="Show or hide inspector (⌘/Ctrl+Shift+I)"><span aria-hidden="true">◨</span><span class="chrome-label">Inspector</span></button>
+          <button id="toggleNavBtn" type="button" class="chrome-btn" aria-controls="sidebarNav" aria-expanded="true" aria-pressed="true" title="Show or hide nav (⌘/Ctrl+B)"><span aria-hidden="true">◧</span><span class="chrome-label">Nav</span></button>
+          <button id="toggleInspectorBtn" type="button" class="chrome-btn" aria-controls="inspector" aria-expanded="false" aria-pressed="false" title="Debug RPC inspector (optional)"><span aria-hidden="true">◨</span><span class="chrome-label">Debug</span></button>
           <button id="densityBtn" type="button" class="chrome-btn" aria-pressed="false" title="Toggle compact density"><span aria-hidden="true">↕</span><span class="chrome-label">Density</span></button>
         </div>
         <div class="signal-strip" aria-live="polite" aria-label="Gateway status">
@@ -505,17 +505,34 @@
           </div>
 
           <!-- TAB 8: Onboarding (Self) -->
-          <div id="tab-onboarding" class="tab-panel active">
-            <div class="panel-header">
-              <h2>Health &amp; connect</h2>
-              <button id="setupRecheckBtn" type="button" class="primary-btn-glow">Recheck</button>
+          <div id="tab-onboarding" class="tab-panel active" data-region="tab-onboarding">
+            <div class="panel-header health-glass-header">
+              <div>
+                <h2>Health</h2>
+                <p class="panel-desc health-lead">Machine truth for this gateway. Daily chat stays in your IDE.</p>
+              </div>
+              <div class="health-header-actions">
+                <span id="probeAge" class="probe-age">probe: …</span>
+                <button id="setupRecheckBtn" type="button" class="primary-btn-glow">Recheck</button>
+              </div>
             </div>
-            <p class="panel-desc">Is UniGrok up, which planes are ready, and what to paste into your IDE. Chat stays in the IDE.</p>
 
-            <div id="setupStatusSummary" class="setup-status-summary" aria-live="polite">Checking the live gateway…</div>
+            <section id="readinessHero" class="readiness-hero state-checking" aria-live="polite">
+              <div class="readiness-hero-main">
+                <span id="readinessDot" class="readiness-dot" aria-hidden="true"></span>
+                <div>
+                  <h3 id="readinessTitle" class="readiness-title">Checking gateway…</h3>
+                  <p id="readinessDetail" class="readiness-detail">Probing /readyz and /runtimez.</p>
+                </div>
+              </div>
+              <div class="readiness-hero-cta">
+                <button id="copyPrimaryActionBtn" type="button" class="primary-btn-glow">Copy IDE MCP config</button>
+                <button id="copyEndpointBtn" type="button" class="secondary-btn">Copy endpoint</button>
+              </div>
+            </section>
 
-            <!-- One plain-language onboarding action, shown only when the
-                 gateway is not ready. No environment variables required. -->
+            <div id="setupStatusSummary" class="setup-status-summary sr-only" aria-live="polite">Checking the live gateway…</div>
+
             <div id="quickStartCard" class="setup-quickstart hidden">
               <strong>Get the gateway running</strong>
               <p>Copy and run this in a terminal. You need Git, Docker Desktop, and uv — nothing else.</p>
@@ -525,15 +542,49 @@ uv run python main.py init
 docker compose up --build -d</code></pre>
               <div class="quickstart-actions">
                 <button id="copyQuickStartBtn" type="button" class="small-btn-glow">Copy commands</button>
-                <span class="quickstart-note">Already installed? Run <code>docker compose up --build -d</code> in the project folder, then Recheck setup.</span>
+                <span class="quickstart-note">Already installed? Run <code>docker compose up --build -d</code> in the project folder, then Recheck.</span>
               </div>
             </div>
 
-            <details class="raw-telemetry-disclosure onboarding-box">
-              <summary><span>Agent-readable setup metadata</span><small>discover_self manifest and OKF paths</small></summary>
-              <button id="copyDiscoverBtn" type="button" class="small-btn-glow">Run discover_self</button>
-              <pre><code id="discoverSelfCode" class="json-code">Run discover_self to inspect the machine-readable contract.</code></pre>
-            </details>
+            <section class="glass-grid" aria-label="Planes and spend">
+              <article class="plane-card" id="cliPlaneCard">
+                <header><span class="section-kicker">CLI subscription</span><span id="cliPlaneState" class="state-chip">…</span></header>
+                <strong id="cliPlaneHeadline">SuperGrok CLI</strong>
+                <p id="cliPlaneDetail">Checking OAuth plane…</p>
+              </article>
+              <article class="plane-card" id="apiPlaneCard">
+                <header><span class="section-kicker">Developer API</span><span id="apiPlaneState" class="state-chip">…</span></header>
+                <strong id="apiPlaneHeadline">xAI API</strong>
+                <p id="apiPlaneDetail">Checking API key plane…</p>
+              </article>
+              <article class="spend-card" id="spendGlanceCard">
+                <header><span class="section-kicker">Spend glance</span><button id="refreshSpendBtn" type="button" class="small-btn">Refresh</button></header>
+                <div class="spend-metrics">
+                  <div><span>API today</span><strong id="spendApiToday">—</strong></div>
+                  <div><span>CLI requests</span><strong id="spendCliRequests">—</strong></div>
+                  <div><span>Verified / unverified</span><strong id="spendVerifiedSplit">—</strong></div>
+                </div>
+                <p id="spendHonesty" class="spend-honesty">Success rates are of receipt-verified outcomes only.</p>
+              </article>
+            </section>
+
+            <section class="connect-panel" aria-label="IDE connect snippets">
+              <div class="panel-header compact">
+                <h3>Connect your IDE</h3>
+                <span class="panel-header-hint">Never put XAI_API_KEY in IDE MCP settings</span>
+              </div>
+              <p class="connect-endpoint">Endpoint <code id="mcpEndpointDisplay">http://localhost:4765/mcp</code></p>
+              <div class="connect-actions">
+                <button id="copyMcpJsonBtn" type="button" class="small-btn-glow">Copy generic MCP JSON</button>
+                <button id="copyAgentPromptBtn" type="button" class="small-btn-glow">Copy agent setup prompt</button>
+                <button id="copyDiscoverBtn" type="button" class="small-btn">Run discover_self</button>
+              </div>
+              <pre class="connect-snippet"><code id="mcpJsonSnippet">{ }</code></pre>
+              <details class="raw-telemetry-disclosure onboarding-box">
+                <summary><span>Agent-readable setup metadata</span><small>discover_self contract</small></summary>
+                <pre><code id="discoverSelfCode" class="json-code">Run discover_self to inspect the machine-readable contract.</code></pre>
+              </details>
+            </section>
           </div>
 
         </section>
@@ -580,6 +631,6 @@ docker compose up --build -d</code></pre>
 
       </section>
     </main>
-  <script type="module" src="./app.js?v=grok-v0.6.0-r7"></script>
+  <script type="module" src="./app.js?v=grok-v0.6.0-r8"></script>
   </body>
 </html>

--- a/mcp_ui/styles.css
+++ b/mcp_ui/styles.css
@@ -1554,13 +1554,321 @@ pre {
 .console-grid[data-resizing="true"] .sidebar-nav,
 .console-grid[data-resizing="true"] .inspector { transition: none !important; }
 
+/* Visually hidden but available to assistive tech / aria-live. */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.hidden {
+  display: none !important;
+}
+
 .setup-status-summary {
   padding: 16px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  background: rgba(255,255,255,.02);
+  background: rgba(255, 255, 255, 0.02);
   color: var(--ink-soft);
   line-height: 1.55;
+}
+
+/* —— Health glass (P2 one-page readiness) —— */
+.health-glass-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.health-lead {
+  margin-top: 4px;
+  max-width: 36rem;
+}
+
+.health-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.probe-age {
+  font-size: 11px;
+  color: var(--ink-faint);
+  font-variant-numeric: tabular-nums;
+}
+
+.panel-header.compact {
+  padding-bottom: 8px;
+  margin-bottom: 4px;
+}
+
+.panel-header.compact h3 {
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.panel-header-hint {
+  font-size: 11px;
+  color: var(--ink-faint);
+}
+
+.readiness-hero {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-top: 12px;
+  padding: 18px 20px;
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) + 2px);
+  background:
+    linear-gradient(135deg, rgba(79, 231, 255, 0.06), transparent 55%),
+    var(--surface);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(14px);
+  -webkit-backdrop-filter: blur(14px);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.readiness-hero-main {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  min-width: 0;
+  flex: 1 1 240px;
+}
+
+.readiness-dot {
+  flex: 0 0 auto;
+  width: 12px;
+  height: 12px;
+  margin-top: 5px;
+  border-radius: 50%;
+  background: var(--ink-faint);
+  box-shadow: 0 0 0 4px rgba(125, 147, 166, 0.12);
+}
+
+.readiness-hero.state-checking .readiness-dot {
+  background: var(--cyan);
+  box-shadow: 0 0 0 4px rgba(79, 231, 255, 0.15);
+  animation: readiness-pulse 1.4s ease-in-out infinite;
+}
+
+.readiness-hero.state-ready {
+  border-color: rgba(22, 240, 174, 0.35);
+  box-shadow: var(--glow-teal), var(--shadow);
+}
+
+.readiness-hero.state-ready .readiness-dot {
+  background: var(--teal);
+  box-shadow: 0 0 0 4px rgba(22, 240, 174, 0.18);
+}
+
+.readiness-hero.state-attention {
+  border-color: rgba(255, 140, 58, 0.4);
+  box-shadow: var(--glow-orange), var(--shadow);
+}
+
+.readiness-hero.state-attention .readiness-dot {
+  background: var(--orange);
+  box-shadow: 0 0 0 4px rgba(255, 140, 58, 0.18);
+}
+
+.readiness-hero.state-offline {
+  border-color: rgba(255, 95, 120, 0.4);
+}
+
+.readiness-hero.state-offline .readiness-dot {
+  background: var(--red);
+  box-shadow: 0 0 0 4px rgba(255, 95, 120, 0.16);
+}
+
+.readiness-title {
+  font-size: clamp(1.05rem, 1.6vw, 1.25rem);
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: var(--ink);
+}
+
+.readiness-detail {
+  margin-top: 4px;
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--ink-soft);
+  max-width: 42rem;
+}
+
+.readiness-hero-cta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+@keyframes readiness-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.55; transform: scale(0.92); }
+}
+
+.glass-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.plane-card,
+.spend-card {
+  min-width: 0;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.plane-card header,
+.spend-card header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.section-kicker {
+  color: var(--ink-faint);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.plane-card strong,
+.spend-card strong {
+  font-size: 15px;
+  font-weight: 650;
+  color: var(--ink);
+}
+
+.plane-card p,
+.spend-honesty {
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--ink-soft);
+}
+
+.spend-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+}
+
+.spend-metrics div {
+  min-width: 0;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: rgba(3, 6, 9, 0.28);
+}
+
+.spend-metrics span {
+  display: block;
+  font-size: 10px;
+  color: var(--ink-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.spend-metrics strong {
+  display: block;
+  margin-top: 4px;
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 13px;
+  overflow-wrap: anywhere;
+}
+
+.connect-panel {
+  margin-top: 14px;
+  padding: 16px 18px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background:
+    linear-gradient(180deg, rgba(79, 231, 255, 0.04), transparent 40%),
+    var(--surface-soft);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.connect-endpoint {
+  font-size: 13px;
+  color: var(--ink-soft);
+}
+
+.connect-endpoint code {
+  color: var(--cyan);
+  font-family: ui-monospace, "JetBrains Mono", monospace;
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.connect-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.connect-snippet {
+  margin: 0;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: rgba(3, 6, 9, 0.55);
+  overflow-x: auto;
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--ink-soft);
+}
+
+@container workbench (max-width: 980px) {
+  .glass-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+  .spend-card {
+    grid-column: 1 / -1;
+  }
+}
+
+@container workbench (max-width: 620px) {
+  .glass-grid {
+    grid-template-columns: 1fr;
+  }
+  .spend-card {
+    grid-column: auto;
+  }
+  .spend-metrics {
+    grid-template-columns: 1fr;
+  }
+  .readiness-hero {
+    padding: 14px;
+  }
 }
 
 /* One-action onboarding card, shown only while the gateway is not ready. */

--- a/mcp_ui/swarm.html
+++ b/mcp_ui/swarm.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>UniGrok Swarm Optimizer — Pareto Playground</title>
-  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r7" />
+  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r8" />
   <style>
     /* Page vocabulary aliases onto the shared UniGrok tokens (tokens.css) so
        the Swarm Optimizer and the Control Center read as one product. */
@@ -270,6 +270,6 @@
     hidden. "Verified" means: the task's own <code>test_target</code> passed.
   </div>
 
-  <script src="./swarm.js?v=grok-v0.6.0-r7"></script>
+  <script src="./swarm.js?v=grok-v0.6.0-r8"></script>
 </body>
 </html>

--- a/mcp_ui/swarm.js
+++ b/mcp_ui/swarm.js
@@ -10,7 +10,7 @@
 // Must match src/version.py UI_ASSET_VERSION and the query token on the
 // swarm.js reference in swarm.html. The sample uses the same token so a
 // revalidated page cannot pair new logic with a heuristically cached payload.
-const UI_ASSET_VERSION = "grok-v0.6.0-r7";
+const UI_ASSET_VERSION = "grok-v0.6.0-r8";
 
 const $ = (id) => document.getElementById(id);
 const SVG_NS = "http://www.w3.org/2000/svg";

--- a/src/version.py
+++ b/src/version.py
@@ -7,4 +7,4 @@ __version__ = "0.6.0"
 # runtime handshake in app.js).
 # Bump the -rN suffix whenever any /ui asset changes; a pytest asserts every
 # copy of this string agrees so HTML and JS can never skew apart silently.
-UI_ASSET_VERSION = "grok-v0.6.0-r7"
+UI_ASSET_VERSION = "grok-v0.6.0-r8"

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -47,9 +47,9 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert index.status_code == 200
     assert "<title>UniGrok Gateway Console v0.6.0</title>" in index.text
     assert '<span class="version-badge">v0.6.0</span>' in index.text
-    assert 'script type="module" src="./app.js?v=grok-v0.6.0-r7"' in index.text
-    assert '<link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r7" />' in index.text
-    assert '<link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r7" />' in index.text
+    assert 'script type="module" src="./app.js?v=grok-v0.6.0-r8"' in index.text
+    assert '<link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r8" />' in index.text
+    assert '<link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r8" />' in index.text
     assert "Console" in index.text
     assert 'id="surfaceModeBadge"' in index.text
     assert 'id="tab-btn-schemas"' not in index.text
@@ -84,6 +84,23 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert "authoritative: false" in script.text
     assert "Live MCP tools/list schemas are authoritative" in script.text
     assert "Health" in index.text
+    assert 'id="readinessHero"' in index.text
+    assert 'id="cliPlaneCard"' in index.text
+    assert 'id="apiPlaneCard"' in index.text
+    assert 'id="spendGlanceCard"' in index.text
+    assert 'id="mcpEndpointDisplay"' in index.text
+    assert 'id="copyMcpJsonBtn"' in index.text
+    assert 'id="copyAgentPromptBtn"' in index.text
+    assert 'id="copyPrimaryActionBtn"' in index.text
+    assert "resolveMcpEndpoint" in script.text
+    assert "renderPlaneCards" in script.text
+    assert "renderSpendGlance" in script.text
+    assert "genericMcpJson" in script.text
+    assert "agentSetupPrompt" in script.text
+    assert ".readiness-hero" in styles.text
+    assert ".glass-grid" in styles.text
+    assert ".plane-card" in styles.text
+    assert ".connect-panel" in styles.text
     assert "startup ingestion is not automatic" in index.text
     assert "before hitting the API" not in script.text
     assert "safely route this call" not in script.text
@@ -402,7 +419,7 @@ def test_mcp_ui_markdown_renderer_is_shared_and_escape_first():
     assert "\\u000E-\\u001F" in renderer.text
     # app.js imports the shared renderer at the current cache-bust version and
     # no longer defines its own.
-    assert 'from "./markdown.js?v=grok-v0.6.0-r7"' in script.text
+    assert 'from "./markdown.js?v=grok-v0.6.0-r8"' in script.text
     assert "import { parseMarkdown" in script.text
     assert "function parseMarkdown" not in script.text
     assert "renderMarkdownInto" in script.text


### PR DESCRIPTION
## Summary
- Rewrite Core Console **Health** as a one-page glass: readiness hero, CLI/API plane cards, spend glance, and IDE connect paste snippets.
- Daily chat stays in IDE MCP; this page is machine truth + pasteables only.
- UI assets bumped to `grok-v0.6.0-r8`; `test_mcp_ui` pins the new contracts.

## Changed paths
- `mcp_ui/index.html`, `mcp_ui/app.js`, `mcp_ui/styles.css`
- `mcp_ui/swarm.html`, `mcp_ui/swarm.js` (asset version only)
- `src/version.py`
- `tests/test_mcp_ui.py`

## Tests
```bash
uv run pytest tests/test_mcp_ui.py tests/test_release_hygiene.py -q
# 39 passed
```

## Risks
- Low: console UI only; no plane routing or credential changes.
- Glass CSS uses container queries already established for workbench reflow.

## Human sponsor
djtelicloud (standing Console redesign approval: go on P2)

## Provenance
- Commit: `b80c88cfb70861ea0c2617300d28d84627e95888`
- Agent-Assisted-By: xAI Grok | model=grok-4.5 | model-source=provider-session | surface=Grok Build | role=implementation

## Landing
Codex/project-admin: review exact head `b80c88c`, then `./scripts/land` from a `codex/*` integration branch.