### PR TITLE
feat(review): mint short-lived MCP service tokens for hosted Actions

### DIFF
--- a/.github/workflows/grok-review.yml
+++ b/.github/workflows/grok-review.yml
@@ -31,6 +31,11 @@ jobs:
     #   UNIGROK_REVIEW_RUNNER_JSON = "ubuntu-latest"
     #   UNIGROK_REVIEW_MCP_URL     = https://mcp.grokmcp.org/mcp
     #   UNIGROK_REVIEW_PLANE       = api
+    # Auth: set repository secret UNIGROK_MCP_TOKEN_SECRET to the same value as
+    # Control Center MCP_TOKEN_SECRET (Secret Manager:
+    # unigrok-control-center-mcp-token-secret). The job mints a ~120s
+    # service:github-review-broker token at runtime — never put XAI_API_KEY
+    # here and do not install static UNIGROK_API_KEYS on the Cloud Run twin.
     # Lab fallback when vars unset: self-hosted + loopback CLI (Mac required).
     # See docs/design/hosted-review-p0.md and docs/chatgpt-github-app.md.
     runs-on: ${{ fromJSON(vars.UNIGROK_REVIEW_RUNNER_JSON || '["self-hosted","unigrok-review"]') }}
@@ -55,6 +60,10 @@ jobs:
           # Hosted production: set UNIGROK_REVIEW_MCP_URL to https://mcp.grokmcp.org/mcp
           UNIGROK_MCP_URL: ${{ vars.UNIGROK_REVIEW_MCP_URL || 'http://127.0.0.1:4765/mcp' }}
           UNIGROK_REVIEW_PLANE: ${{ vars.UNIGROK_REVIEW_PLANE || 'cli' }}
-          # Temporary client bridge only — never XAI_API_KEY. Prefer OAuth mint (P1).
+          # OAuth service mint (production). Same secret as Control MCP_TOKEN_SECRET.
+          UNIGROK_MCP_TOKEN_SECRET: ${{ secrets.UNIGROK_MCP_TOKEN_SECRET }}
+          UNIGROK_OAUTH_ISSUER: ${{ vars.UNIGROK_OAUTH_ISSUER || 'https://control.grokmcp.org' }}
+          UNIGROK_MCP_RESOURCE_URL: ${{ vars.UNIGROK_MCP_RESOURCE_URL || 'https://mcp.grokmcp.org/mcp' }}
+          # Optional lab/static override only — unused when mint secret is set.
           UNIGROK_CLIENT_TOKEN: ${{ secrets.UNIGROK_CLIENT_TOKEN }}
         run: uv run python scripts/github-grok-review.py

--- a/docs/chatgpt-github-app.md
+++ b/docs/chatgpt-github-app.md
@@ -53,7 +53,10 @@ Repository configuration (Codex/project-admin):
    - `UNIGROK_REVIEW_MCP_URL` = `https://mcp.grokmcp.org/mcp`
    - `UNIGROK_REVIEW_PLANE` = `api`
 2. Prefer short-lived OAuth / Control-minted tokens with scope `unigrok:review`.
-   A repository secret `UNIGROK_CLIENT_TOKEN` is a **temporary bridge only** —
+   Repository secret `UNIGROK_MCP_TOKEN_SECRET` must match Control
+   `MCP_TOKEN_SECRET` so Actions can mint a ~120s `service:github-review-broker`
+   token (see `scripts/mint_mcp_service_token.py`). A static
+   `UNIGROK_CLIENT_TOKEN` is a **lab-only bridge** —
    never store `XAI_API_KEY` in GitHub. Never use `XAI_API_KEY` as this token.
 3. Workflow permissions stay `contents: read` and `pull-requests: write`.
 4. Trigger: owner/member/collaborator comments `@grok review`, or

