### PR TITLE
Retire browser chat from Core Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to UniGrok MCP will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **Console is health, evidence, and pasteables only**: removed the legacy
+  browser `agent` playground and its provider-spending controls from the Core
+  UI. Daily Grok work now has one documented path—IDE → UniGrok MCP—while the
+  local Console remains the machine-owner view for readiness, credential
+  planes, costs, receipts, and copyable setup actions.
+
 ### Fixed
 - **Control Center answers survive stale browser caches**: `/ui` and `/docs`
   responses now carry `Cache-Control: no-cache` (Starlette's `StaticFiles`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ collaborators such as Curtis). Product language freeze:
 
 | Topic | LIVE today | TARGET |
 |---|---|---|
-| Core UI `/ui/` | Status + optional legacy `agent` playground | Observe + pasteable actions; IDE remains primary chat |
+| Core UI `/ui/` | Health, cost ledger, plane status, pasteable IDE actions | Observe + paste only; IDE MCP is the chat path |
 | Cloud Console entry | GitHub OAuth + live write+ collaborator check (`write` / `maintain` / `admin`) | Same; always fail closed |
 | Swarm | Contributor mode; prefer `dry_run` | Same; never default-apply |
 | Land / merge | Codex/`scripts/land` + required exact-head Codex Approval | Unchanged; Grok review is advisory only |

--- a/docs/design/public-vs-insider-surfaces.md
+++ b/docs/design/public-vs-insider-surfaces.md
@@ -55,18 +55,14 @@ contributor gates — that is not the public product.
   `review_pull_request`
 - Workspace-neutral (no automatic browse of the user’s app repo)
 - Trusted-loopback Control Center at `http://localhost:4765/ui/` for **this
-  machine’s** health, cost ledger, and optional agent playground. The
-  playground can invoke providers and spend metered credits; IDE MCP remains
-  the primary chat path.
+  machine’s** health, cost ledger, credential-plane status, and pasteable IDE
+  actions. It does not invoke inference; IDE MCP is the chat path.
 - Credentials stay in server env / CLI OAuth volume — never in IDE MCP JSON
 
-**TARGET Console (local Core UI):**
+**LIVE Console (local Core UI):**
 
 - Observe health + paste next actions
-- Not a second primary Grok chat for daily work (IDE MCP is primary)
-
-**LIVE Console note:** the bundled UI may still call `agent` (legacy operator
-playground). Label that as **legacy**; do not document it as the only chat path.
+- Not a second Grok chat for daily work (IDE MCP is primary)
 
 ### 4.2 Contributor Forge (`:4766`) — INSIDER only
 
@@ -138,7 +134,7 @@ public Quick Start.
 |---|---|
 | Public README is vibe-only; insider ops in CONTRIBUTING | Wave-1 docs goal |
 | Stable discover prose does not teach Forge connect | Wave-1 onboarding goal |
-| Console is observe+paste only | **TARGET** (legacy chat still LIVE) |
+| Console is observe+paste only | **LIVE** |
 | GitHub write+ for all cloud Console entry | **LIVE** |
 | Unified single Insider UI (swarm+control+core) | **Deferred** |
 | Silent skill compiler into user repos | **Forbidden** |

--- a/mcp_ui/app.js
+++ b/mcp_ui/app.js
@@ -1,9 +1,9 @@
-import { parseMarkdown, sanitizeHref } from "./markdown.js?v=grok-v0.6.0-r9";
+import { parseMarkdown, sanitizeHref } from "./markdown.js?v=grok-v0.6.0-r10";
 
 // Must match the <meta name="unigrok-ui-version"> baked into index.html and
 // src/version.py UI_ASSET_VERSION; a mismatch means the browser paired a
 // cached page with a different script build (the stale-skew failure class).
-const UI_ASSET_VERSION = "grok-v0.6.0-r9";
+const UI_ASSET_VERSION = "grok-v0.6.0-r10";
 
 const LAYOUT_KEY = "unigrok.mcp.console.layout.v2";
 
@@ -37,7 +37,6 @@ const TAB_IDS = new Set([
   "tab-onboarding",
   "tab-metrics",
   "tab-models",
-  "tab-console",
 ]);
 
 function readLayout() {
@@ -1050,6 +1049,13 @@ function renderSpendGlance(payload) {
   }
 }
 
+function actionableCredentialNotice(contract) {
+  const notices = (contract?.notices || []).filter((notice) => notice.prompt_user);
+  return notices.find((notice) => notice.blocking)
+    || (contract?.effective_plane === "none" ? notices[0] : null)
+    || null;
+}
+
 function renderSetupStatus(data, ready = true, detailText = null) {
   // Offline → show install card. Ready-but-degraded → named checks + credential alert.
   $("quickStartCard")?.classList.toggle("hidden", Boolean(ready) || Boolean(detailText));
@@ -1058,8 +1064,8 @@ function renderSetupStatus(data, ready = true, detailText = null) {
   const effective = contract.effective_plane || "none";
   const runtime = data?.runtime || "unknown";
   const tools = $("toolCountChip")?.textContent?.replace(/^tools:\s*/i, "") || "…";
-  const notices = (contract.notices || []).filter((notice) => notice.prompt_user);
-  const attention = notices.map((notice) => notice.message).join(" ");
+  const notice = actionableCredentialNotice(contract);
+  const attention = notice?.message || "";
 
   const hero = $("readinessHero");
   const title = $("readinessTitle");
@@ -1148,7 +1154,7 @@ function renderCredentialPlanes(contract) {
   const effective = contract.effective_plane || "none";
   planeChip.innerText = `plane: ${preferred} first → ${effective}`;
 
-  const notice = (contract.notices || []).find((item) => item.prompt_user);
+  const notice = actionableCredentialNotice(contract);
   if (!notice) {
     alertCard.classList.add("hidden");
     return;
@@ -2350,14 +2356,10 @@ function init() {
   if ($("tab-schemas") && !$("tab-schemas").hidden) setupSchemaExplorer();
   if ($("tab-guard") && !$("tab-guard").hidden) setupReasoningGuard();
   if ($("tab-okf") && !$("tab-okf").hidden) setupOkfClipboard();
-  setupConsoleActions();
-
   // Proactive safety checks initialization
   checkBrowserCompatibility();
   setupDockerRestart();
   setupCredentialActions();
-  setupApiKeyWizard();
-  setupCostEstimator();
   setupMetricsControls();
 
   $("refreshModelsBtn").addEventListener("click", loadPlaneModelCatalog);

--- a/mcp_ui/index.html
+++ b/mcp_ui/index.html
@@ -7,9 +7,9 @@
     <meta name="unigrok-ui-regions" content="navigation,workbench,rpc-inspector,rpc-logs,result-facts" />
     <!-- Version handshake: app.js compares this against its own build constant
          and self-heals a stale-cached page with one revalidating reload. -->
-    <meta name="unigrok-ui-version" content="grok-v0.6.0-r9" />
-  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r9" />
-  <link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r9" />
+    <meta name="unigrok-ui-version" content="grok-v0.6.0-r10" />
+  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r10" />
+  <link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r10" />
   </head>
   <body>
     <main class="app-shell">
@@ -74,9 +74,6 @@
           <button id="tab-btn-models" type="button" class="nav-btn" data-tab="tab-models" role="tab" aria-selected="false" aria-controls="tab-models" tabindex="-1" title="Models &amp; planes">
             <span class="btn-icon" aria-hidden="true">◫</span><span class="btn-label">Planes</span>
           </button>
-          <button id="tab-btn-console" type="button" class="nav-btn" data-tab="tab-console" role="tab" aria-selected="false" aria-controls="tab-console" tabindex="-1" title="Legacy connectivity probe — not daily chat">
-            <span class="btn-icon" aria-hidden="true">▶</span><span class="btn-label">Legacy smoke</span>
-          </button>
           <a id="nav-link-site" class="nav-link" href="https://grokmcp.org" target="_blank" rel="noopener noreferrer" title="Project site">
             <span class="btn-icon" aria-hidden="true">↗</span><span class="btn-label">Docs site</span>
           </a>
@@ -87,128 +84,6 @@
         <!-- Main Workbench Content Area -->
         <section id="workbench" class="workbench" data-region="workbench" aria-label="Active tool workspace">
           
-          <!-- TAB 1: Agent Playground -->
-          <div id="tab-console" class="tab-panel" role="tabpanel" aria-labelledby="tab-btn-console" data-region="tab-console">
-            <div class="panel-header">
-              <h2>Legacy connectivity smoke</h2>
-              <span class="panel-header-hint">Not daily chat · IDE MCP is primary</span>
-            </div>
-            <p class="panel-desc">Optional one-shot probe that the gateway can answer. Daily Grok chat belongs in your IDE via <code>http://localhost:4765/mcp</code>. Prefer Health for setup and paste snippets.</p>
-
-            <div class="form-layout playground-form">
-              <div id="apiKeyWizard" class="wizard-card hidden">
-                <h4>🔑 UniGrok Gateway Access</h4>
-                <p class="wizard-desc">This is the optional UniGrok client token, not your xAI API key. Never paste XAI_API_KEY into this page.</p>
-                <div class="wizard-inputs">
-                  <input id="wizardTokenInput" type="password" autocomplete="off" spellcheck="false" placeholder="Client token..." class="wizard-input" aria-label="Client token" />
-                  <button id="saveWizardTokenBtn" type="button" class="small-btn-glow">Save Token</button>
-                </div>
-              </div>
-              <div class="form-group task-composer">
-                <label for="promptInput">Your task
-                  <textarea id="promptInput" rows="5" placeholder="Describe what you want Grok to do, or choose a preset below…" aria-label="Prompt task message input"></textarea>
-                </label>
-                <div class="estimator-row">
-                  <span id="costEstimator" class="estimator-text">Local input estimate: ~0 tokens</span>
-                  <label class="budget-guard-label">
-                    <input id="budgetGuardToggle" type="checkbox" checked aria-label="Toggle large prompt safety guard" /> Large Prompt Guard
-                  </label>
-                </div>
-              </div>
-              <div class="form-actions playground-action-dock">
-                <button id="sendBtn" type="button" class="primary-btn-glow" aria-label="Run task with agent">Run Task</button>
-                <button id="clearBtn" type="button" class="secondary-btn" aria-label="Clear history log">Clear History</button>
-              </div>
-            </div>
-
-            <div class="task-presets" aria-label="Task presets">
-              <button id="runSampleBtn" type="button" class="preset-btn" data-prompt="Reply with exactly: UniGrok agent is ready.">Run zero-config sample</button>
-              <button type="button" class="preset-btn prompt-preset" data-prompt="Explain which credential plane and model you would use for a coding task, and why.">Explain routing</button>
-              <button type="button" class="preset-btn prompt-preset" data-prompt="Review this code or error and give me the three most useful next steps:\n\n">Review code or error</button>
-            </div>
-
-            <!-- Scrollable Conversation Log — kept adjacent to the composer so
-                 the chat loop (type, run, read) never crosses secondary UI. -->
-            <div class="conversation-wrapper">
-              <div class="section-title">Playground session</div>
-              <div id="conversation" class="transcript" role="log" aria-live="polite" aria-label="Playground conversation"></div>
-            </div>
-
-            <details class="run-options">
-              <summary>Run options · SuperGrok subscription · Auto</summary>
-              <div class="form-layout">
-              <div class="form-group row-group">
-                <label for="planeInput">
-                  Run With
-                  <select id="planeInput" aria-label="Credential plane selection">
-                    <option value="cli" selected>SuperGrok subscription (Recommended)</option>
-                    <option value="auto">Smart routing (may use metered API)</option>
-                    <option value="api">Developer API (Metered)</option>
-                  </select>
-                </label>
-                <label for="modeInput">
-                  Execution Mode
-                  <select id="modeInput" aria-label="Execution mode selection">
-                    <option value="auto">auto - Smart query evaluation</option>
-                    <option value="fast">fast - Single-turn toolless path</option>
-                    <option value="reasoning">reasoning - Multi-step planner path</option>
-                    <option value="thinking">thinking - Reflected agent loop</option>
-                    <option value="research">research - Citation-grounded fanout</option>
-                  </select>
-                </label>
-                <label for="modelInput">
-                  Pin Model Override
-                  <select id="modelInput" aria-label="Pin model override selection">
-                    <option value="">auto (Recommended)</option>
-                    <!-- Populated dynamically -->
-                  </select>
-                </label>
-                <p id="planeHint" class="plane-hint">Subscription only · no developer API billing</p>
-              </div>
-
-              <details class="advanced-settings">
-                <summary>Advanced RPC settings</summary>
-                <div class="advanced-grid">
-                  <label>Session ID
-                    <input id="sessionInput" type="text" placeholder="auto-generated per browser session" />
-                  </label>
-                  <label>Client ID
-                    <input id="clientIdInput" type="text" value="uni-grok-console" />
-                  </label>
-                  <label>Billing Caller (X-Caller)
-                    <input id="callerInput" type="text" placeholder="e.g. swarm-agent-0" />
-                  </label>
-                  <label>Failure Policy
-                    <select id="fallbackPolicyInput">
-                      <option value="same_plane" selected>Stay on selected plane</option>
-                      <option value="cross_plane">Allow cross-plane fallback</option>
-                    </select>
-                  </label>
-                  <label>Injected System Rules
-                    <textarea id="systemPromptInput" rows="3" placeholder="Additional system prompt instructions..."></textarea>
-                  </label>
-                  <label>Workspace Context
-                    <textarea id="workspaceContextInput" rows="3" placeholder="Optional project material to ground this run (secrets are redacted server-side; over the char limit is rejected)."></textarea>
-                  </label>
-                  <label>Workspace Label
-                    <input id="workspaceLabelInput" type="text" placeholder="e.g. uni-grok-mcp @ HEAD" />
-                  </label>
-                </div>
-              </details>
-              <button id="copyConsoleCallBtn" type="button" class="small-btn-glow">Copy tool call</button>
-            </div>
-            </details>
-
-            <section class="playground-launcher" aria-label="Quick start actions">
-              <div>
-                <span class="model-kicker">No prompt needed</span>
-                <strong>Is UniGrok ready?</strong>
-                <p>Checks credentials, planes, routing policy, and local telemetry without spending an inference turn.</p>
-              </div>
-              <button id="verifySetupBtn" type="button" class="primary-btn-glow">Verify Setup</button>
-            </section>
-          </div>
-
           <!-- TAB 2: Result Shape Guide -->
           <div id="tab-schemas" class="tab-panel retired-panel" hidden>
             <div class="panel-header">
@@ -642,6 +517,6 @@ docker compose up --build -d</code></pre>
 
       </section>
     </main>
-  <script type="module" src="./app.js?v=grok-v0.6.0-r9"></script>
+  <script type="module" src="./app.js?v=grok-v0.6.0-r10"></script>
   </body>
 </html>

--- a/mcp_ui/swarm.html
+++ b/mcp_ui/swarm.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>UniGrok Swarm Optimizer — Pareto Playground</title>
-  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r9" />
+  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r10" />
   <style>
     /* Page vocabulary aliases onto the shared UniGrok tokens (tokens.css) so
        the Swarm Optimizer and the Control Center read as one product. */
@@ -270,6 +270,6 @@
     hidden. "Verified" means: the task's own <code>test_target</code> passed.
   </div>
 
-  <script src="./swarm.js?v=grok-v0.6.0-r9"></script>
+  <script src="./swarm.js?v=grok-v0.6.0-r10"></script>
 </body>
 </html>

--- a/mcp_ui/swarm.js
+++ b/mcp_ui/swarm.js
@@ -10,7 +10,7 @@
 // Must match src/version.py UI_ASSET_VERSION and the query token on the
 // swarm.js reference in swarm.html. The sample uses the same token so a
 // revalidated page cannot pair new logic with a heuristically cached payload.
-const UI_ASSET_VERSION = "grok-v0.6.0-r9";
+const UI_ASSET_VERSION = "grok-v0.6.0-r10";
 
 const $ = (id) => document.getElementById(id);
 const SVG_NS = "http://www.w3.org/2000/svg";

--- a/src/version.py
+++ b/src/version.py
@@ -7,4 +7,4 @@ __version__ = "0.6.0"
 # runtime handshake in app.js).
 # Bump the -rN suffix whenever any /ui asset changes; a pytest asserts every
 # copy of this string agrees so HTML and JS can never skew apart silently.
-UI_ASSET_VERSION = "grok-v0.6.0-r9"
+UI_ASSET_VERSION = "grok-v0.6.0-r10"

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -47,9 +47,9 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert index.status_code == 200
     assert "<title>UniGrok Gateway Console v0.6.0</title>" in index.text
     assert '<span class="version-badge">v0.6.0</span>' in index.text
-    assert 'script type="module" src="./app.js?v=grok-v0.6.0-r9"' in index.text
-    assert '<link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r9" />' in index.text
-    assert '<link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r9" />' in index.text
+    assert 'script type="module" src="./app.js?v=grok-v0.6.0-r10"' in index.text
+    assert '<link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r10" />' in index.text
+    assert '<link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r10" />' in index.text
     assert "Console" in index.text
     assert 'id="surfaceModeBadge"' in index.text
     assert 'id="tab-btn-schemas"' not in index.text
@@ -65,12 +65,14 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert 'Swarm Optimizer' not in index.text
     assert 'product-law' in index.text
     assert "Bearer token" not in index.text
-    assert "Legacy connectivity smoke" in index.text
-    assert 'id="verifySetupBtn"' in index.text
-    assert 'id="runSampleBtn"' in index.text
-    assert "IDE MCP is primary" in index.text or "Legacy connectivity smoke" in index.text
+    assert 'id="tab-btn-console"' not in index.text
+    assert 'id="tab-console"' not in index.text
+    assert 'id="verifySetupBtn"' not in index.text
+    assert 'id="runSampleBtn"' not in index.text
+    assert "Chat lives in your IDE" in index.text
     assert "Legacy Mode" not in index.text
-    assert "verifyPlaygroundSetup" in script.text
+    init_body = script.text.split("function init()", 1)[1]
+    assert "setupConsoleActions();" not in init_body
     assert "switchTab(\"tab-onboarding\")" in script.text or "switchTab('tab-onboarding')" in script.text
     assert script.status_code == 200
     assert "tools/call" in script.text
@@ -151,7 +153,9 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert "Models &amp; Credential Planes" in index.text
     assert 'id="copyCredentialActionBtn"' in index.text
     assert "renderCredentialPlanes" in script.text
-    assert "Never paste XAI_API_KEY into this page" in index.text
+    assert "actionableCredentialNotice" in script.text
+    assert 'contract?.effective_plane === "none"' in script.text
+    assert "Never put XAI_API_KEY in IDE MCP settings" in index.text
     assert "Optional organization API comparison" in index.text
     assert "renderRoutingReceipts" in script.text
     assert 'fetchMcpCall("grok_mcp_discover_self", { include_models: true })' in script.text
@@ -177,16 +181,9 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert "mcp.console.layout.v2" in script.text
     assert "grid-template-columns: 1fr !important" not in styles.text
     assert "fonts.googleapis.com" not in index.text
-    assert 'id="planeInput"' in index.text
-    assert 'value="cli" selected' in index.text
-    assert 'id="fallbackPolicyInput"' in index.text
-    assert 'value="same_plane" selected' in index.text
+    assert 'id="planeInput"' not in index.text
+    assert 'id="fallbackPolicyInput"' not in index.text
     assert 'id="factBilling"' in index.text
-    assert "syncModelOptions" in script.text
-    assert "Explicit pins use metered API" in script.text
-    assert "Direct CLI-only pins" in script.text
-    assert 'plane: $("planeInput").value' in script.text
-    assert 'fallback_policy: $("fallbackPolicyInput").value' in script.text
 
 
 def test_mcp_ui_swarm_playground_is_served_and_honest(monkeypatch):
@@ -283,7 +280,7 @@ def test_mcp_ui_layout_engine_is_local_and_ide_first():
     assert '.console-grid[data-inspector="hidden"]' in styles.text
     assert '.console-grid[data-inspector="drawer"]' in styles.text
     assert 'data-inspector-drawer="closed"' in index.text
-    assert 'class="form-actions playground-action-dock"' in index.text
+    assert 'class="form-actions playground-action-dock"' not in index.text
     assert "Health" in index.text
     assert 'id="advancedNav"' not in index.text
     assert "product-law" in index.text
@@ -359,13 +356,13 @@ def test_mcp_ui_browser_warning():
     assert "Browser note" in index.text
 
 
-def test_mcp_ui_token_drift_wizard():
+def test_mcp_ui_has_no_browser_credential_wizard():
     with TestClient(create_app(), base_url="http://localhost:8080") as client:
         index = client.get("/ui/")
     assert index.status_code == 200
-    assert 'id="apiKeyWizard"' in index.text
-    assert 'id="wizardTokenInput"' in index.text
-    assert 'id="saveWizardTokenBtn"' in index.text
+    assert 'id="apiKeyWizard"' not in index.text
+    assert 'id="wizardTokenInput"' not in index.text
+    assert 'id="saveWizardTokenBtn"' not in index.text
 
 
 def test_mcp_ui_token_storage_is_in_memory_only():
@@ -376,13 +373,13 @@ def test_mcp_ui_token_storage_is_in_memory_only():
     assert 'localStorage.getItem("unigrok.clientToken"' not in script.text
 
 
-def test_mcp_ui_cost_estimator():
+def test_mcp_ui_has_no_browser_inference_cost_estimator():
     with TestClient(create_app(), base_url="http://localhost:8080") as client:
         index = client.get("/ui/")
     assert index.status_code == 200
-    assert 'id="costEstimator"' in index.text
-    assert 'id="budgetGuardToggle"' in index.text
-    assert "Local input estimate" in index.text
+    assert 'id="costEstimator"' not in index.text
+    assert 'id="budgetGuardToggle"' not in index.text
+    assert "Local input estimate" not in index.text
     assert "Estimated Cost" not in index.text
 
 
@@ -391,8 +388,10 @@ def test_mcp_ui_accessibility_audit():
         index = client.get("/ui/")
         styles = client.get("/ui/styles.css")
     assert index.status_code == 200
-    assert 'aria-label="Prompt task message input"' in index.text
-    assert 'aria-label="Client token"' in index.text
+    assert 'aria-label="Console sections"' in index.text
+    assert 'aria-label="Gateway status"' in index.text
+    assert 'aria-label="Prompt task message input"' not in index.text
+    assert 'aria-label="Client token"' not in index.text
     assert styles.status_code == 200
     assert "prefers-reduced-motion" in styles.text
 
@@ -426,7 +425,7 @@ def test_mcp_ui_markdown_renderer_is_shared_and_escape_first():
     assert "\\u000E-\\u001F" in renderer.text
     # app.js imports the shared renderer at the current cache-bust version and
     # no longer defines its own.
-    assert 'from "./markdown.js?v=grok-v0.6.0-r9"' in script.text
+    assert 'from "./markdown.js?v=grok-v0.6.0-r10"' in script.text
     assert "import { parseMarkdown" in script.text
     assert "function parseMarkdown" not in script.text
     assert "renderMarkdownInto" in script.text
@@ -482,10 +481,9 @@ def test_mcp_ui_github_review_widget_is_marked_and_honest():
     assert "data.degraded" in page.text
 
 
-def test_mcp_ui_surfaces_receipts_and_session_honesty():
-    """Stage 3/5: the facts pane holds the agent receipt only (background calls
-    don't clobber it), citations and mode provenance are surfaced, workspace
-    context is exercisable, and the session id is per-browser."""
+def test_mcp_ui_retains_receipt_inspection_without_browser_chat():
+    """Historical agent receipts remain inspectable, while the Core UI no
+    longer exposes a prompt, workspace-context, or browser-session surface."""
     with TestClient(create_app(), base_url="http://localhost:8080") as client:
         index = client.get("/ui/")
         script = client.get("/ui/app.js")
@@ -496,28 +494,22 @@ def test_mcp_ui_surfaces_receipts_and_session_honesty():
     for fid in ("factRequestedMode", "factModeSource", "factDialedPort"):
         assert f'id="{fid}"' in index.text
     assert "payload.requested_mode" in script.text
-    # Workspace context is wired to the agent tool arguments.
-    assert 'id="workspaceContextInput"' in index.text
-    assert "args.workspace_context" in script.text
-    assert "args.workspace_label" in script.text
-    # Per-browser session id, and the old shared default is gone.
-    assert "console-session-1" not in index.text
-    assert "genSessionId" in script.text
-    # Clear History is honest that the server session persists.
-    assert "clearConversation" in script.text
-    assert "server still holds the prior session" in script.text
+    assert 'id="workspaceContextInput"' not in index.text
+    assert 'id="sessionInput"' not in index.text
+    assert 'id="promptInput"' not in index.text
+    assert "setupConsoleActions();" not in script.text.split("function init()", 1)[1]
 
 
 def test_mcp_ui_accessibility_and_dead_code_cleanup():
-    """Stage 6: live regions on the transcript and offline banner, keyboard-
-    operable OKF list, password token field, and removed dead code."""
+    """Status remains accessible after browser-chat controls are removed."""
     with TestClient(create_app(), base_url="http://localhost:8080") as client:
         index = client.get("/ui/")
         script = client.get("/ui/app.js")
         styles = client.get("/ui/styles.css")
-    assert 'id="conversation" class="transcript" role="log" aria-live="polite"' in index.text
     assert 'id="dockerOfflineAlert" class="alert-banner hidden" role="alert"' in index.text
-    assert 'id="wizardTokenInput" type="password"' in index.text
+    assert 'role="tablist" aria-label="Console sections"' in index.text
+    assert 'id="conversation"' not in index.text
+    assert 'id="wizardTokenInput"' not in index.text
     # OKF list items are buttons, not click-only divs.
     assert 'document.createElement("button")' in script.text
     # Dead code is gone.


### PR DESCRIPTION
## Summary
- removes the legacy browser `agent` playground and all prompt/run controls from Core `/ui/`
- keeps Health, Usage, Planes, receipts, and pasteable IDE setup actions
- suppresses optional secondary-plane banners when another credential plane is already usable
- updates the accepted public-vs-insider product freeze from TARGET to LIVE

## Exact head
`4b51e3906e9070116d4afaee8ab5691d1258be07`

## Changed paths
- `mcp_ui/{index.html,app.js,swarm.html,swarm.js}`
- `src/version.py`
- `tests/test_mcp_ui.py`
- `docs/design/public-vs-insider-surfaces.md`
- `CONTRIBUTING.md`, `CHANGELOG.md`

## Verification
- `uv run pytest tests/test_mcp_ui.py tests/test_release_hygiene.py -q` — 39 passed
- `uv run pytest -q` — 1,965 passed
- desktop live browser: r10, Health/Usage/Planes/Docs only, zero prompt controls
- mobile 390×844: no horizontal overflow; health cards reflow correctly
- Core and Forge health checks remain green

## Risk
Low and UI-bounded. No provider routing, MCP tool contract, Swarm, training, or credential storage change. Historical receipt inspection remains available.

## Human sponsor
djtelicloud

Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=implementation