### PR TITLE
feat(ui): Health P3 pasteables polish and spend honesty

### DIFF
--- a/mcp_ui/app.js
+++ b/mcp_ui/app.js
@@ -1,9 +1,9 @@
-import { parseMarkdown, sanitizeHref } from "./markdown.js?v=grok-v0.6.0-r8";
+import { parseMarkdown, sanitizeHref } from "./markdown.js?v=grok-v0.6.0-r9";
 
 // Must match the <meta name="unigrok-ui-version"> baked into index.html and
 // src/version.py UI_ASSET_VERSION; a mismatch means the browser paired a
 // cached page with a different script build (the stale-skew failure class).
-const UI_ASSET_VERSION = "grok-v0.6.0-r8";
+const UI_ASSET_VERSION = "grok-v0.6.0-r9";
 
 const LAYOUT_KEY = "unigrok.mcp.console.layout.v2";
 
@@ -870,13 +870,16 @@ function setupMetricsControls() {
 
 // --- Discover Self Onboarding ---
 async function runDiscoverSelfOnboarding() {
-  $("discoverSelfCode").innerText = "Calling discover_self...";
+  const code = $("discoverSelfCode");
+  const details = code?.closest("details");
+  if (details) details.open = true;
+  if (code) code.textContent = "Calling discover_self...";
   try {
     const res = await fetchMcpCall("grok_mcp_discover_self", {});
     const payload = extractToolPayload(res);
-    $("discoverSelfCode").innerText = JSON.stringify(payload, null, 2);
+    if (code) code.textContent = JSON.stringify(payload, null, 2);
   } catch (err) {
-    $("discoverSelfCode").innerText = `Error: ${err.message}`;
+    if (code) code.textContent = `Error: ${err.message}`;
   }
 }
 
@@ -976,7 +979,25 @@ function renderConnectSnippets() {
   const endpoint = resolveMcpEndpoint();
   if ($("mcpEndpointDisplay")) $("mcpEndpointDisplay").textContent = endpoint;
   if ($("mcpJsonSnippet")) $("mcpJsonSnippet").textContent = genericMcpJson(endpoint);
+  if ($("agentPromptSnippet")) $("agentPromptSnippet").textContent = agentSetupPrompt(endpoint);
   return endpoint;
+}
+
+/** Keep the hero primary CTA label aligned with readiness state. */
+function syncPrimaryCta(ready, detailText = null) {
+  const btn = $("copyPrimaryActionBtn");
+  if (!btn) return;
+  const offline = !ready && !detailText;
+  if (offline) {
+    btn.textContent = "Copy install commands";
+    btn.dataset.cta = "install";
+  } else if (!ready && detailText) {
+    btn.textContent = "Copy IDE MCP config";
+    btn.dataset.cta = "mcp";
+  } else {
+    btn.textContent = "Copy IDE MCP config";
+    btn.dataset.cta = "mcp";
+  }
 }
 
 function renderPlaneCards(contract) {
@@ -1006,19 +1027,21 @@ function renderPlaneCards(contract) {
 
 function renderSpendGlance(payload) {
   if (!payload?.usage) return;
-  const period = payload.usage.today || payload.usage.lifetime || {};
-  const summary = period.summary || {};
-  const planes = period.planes || {};
-  const api = planes.API || {};
-  const cli = planes.CLI || {};
-  const cliFb = planes["CLI-Fallback"] || {};
-  const cliReqs = Number(cli.requests || 0) + Number(cliFb.requests || 0);
+  const period = payload.usage.today ?? payload.usage.lifetime ?? {};
+  const summary = period.summary ?? {};
+  const planes = period.planes ?? {};
+  const api = planes.API ?? {};
+  const cli = planes.CLI ?? {};
+  const cliFb = planes["CLI-Fallback"] ?? {};
+  const cliReqs = Number(cli.requests ?? 0) + Number(cliFb.requests ?? 0);
   if ($("spendApiToday")) {
-    $("spendApiToday").textContent = `$${Number(summary.api_cost_usd || api.api_cost_usd || api.total_cost_usd || 0).toFixed(4)}`;
+    // Prefer nullish coalescing so a legitimate $0 cost is not skipped for a non-zero fallback.
+    const usd = summary.api_cost_usd ?? api.api_cost_usd ?? api.total_cost_usd ?? 0;
+    $("spendApiToday").textContent = `$${Number(usd).toFixed(4)}`;
   }
   if ($("spendCliRequests")) $("spendCliRequests").textContent = String(cliReqs);
-  const verified = Number(summary.verified_outcomes || 0);
-  const unverified = Number(summary.unverified_requests || 0);
+  const verified = Number(summary.verified_outcomes ?? 0);
+  const unverified = Number(summary.unverified_requests ?? 0);
   if ($("spendVerifiedSplit")) $("spendVerifiedSplit").textContent = `${verified} / ${unverified}`;
   if ($("spendHonesty")) {
     $("spendHonesty").textContent = verified
@@ -1034,7 +1057,7 @@ function renderSetupStatus(data, ready = true, detailText = null) {
   const contract = data?.credential_planes || {};
   const effective = contract.effective_plane || "none";
   const runtime = data?.runtime || "unknown";
-  const tools = $("toolCountChip")?.innerText?.replace(/^tools:\s*/i, "") || "…";
+  const tools = $("toolCountChip")?.textContent?.replace(/^tools:\s*/i, "") || "…";
   const notices = (contract.notices || []).filter((notice) => notice.prompt_user);
   const attention = notices.map((notice) => notice.message).join(" ");
 
@@ -1062,6 +1085,7 @@ function renderSetupStatus(data, ready = true, detailText = null) {
     $("probeAge").textContent = `probed ${new Date().toLocaleTimeString()}`;
   }
 
+  syncPrimaryCta(ready, detailText);
   renderPlaneCards(contract);
   renderConnectSnippets();
 
@@ -2341,7 +2365,7 @@ function init() {
   // Onboarding actions
   $("copyDiscoverBtn").addEventListener("click", runDiscoverSelfOnboarding);
   $("copyQuickStartBtn")?.addEventListener("click", function () {
-    copyTextToClipboard($("quickStartCommands")?.innerText || "", this);
+    copyTextToClipboard($("quickStartCommands")?.textContent || "", this);
   });
   $("copyEndpointBtn")?.addEventListener("click", function () {
     copyTextToClipboard(resolveMcpEndpoint(), this);
@@ -2353,9 +2377,9 @@ function init() {
     copyTextToClipboard(agentSetupPrompt(resolveMcpEndpoint()), this);
   });
   $("copyPrimaryActionBtn")?.addEventListener("click", function () {
-    // Ready → IDE config; offline → install commands when visible
-    if (!$("quickStartCard")?.classList.contains("hidden")) {
-      copyTextToClipboard($("quickStartCommands")?.innerText || "", this);
+    // Label and action stay aligned via syncPrimaryCta: install only when offline.
+    if (this.dataset.cta === "install" || !$("quickStartCard")?.classList.contains("hidden")) {
+      copyTextToClipboard($("quickStartCommands")?.textContent || "", this);
       return;
     }
     copyTextToClipboard(genericMcpJson(resolveMcpEndpoint()), this);

--- a/mcp_ui/index.html
+++ b/mcp_ui/index.html
@@ -7,9 +7,9 @@
     <meta name="unigrok-ui-regions" content="navigation,workbench,rpc-inspector,rpc-logs,result-facts" />
     <!-- Version handshake: app.js compares this against its own build constant
          and self-heals a stale-cached page with one revalidating reload. -->
-    <meta name="unigrok-ui-version" content="grok-v0.6.0-r8" />
-  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r8" />
-  <link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r8" />
+    <meta name="unigrok-ui-version" content="grok-v0.6.0-r9" />
+  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r9" />
+  <link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r9" />
   </head>
   <body>
     <main class="app-shell">
@@ -574,13 +574,24 @@ docker compose up --build -d</code></pre>
                 <span class="panel-header-hint">Never put XAI_API_KEY in IDE MCP settings</span>
               </div>
               <p class="connect-endpoint">Endpoint <code id="mcpEndpointDisplay">http://localhost:4765/mcp</code></p>
+              <div class="connect-snippet-block">
+                <div class="connect-snippet-header">
+                  <span class="section-kicker">Generic MCP JSON</span>
+                  <button id="copyMcpJsonBtn" type="button" class="small-btn-glow">Copy</button>
+                </div>
+                <pre class="connect-snippet" tabindex="0"><code id="mcpJsonSnippet">{ }</code></pre>
+              </div>
+              <div class="connect-snippet-block">
+                <div class="connect-snippet-header">
+                  <span class="section-kicker">Agent setup prompt</span>
+                  <button id="copyAgentPromptBtn" type="button" class="small-btn-glow">Copy</button>
+                </div>
+                <pre class="connect-snippet connect-snippet-prompt" tabindex="0"><code id="agentPromptSnippet">…</code></pre>
+              </div>
               <div class="connect-actions">
-                <button id="copyMcpJsonBtn" type="button" class="small-btn-glow">Copy generic MCP JSON</button>
-                <button id="copyAgentPromptBtn" type="button" class="small-btn-glow">Copy agent setup prompt</button>
                 <button id="copyDiscoverBtn" type="button" class="small-btn">Run discover_self</button>
               </div>
-              <pre class="connect-snippet"><code id="mcpJsonSnippet">{ }</code></pre>
-              <details class="raw-telemetry-disclosure onboarding-box">
+              <details id="discoverSelfDetails" class="raw-telemetry-disclosure onboarding-box">
                 <summary><span>Agent-readable setup metadata</span><small>discover_self contract</small></summary>
                 <pre><code id="discoverSelfCode" class="json-code">Run discover_self to inspect the machine-readable contract.</code></pre>
               </details>
@@ -631,6 +642,6 @@ docker compose up --build -d</code></pre>
 
       </section>
     </main>
-  <script type="module" src="./app.js?v=grok-v0.6.0-r8"></script>
+  <script type="module" src="./app.js?v=grok-v0.6.0-r9"></script>
   </body>
 </html>

--- a/mcp_ui/styles.css
+++ b/mcp_ui/styles.css
@@ -1835,6 +1835,19 @@ pre {
   gap: 8px;
 }
 
+.connect-snippet-block {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.connect-snippet-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .connect-snippet {
   margin: 0;
   padding: 12px 14px;
@@ -1845,6 +1858,17 @@ pre {
   font-size: 12px;
   line-height: 1.55;
   color: var(--ink-soft);
+  max-height: 12rem;
+}
+
+.connect-snippet-prompt {
+  max-height: 10rem;
+  white-space: pre-wrap;
+}
+
+.connect-snippet:focus-visible {
+  outline: 2px solid var(--cyan);
+  outline-offset: 2px;
 }
 
 @container workbench (max-width: 980px) {

--- a/mcp_ui/swarm.html
+++ b/mcp_ui/swarm.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>UniGrok Swarm Optimizer — Pareto Playground</title>
-  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r8" />
+  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r9" />
   <style>
     /* Page vocabulary aliases onto the shared UniGrok tokens (tokens.css) so
        the Swarm Optimizer and the Control Center read as one product. */
@@ -270,6 +270,6 @@
     hidden. "Verified" means: the task's own <code>test_target</code> passed.
   </div>
 
-  <script src="./swarm.js?v=grok-v0.6.0-r8"></script>
+  <script src="./swarm.js?v=grok-v0.6.0-r9"></script>
 </body>
 </html>

--- a/mcp_ui/swarm.js
+++ b/mcp_ui/swarm.js
@@ -10,7 +10,7 @@
 // Must match src/version.py UI_ASSET_VERSION and the query token on the
 // swarm.js reference in swarm.html. The sample uses the same token so a
 // revalidated page cannot pair new logic with a heuristically cached payload.
-const UI_ASSET_VERSION = "grok-v0.6.0-r8";
+const UI_ASSET_VERSION = "grok-v0.6.0-r9";
 
 const $ = (id) => document.getElementById(id);
 const SVG_NS = "http://www.w3.org/2000/svg";

--- a/src/version.py
+++ b/src/version.py
@@ -7,4 +7,4 @@ __version__ = "0.6.0"
 # runtime handshake in app.js).
 # Bump the -rN suffix whenever any /ui asset changes; a pytest asserts every
 # copy of this string agrees so HTML and JS can never skew apart silently.
-UI_ASSET_VERSION = "grok-v0.6.0-r8"
+UI_ASSET_VERSION = "grok-v0.6.0-r9"

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -47,9 +47,9 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert index.status_code == 200
     assert "<title>UniGrok Gateway Console v0.6.0</title>" in index.text
     assert '<span class="version-badge">v0.6.0</span>' in index.text
-    assert 'script type="module" src="./app.js?v=grok-v0.6.0-r8"' in index.text
-    assert '<link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r8" />' in index.text
-    assert '<link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r8" />' in index.text
+    assert 'script type="module" src="./app.js?v=grok-v0.6.0-r9"' in index.text
+    assert '<link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r9" />' in index.text
+    assert '<link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r9" />' in index.text
     assert "Console" in index.text
     assert 'id="surfaceModeBadge"' in index.text
     assert 'id="tab-btn-schemas"' not in index.text
@@ -92,15 +92,22 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert 'id="copyMcpJsonBtn"' in index.text
     assert 'id="copyAgentPromptBtn"' in index.text
     assert 'id="copyPrimaryActionBtn"' in index.text
+    assert 'id="agentPromptSnippet"' in index.text
+    assert 'id="discoverSelfDetails"' in index.text
     assert "resolveMcpEndpoint" in script.text
     assert "renderPlaneCards" in script.text
     assert "renderSpendGlance" in script.text
     assert "genericMcpJson" in script.text
     assert "agentSetupPrompt" in script.text
+    assert "syncPrimaryCta" in script.text
+    assert "api_cost_usd ??" in script.text
+    assert "details.open = true" in script.text
+    assert 'textContent?.replace(/^tools:' in script.text or "textContent?.replace(/^tools:" in script.text
     assert ".readiness-hero" in styles.text
     assert ".glass-grid" in styles.text
     assert ".plane-card" in styles.text
     assert ".connect-panel" in styles.text
+    assert ".connect-snippet-block" in styles.text
     assert "startup ingestion is not automatic" in index.text
     assert "before hitting the API" not in script.text
     assert "safely route this call" not in script.text
@@ -419,7 +426,7 @@ def test_mcp_ui_markdown_renderer_is_shared_and_escape_first():
     assert "\\u000E-\\u001F" in renderer.text
     # app.js imports the shared renderer at the current cache-bust version and
     # no longer defines its own.
-    assert 'from "./markdown.js?v=grok-v0.6.0-r8"' in script.text
+    assert 'from "./markdown.js?v=grok-v0.6.0-r9"' in script.text
     assert "import { parseMarkdown" in script.text
     assert "function parseMarkdown" not in script.text
     assert "renderMarkdownInto" in script.text


### PR DESCRIPTION
## Summary
- Health hero primary CTA tracks readiness: offline → **Copy install commands**, live/attention → **Copy IDE MCP config**.
- Connect panel shows first-class **MCP JSON** and **agent setup prompt** paste blocks (not a single mystery pre).
- Spend glance uses `??` so legitimate **$0.0000** is not overwritten.
- `discover_self` auto-opens its `<details>` panel; prefer `textContent` for chips/clipboard.
- UI assets **r9**.

## Changed paths
- `mcp_ui/index.html`, `mcp_ui/app.js`, `mcp_ui/styles.css`
- `mcp_ui/swarm.html`, `mcp_ui/swarm.js` (version pin only)
- `src/version.py`
- `tests/test_mcp_ui.py`

## Tests
```bash
uv run pytest tests/test_mcp_ui.py tests/test_release_hygiene.py -q
# 39 passed
```

## Risks
- Low: Console Health UX only. No plane routing, credentials, or provider broker changes.
- Does not touch Codex’s live broker/projection worktree.

## Human sponsor
djtelicloud (approved P3 polish)

## Provenance
- Exact head: `8892c546ac470b101f5ffe19a3c80d7cf1da84c0`
- Agent-Assisted-By: xAI Grok | model=grok-4.5 | model-source=provider-session | surface=Grok Build | role=implementation

## Landing (Codex only)
Review exact head `8892c54`. If green: land from a `codex/*` integration branch with `./scripts/land`.  
**Grok will not land or push main.**