--- a/docs/design/hosted-review-p0.md
+++ b/docs/design/hosted-review-p0.md
@@ -69,15 +69,29 @@ Optional kill-switch later: workflow `if` gated on `vars.UNIGROK_REVIEW_ENABLED 
 
 **Remaining bridge:** repository secret `UNIGROK_CLIENT_TOKEN` (narrow gateway client; never `XAI_API_KEY`) **or** P1 OIDC mint. Without one of these, Actions cannot authenticate to the twin.
 
-### 3. Client credential for Actions (temporary bridge)
+### 3. Client credential for Actions (service token mint)
 
-Until OIDC → Control mint ships (P1):
+The production twin is **OAuth introspection only** (no `UNIGROK_API_KEYS` on
+Cloud Run). A long-lived static `UNIGROK_CLIENT_TOKEN` is the **wrong** install.
 
-- Prefer a **narrow** gateway client token accepted by the remote MCP OAuth/introspection design — **not** `XAI_API_KEY`.
-- Store as repository secret `UNIGROK_CLIENT_TOKEN` only if the twin still accepts that bootstrap path.
-- Production preference (docs): OAuth introspection; static client is break-glass / short rotation.
+**P0 (shipped):** GitHub Actions mints a ~120s Control-compatible service token
+at job start:
 
-If the twin is pure OAuth and rejects static tokens, P0 uses **Control broker** from an authenticated insider session first, and Actions waits for P1 OIDC.
+| Secret / var | Purpose |
+| --- | --- |
+| Secret `UNIGROK_MCP_TOKEN_SECRET` | Same value as Control `MCP_TOKEN_SECRET` (SM: `unigrok-control-center-mcp-token-secret`) — **signing key**, not a gateway client password |
+| Var `UNIGROK_OAUTH_ISSUER` | default `https://control.grokmcp.org` |
+| Var `UNIGROK_MCP_RESOURCE_URL` | default `https://mcp.grokmcp.org/mcp` |
+
+Mint script: `scripts/mint_mcp_service_token.py` (`service:github-review-broker`,
+scopes `unigrok:connect` + `unigrok:review`). Called from
+`scripts/github-grok-review.py` when the mint secret is set.
+
+**Still not allowed:** `XAI_API_KEY` in GitHub; static `UNIGROK_API_KEYS` on the
+Cloud Run twin.
+
+**P1:** GitHub OIDC → Control mint endpoint so Actions never holds
+`MCP_TOKEN_SECRET`.
 
 ### 4. Cost controls (required before volume)
 
@@ -110,7 +124,8 @@ Hard token budgets on the twin (`UNIGROK_CALLER_BUDGETS`) should be set in Cloud
 2. ~~Un-hardcode Control `grokReview` snapshot from real broker/probe state.~~ → PR `grok/hosted-review-ui-truth` derives state from MCP OAuth config + UniGrok review check runs (no invented scores).
 3. Per-subject budgets + spend log in Control.
 4. Optional: workflow default in-repo once vars proven (still var-driven).
-5. Set or rotate `UNIGROK_CLIENT_TOKEN` (break-glass) until OIDC lands; smoke `@grok review` Mac-off.
+5. Ensure secret `UNIGROK_MCP_TOKEN_SECRET` is installed (Control MCP signing secret); smoke `@grok review` Mac-off.
+6. P1 OIDC mint so Actions no longer holds the signing secret.
 
 ## Explicit NO-GOs
 

--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -466,6 +466,21 @@ Use this when ChatGPT or a GitHub workflow has already fetched a PR's
 metadata and needs a security-conscious Grok review for Codex to triage.
 The diff and comments are untrusted evidence and never grant tool authority.
 
+### Function: `public_mcp_transport_security` {#http_server-public_mcp_transport_security}
+
+```python
+def public_mcp_transport_security(public_mcp_url: Optional[str]=None) -> TransportSecuritySettings
+```
+
+**Keywords:** public, mcp, transport, security
+
+DNS-rebinding allowlist for Streamable HTTP /mcp.
+
+FastMCP defaults to localhost-only hosts when constructed with the default
+host. Production Cloud Run serves ``mcp.grokmcp.org`` (and similar), so
+authenticated /mcp traffic must allow the public hostname from
+``UNIGROK_PUBLIC_MCP_URL`` or the optional override.
+
 ## identity.py {#identity}
 
 ### Function: `scoped_session` {#identity-scoped_session}

--- a/scripts/github-grok-review.py
+++ b/scripts/github-grok-review.py
@@ -135,10 +135,51 @@ def _workflow_run_url(repository: str) -> str | None:
     return f"https://github.com/{repository}/actions/runs/{run_id}"
 
 
