### PR TITLE
fix(review): raise MCP client timeout for hosted review

### DIFF
--- a/.github/workflows/grok-review.yml
+++ b/.github/workflows/grok-review.yml
@@ -39,7 +39,7 @@ jobs:
     # Lab fallback when vars unset: self-hosted + loopback CLI (Mac required).
     # See docs/design/hosted-review-p0.md and docs/chatgpt-github-app.md.
     runs-on: ${{ fromJSON(vars.UNIGROK_REVIEW_RUNNER_JSON || '["self-hosted","unigrok-review"]') }}
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       # Run only trusted default-branch code. Never check out, execute, install,
       # or import code from the reviewed PR.

--- a/scripts/github-grok-review.py
+++ b/scripts/github-grok-review.py
@@ -182,9 +182,9 @@ async def _call_unigrok(arguments: dict[str, Any]) -> dict[str, Any]:
     gateway_token = _gateway_bearer_token()
     if gateway_token:
         headers["Authorization"] = f"Bearer {gateway_token}"
-    async with httpx.AsyncClient(headers=headers, timeout=180.0) as client:
+    async with httpx.AsyncClient(headers=headers, timeout=540.0) as client:
         async with streamable_http_client(url, http_client=client) as (read, write, _):
-            async with ClientSession(read, write, read_timeout_seconds=timedelta(seconds=180)) as session:
+            async with ClientSession(read, write, read_timeout_seconds=timedelta(seconds=540)) as session:
                 await session.initialize()
                 result = await session.call_tool("review_pull_request", arguments)
     if result.isError:


### PR DESCRIPTION
LANDED: 411875d. Root cause: 180s ClientRequest timeout during review_pull_request.