### PR TITLE
docs: hosted PR review P0 plan (live mcp.grokmcp.org twin)

### DIFF
--- a/.github/workflows/grok-review.yml
+++ b/.github/workflows/grok-review.yml
@@ -27,9 +27,12 @@ jobs:
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
        contains(github.event.comment.body, '@grok review'))
     name: UniGrok review
-    # Default is the existing trusted local runner. A repository admin may set
-    # UNIGROK_REVIEW_RUNNER_JSON to the JSON string "ubuntu-latest" only after
-    # configuring the authenticated API-plane endpoint documented below.
+    # Production (hosted): set repository variables
+    #   UNIGROK_REVIEW_RUNNER_JSON = "ubuntu-latest"
+    #   UNIGROK_REVIEW_MCP_URL     = https://mcp.grokmcp.org/mcp
+    #   UNIGROK_REVIEW_PLANE       = api
+    # Lab fallback when vars unset: self-hosted + loopback CLI (Mac required).
+    # See docs/design/hosted-review-p0.md and docs/chatgpt-github-app.md.
     runs-on: ${{ fromJSON(vars.UNIGROK_REVIEW_RUNNER_JSON || '["self-hosted","unigrok-review"]') }}
     timeout-minutes: 10
     steps:
@@ -49,7 +52,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          # Hosted production: set UNIGROK_REVIEW_MCP_URL to https://mcp.grokmcp.org/mcp
           UNIGROK_MCP_URL: ${{ vars.UNIGROK_REVIEW_MCP_URL || 'http://127.0.0.1:4765/mcp' }}
           UNIGROK_REVIEW_PLANE: ${{ vars.UNIGROK_REVIEW_PLANE || 'cli' }}
+          # Temporary client bridge only — never XAI_API_KEY. Prefer OAuth mint (P1).
           UNIGROK_CLIENT_TOKEN: ${{ secrets.UNIGROK_CLIENT_TOKEN }}
         run: uv run python scripts/github-grok-review.py

--- a/docs/chatgpt-github-app.md
+++ b/docs/chatgpt-github-app.md
@@ -38,32 +38,38 @@ development, an HTTPS tunnel may forward to `http://127.0.0.1:4765`.
 The widget has no external network access and declares empty CSP domain lists.
 Do not grant the ChatGPT App GitHub write credentials.
 
-## GitHub runner setup
+## Production path (hosted API plane — default goal)
 
-The workflow requires a self-hosted runner on the same trusted machine as the
-stable UniGrok service. Apply the custom label `unigrok-review` when registering
-the runner. The runner needs outbound HTTPS to GitHub and loopback access to
-`127.0.0.1:4765`; it does not need inbound public access.
+**Production review must not depend on a developer Mac, local Docker, or
+tunnel.** The private twin at `https://mcp.grokmcp.org/mcp` is the API-plane
+resource (`UNIGROK_RUNTIME=cloudrun`). Health/ready probes are public;
+MCP calls require auth (see [remote-mcp-deployment.md](remote-mcp-deployment.md)
+and [hosted-review-p0.md](design/hosted-review-p0.md)).
 
-Repository configuration (owned by Codex/project-admin automation; the user
-does not need to operate Git or babysit the runner):
+Repository configuration (Codex/project-admin):
 
-1. Add the self-hosted runner with labels `self-hosted` and `unigrok-review`.
-2. If the local gateway requires a client token, add repository secret
-   `UNIGROK_CLIENT_TOKEN`. Never use `XAI_API_KEY` as this token.
-3. Ensure workflow permissions allow pull-request reads and timeline comments;
-   the checked-in workflow uses `contents: read` and `pull-requests: write`
-   without contents, actions, deployments, or administration write access.
-4. Manually dispatch the workflow with a PR number, or have an owner, member,
-   or collaborator comment `@grok review` on a PR. Opening or updating a PR
-   does not trigger this workflow.
+1. Set repository variables:
+   - `UNIGROK_REVIEW_RUNNER_JSON` = `"ubuntu-latest"` (JSON string)
+   - `UNIGROK_REVIEW_MCP_URL` = `https://mcp.grokmcp.org/mcp`
+   - `UNIGROK_REVIEW_PLANE` = `api`
+2. Prefer short-lived OAuth / Control-minted tokens with scope `unigrok:review`.
+   A repository secret `UNIGROK_CLIENT_TOKEN` is a **temporary bridge only** —
+   never store `XAI_API_KEY` in GitHub. Never use `XAI_API_KEY` as this token.
+3. Workflow permissions stay `contents: read` and `pull-requests: write`.
+4. Trigger: owner/member/collaborator comments `@grok review`, or
+   `workflow_dispatch` with a PR number. Opening or updating a PR does not trigger this workflow
+   (cost control).
 
-The checked-in defaults intentionally preserve this local path:
+Checked-in workflow defaults still fall back to the **lab** self-hosted path
+when variables are unset (local loopback + CLI). Operators must set the vars
+above to activate hosted production review.
 