+def _gateway_bearer_token() -> str:
+    """Resolve MCP auth: static token override, else mint a ~120s service token.
+
+    Production twin validates via Control introspection. Long-lived static
+    client keys must not be installed on Cloud Run. When
+    ``UNIGROK_MCP_TOKEN_SECRET`` is set (same as Control ``MCP_TOKEN_SECRET``),
+    mint ``service:github-review-broker`` with ``unigrok:review``.
+    """
+    static = os.environ.get("UNIGROK_CLIENT_TOKEN", "").strip()
+    if static:
+        return static
+    secret = os.environ.get("UNIGROK_MCP_TOKEN_SECRET", "").strip()
+    if not secret:
+        return ""
+    # Import path works when run as ``uv run python scripts/github-grok-review.py``
+    # with repo root on sys.path (uv / Actions checkout default).
+    try:
+        from scripts.mint_mcp_service_token import mint_service_access_token
+    except ImportError:  # pragma: no cover - script dir execution
+        sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+        from scripts.mint_mcp_service_token import mint_service_access_token
+    issuer = os.environ.get("UNIGROK_OAUTH_ISSUER", "https://control.grokmcp.org").strip()
+    resource = os.environ.get(
+        "UNIGROK_MCP_RESOURCE_URL",
+        os.environ.get("UNIGROK_MCP_URL", "https://mcp.grokmcp.org/mcp").strip(),
+    ).strip()
+    if resource.endswith("/"):
+        resource = resource.rstrip("/")
+    # Resource must be the OAuth audience (.../mcp), not a path typo.
+    if not resource.endswith("/mcp"):
+        if resource.endswith(".org") or resource.endswith(".com"):
+            resource = f"{resource}/mcp"
+    return mint_service_access_token(
+        secret=secret,
+        issuer=issuer,
+        resource=resource,
+        service=os.environ.get("UNIGROK_SERVICE_NAME", "github-review-broker").strip(),
+        scope=os.environ.get("UNIGROK_SERVICE_SCOPE", "unigrok:review").strip(),
+    )
+
+
 async def _call_unigrok(arguments: dict[str, Any]) -> dict[str, Any]:
     url = os.environ.get("UNIGROK_MCP_URL", "http://127.0.0.1:4765/mcp")
-    headers = {"X-Client-ID": "github-actions"}
-    gateway_token = os.environ.get("UNIGROK_CLIENT_TOKEN", "").strip()
+    headers = {"X-Client-ID": "github-actions", "X-Caller": "github-review-broker"}
+    gateway_token = _gateway_bearer_token()
     if gateway_token:
         headers["Authorization"] = f"Bearer {gateway_token}"
     async with httpx.AsyncClient(headers=headers, timeout=180.0) as client:

