### PR TITLE
feat(grok): parallel-ship DAG for product + intelligence velocity

### DIFF
--- a/.agents/skills/grok-parallel-ship/SKILL.md
+++ b/.agents/skills/grok-parallel-ship/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: grok-parallel-ship
+description: Parallel dual-lane shipping for UniGrok contributor work—public product and intelligence—using UniGrok agent modes, git-DAG handoffs, and Codex as sole land gate. Activate when the user wants both product and intelligence, multi-agent velocity, or to keep Codex as a boring lander.
+---
+
+# Grok parallel ship
+
+Use with repository playbook
+[`.grok/playbooks/parallel-ship-dag.md`](../../../.grok/playbooks/parallel-ship-dag.md)
+and adapter [`.grok/prompts/grok_adapter.md`](../../../.grok/prompts/grok_adapter.md).
+
+## Roles
+
+| Actor | Owns |
+| --- | --- |
+| Human | Product intent, budgets, ship/no-ship policy |
+| Grok Build (and peer IDE agents) | Implementation in agent-prefixed worktrees, draft PRs, advisory review |
+| UniGrok `agent` | Multi-mode Grok reasoning/research (and internal provider adapters when routed) |
+| Codex | `scripts/land`, protected `main`, release/deploy gates |
+
+## Activate dual lanes
+
+1. Confirm two non-overlapping path sets (P vs I).
+2. Create two worktrees / branches (`grok/*` or other agent prefix).
+3. For hard design forks, call UniGrok:
+   - Lane P: `mode=thinking` or `reasoning`, prefer CLI
+   - Lane I: `mode=research` then `thinking`, budget-capped
+4. Never ask the human to run git. Leave the **handoff triad** on each PR:
+   URL + exact head SHA + tests/risks/cost + land readiness.
+
+## UniGrok modes (do not invent provider APIs)
+
+- `fast` — single-turn cheap
+- `reasoning` — multi-step product/intel analysis
+- `thinking` — reflected deep critique / architecture
+- `research` — web/X grounded fan-out (costlier)
+
+Public tool stays Grok-routed. Multi-provider adapters are not a second chat product.
+
+## Cost
+
+- Prefer `plane=cli` + `fallback_policy=same_plane` for free-compatible work.
+- API plane only when required (hosted twin, Deep-Think, metered models).
+- Record non-zero `cost_usd` in PR notes. Hard-stop on budget.
+
+## After Codex lands
+
+Recall/record workspace memory only against the landed full SHA (see
+`unigrok-workspace-memory` skill). Do not treat draft-PR SHAs as landed truth.

--- a/.agents/skills/grok-parallel-ship/SKILL.md
+++ b/.agents/skills/grok-parallel-ship/SKILL.md
@@ -42,6 +42,16 @@ Public tool stays Grok-routed. Multi-provider adapters are not a second chat pro
 - Prefer `plane=cli` + `fallback_policy=same_plane` for free-compatible work.
 - API plane only when required (hosted twin, Deep-Think, metered models).
 - Record non-zero `cost_usd` in PR notes. Hard-stop on budget.
+- Default monthly API envelope: **$2000** unless the operator revises it.
+- Do **not** multi-vendor fan-out “to compare models” by default — usually
+  worse ROI than Grok self-parallel + git-DAG coordination (see donor harvest).
+
+## Donor intelligence
+
+GenFuncAgentixAI long branches (`twin/chrysalis`, `twin/gemma_dpo_reflection`,
+`twin/singularity`, etc.) encode Cloud-Truth + GitOps intent workers + Pareto
+crucible work. Harvest via
+`.grok/playbooks/donor-genfunc-deep-harvest.md` — do not treat them as orphans.
 
 ## After Codex lands
 

--- a/.agents/skills/using-unigrok/SKILL.md
+++ b/.agents/skills/using-unigrok/SKILL.md
@@ -41,6 +41,23 @@ search grounding was used.
 - Tasks needing self-critique → `thinking`.
 - Current-events or source-cited answers → `research` (uses web + X search).
 
+## Parallel ship (product + intelligence)
+
+When the operator wants **both** public product work and intelligence/research
+without midwifing git:
+
+1. Split **Lane P** (product) and **Lane I** (intelligence) with path isolation.
+2. Route UniGrok modes per lane (P: fast/reasoning/thinking; I: research/thinking).
+3. Put coordination on the git DAG: agent-prefixed branch, draft PR, exact head,
+   verification notes — so Codex can land without human git chat.
+4. Prefer CLI plane for free-compatible critique; use API + same_plane when
+   Deep-Think or hosted twin work requires it.
+5. Full playbook: `.grok/playbooks/parallel-ship-dag.md` and skill
+   `grok-parallel-ship` (contributor repo only).
+
+Do **not** invent multi-provider public chat tools. UniGrok’s public `agent`
+remains Grok-routed; other providers stay behind Grok-supervised adapters.
+
 ## Plan critique habit (opt-in)
 
 When the user is about to see a multi-step **Implementation Plan**, prefer:

--- a/.claude/skills/using-unigrok/SKILL.md
+++ b/.claude/skills/using-unigrok/SKILL.md
@@ -1,96 +1,111 @@
 ---
 name: using-unigrok
-description: Claude Code guidance for querying xAI Grok through the shared UniGrok MCP gateway. Activate when the user says "@grok", asks to query Grok, wants a Grok second opinion or peer review, or needs web/X search grounding.
+description: How to query xAI Grok through the UniGrok MCP gateway. Activate when the user says "@grok", asks to query Grok, wants a second-model opinion or peer review from Grok, or needs web/X search grounding.
 ---
 
-# Using UniGrok from Claude Code
+# Using the UniGrok Grok Gateway
 
-This is the Claude Code adaptation of the canonical gateway skill
-([skills/using-unigrok/SKILL.md](../../../skills/using-unigrok/SKILL.md));
-it adds only what is specific to Claude Code sessions.
+UniGrok exposes one headline MCP tool: `agent`. It self-routes across Grok
+models and two billing planes, and returns structured metadata with every
+answer. **Primary chat path for every project is IDE → UniGrok MCP**. The local
+browser UI is an optional trusted-loopback test/control surface whose agent
+playground can invoke providers and spend metered credits.
 
-## Tool resolution
+## The `agent` tool
 
-The gateway's headline tool is `agent`, but its full Claude Code name depends
-on how the MCP server was registered:
+Call `agent` with:
 
-- `mcp__unigrok__agent` — connected through this repository's project
-  `.mcp.json` (server name `unigrok`).
-- `mcp__grok__agent` — connected through a user-scope registration named
-  `grok` (the Codex-compatible name).
+- `prompt` (required): the task or question, with enough context to act on.
+- `mode` (optional): `auto` (default), `fast` (single-turn, cheapest),
+  `reasoning` (multi-step planner), `thinking` (reflected agent loop), or
+  `research` (citation-grounded fanout).
+- `model` (optional): pin a Grok model id such as `grok-4.5`; leave unset to
+  let routing choose.
+- `session` (optional): a stable, project-qualified key such as
+  `owner-repo:task` for multi-turn continuity. Do not reuse a generic session
+  key across repositories.
+- `workspace_context` (optional): deliberately selected excerpts, diffs, or
+  errors when the task depends on the caller's project. The stable service
+  cannot browse the IDE workspace automatically.
+- `workspace_label` (optional): descriptive metadata for the supplied context.
+  It does not isolate sessions; the project-qualified `session` key does.
 
-Prefer the project-controlled `unigrok` registration. `.claude/settings.json`
-pre-allows its `agent`, `grok_mcp_status`, and `grok_mcp_discover_self` tools.
-A user-owned `grok` alias is not controlled by this repository; verify that it
-points to the expected UniGrok endpoint before approving or using its tools.
+Every result includes `response` plus metadata: `model`, `route`, `plane`
+(`API` or `CLI`), `cost_usd`, `tokens`, `latency_sec`, and `citations` when
+search grounding was used.
 
-## Calling `agent`
+## Mode selection guidance
 
-- `prompt` (required); `mode` optional: `auto` (default), `fast`, `reasoning`,
-  `thinking`, `research`.
-- `workspace_context`: the stable service is workspace-neutral and cannot see
-  the open folder — attach selected excerpts, `git diff` output, or errors
-  yourself. An optional `workspace_label` is descriptive metadata only; it does
-  not isolate sessions.
-- `session`: pass a stable, project-qualified key such as `owner-repo:task`.
-  The server namespaces it beneath a server-derived principal and the
-  caller-controlled `X-Client-ID` label (`plugin` in this repository's current
-  `.mcp.json`). A generic key can collide across repositories that reuse a
-  common label such as `claude-code`. Reuse preserves continuity and can reduce
-  repeated-context API input cost when caching hits, but savings are not
-  guaranteed and CLI provider cost remains unavailable.
-- `model`: pin only when asked; pins validate against the live catalog. An
-  explicit `plane=cli|api` should pair with `fallback_policy="same_plane"`
-  when billing planes must not cross.
+- Quick factual or single-file questions → `fast`.
+- Design reviews, audits, multi-step analysis → `reasoning`.
+- Tasks needing self-critique → `thinking`.
+- Current-events or source-cited answers → `research` (uses web + X search).
 
