### PR TITLE
docs: public knowledge is README + OKF; GitHub Wiki not a product

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,6 +96,14 @@ mutate. Pasteable terminal prompts for agents beat multi-step browser forms.
 - Prefer existing helpers and architecture over new parallel abstractions.
 - Update `README.md` (public) and this file / design docs when behavior changes
   audience-facing setup.
+- **Documentation surfaces (do not fork truth):**
+  - **Public humans:** `README.md`
+  - **Agents / machine-readable knowledge:** `docs/okf/` (generated pieces via
+    `scripts/generate_okf.py`, mirrored to the public site and gateway)
+  - **Insiders:** this file + `docs/design/*`
+  - **GitHub Wiki is not a product surface.** Do not hand-edit it as source of
+    truth, do not auto-publish full OKF into `.wiki.git`, and do not send
+    public users there. Prefer disabling the Wiki tab or leaving it empty.
 - Run `uv run pytest` before opening a PR.
 
 Human contributors and coding agents use the same evidence contract: intent,

--- a/README.md
+++ b/README.md
@@ -142,11 +142,23 @@ repo role; a **Sites rollback fallback** remains only for the legacy identity
 binding path. That control plane does not replace local UniGrok MCP on
 `localhost:4765`, and it never holds your xAI key.
 
-## 8. Next steps
+## 8. Where docs live
+
+| You are… | Use |
+|---|---|
+| Installing / connecting an IDE | This README |
+| An agent needing schemas and operations | [OKF knowledge bundle](https://grokmcp.org/docs/okf/) (also via `discover_self` and local `/docs/okf/`) |
+| Changing UniGrok itself | [CONTRIBUTING.md](CONTRIBUTING.md) |
+
+There is **no** separate GitHub Wiki product surface. Prefer these three paths
+over any Wiki tab so public install and agent knowledge stay one source of truth.
+
+## 9. Next steps
 
 | I want… | Go here |
 |---|---|
 | More IDE examples | [docs/ide-setup.md](docs/ide-setup.md) |
+| Agent knowledge (OKF) | [https://grokmcp.org/docs/okf/](https://grokmcp.org/docs/okf/) |
 | Architecture | [architecture.md](architecture.md) |
 | Security reporting | [SECURITY.md](SECURITY.md) |
 | **Contribute to UniGrok itself** | [CONTRIBUTING.md](CONTRIBUTING.md) |

--- a/docs/design/public-vs-insider-surfaces.md
+++ b/docs/design/public-vs-insider-surfaces.md
@@ -138,6 +138,7 @@ public Quick Start.
 | GitHub write+ for all cloud Console entry | **LIVE** |
 | Unified single Insider UI (swarm+control+core) | **Deferred** |
 | Silent skill compiler into user repos | **Forbidden** |
+| GitHub Wiki as second docs tree / auto-synced `.wiki.git` from OKF | **Forbidden** — public knowledge is README + OKF only |
 
 ## 8. Related docs
 

--- a/tests/test_release_hygiene.py
+++ b/tests/test_release_hygiene.py
@@ -144,6 +144,24 @@ def test_public_setup_surfaces_use_the_grok_phoneword_endpoint():
         assert "http://localhost:8080" not in text, path
 
 
+def test_public_docs_surfaces_exclude_github_wiki_as_product():
+    """Public knowledge is README + OKF; GitHub Wiki is not a second tree."""
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    contributing = (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+    freeze = (ROOT / "docs" / "design" / "public-vs-insider-surfaces.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "## 8. Where docs live" in readme
+    assert "https://grokmcp.org/docs/okf/" in readme
+    assert "There is **no** separate GitHub Wiki product surface" in readme
+    assert "GitHub Wiki is not a product surface" in contributing
+    assert "Do not hand-edit it as source of" in contributing
+    assert "auto-publish full OKF into `.wiki.git`" in contributing
+    assert "GitHub Wiki as second docs tree" in freeze
+    assert "Forbidden** — public knowledge is README + OKF only" in freeze
+
+
 def test_agent_guidance_preserves_workspace_and_credential_boundaries():
     using_unigrok = (ROOT / "skills" / "using-unigrok" / "SKILL.md").read_text(encoding="utf-8")
     claude = (ROOT / ".claude" / "skills" / "using-unigrok" / "SKILL.md").read_text(


### PR DESCRIPTION
## Summary
Codifies the public-user docs decision:
- **Humans:** README
- **Agents:** OKF (`docs/okf` → grokmcp.org + gateway)
- **Insiders:** CONTRIBUTING + design docs
- **GitHub Wiki is not a product surface** — no second tree, no auto-sync of OKF into `.wiki.git`

## Changed paths
- `README.md` — new “Where docs live” + OKF next-step row
- `CONTRIBUTING.md` — documentation surfaces rules for agents
- `docs/design/public-vs-insider-surfaces.md` — freeze row **Forbidden**
- `tests/test_release_hygiene.py` — pin the policy

## Tests
```bash
uv run pytest tests/test_release_hygiene.py -q
# 13 passed
```

## Risks
- Docs-only. Optional maintainer action outside git: disable Wiki in GitHub settings so `/wiki` does not look abandoned.

## Human sponsor
djtelicloud (approved public-user interest call)

## Provenance
- Exact head: `4513369aeb20dd022e90e66fd4cf5f72ceb12367`
- Agent-Assisted-By: xAI Grok | model=grok-4.5 | model-source=provider-session | surface=Grok Build | role=documentation

## Landing
Codex-only: review exact head, then `./scripts/land` if approved. **Grok will not land or push main.**