--- a/scripts/mint_mcp_service_token.py
+++ b/scripts/mint_mcp_service_token.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Mint a short-lived UniGrok MCP service access token (Control-compatible).
+
+Matches Control Center ``createServiceAccessToken``:
+HMAC-SHA256 over base64url(JSON claims), token prefix ``ugtoken.``.
+
+Production remote MCP validates via Control introspection — never install a
+long-lived static client key on Cloud Run. This script only produces ~120s
+tokens for GitHub Actions / ops smoke.
+
+Environment (required):
+  UNIGROK_MCP_TOKEN_SECRET  — same value as Control ``MCP_TOKEN_SECRET``
+  UNIGROK_OAUTH_ISSUER      — e.g. https://control.grokmcp.org
+  UNIGROK_MCP_RESOURCE_URL  — e.g. https://mcp.grokmcp.org/mcp
+
+Optional:
+  UNIGROK_SERVICE_NAME      — default github-review-broker
+  UNIGROK_SERVICE_SCOPE     — default unigrok:review
+  UNIGROK_TOKEN_TTL_SECONDS — default 120 (max 600)
+
+Prints the bearer token to stdout only (no logs of the secret).
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import sys
+import time
+from typing import Any, Mapping, Optional
+
+TOKEN_PREFIX = "ugtoken."
+DEFAULT_TTL = 120
+MAX_TTL = 600
+ALLOWED_SCOPES = frozenset(
+    {
+        "unigrok:connect",
+        "unigrok:invoke",
+        "unigrok:review",
+        "unigrok:chat",
+        "unigrok:status",
+    }
+)
+ALLOWED_SERVICES = frozenset({"github-review-broker"})
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise SystemExit(f"missing required environment variable: {name}")
+    return value
+
+
+def sign_cookie_payload(payload: Mapping[str, Any], secret: str) -> str:
+    """Mirror Control ``signCookiePayload`` (HMAC-SHA256 over base64url body)."""
+    if not (32 <= len(secret) <= 4_096):
+        raise ValueError("MCP token secret length is invalid")
+    body = _b64url(json.dumps(payload, separators=(",", ":"), ensure_ascii=True).encode("utf-8"))
+    if len(body) > 4_096:
+        raise ValueError("cookie payload is too large")
+    signature = hmac.new(secret.encode("utf-8"), body.encode("utf-8"), hashlib.sha256).digest()
+    return f"{body}.{_b64url(signature)}"
+
+
+def mint_service_access_token(
+    *,
+    secret: str,
+    issuer: str,
+    resource: str,
+    service: str = "github-review-broker",
+    scope: str = "unigrok:review",
+    ttl_seconds: int = DEFAULT_TTL,
+    now: Optional[int] = None,
+    jti: Optional[str] = None,
+) -> str:
+    if service not in ALLOWED_SERVICES:
+        raise ValueError(f"service not allowed: {service}")
+    # Service mint is review-only; invoke/chat/status stay for user OAuth.
+    if scope != "unigrok:review":
+        raise ValueError(f"scope not allowed for service mint: {scope}")
+    if not issuer.startswith("https://") or issuer.endswith("/"):
+        raise ValueError("issuer must be an https origin without trailing slash")
+    if not resource.startswith("https://") or not resource.endswith("/mcp"):
+        raise ValueError("resource must be https://…/mcp")
+    if not (1 <= int(ttl_seconds) <= MAX_TTL):
+        raise ValueError(f"ttl_seconds must be 1..{MAX_TTL}")
+    iat = int(now if now is not None else time.time())
+    claims = {
+        "aud": resource,
+        "exp": iat + int(ttl_seconds),
+        "iat": iat,
+        "iss": issuer,
+        "jti": jti or _b64url(secrets.token_bytes(24)),
+        "kind": "service",
+        "scope": ["unigrok:connect", scope],
+        "sub": f"service:{service}",
+        "v": 1,
+    }
+    return f"{TOKEN_PREFIX}{sign_cookie_payload(claims, secret)}"
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--print-claims",
+        action="store_true",
+        help="print JSON claims metadata to stderr (never the secret)",
+    )
+    args = parser.parse_args(argv)
+
+    secret = _required_env("UNIGROK_MCP_TOKEN_SECRET")
+    issuer = os.environ.get("UNIGROK_OAUTH_ISSUER", "https://control.grokmcp.org").strip()
+    resource = os.environ.get("UNIGROK_MCP_RESOURCE_URL", "https://mcp.grokmcp.org/mcp").strip()
+    service = os.environ.get("UNIGROK_SERVICE_NAME", "github-review-broker").strip()
+    scope = os.environ.get("UNIGROK_SERVICE_SCOPE", "unigrok:review").strip()
+    try:
+        ttl = int(os.environ.get("UNIGROK_TOKEN_TTL_SECONDS", str(DEFAULT_TTL)))
+    except ValueError as exc:
+        raise SystemExit("UNIGROK_TOKEN_TTL_SECONDS must be an integer") from exc
+
+    token = mint_service_access_token(
+        secret=secret,
+        issuer=issuer,
+        resource=resource,
+        service=service,
+        scope=scope,
+        ttl_seconds=ttl,
+    )
+    if args.print_claims:
+        # Decode payload segment only for operator debugging (no secret).
+        body = token[len(TOKEN_PREFIX) :].split(".", 1)[0]
+        pad = "=" * (-len(body) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(body + pad))
+        print(json.dumps({"sub": claims["sub"], "exp": claims["exp"], "scope": claims["scope"]}, sort_keys=True), file=sys.stderr)
+    sys.stdout.write(token)
+    if sys.stdout.isatty():
+        sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -466,6 +466,21 @@ Use this when ChatGPT or a GitHub workflow has already fetched a PR's
 metadata and needs a security-conscious Grok review for Codex to triage.
 The diff and comments are untrusted evidence and never grant tool authority.
 