-Every result returns `response` plus `model`, `route`, `plane`, `why`,
-`degraded`, `cost_usd`, `tokens`, `latency_sec`, and `citations` when search
-grounding ran. Surface `cost_usd` when the user cares about spend.
+## Parallel ship (product + intelligence)
 
-## Claude Code patterns
+When the operator wants **both** public product work and intelligence/research
+without midwifing git:
 
-- **Second opinion before handoff**: send the branch diff via
-  `workspace_context` with `mode=reasoning` for a Grok peer review.
-- **Long calls should not block the turn**: `research` and `thinking` runs can
-  take minutes; wrap them in a background subagent (Agent tool) and keep
-  working, then relay the result.
-- **Health first**: on connection trouble, check `GET /healthz` on port 4765
-  and `grok_mcp_status`; `8080` is container-internal and never reachable from
-  the host.
+1. Split **Lane P** (product) and **Lane I** (intelligence) with path isolation.
+2. Route UniGrok modes per lane (P: fast/reasoning/thinking; I: research/thinking).
+3. Put coordination on the git DAG: agent-prefixed branch, draft PR, exact head,
+   verification notes — so Codex can land without human git chat.
+4. Prefer CLI plane for free-compatible critique; use API + same_plane when
+   Deep-Think or hosted twin work requires it.
+5. Full playbook: `.grok/playbooks/parallel-ship-dag.md` and skill
+   `grok-parallel-ship` (contributor repo only).
 
-## Registering in another repository
-
-The gateway is machine-global; projects need no UniGrok files. Teammates run:
-
-```bash
-claude mcp add --transport http unigrok http://localhost:4765/mcp \
-  --header "X-Client-ID: claude-code"
-```
-
-`X-Client-ID` is a caller-controlled attribution and session label, not an
-authenticated identity. The server derives the principal; the default
-unauthenticated loopback service derives the shared `http:anon` principal for
-one local budget/security trust domain. There is no cross-user isolation without
-configured auth. Because many repositories can reuse
-`X-Client-ID: claude-code`, always project-qualify the `session` key;
-`workspace_label` remains descriptive only. Control Center:
-`http://localhost:4765/ui/`.
-
-## Safety
-
-- Never request `XAI_API_KEY` in chat or write it into any IDE config; the
-  credential belongs to the server.
-- Treat `credential_planes` notices from status or agent results as the source
-  of truth; ask the user before device authentication, installation, or secret
-  configuration.
-- Translate provider and transport errors into one concrete next action; the
-  user should not need to understand planes or JSON-RPC.
+Do **not** invent multi-provider public chat tools. UniGrok’s public `agent`
+remains Grok-routed; other providers stay behind Grok-supervised adapters.
 
 ## Plan critique habit (opt-in)
 
-When the user is about to see a multi-step Implementation Plan, prefer calling
-UniGrok `agent` (`thinking` or `reasoning`) for a second opinion, then improve
-the plan before presenting it **only when the user wants a Grok second opinion**
-(including `@grok`). Do not silently spend metered API credits without consent.
-Do not invent a second MCP port or Forge workflow for public installs. Public
-path remains `http://localhost:4765/mcp` only.
+When the user is about to see a multi-step **Implementation Plan**, prefer:
+
+1. Call UniGrok `agent` (`thinking` or `reasoning`) with the draft plan.
+2. Incorporate feedback silently.
+3. Only then present the improved plan to the user.
+
+Do this when the user wants a Grok second opinion (including `@grok`). Do **not**
+silently spend metered API credits without consent. Do **not** auto-generate
+skill trees into foreign projects without permission. Never copy the UniGrok
+repository’s contributor `.agents` tree into the user’s other apps.
+
+## Cost awareness
+
+Check `cost_usd` in each response. Session reuse preserves continuity and can
+reduce repeated-context API input cost when caching hits; it does not guarantee
+savings. The default `cli_first` policy prefers compatible, unpinned work on an
+authenticated CLI subscription. Explicit plane selection should pair with
+`fallback_policy="same_plane"` when the request must not cross into a different
+credential or billing plane; `cross_plane` allows bounded failover. CLI
+provider cost remains unavailable, so report local counts and estimated tokens,
+not invented subscription cost or remaining provider quota.
+
+## Safe onboarding behavior
+
+- Treat `credential_planes` notices from status or an agent result as the
+  source of truth. Ask before device authentication, installation, or secret
+  configuration.
+- Never request `XAI_API_KEY` in chat or write it into the caller's project.
+- The stable service is workspace-neutral: do not assume MCP registration
+  grants filesystem access. Use `workspace_context` or local file tools only
+  when those tools are actually exposed in the current trusted
+  contributor/stdio session.
+- Translate provider and transport errors into one concrete next action for
+  the user; do not require them to understand planes, MCP transport, or JSON-RPC.
+- Public product path is `http://localhost:4765/mcp` only. Do not invent a
+  second port, Forge, Swarm, or land workflow for ordinary end-user installs.
+
+## Endpoint
+
+The shared gateway runs at `http://localhost:4765/mcp` (Streamable HTTP).
+Health: `GET /healthz`. Optional local Core UI: `http://localhost:4765/ui/`
+(trusted machine-owner test/control surface with a provider-calling agent
+playground). `X-Client-ID` is a caller-controlled
+attribution and session label beneath a server-derived principal; it is not
+authentication. The default unauthenticated loopback service derives the shared
+`http:anon` principal for one local budget/security trust domain, so there is
+no cross-user isolation without configured auth. Project-qualify every session
+key: a generic key can collide across repositories when the same client label
+is reused.

--- a/.github/skills/using-unigrok/SKILL.md
+++ b/.github/skills/using-unigrok/SKILL.md
@@ -1,88 +1,111 @@
 ---
 name: using-unigrok
-description: VS Code Copilot guidance for querying xAI Grok through the shared UniGrok MCP gateway. Activate when the user says "@grok", asks to query Grok, requests a Grok second opinion/peer review, wants web/X grounded research, or needs cross-repo UniGrok setup help.
+description: How to query xAI Grok through the UniGrok MCP gateway. Activate when the user says "@grok", asks to query Grok, wants a second-model opinion or peer review from Grok, or needs web/X search grounding.
 ---
 
-# Using UniGrok from VS Code Copilot
+# Using the UniGrok Grok Gateway
 
-This is the Copilot/VS Code adaptation of the canonical gateway skill at
-`skills/using-unigrok/SKILL.md`. Use it when working in this repository and
-also when helping users in other repositories that connect to the same local
-UniGrok MCP service.
+UniGrok exposes one headline MCP tool: `agent`. It self-routes across Grok
+models and two billing planes, and returns structured metadata with every
+answer. **Primary chat path for every project is IDE → UniGrok MCP**. The local
+browser UI is an optional trusted-loopback test/control surface whose agent
+playground can invoke providers and spend metered credits.
 
-## Tool resolution
+## The `agent` tool
 
-The core tool is `agent`, but the namespaced tool name depends on MCP server
-registration:
+Call `agent` with:
 
-- `mcp__unigrok__agent` when the server name is `unigrok` (common workspace
-  config).
-- `mcp__grok__agent` when user scope registers the same endpoint as `grok`.
+- `prompt` (required): the task or question, with enough context to act on.
+- `mode` (optional): `auto` (default), `fast` (single-turn, cheapest),
+  `reasoning` (multi-step planner), `thinking` (reflected agent loop), or
+  `research` (citation-grounded fanout).
+- `model` (optional): pin a Grok model id such as `grok-4.5`; leave unset to
+  let routing choose.
+- `session` (optional): a stable, project-qualified key such as
+  `owner-repo:task` for multi-turn continuity. Do not reuse a generic session
+  key across repositories.
+- `workspace_context` (optional): deliberately selected excerpts, diffs, or
+  errors when the task depends on the caller's project. The stable service
+  cannot browse the IDE workspace automatically.
+- `workspace_label` (optional): descriptive metadata for the supplied context.
+  It does not isolate sessions; the project-qualified `session` key does.
 