-- `UNIGROK_REVIEW_RUNNER_JSON` unset means
-  `["self-hosted","unigrok-review"]`;
-- `UNIGROK_REVIEW_MCP_URL` unset means `http://127.0.0.1:4765/mcp`;
-- `UNIGROK_REVIEW_PLANE` unset means `cli`.
+## Lab path (local self-hosted runner)
+
+Optional development only. Requires a self-hosted runner labeled
+`self-hosted` and `unigrok-review` on the same machine as local Core
+`http://127.0.0.1:4765/mcp`, with plane `cli` if desired. Do not document this
+as the always-on product path.
 
 ## Security contract
 
@@ -82,18 +88,12 @@ The checked-in defaults intentionally preserve this local path:
 - The tool and workflow cannot merge, push, tag, release, or change protection.
 - The review comment explicitly hands authority back to Codex.
 
-## Production options
+## Path summary
 
-- **Local subscription plane:** the self-hosted runner calls the local MCP and
-  uses `plane=cli` with same-plane failure behavior. Reviews require the Mac and
-  UniGrok service to be online.
-- **Always-on API plane:** deploy a separately authenticated API-only UniGrok
-  service behind stable HTTPS. Set repository variable
-  `UNIGROK_REVIEW_RUNNER_JSON` to the JSON string `"ubuntu-latest"`, set
-  `UNIGROK_REVIEW_MCP_URL` to that service's `/mcp` URL, set
-  `UNIGROK_REVIEW_PLANE=api`, and store the service's narrowly scoped client
-  credential as `UNIGROK_CLIENT_TOKEN`. Do not copy the local CLI OAuth volume
-  to cloud infrastructure.
+- **Hosted API plane (production):** `ubuntu-latest` → `https://mcp.grokmcp.org/mcp`
+  with `plane=api`. Mac may be off. Metered XAI only; no CLI volume in cloud.
+- **Local CLI plane (lab):** self-hosted runner → loopback Core with `plane=cli`.
+  Requires the machine online. Do not use for team-critical review.
 
 There is no switch that permits outside contributors to schedule automatic
 reviews. The hosted API path is invoked explicitly by an authorized contributor,