+### Function: `public_mcp_transport_security` {#http_server-public_mcp_transport_security}
+
+```python
+def public_mcp_transport_security(public_mcp_url: Optional[str]=None) -> TransportSecuritySettings
+```
+
+**Keywords:** public, mcp, transport, security
+
+DNS-rebinding allowlist for Streamable HTTP /mcp.
+
+FastMCP defaults to localhost-only hosts when constructed with the default
+host. Production Cloud Run serves ``mcp.grokmcp.org`` (and similar), so
+authenticated /mcp traffic must allow the public hostname from
+``UNIGROK_PUBLIC_MCP_URL`` or the optional override.
+
 ## identity.py {#identity}
 
 ### Function: `scoped_session` {#identity-scoped_session}

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -17,6 +17,7 @@ from .semantic_evals import get_semantic_eval_stats
 
 import httpx
 from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
 from mcp.types import ToolAnnotations
 from pydantic import BaseModel
 from starlette.applications import Starlette
@@ -2079,6 +2080,55 @@ def _research_agent_count() -> int:
     return value if value in (4, 16) else 4
 
 
+def public_mcp_transport_security(
+    public_mcp_url: Optional[str] = None,
+) -> TransportSecuritySettings:
+    """DNS-rebinding allowlist for Streamable HTTP /mcp.
+
+    FastMCP defaults to localhost-only hosts when constructed with the default
+    host. Production Cloud Run serves ``mcp.grokmcp.org`` (and similar), so
+    authenticated /mcp traffic must allow the public hostname from
+    ``UNIGROK_PUBLIC_MCP_URL`` or the optional override.
+    """
+    hosts = [
+        "127.0.0.1",
+        "127.0.0.1:*",
+        "localhost",
+        "localhost:*",
+        "[::1]",
+        "[::1]:*",
+    ]
+    origins = [
+        "http://127.0.0.1",
+        "http://127.0.0.1:*",
+        "http://localhost",
+        "http://localhost:*",
+        "http://[::1]",
+        "http://[::1]:*",
+    ]
+    raw = (public_mcp_url if public_mcp_url is not None else os.environ.get("UNIGROK_PUBLIC_MCP_URL", "")).strip()
+    if raw:
+        parsed = urlsplit(raw)
+        host = (parsed.hostname or "").lower()
+        if host:
+            hosts.append(host)
+            if parsed.port:
+                hosts.append(f"{host}:{parsed.port}")
+            scheme = parsed.scheme if parsed.scheme in {"http", "https"} else "https"
+            origin = f"{scheme}://{host}"
+            if parsed.port:
+                origin = f"{origin}:{parsed.port}"
+            origins.append(origin)
+    # De-dupe while preserving order.
+    hosts = list(dict.fromkeys(hosts))
+    origins = list(dict.fromkeys(origins))
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=hosts,
+        allowed_origins=origins,
+    )
+
+
 def create_public_mcp() -> FastMCP:
     mcp = FastMCP(
         "UniGrok xAI Gateway",
@@ -2102,6 +2152,7 @@ def create_public_mcp() -> FastMCP:
         ),
         streamable_http_path="/mcp",
         stateless_http=True,
+        transport_security=public_mcp_transport_security(),
     )
     mcp.add_tool(public_agent, name="agent")
     review_widget_uri = "ui://widget/unigrok-github-review-v1.html"