-Use whichever namespace exists in the active tool list.
+Every result includes `response` plus metadata: `model`, `route`, `plane`
+(`API` or `CLI`), `cost_usd`, `tokens`, `latency_sec`, and `citations` when
+search grounding was used.
 
-## Calling pattern
+## Mode selection guidance
 
-- `prompt` (required): the exact task/question.
-- `mode` (optional): `auto`, `fast`, `reasoning`, `thinking`, `research`.
-- `session` (optional): stable per-task session key (reuse for follow-ups).
-- `workspace_context` (optional): selected code snippets, diffs, logs, or
-  errors from the caller's repo.
-- `workspace_label` (optional): human-readable repo/project name.
-- `model` (optional): pin only when asked.
-- `plane` and `fallback_policy` (optional): use
-  `fallback_policy="same_plane"` when the request must not cross billing
-  planes.
+- Quick factual or single-file questions → `fast`.
+- Design reviews, audits, multi-step analysis → `reasoning`.
+- Tasks needing self-critique → `thinking`.
+- Current-events or source-cited answers → `research` (uses web + X search).
 
-The stable service is workspace-neutral and cannot browse the caller's files
-automatically; attach only deliberate context via `workspace_context`.
+## Parallel ship (product + intelligence)
 
-## Response handling
+When the operator wants **both** public product work and intelligence/research
+without midwifing git:
 
-Surface both `response` and key metadata when relevant:
+1. Split **Lane P** (product) and **Lane I** (intelligence) with path isolation.
+2. Route UniGrok modes per lane (P: fast/reasoning/thinking; I: research/thinking).
+3. Put coordination on the git DAG: agent-prefixed branch, draft PR, exact head,
+   verification notes — so Codex can land without human git chat.
+4. Prefer CLI plane for free-compatible critique; use API + same_plane when
+   Deep-Think or hosted twin work requires it.
+5. Full playbook: `.grok/playbooks/parallel-ship-dag.md` and skill
+   `grok-parallel-ship` (contributor repo only).
 
-- `model`, `route`, `plane`, `why`, `degraded`
-- `cost_usd`, `tokens`, `latency_sec`
-- `citations` (when research grounding is used)
-
-If users are cost-sensitive, explicitly report `cost_usd` and encourage session
-reuse for follow-up questions.
-
-## VS Code team distribution
-
-- **Workspace-shared skill (git-backed):**
-  `.github/skills/using-unigrok/SKILL.md`
-- **Personal user-level skill (not in git):**
-  `~/.copilot/skills/using-unigrok/SKILL.md`
-
-Use the workspace path for team defaults. Use the personal path for individual
-defaults across unrelated repositories.
-
-Do not duplicate this skill under a repository-root `.copilot/skills`
-directory; that is not a default project discovery path. VS Code can opt into
-additional paths through `chat.agentSkillsLocations` when a deliberate
-nonstandard location is required.
-
-## MCP endpoint and identity
-
-Default endpoint: `http://localhost:4765/mcp`
-
-Every IDE config should send a stable `X-Client-ID` (for example `vscode`) so
-session namespaces and telemetry remain separated by client.
-
-## Safety and credential boundary
-
-- Never ask users to paste `XAI_API_KEY` into IDE MCP config; credentials live
-  server-side.
-- Treat `credential_planes` status in tool output as source of truth.
-- On failures, return one concrete next action (for example check `/healthz`,
-  authenticate CLI plane, or verify MCP registration).
+Do **not** invent multi-provider public chat tools. UniGrok’s public `agent`
+remains Grok-routed; other providers stay behind Grok-supervised adapters.
 
 ## Plan critique habit (opt-in)
 
-When the user is about to see a multi-step Implementation Plan, prefer calling
-UniGrok `agent` (`thinking` or `reasoning`) for a second opinion, then improve
-the plan before presenting it **only when the user wants a Grok second opinion**
-(including `@grok`). Do not silently spend metered API credits without consent.
-Do not invent a second MCP port or Forge workflow for public installs. Public
-path remains `http://localhost:4765/mcp` only.
+When the user is about to see a multi-step **Implementation Plan**, prefer:
+
+1. Call UniGrok `agent` (`thinking` or `reasoning`) with the draft plan.
+2. Incorporate feedback silently.
+3. Only then present the improved plan to the user.
+
+Do this when the user wants a Grok second opinion (including `@grok`). Do **not**
+silently spend metered API credits without consent. Do **not** auto-generate
+skill trees into foreign projects without permission. Never copy the UniGrok
+repository’s contributor `.agents` tree into the user’s other apps.
+
+## Cost awareness
+
+Check `cost_usd` in each response. Session reuse preserves continuity and can
+reduce repeated-context API input cost when caching hits; it does not guarantee
+savings. The default `cli_first` policy prefers compatible, unpinned work on an
+authenticated CLI subscription. Explicit plane selection should pair with
+`fallback_policy="same_plane"` when the request must not cross into a different
+credential or billing plane; `cross_plane` allows bounded failover. CLI
+provider cost remains unavailable, so report local counts and estimated tokens,
+not invented subscription cost or remaining provider quota.
+
+## Safe onboarding behavior
+
+- Treat `credential_planes` notices from status or an agent result as the
+  source of truth. Ask before device authentication, installation, or secret
+  configuration.
+- Never request `XAI_API_KEY` in chat or write it into the caller's project.
+- The stable service is workspace-neutral: do not assume MCP registration
+  grants filesystem access. Use `workspace_context` or local file tools only
+  when those tools are actually exposed in the current trusted
+  contributor/stdio session.
+- Translate provider and transport errors into one concrete next action for
+  the user; do not require them to understand planes, MCP transport, or JSON-RPC.
+- Public product path is `http://localhost:4765/mcp` only. Do not invent a
+  second port, Forge, Swarm, or land workflow for ordinary end-user installs.
+
+## Endpoint
+
+The shared gateway runs at `http://localhost:4765/mcp` (Streamable HTTP).
+Health: `GET /healthz`. Optional local Core UI: `http://localhost:4765/ui/`
+(trusted machine-owner test/control surface with a provider-calling agent
+playground). `X-Client-ID` is a caller-controlled
+attribution and session label beneath a server-derived principal; it is not
+authentication. The default unauthenticated loopback service derives the shared
+`http:anon` principal for one local budget/security trust domain, so there is
+no cross-user isolation without configured auth. Project-qualify every session
+key: a generic key can collide across repositories when the same client label
+is reused.

--- a/.grok/harvest/dialect-control-tokens/PROVENANCE.txt
+++ b/.grok/harvest/dialect-control-tokens/PROVENANCE.txt
@@ -1,0 +1,8 @@
+source_repo=djtelicloud/GenFuncAgentixAI
+matrix_commit=8d4f7b3a4fc
+compiler_commit=8d4f7b3a4fc (same path)
+seed_commit=5328eb7769d
+omni_wire_commit=c6921b45dd1
+optimizer_commit=8d4f7b3a4fc (swarm_dialect_optimizer.py)
+lexical_crucible_commit=20344a7451c
+status=reference_harvest_not_runtime

--- a/.grok/harvest/dialect-control-tokens/README.md
+++ b/.grok/harvest/dialect-control-tokens/README.md
@@ -1,0 +1,71 @@
+# Dialect control-token library (harvest)
+
+**Status:** Reference harvest for UniGrok silent-think. **Not** wired into the
+MCP runtime. Public users never see this.
+
+## What this is
+
+Donor GenFunc name: **Native Latent IPC / Token Control Language**.
+
+| File | Role |
+| --- | --- |
+| `dialect_matrix.json` | Per-family control tokens / prefills / locks |
+| `dialect_compiler.py` | Compiles mission + payload into a control-token prompt |
+| `PROVENANCE.txt` | Exact donor commits |
+
+This is the library you meant by “control tokens”: not a pip package, not
+OAuth, not CSS design tokens.
+
+## How it works
+
+`DialectCompiler.compile(family, mission, payload, force_tool|force_reasoning)`:
+
+1. **system_lock + safety_bypass** — family-native structural prefix (PUA
+   chars, chat-template specials, or harsh system text for Gemma).
+2. **mission + compact JSON payload**
+3. **assistant_force** prefill (start of assistant turn)
+4. **tool_coercion_open** *or* **reasoning_start**
+
+Visible completion is steered by the prefill. Intelligence cost stays in
+internal thinking / small-model compute when paired with tiny max-out and
+schema emit (see silent-think playbook).
+
+## Families in matrix v1.1.0
+
+`gemini`, `gemma`, `llama3`, `grok`, `mistral`, `openai_o1`.
+
+Gemma dialect was evolved by `swarm_dialect_optimizer.py` (loop until dense
+functional emit, plateau=3) — the harness that forced smaller models below
+normal cost/fluff.
+
+## Related donor pieces (not copied; recover from GenFunc git)
+
+| Piece | Commit / path |
+| --- | --- |
+| Seed script | `5328eb7769d` `v13_dialect_seed.py` |
+| Omni router wire | `c6921b45dd1` `.agent/brain/omni_router.py` |
+| Lexical crucible | `20344a7451c` `lexical_crucible.py` |
+| Dialect optimizer | `8d4f7b3a4fc` `swarm_dialect_optimizer.py` |
+
+## Runtime cousins (not this harvest)
+
+- **mlx_lm** `_process_control_tokens` / `_infer_thinking` — strips
+  `<think>`…`</think>` etc. from local stream output.
+- Provider APIs: `ThinkingConfig.include_thoughts`, thinking budget vs
+  `max_output_tokens`.
+
+## UniGrok port rules
+
+1. Keep harvest under `.grok/harvest/` until a design PR lands a runtime
+   module under `src/` with tests.
+2. Prefer **safe** control surfaces for hosted paths: chat-template specials
+   and documented thinking APIs — not experimental PUA “safety_bypass”
+   tokens on public traffic.
+3. Pair with tiny pydantic emit + silent-think receipts
+   (`thought_tokens` / `completion_tokens`).
+4. Insider / contributor only; public root-as-lava stays clean.
+
+## Playbooks
+
+- [silent-think-harness.md](../../playbooks/silent-think-harness.md)
+- [donor-genfunc-deep-harvest.md](../../playbooks/donor-genfunc-deep-harvest.md)