--- a/docs/design/hosted-review-p0.md
+++ b/docs/design/hosted-review-p0.md
@@ -1,0 +1,126 @@
+# Hosted Grok PR review — P0 operator plan
+
+- **Status:** Execution checklist (Wave following Console Health glass + docs policy)
+- **Date:** 2026-07-14
+- **Decision owner:** Human sponsor; Codex owns land/deploy gates
+- **North star:** Production review never depends on a developer Mac, Docker, or tunnel.
+
+## Live evidence (re-verify before each step)
+
+| Probe | Expected (observed 2026-07-14) |
+| --- | --- |
+| `GET https://mcp.grokmcp.org/healthz` | `200` `{"status":"healthy"}` |
+| `GET https://mcp.grokmcp.org/readyz` | `200` `status=ready`, `model_auth=true` |
+| `POST https://mcp.grokmcp.org/mcp` (no token) | `401` + `WWW-Authenticate` resource metadata |
+| `GET https://control.grokmcp.org/api/public/v1/project` | `200` project JSON |
+| Local Mac powered off | Hosted review still works after P0 complete |
+
+**Implication:** The API-plane Cloud Run twin is already up. P0 is **wire review to it**, not invent a new service.
+
+## What P0 is / is not
+
+| In scope | Out of scope |
+| --- | --- |
+| GitHub Actions → hosted MCP (API plane) | Tunnel to `127.0.0.1:4765` for production |
+| Short-lived or scoped client auth for Actions | Putting `XAI_API_KEY` in GitHub Secrets |
+| Cost caps + kill-switch vars | Auto-review every PR / multi-agent fan-out |
+| Control broker smoke (server-side) | Control UI score invention |
+| Docs: hosted path is production default | GenFunc-style in-container git hot-reload |
+
+## Architecture (locked)
+
+```text
+@grok review  (OWNER/MEMBER/COLLABORATOR)
+        │
+        ▼
+GitHub Actions  runs-on: ubuntu-latest
+        │  immutable base...head evidence (scripts/github-grok-review.py)
+        ▼
+https://mcp.grokmcp.org/mcp   plane=api
+  OAuth / scoped client token with unigrok:review
+  XAI_API_KEY only in Cloud Run Secret Manager
+        │
+        ▼
+Advisory PR comment → Codex lands (or not)
+```
+
+Control `POST /api/control/reviews` remains the insider broker (same twin).
+Local self-hosted + CLI plane stays a **lab** path only.
+
+## Operator steps (Codex / project admin)
+
+### 1. Land remaining docs PR
+
+- Draft **#109** (wiki not a product) rebased on post-#108 `main`.
+- Exact head after rebase: verify with `gh pr view 109 --json headRefOid`.
+- `./scripts/land` from a `codex/*` branch only.
+
+### 2. Repository variables (hosted production)
+
+Set on `djtelicloud/grok-mcp-server`:
+
+| Variable | Value |
+| --- | --- |
+| `UNIGROK_REVIEW_RUNNER_JSON` | `"ubuntu-latest"` (JSON string) |
+| `UNIGROK_REVIEW_MCP_URL` | `https://mcp.grokmcp.org/mcp` |
+| `UNIGROK_REVIEW_PLANE` | `api` |
+
+Optional kill-switch later: workflow `if` gated on `vars.UNIGROK_REVIEW_ENABLED != '0'`.
+
+### 3. Client credential for Actions (temporary bridge)
+
+Until OIDC → Control mint ships (P1):
+
+- Prefer a **narrow** gateway client token accepted by the remote MCP OAuth/introspection design — **not** `XAI_API_KEY`.
+- Store as repository secret `UNIGROK_CLIENT_TOKEN` only if the twin still accepts that bootstrap path.
+- Production preference (docs): OAuth introspection; static client is break-glass / short rotation.
+
+If the twin is pure OAuth and rejects static tokens, P0 uses **Control broker** from an authenticated insider session first, and Actions waits for P1 OIDC.
+
+### 4. Cost controls (required before volume)
+
+| Control | Suggested default |
+| --- | --- |
+| Trigger | Explicit `@grok review` or `workflow_dispatch` only (already true) |
+| Plane | `api` only (no cross-plane) |
+| Max reviews | Human discipline: 1–2 / PR / day until broker budgets land |
+| Kill | Unset vars or set runner back to disabled |
+
+Hard token budgets on the twin (`UNIGROK_CALLER_BUDGETS`) should be set in Cloud Run env when available.
+
+### 5. Smoke tests
+
+1. Laptop can sleep; use phone/other machine if needed.
+2. On a draft PR: collaborator comments `@grok review` **or** dispatch workflow with PR number.
+3. Expect one advisory comment bound to base/head SHA.
+4. Confirm no merge/land action by the workflow.
+5. Control UI may still show Grok review “Not connected” until UI snapshot work (P1) — **PR comment is the success metric for P0**.
+
+### 6. Fail-closed checks
+
+- Missing token → no comment, red job (acceptable).
+- Twin 5xx → no invented score on Control.
+- Outside contributor `@grok review` → workflow does not run (association gate).
+
+## P1 (next, not this PR)
+
+1. GitHub OIDC → Control short-lived `unigrok:review` mint (retire static client).
+2. Un-hardcode Control `grokReview` snapshot from real broker/probe state.
+3. Per-subject budgets + spend log in Control.
+4. Optional: workflow default in-repo once vars proven (still var-driven).
+
+## Explicit NO-GOs
+
+- Production tunnel to local Docker / self-hosted Mac runner as the only path.
+- CLI plane on Cloud Run.
+- `XAI_API_KEY` in GitHub Actions secrets.
+- Needle live generation until hosted review + budgets proven.
+- GitHub Wiki as second docs tree.
+- Grok auto-land of `main`.
+
+## Related
+
+- [remote-mcp-deployment.md](../remote-mcp-deployment.md)
+- [chatgpt-github-app.md](../chatgpt-github-app.md)
+- [ADR 0001](../adr/0001-cloud-control-plane-governance.md)
+- [public-vs-insider-surfaces.md](public-vs-insider-surfaces.md)

--- a/docs/remote-mcp-deployment.md
+++ b/docs/remote-mcp-deployment.md
@@ -5,6 +5,11 @@ It is not an anonymous inference endpoint and it never receives the local Grok
 CLI OAuth volume. The Python gateway runs with `UNIGROK_RUNTIME=cloudrun`, which
 disables the CLI plane and all local agent-tool execution.
 
+**Live probes (re-verify):** `GET /healthz` and `GET /readyz` on the same host
+are public process gates. Authenticated MCP and status routes return `401`
+without a bearer. Hosted PR review wiring is
+[design/hosted-review-p0.md](design/hosted-review-p0.md).
+
 ## Runtime contract
 
 Deploy the repository `Dockerfile` to a dedicated Cloud Run service and set:


### PR DESCRIPTION
## Summary
- Live probes show **mcp.grokmcp.org is already up** (`/healthz`, `/readyz` ready; MCP `401` without bearer).
- P0 is **wire GitHub review to the twin**, not invent a new service.
- New operator checklist: `docs/design/hosted-review-p0.md`
- Docs: hosted API plane = production; self-hosted CLI = lab only
- Workflow comments document the three repository variables for `ubuntu-latest` + `plane=api`

## Does not
- Land #109 or set GitHub vars/secrets (Codex/human ops)
- Change Control UI hardcode (P1)
- Deploy Cloud Run (twin already live)

## Related land queue for Codex
1. **#109** (rebased) — wiki-not-product docs  
2. **This PR** after or with #109  
3. **Ops:** set `UNIGROK_REVIEW_*` vars → smoke `@grok review` with Mac off

## Exact head
`69c189e8a90b91c6cb50d2174393a50b7ef7cdc5`

Agent-Assisted-By: xAI Grok | model=grok-4.5 | model-source=provider-session | surface=Grok Build | role=documentation