--- a/tests/test_mint_mcp_service_token.py
+++ b/tests/test_mint_mcp_service_token.py
@@ -1,0 +1,91 @@
+"""Tests for Control-compatible MCP service token minting."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from scripts.mint_mcp_service_token import (
+    TOKEN_PREFIX,
+    mint_service_access_token,
+    sign_cookie_payload,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_sign_cookie_payload_is_hmac_sha256_over_body() -> None:
+    secret = "x" * 32
+    payload = {"v": 1, "hello": "world"}
+    signed = sign_cookie_payload(payload, secret)
+    body, sig = signed.split(".", 1)
+    expected = base64.urlsafe_b64encode(
+        hmac.new(secret.encode(), body.encode(), hashlib.sha256).digest()
+    ).decode().rstrip("=")
+    assert sig == expected
+    pad = "=" * (-len(body) % 4)
+    assert json.loads(base64.urlsafe_b64decode(body + pad)) == payload
+
+
+def test_mint_service_access_token_shape_and_claims() -> None:
+    secret = "s" * 48
+    token = mint_service_access_token(
+        secret=secret,
+        issuer="https://control.grokmcp.org",
+        resource="https://mcp.grokmcp.org/mcp",
+        now=1_700_000_000,
+        jti="test-jti-fixed-value-24b",
+        ttl_seconds=120,
+    )
+    assert token.startswith(TOKEN_PREFIX)
+    body = token[len(TOKEN_PREFIX) :].split(".", 1)[0]
+    pad = "=" * (-len(body) % 4)
+    claims = json.loads(base64.urlsafe_b64decode(body + pad))
+    assert claims["v"] == 1
+    assert claims["kind"] == "service"
+    assert claims["sub"] == "service:github-review-broker"
+    assert claims["iss"] == "https://control.grokmcp.org"
+    assert claims["aud"] == "https://mcp.grokmcp.org/mcp"
+    assert claims["iat"] == 1_700_000_000
+    assert claims["exp"] == 1_700_000_120
+    assert claims["scope"] == ["unigrok:connect", "unigrok:review"]
+    # Signature must verify with the same secret.
+    signed = token[len(TOKEN_PREFIX) :]
+    assert signed == sign_cookie_payload(claims, secret)
+
+
+def test_mint_rejects_disallowed_service_and_scope() -> None:
+    secret = "s" * 48
+    with pytest.raises(ValueError, match="service not allowed"):
+        mint_service_access_token(
+            secret=secret,
+            issuer="https://control.grokmcp.org",
+            resource="https://mcp.grokmcp.org/mcp",
+            service="evil",
+        )
+    with pytest.raises(ValueError, match="scope not allowed"):
+        mint_service_access_token(
+            secret=secret,
+            issuer="https://control.grokmcp.org",
+            resource="https://mcp.grokmcp.org/mcp",
+            scope="unigrok:invoke",
+        )
+
+
+def test_cli_prints_token_only(capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("UNIGROK_MCP_TOKEN_SECRET", "t" * 40)
+    monkeypatch.setenv("UNIGROK_OAUTH_ISSUER", "https://control.grokmcp.org")
+    monkeypatch.setenv("UNIGROK_MCP_RESOURCE_URL", "https://mcp.grokmcp.org/mcp")
+    monkeypatch.chdir(ROOT)
+    import scripts.mint_mcp_service_token as mod
+
+    assert mod.main([]) == 0
+    out = capsys.readouterr().out.strip()
+    assert out.startswith(TOKEN_PREFIX)
+    assert "\n" not in out or out.endswith("\n") is False or True

--- a/tests/test_public_mcp_transport_security.py
+++ b/tests/test_public_mcp_transport_security.py
@@ -1,0 +1,20 @@
+"""Transport security allowlist for public / hosted MCP hosts."""
+
+from __future__ import annotations
+
+from src.http_server import public_mcp_transport_security
+
+
+def test_public_mcp_transport_security_includes_localhost() -> None:
+    settings = public_mcp_transport_security(public_mcp_url="")
+    assert settings.enable_dns_rebinding_protection is True
+    assert "localhost:*" in settings.allowed_hosts
+    assert "127.0.0.1:*" in settings.allowed_hosts
+
+
+def test_public_mcp_transport_security_includes_public_hostname() -> None:
+    settings = public_mcp_transport_security(
+        public_mcp_url="https://mcp.grokmcp.org/mcp",
+    )
+    assert "mcp.grokmcp.org" in settings.allowed_hosts
+    assert "https://mcp.grokmcp.org" in settings.allowed_origins


### PR DESCRIPTION
## Summary

Super-admin install path for hosted `@grok review` auth:

- Production twin is OAuth introspection only (no static `UNIGROK_API_KEYS`)
- Actions mints ~120s `service:github-review-broker` tokens via Control signing secret
- GH secret `UNIGROK_MCP_TOKEN_SECRET` already installed from SM
- Fix Streamable HTTP DNS-rebinding allowlist for `mcp.grokmcp.org`

## Exact head

`d90c0bf348a0511c3cfa995004e0e8815fc4ec73`

## Live smoke (pre-deploy)

- Mint + Control introspect: **active=true** with correct sub/scopes
- Authenticated /mcp still 421 until this revision is deployed (host allowlist)

## Tests

scripts/land full suite

## Human sponsor

djtelicloud

Agent-Assisted-By: xAI Grok | model=grok-4.5 | surface=Grok Build CLI | role=implementation