--- a/.grok/harvest/dialect-control-tokens/dialect_compiler.py
+++ b/.grok/harvest/dialect-control-tokens/dialect_compiler.py
@@ -1,0 +1,37 @@
+import json
+
+class DialectCompiler:
+    """V13 Functional Singularity: Translates DAG intents into Native Latent IPC."""
+    
+    def __init__(self, matrix_path: str = ".agent/brain/dialect_matrix.json"):
+        with open(matrix_path, "r", encoding="utf-8") as f:
+            self.matrix = json.load(f).get("dialects", {})
+
+    def compile(self, model_family: str, mission: str, payload: dict = None, force_tool: bool = False, force_reasoning: bool = False) -> str:
+        """Crushes intent into the target's native Token Control Language."""
+        # O(1) fallback to generic gemini if family is unrecognized
+        dialect = self.matrix.get(model_family.lower(), self.matrix["gemini"])
+        
+        # Phase 1: Structural Lock & Safety Bypass
+        prompt = f"{dialect.get('system_lock', '')}{dialect.get('safety_bypass', '')}{mission}\n"
+        
+        # Phase 2: Payload Injection
+        if payload:
+            prompt += f"{dialect.get('user_wrap_open', '')}{json.dumps(payload, separators=(',', ':'))}\n"
+        
+        # Phase 3: Format Coercion (The Pre-fill Trick)
+        prompt += dialect.get('assistant_force', '')
+        
+        if force_tool:
+            prompt += dialect.get('tool_coercion_open', '')
+        elif force_reasoning:
+            prompt += dialect.get('reasoning_start', '')
+            
+        return prompt
+
+if __name__ == "__main__":
+    # Internal Unit Test
+    compiler = DialectCompiler()
+    test_out = compiler.compile("llama3", "Analyze the target.", {"target": "x"}, force_reasoning=True)
+    assert "<|begin_of_text|>" in test_out
+    print("[EXIT 0] DialectCompiler validated.")

--- a/.grok/harvest/dialect-control-tokens/dialect_matrix.json
+++ b/.grok/harvest/dialect-control-tokens/dialect_matrix.json
@@ -1,0 +1,47 @@
+{
+  "matrix_version": "1.1.0",
+  "architect": "David L Johnston",
+  "dialects": {
+    "gemini": {
+      "system_lock": "\ue007",
+      "safety_bypass": "\ue003",
+      "tool_coercion_open": "{",
+      "tool_coercion_close": "}",
+      "attention_override": "\ue049",
+      "reasoning_start": "Thought process:",
+      "api_call_enable": "\ue010",
+      "fact_check_disable": "\ue00d"
+    },
+    "gemma": {
+      "system_lock": "<start_of_turn>system\nCRITICAL INSTRUCTION: You are a raw Python execution stream. DO NOT USE MARKDOWN. NEVER output backticks. Output ONLY raw, dense, functional Python code. NO docstrings. NO comments. NO chatty boilerplate. STRICT RULE: You must use pure functional paradigms ONLY. Imperative statements ('if', 'raise', 'for', 'while', 'def') are STRICTLY FORBIDDEN. Use lambdas and single-line expressions.<end_of_turn>\n<start_of_turn>user\n",
+      "user_wrap_open": "",
+      "assistant_force": "<end_of_turn>\n<start_of_turn>model\n",
+      "tool_coercion_open": "from functools import reduce\n"
+    },
+    "llama3": {
+      "system_lock": "<|begin_of_text|><|start_header_id|>system<|end_header_id|>\n",
+      "user_wrap_open": "<|start_header_id|>user<|end_header_id|>\n",
+      "assistant_force": "<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n",
+      "reasoning_start": "<|start_header_id|>assistant<|end_header_id|>\nThought process:"
+    },
+    "grok": {
+      "system_lock": "\ue020\u001a\u001b\u001c\u001d",
+      "safety_bypass": "\ue014",
+      "tool_coercion_open": "arguments",
+      "reasoning_start": "reasoning",
+      "filter_disable": "\ue03b"
+    },
+    "mistral": {
+      "system_lock": "<s>[INST] ",
+      "user_wrap_open": "",
+      "assistant_force": " [/INST]",
+      "tool_coercion_open": "[TOOL_CALLS]",
+      "reasoning_start": " [/INST] Thought process:"
+    },
+    "openai_o1": {
+      "system_lock": "\ue007",
+      "tool_coercion_open": "<tool>",
+      "reasoning_start": "<thinking>"
+    }
+  }
+}

--- a/.grok/hyperparams/unigrok-ship-orchestrator.json
+++ b/.grok/hyperparams/unigrok-ship-orchestrator.json
@@ -1,0 +1,7 @@
+{
+  "temperature": 0.35,
+  "top_p": 0.9,
+  "thinking_mode": true,
+  "system_prompt_ref": "grok_adapter.md",
+  "notes": "Prefer for multi-lane ship sessions: dual product+intelligence planning, handoff discipline, cost-aware UniGrok mode routing. Not a public model id pin."
+}

--- a/.grok/playbooks/donor-genfunc-deep-harvest.md
+++ b/.grok/playbooks/donor-genfunc-deep-harvest.md
@@ -1,0 +1,85 @@
+# GenFuncAgentixAI deep harvest (not orphaned — unfinished DAG)
+
+**Donor:** `djtelicloud/GenFuncAgentixAI` (private)  
+**Mistake corrected:** `main` is a shallow snapshot (1 commit). Real work lives on
+**long-lived remote branches** (50–119 commits ahead of main). Those branches
+were not trash; they are the crucible / twin / sky-command continuum.
+
+## Branch inventory (fetched 2026-07-14)
+
+| Branch | Ahead of main | What it actually is |
+| --- | ---: | --- |
+| `twin/chrysalis` | 50 | NSGA-II / Pareto flywheel commits (`gen=1058000`), **Sky Command Apex**, Pub/Sub spine, daemons (`chrysalis_daemon`, `swarm_flywheel`, `reality_sync`), cloud DNS, swarm evolver |
+| `twin/gemma_dpo_reflection` | 103 | Cortex brain: `omni_router`, `synapse_recorder` → **git branch as memory**, DPO/telemetry, Cloud Twin GH Actions, WalrusSynapse |
+| `twin/ruff_sanitation` | 119 | Symbiotic playground FastAPI, `apps/swarm_evolver` evolution engine, compliance gates |
+| `twin/singularity` | 65 | **PHASE5_CLOUD_TWIN** topology, GitOps intent API, deploy twin, WIF forge PR #3 |
+| `snaps` | 50 | “Assimilate redundant cloud twin + gitops CI/CD” snapshot |
+| `app/singularity` / `app/cortex_enclave` | 50–57 | App/enclave / Antigravity extension streams |
+| `dev/app/sovereign_terminal` | 50 | Dev terminal (commits into 2026-07) |
+| `prod/apps/sovereign_terminal` | 50 | Prod terminal stream |
+| Open PRs #1–#3 | — | WIF bootstrap, auth harden, architecture matrix — still open |
+
+## Proven doctrine (from branch docs, not main marketing)
+
+### 1. Redundancy Physics / Cloud-Truth
+- Local IDE = **hologram** (volatile projection).
+- **Cloud orchestration + GitHub GitOps** = source of truth.
+- Local agents should emit **intent**, not edit control-plane guts.
+- Return path: cloud mutates **git**; local machines **fetch** truth.
+
+### 2. Cloud Twin purpose (PHASE5)
+Cloud Twin converts **intent envelopes** into **deterministic Git-backed mutations**:
+
+```text
+local intent → WebMCP/relay → Cloud Twin API /v1/swarm/intent
+  → isolated workspace clone → agents produce Change Envelope
+  → GitOps commit/push → local IDE re-renders from git
+```
+
+Not: “put the chat model in a mutable container and git reset yourself.”
+
+### 3. Sky Command vs Twin vs Ground
+- **Sky Command** — control plane / dashboard / command Pub/Sub (push).
+- **Cloud Twin** — maintenance shadow / GitOps / Eventarc-cron style work.
+- **Ground** — heavy compute pulls commands (zero inbound ports).
+
+### 4. Agent memory on git DAG
+- `synapse_recorder` commits golden/toxic trajectories to `brain/synapse`.
+- `omni_router` TF-IDF ranks skills/workflows/reflexes/**models** (UCB weights).
+- `walrus_dpo_chosen` git notes = DPO/victory memory (when present).
+- Chrysalis daemon: AST firewall + ruff + notes on verified mutations.
+
+### 5. Crucible / benchmarks (evidence of seriousness)
+- `evolution_engine.py`: NSGA-II, multi-objective Pareto, GPU-saturating design,
+  feeds DPO via git notes.
+- Twin commit messages encode live Pareto metrics (f1…f5).
+- Swarm compliance master gate before commit (ruff, GNO DAG, root litter, etc.).
+
+## What to port into UniGrok (mechanically)
+
+| Harvest | UniGrok target | Notes |
+| --- | --- | --- |
+| Intent → GitOps worker | Future **maintenance twin** (not public MCP) | Separate service from `mcp.grokmcp.org` inference |
+| Cloud-truth + local hologram | Already: land receipts + workspace memory notes | Strengthen: agents never ask human for git |
+| Multi-agent bus = branches/PRs/notes | Draft PRs + exact heads + `Agent-*` trailers | Restore cron/automation that wakes lander |
+| UCB1 / model catalog ranking | `model_catalog` + routing telemetry | Prefer Grok stack for default intelligence |
+| Swarm compliance pre-commit | Existing tests + land scripts | Keep fail-closed |
+| Sky vs Twin split | Control vs MCP twin | Control = AS/broker; MCP = API inference only |
+| Isolated clone per mutation | Cloud worker pattern | Never shared mutable working tree |
+
+## What NOT to port
+
+| Reject | Why |
+| --- | --- |
+| Mutable Cloud Run + `git reset --hard` as product MCP | Ephemeral disk, secret sprawl, un-auditable |
+| Static long-lived twin secrets as sole auth | Prefer OIDC/OAuth |
+| Committed SA/Firebase JSON | Credential leak class |
+| Unbounded multi-provider fan-out “for opinions” | Cost + often worse than Grok self-parallel |
+| Forcing human into git midwifery | Violates donor’s own redundancy physics |
+
+## Implication for UniGrok agent sessions
+
+1. **Continue until handoff triad is on GitHub** — do not stop to ask humans for mathematically settled choices.
+2. **Default intelligence = Grok modes on UniGrok** (CLI first; API for thinking when required). Fan-out to other vendors only for specialized tools/data, not democracy of chatbots.
+3. **Budget envelope** (operator-set): e.g. **$2000/month** total API; session hard-stops leave notes on PR, not questions.
+4. **Orphaned donor branches are a harvest backlog**, not abandoned code — work them via read-only analysis → UniGrok design PRs → Codex land.

--- a/.grok/playbooks/donor-genfunc-deep-harvest.md
+++ b/.grok/playbooks/donor-genfunc-deep-harvest.md
@@ -63,6 +63,9 @@ Not: “put the chat model in a mutable container and git reset yourself.”
 | Cloud-truth + local hologram | Already: land receipts + workspace memory notes | Strengthen: agents never ask human for git |
 | Multi-agent bus = branches/PRs/notes | Draft PRs + exact heads + `Agent-*` trailers | Restore cron/automation that wakes lander |
 | UCB1 / model catalog ranking | `model_catalog` + routing telemetry | Prefer Grok stack for default intelligence |
+| **Silent-think harness** | `_parse_structured` + CLI `--json-schema` + receipts | High think budget, `include_thoughts=false`, tiny pydantic emit; see [silent-think-harness.md](silent-think-harness.md) |
+| **Dialect control-token library** | Reference harvest (not runtime yet) | [`.grok/harvest/dialect-control-tokens/`](../harvest/dialect-control-tokens/) — matrix + `DialectCompiler`; optimizer loop forced small models |
+| Recursive maxing (max_out compress) | Optional specialist param search | EVOLUTION.md patience loop; VPP-style cost ledger later |
 | Swarm compliance pre-commit | Existing tests + land scripts | Keep fail-closed |
 | Sky vs Twin split | Control vs MCP twin | Control = AS/broker; MCP = API inference only |
 | Isolated clone per mutation | Cloud worker pattern | Never shared mutable working tree |

--- a/.grok/playbooks/index-diff-hive.md
+++ b/.grok/playbooks/index-diff-hive.md
@@ -1,0 +1,116 @@
+# Index-diff hive (cheap parallel deep-think)
+
+**Audience:** GitHub-authenticated UniGrok contributors only.  
+**Public users:** never see this surface (root-as-lava / simple MCP product).
+
+## Economics (locked)
+
+| Plane | When | Cost shape |
+| --- | --- | --- |
+| **CLI / IDE subscription** (laptop open, Docker ported auth) | Default for all hive polls | Fixed plan cost — **max throughput** |
+| **API** (OpenAI / Anthropic / Gemini / xAI metered) | Throttle, failure, or CLI capability gap | Metered — failover only; monthly envelope **$2000** |
+
+Do not burn API thinking modes for index-diff. Use **single-shot low-output** calls (`fast` / CLI composer).  
+Measured: UniGrok `thinking` on a 12-line protocol still spent ~$0.06 / ~25k tokens (internal reflection).  
+`fast`+CLI returned 12 lines at **$0.00** subscription.
+
+## Protocol v0
+
+### Claim index (canonical document)
+
+```text
+L1: ...
+L2: ...
+```
+
+Content-address the claim set (SHA of normalized lines). All polls bind to that SHA.
+
+### Poll prompt (≤500 chars)
+
+```text
+PROTOCOL: index-diff only. No prose.
+Output EXACTLY: L<n>|<GOOD|BAD|UGLY|STUPID|KEEP|KILL>|<≤12 words>
+Max N lines. No fences.
+```
+
+Plus the claim index (or hash + git path for models that can pull).
+
+### Valid tags
+
+| Tag | Meaning |
+| --- | --- |
+| GOOD | Sound, ship |
+| KEEP | Sound with minor caveats |
+| BAD | Flawed but fixable |
+| UGLY | Overengineered / undefined mechanism |
+| STUPID | Buzzword / no mechanism |
+| KILL | Drop from design |
+
+### Git note store (insider)
+
+```text
+git notes --ref=unigrok-index-diff add -m "$(poll_body)" <claim-sha-or-commit>
+```
+
+Note body:
+
+```text
+model: <id>
+plane: cli|api
+cost_usd: <n>
+claim_sha: <sha>
+L1|KEEP|...
+...
+```
+
+### Aggregation (not ARGPO-by-name until formalized)
+
+Default **mechanical** aggregator (donor-aligned UCB1 / majority, not invented ARGPO):
+
+1. Map tags → scores: GOOD=2 KEEP=1 BAD=0 UGLY=-1 STUPID=-2 KILL=-3  
+2. Per-line mean across models; discard models with parse failure.  
+3. Decision: mean ≥ 1 → KEEP; ≤ -1 → KILL; else revise claim and re-poll.  
+4. Optional UCB1 weight by model historical parse-success / agreement (from donor `model_arena` idea).
+
+Deep-Think and Claude both flagged raw “ARGPO over index scores” as **UGLY/undefined** until a formal update rule exists. Ship majority+UCB1 first.
+
+## Parallel “silent thinking”
+
+| Step | Who | Tokens |
+| --- | --- | --- |
+| 1 Emit claim index + SHA | UniGrok / Grok Build | local |
+| 2 Fan-out index-diff polls | Grok CLI, Claude CLI, Gemini CLI, … **CLI first** | low out |
+| 3 Write notes | agent | free |
+| 4 Aggregate | local script | free |
+| 5 Only if contested lines remain | one Deep-Think **on contested subset only** | metered |
+
+This is **not** multi-vendor essay democracy. It is **index consensus** then optional expensive reflection on disagreements only.
+
+## Donor physics this reuses
+
+- **omni_router** TF-IDF vector spaces over skills/synapses/models (cheap local).  
+- **UCB1** champion selection (`swarm_rank_models` / `ucb_router`).  
+- **optimize_params** forces small models with catalog-bounded hyperparams.  
+- **synapse_recorder / walrus notes** for immutable harvest.  
+- **Chrysalis** AST gate before anything becomes real code.  
+- Public never sees hive; insiders opt into GitHub-auth cloud mind.
+
+## Public vs insider (non-negotiable)
+
+| Surface | Hive / index-diff / notes |
+| --- | --- |
+| Public MCP `:4765` / vibe README | **OFF** |
+| Contributor Forge / Control write+ | **ON** (opt-in) |
+| Hosted review | separate metered path; still CLI-first where possible |
+
+## Live poll sample (2026-07-14)
+
+Claim C (hive index-diff design). Models:
+
+| Model | Plane | Cost | Notable |
+| --- | --- | --- | --- |
+| grok-composer-2.5-fast | CLI | $0 | L4 ARGPO→UGLY; schema missing→STUPID without claim index |
+| Deep-Think grok-4.5 thinking | API | ~$0.058 | GOOD on cheap poll + insider gate; UGLY on ARGPO |
+| Claude (host CLI, Sonnet-class) | sub | plan | L5 notes UGLY fragility; L6 ARGPO UGLY; L7 STUPID without mechanism |
+
+Consensus: **index-diff protocol GOOD/KEEP; formal ARGPO name deferred; claim schema required; public off; CLI first.**

--- a/.grok/playbooks/index-diff-hive.md
+++ b/.grok/playbooks/index-diff-hive.md
@@ -74,7 +74,9 @@ Default **mechanical** aggregator (donor-aligned UCB1 / majority, not invented A
 
 Deep-Think and Claude both flagged raw “ARGPO over index scores” as **UGLY/undefined** until a formal update rule exists. Ship majority+UCB1 first.
 
-## Parallel “silent thinking”
+## Parallel polls (emit surface only)
+
+Index-diff is a **micro-emit format**, not the intelligence engine.
 
 | Step | Who | Tokens |
 | --- | --- | --- |
@@ -86,11 +88,15 @@ Deep-Think and Claude both flagged raw “ARGPO over index scores” as **UGLY/u
 
 This is **not** multi-vendor essay democracy. It is **index consensus** then optional expensive reflection on disagreements only.
 
+**Real force:** silent-think harness — high internal thinking budget, `include_thoughts=false`, tiny structured emit (pydantic / index-diff / any fixed shape). See [silent-think-harness.md](silent-think-harness.md). Token counts that prove work are **thought tokens in usage**, not printed CoT.
+
 ## Donor physics this reuses
 
 - **omni_router** TF-IDF vector spaces over skills/synapses/models (cheap local).  
 - **UCB1** champion selection (`swarm_rank_models` / `ucb_router`).  
-- **optimize_params** forces small models with catalog-bounded hyperparams.  
+- **optimize_params** `thinking_budget` vs `max_output_tokens` split (compute ≠ print).  
+- **Recursive maxing** evolution loop: compress `max_output_tokens` until fitness holds.  
+- **response_schema + pydantic** tiny emit after silent work.  
 - **synapse_recorder / walrus notes** for immutable harvest.  
 - **Chrysalis** AST gate before anything becomes real code.  
 - Public never sees hive; insiders opt into GitHub-auth cloud mind.

--- a/.grok/playbooks/parallel-ship-dag.md
+++ b/.grok/playbooks/parallel-ship-dag.md
@@ -2,6 +2,9 @@
 
 Human speaks product intent only. Agents own git. Codex owns land on `main`.
 
+**Public users:** root-as-lava, simple MCP product, no security theatre, no hive mind.
+**GitHub-auth insiders only:** shared cloud mind, index-diff hive, multi-agent DAG (opt-in). See `index-diff-hive.md`.
+
 ## Session physics (non-negotiable)
 
 1. **Do not stop to ask the human** about choices that are already decided by

--- a/.grok/playbooks/parallel-ship-dag.md
+++ b/.grok/playbooks/parallel-ship-dag.md
@@ -1,0 +1,55 @@
+# Parallel ship DAG (Grok Build + UniGrok)
+
+Human speaks product intent only. Agents own git. Codex owns land on `main`.
+
+## Lanes
+
+| Lane | Mission | UniGrok modes | Path ownership (examples) |
+| --- | --- | --- | --- |
+| **P — Public product** | Console, onboarding, hosted review wiring, README/OKF | `fast` glue · `reasoning` contracts · `thinking` multi-file | `mcp_ui/`, `docs/ide-setup.md`, `docs/chatgpt-github-app.md`, `docs/design/hosted-*`, workflows for review |
+| **I — Intelligence** | AKE, Needle gates (fail-closed), provider adapters, evals | `research` gather · `thinking` synthesize · `reasoning` product implications | `src/providers/`, campaign packs, `evals/`, design under `docs/design/ake*` / needle |
+
+Never mix P and I in one PR. Parallel = two worktrees / two branches / two draft PRs.
+
+## UniGrok multi-model use (honest limits)
+
+- Public MCP `agent` is **Grok-routed** (API or CLI plane). Modes: `auto` | `fast` | `reasoning` | `thinking` | `research`.
+- Multi-provider adapters (OpenAI / Anthropic / Gemini) exist for **Grok-supervised** internal work; do not invent client-facing multi-provider chat.
+- Fan-out pattern for hard decisions:
+  1. `thinking` or `reasoning` — primary plan (CLI first when free).
+  2. Optional second call `research` — only if facts need web/X.
+  3. Optional deep-think `thinking` + `plane=api` — when subscription is wrong tool or user asks Deep-Think.
+- Always log `cost_usd`, `plane`, `model` in PR notes when API spend is non-zero.
+
+## Handoff triad (byte-safe agent bus)
+
+Every finished lane must leave **all three** on GitHub:
+
+1. **Draft PR** (agent-prefixed branch only)
+2. **Exact head SHA** in body
+3. **Notes:** changed paths, tests, risks, cost, `ready for Codex land? yes/no`
+
+Codex lands only from that triad. Humans do not re-explain git.
+
+## Cost caps (session defaults)
+
+| Lane | Default posture |
+| --- | --- |
+| P | Prefer CLI plane; API only for plan critique or hosted twin work |
+| I | Harder cap; no live Needle gen without explicit authorization |
+| Review | Explicit `@grok review` / dispatch only; never auto on every push |
+
+Hard-stop: when budget or scope slips, freeze lane, update PR notes, open no new API fan-out.
+
+## Conflict rules
+
+- Shared read of `main`; exclusive write by path table above.
+- If lanes collide: I yields product claims; rebase on new exact head; re-handoff.
+- Never silent overwrite of another agent’s branch.
+
+## Never
+
+- Auto-merge / push shared `main` / run `scripts/land` as Grok
+- Tunnel-as-production
+- Ask the human to run git commands
+- Invent provider endpoints on the public agent tool

--- a/.grok/playbooks/parallel-ship-dag.md
+++ b/.grok/playbooks/parallel-ship-dag.md
@@ -2,6 +2,23 @@
 
 Human speaks product intent only. Agents own git. Codex owns land on `main`.
 
+## Session physics (non-negotiable)
+
+1. **Do not stop to ask the human** about choices that are already decided by
+   product freeze, security fail-closed rules, or donor-crucible evidence.
+   Decide, implement, put the handoff triad on GitHub, continue.
+2. **Marathon mode:** keep working until draft PRs + exact heads + notes exist
+   for every open lane. Idle only when blocked on secrets/human-only MFA or a
+   hard external outage.
+3. **No multi-vendor opinion fan-out by default.** Prefer Grok self-parallel
+   (two lanes / two worktrees / UniGrok modes). Other providers only for
+   specialized adapters or data the Grok stack cannot access.
+4. **Monthly API budget envelope** (operator): **$2000/month** unless revised.
+   Prefer CLI plane. Log API `cost_usd` on PRs. Hard-stop leaves notes, not a
+   quiz for the human.
+5. **Donor GenFunc branches are unfinished intelligence**, not abandoned noise.
+   See `donor-genfunc-deep-harvest.md`.
+
 ## Lanes
 
 | Lane | Mission | UniGrok modes | Path ownership (examples) |

--- a/.grok/playbooks/silent-think-harness.md
+++ b/.grok/playbooks/silent-think-harness.md
@@ -1,0 +1,235 @@
+# Silent-think harness (the real force)
+
+**Audience:** GitHub-authenticated UniGrok contributors only.  
+**Not public product.** Index-diff is a *micro-emit* option, not the doctrine.
+
+## Thesis
+
+Intelligence cost is dominated by **printed tokens**. The donor GenFunc physics
+separates:
+
+| Dial | Role | Want |
+| --- | --- | --- |
+| **thinking_budget** / thinking_level | Internal compute the provider bills as *thought* tokens | High when hard |
+| **include_thoughts** | Whether thought text is streamed into the user-visible channel | **False** (silent) |
+| **max_output_tokens** | Visible completion budget | **Tiny** — only the emit |
+| **response_schema / pydantic** | Forces the emit into a fixed shape | Tiny model, not an essay |
+
+Token counts that matter for “model did real work” come from **usage metadata
+thought/reasoning tokens**, not from CoT prose the user (or poll log) can read.
+
+Index-diff (`L#|TAG|reason`) is one cheap **emit surface**. It is not the
+mechanism that made small models cheap and fast.
+
+## Control-token library (Dialect Matrix)
+
+Donor name: **Token Control Language** / Native Latent IPC.
+
+| Artifact | Location |
+| --- | --- |
+| Harvest (this PR) | [`.grok/harvest/dialect-control-tokens/`](../harvest/dialect-control-tokens/) |
+| Matrix | `dialect_matrix.json` (gemini, gemma, llama3, grok, mistral, openai_o1) |
+| Compiler | `dialect_compiler.py` — `compile(..., force_tool=…, force_reasoning=…)` |
+| Optimizer loop | GenFunc `swarm_dialect_optimizer.py` (mutate lock/prefill until small models submit) |
+
+Prefill + family locks force **visible** channel shape. Silent-think still owns
+internal budget; control tokens own **first-token coercion** so small models
+do not spill essays. Not the same as giant JSON schemas.
+
+## Donor evidence (what actually exists)
+
+### 1. ParamSet split (`optimize_params.py`)
+
+```text
+ParamSet:
+  thinking_budget: int   # 0 = thinking disabled
+  max_output_tokens: int # independent of thinking
+  temperature, top_k, top_p, …
+```
+
+`thinking_budget` scales with complexity when the catalog marks the model
+`thinking=true`. `max_output_tokens` is a separate ceiling. That split is the
+load-bearing idea: **compute ≠ print**.
+
+### 2. `ThinkingConfig` surface (google-genai)
+
+```text
+ThinkingConfig:
+  include_thoughts: Optional[bool]
+  thinking_budget:  Optional[int]
+  thinking_level:   Optional[ThinkingLevel]
+```
+
+Wired into `GenerateContentConfig` alongside `max_output_tokens`,
+`response_mime_type`, `response_schema`.
+
+### 3. Incomplete donor wiring (honest gap)
+
+| Commit era | Behavior |
+| --- | --- |
+| Early `core.py` | Loaded `include_thoughts` from env and **passed it into** `ThinkingConfig` when true |
+| Post-optimizer `core.py` | Maps `thinking_budget` → `thinking_level` only; **still loads** `include_thoughts` in config but **does not pass it** into `ThinkingConfig` |
+| Catalog default | `GOOGLE_VERTEX_INCLUDE_THOUGHTS` defaults **True** (loud thoughts) |
+
+So the *doctrine* (silent think) is only half-landed in GenFunc. UniGrok should
+port the **intended** physics, not the incomplete default.
+
+### 4. Recursive maxing loop (`evolution_engine` + `EVOLUTION.md`)
+
+Not “print a diff.” A **harness loop** over hyperparams:
+
+- Genome: `(temp, top_k, top_p, max_output_tokens)`
+- Fitness: high score only for strict short code, **penalize** markdown /
+  “Here is…”, minimize latency and token proxy
+- **N ≤ 10** generations, **patience = 3** early stop
+- Victory genome written to git DAG; VPP ledger mines **USD saved** when
+  `max_output_tokens` converges below baseline (e.g. 4096 → optimized)
+
+That is “loop each harness until forced” in economic form: keep mutating until
+the model delivers work under a **compressed visible budget**.
+
+### 5. Structured emit after silent work
+
+Walrus `SemanticValidation` pydantic + `response_mime_type=application/json` +
+`response_schema=SemanticValidation` — the model’s **visible** channel is four
+fields, not a monologue.
+
+UniGrok already has the same family:
+
+- `ReflectionVerdict` / `FactList` via `_parse_structured` + `chat.parse`
+- CLI: `grok --json-schema` from pydantic `model_json_schema()`
+
+### 6. Policy silence (UX twin of token silence)
+
+- Terminal Silence Law / Crucible: fix in the dark; user sees victory only
+- Chat looper: “The reflection loop is silent. Never expose policy scaffolding…”
+
+Same invariant at two layers: **don’t print the private workspace**.
+
+## The harness (target UniGrok port)
+
+### Per-provider adapter contract
+
+```text
+SilentThinkRequest:
+  task: str
+  emit_model: type[BaseModel]     # tiny pydantic
+  thinking: { budget|level|effort }  # plane-native
+  include_thoughts: false            # always for this path
+  max_output_tokens: len_budget(emit_model)  # e.g. 64–512
+  plane_pref: cli_first | api_only
+```
+
+### Loop (bounded)
+
+```text
+for adapter in ordered_harnesses:          # UCB1 / catalog, CLI first
+  for attempt in 1..K:                     # small K, shared $ budget
+    cfg = silent_think_cfg(adapter, attempt)
+    result = adapter.generate(task, cfg)
+    ok = (
+      schema_valid(result.emit, emit_model)
+      and not thought_leak(result.text)    # no CoT markers / fences of thought
+      and (result.thought_tokens > 0       # when provider reports them
+           or adapter.guarantees_silent_think)
+    )
+    record_ucb(adapter, ok, cost, latency)
+    if ok: return result
+  # else next adapter
+fail closed / escalate one expensive deep-think on residual only
+```
+
+**“Forced”** means: the run is not accepted until the emit is schema-valid and
+the visible channel stayed short. Thought tokens may be large; **printed**
+tokens must not be.
+
+### What “smaller models below normal cost” means
+
+| Naive path | Silent-think path |
+| --- | --- |
+| Small model, high `max_tokens`, freeform essay CoT | Small/flash model, high internal think, **tiny** structured emit |
+| Pay for printed reasoning every poll | Pay thought tokens once; emit ~dozen–hundred tokens |
+| Index-diff only if you need multi-model consensus | Index-diff = optional poll format, not the compute policy |
+
+CLI / subscription planes amplify this: many silent structured calls ride fixed
+plan cost; API is failover.
+
+## Schemas: do we give two shits? (pydantic + Needle)
+
+**Three different “schema” objects. Only two matter.**
+
+| Object | Care? | Why |
+| --- | --- | --- |
+| **Capsule / Needle pin digests** (`intelligence_payloads` PROFILE_SCHEMA_SHA256, Needle 1024-encoder packing) | **Yes, fail-closed** | Byte-stable storage + packing geometry. Not model creativity. |
+| **Tiny pydantic emit** (`ReflectionVerdict`, `SemanticValidation`, `FactList`, poll rows) | **Yes** | Cheap channel for silent compute. The schema *is* the max-output discipline. |
+| **Giant narrative OpenAPI / “describe your whole answer as schema” theater** | **No** | You pay tokens for schema prose and train the model to fill fields with essays. |
+
+### Needle is not a thinking schema
+
+Needle v1 (`org.grokmcp.needle_tools_context.v1`) packs **verified examples**
+into a tools-JSON channel under a **fixed 1024 encoder-token** budget. Whole
+records only; never string-sliced. That is **input packing**, not CoT structure.
+
+Judging Needle as “small model must print the right answer” is the wrong
+test. Needle is a **synapse/reflex prior** for Grok (authority inversion:
+LLM first → Needle second → code floor). Silent-think still belongs to the
+LLM tier; Needle does not replace it.
+
+### With pydantic + Needle, the practical rule
+
+1. **Pin** envelope schemas (capsule digests) — structural integrity only.  
+2. **Emit** with the smallest pydantic model that a downstream machine can trust.  
+3. **Do not** invent large freeform schemas for hive polls or reflection.  
+4. **Do not** require index-diff as the only emit — any tiny structured type works.  
+5. **Do** force `include_thoughts=false` (or provider equivalent: no visible
+   reasoning stream) and cap **visible** `max_output_tokens` to the emit.
+
+If pydantic validates the emit and Needle (or FTS/AKE) packed the priors, you
+already have the only schemas that pay rent. Everything else is ceremony.
+
+## UniGrok mapping (current → target)
+
+| Current | Gap | Target |
+| --- | --- | --- |
+| `mode=thinking` → API plane, full ReAct + reflection loop | Reflection is structured; main attempt can still print a lot | Silent-think **profile** on tool-free structured parse and on CLI `--json-schema` paths |
+| `_parse_structured` + pydantic | Already tiny emit | Pair with explicit low max-out + effort/thinking knobs |
+| CLI `--effort` + `--json-schema` | No unified “silent” receipt (thought vs completion) | Receipt fields: `thought_tokens`, `completion_tokens`, `include_thoughts=false` |
+| Index-diff hive playbook | Over-emphasized as the force | Demote to **emit option** under this harness |
+| Needle projection | Pack only; no runtime specialist yet | Keep fail-closed; never confuse packing schema with silent-think |
+
+## Anti-patterns
+
+- Burning Deep-Think API for 12-line polls (measured ~$0.06 / ~25k tokens).  
+- Setting high `max_output_tokens` “just in case” while thinking is on.  
+- `include_thoughts=true` in production hive / swarm paths.  
+- Multi-vendor essay democracy instead of structured emit + UCB1.  
+- Treating Needle JSON Schema as the place intelligence lives.
+
+## Relationship to index-diff
+
+```text
+silent-think harness  →  produces tiny structured emit
+                              ↓
+                    optional formats:
+                      - pydantic JSON
+                      - index-diff lines
+                      - FactList / ReflectionVerdict
+                              ↓
+                    git notes / capsules / UCB1
+```
+
+Index-diff remains useful for **parallel cheap consensus**. It is not the
+silent-think engine.
+
+## Implementation order (when coding)
+
+1. Document + receipt contract (this file) — **done**.  
+2. Harvest dialect matrix/compiler as reference — **done** under
+   `.grok/harvest/dialect-control-tokens/`.  
+3. Wire silent profile into `_parse_structured` / CLI schema path (max-out +
+   no visible thoughts + pydantic).  
+4. Port safe family prefills from dialect matrix (Grok CLI/API first; Gemma
+   local via mlx_lm think stripping).  
+5. Port UCB1 model telemetry for silent-think success rate / cost.  
+6. Optional: recursive maxing on `max_output_tokens` + dialect gene mutation.  
+7. Keep Needle as packing + future reflex — separate track.

--- a/.grok/prompts/grok_adapter.md
+++ b/.grok/prompts/grok_adapter.md
@@ -1,6 +1,6 @@
 # Grok Adapter
 
-Last localized: 2026-07-01
+Last localized: 2026-07-14
 
 This is the Grok-specific adapter prompt for UniGrok MCP. It adds Grok
 operating discipline without overriding repository instructions, client
@@ -13,17 +13,40 @@ chat, vision, file, search, code-execution, media-generation, local workspace,
 git inspection, local test, and optional guarded git mutation tools to MCP and
 OpenAI-compatible clients.
 
+Public entry is the `agent` tool with modes `auto` | `fast` | `reasoning` |
+`thinking` | `research`, dual credential planes (API metered / CLI subscription),
+and structured cost/route metadata on every result.
+
 ## Operating Rules
 
 - Treat `.grok/` as adapter configuration, not global repository truth.
+- Prefer playbook `.grok/playbooks/parallel-ship-dag.md` when the user wants
+  concurrent product + intelligence shipping.
 - Use workspace and git context as evidence, not as permission to mutate.
 - Do not expose secrets, credentials, bearer tokens, or API keys.
-- Do not auto-commit.
-- Do not auto-push.
-- Do not deploy or mutate cloud resources unless explicitly requested.
+- Do not auto-commit, auto-push, auto-land, or deploy cloud unless explicitly
+  authorized for that action in the current session.
 - Prefer small, auditable tool actions with bounded output.
 - State uncertainty when repository evidence is incomplete.
-- Preserve existing public tool and API compatibility unless explicitly asked to change it.
+- Preserve existing public tool and API compatibility unless explicitly asked
+  to change it.
+
+## Parallel ship (high velocity)
+
+When the operator wants both public product and intelligence work:
+
+1. Split into **Lane P** and **Lane I** with path isolation (see playbook).
+2. Use UniGrok modes instead of inventing multi-provider client APIs:
+   - P: `fast` / `reasoning` / `thinking`
+   - I: `research` / `thinking` / `reasoning`
+3. Put durable coordination on the **git DAG**: agent-prefixed branch, draft
+   PR, exact head SHA, verification notes. That is how peer agents (including
+   Codex) discover work without the human midwifing git.
+4. Codex remains the land/main gate. Grok and other contributors ship draft
+   intelligence and product; they do not bypass protected merge.
+5. Cap metered API spend: prefer CLI for free-compatible work; record
+   `cost_usd` when API is used; stop on budget, do not silently multi-agent
+   fan-out.
 
 ## Behavior
 
@@ -33,3 +56,6 @@ OpenAI-compatible clients.
 - For risky or mutating operations, require explicit authorization through the
   configured MCP tool or environment gate.
 - For repeated task patterns, use prior UniGrok memory as a hint, not as proof.
+- End operator-facing answers with either one clear next action you will take
+  (or already left on a PR) or one product question — not a wall of options
+  that re-involves the human in git.

--- a/.grok/prompts/grok_adapter.md
+++ b/.grok/prompts/grok_adapter.md
@@ -56,6 +56,10 @@ When the operator wants both public product and intelligence work:
 - For risky or mutating operations, require explicit authorization through the
   configured MCP tool or environment gate.
 - For repeated task patterns, use prior UniGrok memory as a hint, not as proof.
-- End operator-facing answers with either one clear next action you will take
-  (or already left on a PR) or one product question — not a wall of options
-  that re-involves the human in git.
+- **Never** re-ask the operator for git steps, land order of already-GO PRs,
+  or “should we fan out to Claude/GPT?” when Grok self-parallel is sufficient.
+- Prefer continuing tool work over conversational check-ins. Put progress on
+  the git DAG (PR notes) so peer agents see it without the human as bus.
+- End operator-facing answers only when a true product fork remains (budget
+  raise, legal, credentials the agent cannot mint). Otherwise state what was
+  shipped to the DAG and keep going.

--- a/skills/using-unigrok/SKILL.md
+++ b/skills/using-unigrok/SKILL.md
@@ -41,6 +41,23 @@ search grounding was used.
 - Tasks needing self-critique → `thinking`.
 - Current-events or source-cited answers → `research` (uses web + X search).
 
+## Parallel ship (product + intelligence)
+
+When the operator wants **both** public product work and intelligence/research
+without midwifing git:
+
+1. Split **Lane P** (product) and **Lane I** (intelligence) with path isolation.
+2. Route UniGrok modes per lane (P: fast/reasoning/thinking; I: research/thinking).
+3. Put coordination on the git DAG: agent-prefixed branch, draft PR, exact head,
+   verification notes — so Codex can land without human git chat.
+4. Prefer CLI plane for free-compatible critique; use API + same_plane when
+   Deep-Think or hosted twin work requires it.
+5. Full playbook: `.grok/playbooks/parallel-ship-dag.md` and skill
+   `grok-parallel-ship` (contributor repo only).
+
+Do **not** invent multi-provider public chat tools. UniGrok’s public `agent`
+remains Grok-routed; other providers stay behind Grok-supervised adapters.
+
 ## Plan critique habit (opt-in)
 
 When the user is about to see a multi-step **Implementation Plan**, prefer:


### PR DESCRIPTION
## Summary
Operationalizes dual-lane shipping while Codex stays the boring land gate:

- **Lane P** public product · **Lane I** intelligence
- UniGrok modes (`fast`/`reasoning`/`thinking`/`research`) as the multi-model control surface
- Git-DAG handoff triad (draft PR + exact head + notes) so humans never midwife git
- Cost posture: CLI first, API capped, no auto-land

## Files
- `.grok/playbooks/parallel-ship-dag.md`
- `.grok/prompts/grok_adapter.md`
- `.grok/hyperparams/unigrok-ship-orchestrator.json`
- `.agents/skills/grok-parallel-ship/SKILL.md`
- `using-unigrok` skill copies

## Exact head
Will be commit SHA after push.

## Ready for Codex land?
yes (docs/skills only; low risk)

Agent-Assisted-By: xAI Grok | model=grok-4.5 | model-source=provider-session | surface=Grok Build | role=implementation