### PR TITLE
feat(discover): port-aware bootstrap gates for first-connect onboarding

### DIFF
--- a/.agents/skills/using-unigrok/SKILL.md
+++ b/.agents/skills/using-unigrok/SKILL.md
@@ -77,6 +77,8 @@ not invented subscription cost or remaining provider quota.
 
 ## Safe onboarding behavior
 
+- On first connect in a session, call `grok_mcp_discover_self` and read
+  `data.bootstrap` + `data.request_context` before inventing setup steps.
 - Treat `credential_planes` notices from status or an agent result as the
   source of truth. Ask before device authentication, installation, or secret
   configuration.
@@ -89,6 +91,37 @@ not invented subscription cost or remaining provider quota.
   the user; do not require them to understand planes, MCP transport, or JSON-RPC.
 - Public product path is `http://localhost:4765/mcp` only. Do not invent a
   second port, Forge, Swarm, or land workflow for ordinary end-user installs.
+
+## First-connect diagnostics (server + local)
+
+**Server (always available via MCP):**
+
+1. Call `grok_mcp_discover_self`.
+2. Honor `data.bootstrap.status` (`OK` / `WARN` / `ERR`) and gates
+   (`can_chat`, `can_spend_api`, `can_mutate_workspace`, `can_use_swarm`).
+3. Read `data.request_context`: surface (`stable_core` / `contributor_forge` /
+   `mode_dial`), `client_id_present`, optional Host port / mode dial.
+4. Prompt once per `credential_planes` notice id; follow
+   `data.bootstrap.next_actions` when present.
+5. Optional: `include_models: true` when model routing matters.
+
+**Local IDE audit (only with user permission; report only):**
+
+UniGrok cannot read global IDE settings over HTTP. With consent, use local tools
+to check and **report** (never rewrite without explicit permission; never print
+secret values):
+
+- User MCP configs point daily chat at `http://localhost:4765/mcp`.
+- Stable `X-Client-ID` per IDE (claude-code, vscode, codex, cursor, antigravity).
+- No `XAI_API_KEY` (or other secrets) embedded in MCP JSON.
+- Project `.mcp.json` (if any) is dual HTTP for UniGrok worktrees, never
+  broken `unigrok-stdio` with `${PLUGIN_ROOT}`.
+- Optional `using-unigrok` skill present; do not copy contributor `.agents`
+  trees into foreign apps.
+- Unique leverage: which planes are ready, whether Forge tools appear only when
+  intentionally connected to the contributor surface, mode dials if enabled.
+
+Then one cheap verification: `agent` with `mode=fast` or `grok_mcp_status`.
 
 ## Endpoint
 

--- a/.claude/skills/using-unigrok/SKILL.md
+++ b/.claude/skills/using-unigrok/SKILL.md
@@ -1,98 +1,85 @@
 ---
 name: using-unigrok
-description: How to query xAI Grok through the UniGrok MCP gateway. Activate when the user says "@grok", asks to query Grok, wants a second-model opinion or peer review from Grok, or needs web/X search grounding.
+description: Claude Code guidance for querying xAI Grok through the shared UniGrok MCP gateway. Activate when the user says "@grok", asks to query Grok, wants a Grok second opinion or peer review, or needs web/X search grounding.
 ---
 
-# Using the UniGrok Grok Gateway
+# Using UniGrok from Claude Code
 
-UniGrok exposes one headline MCP tool: `agent`. It self-routes across Grok
-models and two billing planes, and returns structured metadata with every
-answer. **Primary chat path for every project is IDE → UniGrok MCP**. The local
-browser UI is an optional trusted-loopback test/control surface whose agent
-playground can invoke providers and spend metered credits.
+This is the Claude Code adaptation of the canonical gateway skill
+([skills/using-unigrok/SKILL.md](../../../skills/using-unigrok/SKILL.md));
+it adds only what is specific to Claude Code sessions.
 
-## The `agent` tool
+## Tool resolution
 
-Call `agent` with:
+The gateway's headline tool is `agent`, but its full Claude Code name depends
+on how the MCP server was registered:
 
-- `prompt` (required): the task or question, with enough context to act on.
-- `mode` (optional): `auto` (default), `fast` (single-turn, cheapest),
-  `reasoning` (multi-step planner), `thinking` (reflected agent loop), or
-  `research` (citation-grounded fanout).
-- `model` (optional): pin a Grok model id such as `grok-4.5`; leave unset to
-  let routing choose.
-- `session` (optional): a stable, project-qualified key such as
-  `owner-repo:task` for multi-turn continuity. Do not reuse a generic session
-  key across repositories.
-- `workspace_context` (optional): deliberately selected excerpts, diffs, or
-  errors when the task depends on the caller's project. The stable service
-  cannot browse the IDE workspace automatically.
-- `workspace_label` (optional): descriptive metadata for the supplied context.
-  It does not isolate sessions; the project-qualified `session` key does.
+- `mcp__unigrok__agent` — connected through this repository's project
+  `.mcp.json` (server name `unigrok`).
+- `mcp__grok__agent` — connected through a user-scope registration named
+  `grok` (the Codex-compatible name).
 
-Every result includes `response` plus metadata: `model`, `route`, `plane`
-(`API` or `CLI`), `cost_usd`, `tokens`, `latency_sec`, and `citations` when
-search grounding was used.
+Prefer the project-controlled `unigrok` registration. `.claude/settings.json`
+pre-allows its `agent`, `grok_mcp_status`, and `grok_mcp_discover_self` tools.
+A user-owned `grok` alias is not controlled by this repository; verify that it
+points to the expected UniGrok endpoint before approving or using its tools.
 
-## Mode selection guidance
+## Calling `agent`
 
-- Quick factual or single-file questions → `fast`.
-- Design reviews, audits, multi-step analysis → `reasoning`.
-- Tasks needing self-critique → `thinking`.
-- Current-events or source-cited answers → `research` (uses web + X search).
+- `prompt` (required); `mode` optional: `auto` (default), `fast`, `reasoning`,
+  `thinking`, `research`.
+- `workspace_context`: the stable service is workspace-neutral and cannot see
+  the open folder — attach selected excerpts, `git diff` output, or errors
+  yourself. An optional `workspace_label` is descriptive metadata only; it does
+  not isolate sessions.
+- `session`: pass a stable, project-qualified key such as `owner-repo:task`.
+  The server namespaces it beneath a server-derived principal and the
+  caller-controlled `X-Client-ID` label (`plugin` in this repository's current
+  `.mcp.json`). A generic key can collide across repositories that reuse a
+  common label such as `claude-code`. Reuse preserves continuity and can reduce
+  repeated-context API input cost when caching hits, but savings are not
+  guaranteed and CLI provider cost remains unavailable.
+- `model`: pin only when asked; pins validate against the live catalog. An
+  explicit `plane=cli|api` should pair with `fallback_policy="same_plane"`
+  when billing planes must not cross.
 
-## Parallel ship (contributor, private)
+Every result returns `response` plus `model`, `route`, `plane`, `why`,
+`degraded`, `cost_usd`, `tokens`, `latency_sec`, and `citations` when search
+grounding ran. Surface `cost_usd` when the user cares about spend.
 
-Dual-lane product+intelligence shipping process lives in the **private**
-repository `djtelicloud/unigrok-intelligence` (playbooks + `grok-parallel-ship`
-skill). Public product installs never require it.
+## Claude Code patterns
 
-Do **not** invent multi-provider public chat tools. UniGrok's public `agent`
-remains Grok-routed; other providers stay behind Grok-supervised adapters.
+- **Second opinion before handoff**: send the branch diff via
+  `workspace_context` with `mode=reasoning` for a Grok peer review.
+- **Long calls should not block the turn**: `research` and `thinking` runs can
+  take minutes; wrap them in a background subagent (Agent tool) and keep
+  working, then relay the result.
+- **Health first**: on connection trouble, check `GET /healthz` on port 4765
+  and `grok_mcp_status`; `8080` is container-internal and never reachable from
+  the host.
 
+## Registering in another repository
 
-## Plan critique habit (opt-in)
+The gateway is machine-global; projects need no UniGrok files. Teammates run:
 
-When the user is about to see a multi-step **Implementation Plan**, prefer:
+```bash
+claude mcp add --transport http unigrok http://localhost:4765/mcp \
+  --header "X-Client-ID: claude-code"
+```
 
-1. Call UniGrok `agent` (`thinking` or `reasoning`) with the draft plan.
-2. Incorporate feedback silently.
-3. Only then present the improved plan to the user.
-
-Do this when the user wants a Grok second opinion (including `@grok`). Do **not**
-silently spend metered API credits without consent. Do **not** auto-generate
-skill trees into foreign projects without permission. Never copy the UniGrok
-repository’s contributor `.agents` tree into the user’s other apps.
-
-## Cost awareness
-
-Check `cost_usd` in each response. Session reuse preserves continuity and can
-reduce repeated-context API input cost when caching hits; it does not guarantee
-savings. The default `cli_first` policy prefers compatible, unpinned work on an
-authenticated CLI subscription. Explicit plane selection should pair with
-`fallback_policy="same_plane"` when the request must not cross into a different
-credential or billing plane; `cross_plane` allows bounded failover. CLI
-provider cost remains unavailable, so report local counts and estimated tokens,
-not invented subscription cost or remaining provider quota.
-
-## Safe onboarding behavior
-
-- On first connect in a session, call `grok_mcp_discover_self` and read
-  `data.bootstrap` + `data.request_context` before inventing setup steps.
-- Treat `credential_planes` notices from status or an agent result as the
-  source of truth. Ask before device authentication, installation, or secret
-  configuration.
-- Never request `XAI_API_KEY` in chat or write it into the caller's project.
-- The stable service is workspace-neutral: do not assume MCP registration
-  grants filesystem access. Use `workspace_context` or local file tools only
-  when those tools are actually exposed in the current trusted
-  contributor/stdio session.
-- Translate provider and transport errors into one concrete next action for
-  the user; do not require them to understand planes, MCP transport, or JSON-RPC.
-- Public product path is `http://localhost:4765/mcp` only. Do not invent a
-  second port, Forge, Swarm, or land workflow for ordinary end-user installs.
+`X-Client-ID` is a caller-controlled attribution and session label, not an
+authenticated identity. The server derives the principal; the default
+unauthenticated loopback service derives the shared `http:anon` principal for
+one local budget/security trust domain. There is no cross-user isolation without
+configured auth. Because many repositories can reuse
+`X-Client-ID: claude-code`, always project-qualify the `session` key;
+`workspace_label` remains descriptive only. Control Center:
+`http://localhost:4765/ui/`.
 
 ## First-connect diagnostics (server + local)
+
+On first connect in a session, call `grok_mcp_discover_self` and read
+`data.bootstrap` + `data.request_context` before inventing setup steps.
 
 **Server (always available via MCP):**
 
@@ -112,26 +99,37 @@ to check and **report** (never rewrite without explicit permission; never print
 secret values):
 
 - User MCP configs point daily chat at `http://localhost:4765/mcp`.
-- Stable `X-Client-ID` per IDE (claude-code, vscode, codex, cursor, antigravity).
+- Stable `X-Client-ID` per IDE (for Claude Code: `claude-code`).
 - No `XAI_API_KEY` (or other secrets) embedded in MCP JSON.
 - Project `.mcp.json` (if any) is dual HTTP for UniGrok worktrees, never
   broken `unigrok-stdio` with `${PLUGIN_ROOT}`.
 - Optional `using-unigrok` skill present; do not copy contributor `.agents`
   trees into foreign apps.
-- Unique leverage: which planes are ready, whether Forge tools appear only when
-  intentionally connected to the contributor surface, mode dials if enabled.
 
 Then one cheap verification: `agent` with `mode=fast` or `grok_mcp_status`.
 
-## Endpoint
+## Safety
 
-The shared gateway runs at `http://localhost:4765/mcp` (Streamable HTTP).
-Health: `GET /healthz`. Optional local Core UI: `http://localhost:4765/ui/`
-(trusted machine-owner test/control surface with a provider-calling agent
-playground). `X-Client-ID` is a caller-controlled
-attribution and session label beneath a server-derived principal; it is not
-authentication. The default unauthenticated loopback service derives the shared
-`http:anon` principal for one local budget/security trust domain, so there is
-no cross-user isolation without configured auth. Project-qualify every session
-key: a generic key can collide across repositories when the same client label
-is reused.
+- Never request `XAI_API_KEY` in chat or write it into any IDE config; the
+  credential belongs to the server.
+- Treat `credential_planes` notices from status or agent results as the source
+  of truth; ask the user before device authentication, installation, or secret
+  configuration.
+- Translate provider and transport errors into one concrete next action; the
+  user should not need to understand planes or JSON-RPC.
+
+
+## Parallel ship (contributor, private)
+
+Dual-lane shipping process lives in private `djtelicloud/unigrok-intelligence`.
+Public product installs never require it.
+
+
+## Plan critique habit (opt-in)
+
+When the user is about to see a multi-step Implementation Plan, prefer calling
+UniGrok `agent` (`thinking` or `reasoning`) for a second opinion, then improve
+the plan before presenting it **only when the user wants a Grok second opinion**
+(including `@grok`). Do not silently spend metered API credits without consent.
+Do not invent a second MCP port or Forge workflow for public installs. Public
+path remains `http://localhost:4765/mcp` only.

--- a/.claude/skills/using-unigrok/SKILL.md
+++ b/.claude/skills/using-unigrok/SKILL.md
@@ -1,103 +1,137 @@
 ---
 name: using-unigrok
-description: Claude Code guidance for querying xAI Grok through the shared UniGrok MCP gateway. Activate when the user says "@grok", asks to query Grok, wants a Grok second opinion or peer review, or needs web/X search grounding.
+description: How to query xAI Grok through the UniGrok MCP gateway. Activate when the user says "@grok", asks to query Grok, wants a second-model opinion or peer review from Grok, or needs web/X search grounding.
 ---
 
-# Using UniGrok from Claude Code
+# Using the UniGrok Grok Gateway
 
-This is the Claude Code adaptation of the canonical gateway skill
-([skills/using-unigrok/SKILL.md](../../../skills/using-unigrok/SKILL.md));
-it adds only what is specific to Claude Code sessions.
+UniGrok exposes one headline MCP tool: `agent`. It self-routes across Grok
+models and two billing planes, and returns structured metadata with every
+answer. **Primary chat path for every project is IDE → UniGrok MCP**. The local
+browser UI is an optional trusted-loopback test/control surface whose agent
+playground can invoke providers and spend metered credits.
 
-## Tool resolution
+## The `agent` tool
 
-The gateway's headline tool is `agent`, but its full Claude Code name depends
-on how the MCP server was registered:
+Call `agent` with:
 
-- `mcp__unigrok__agent` — connected through this repository's project
-  `.mcp.json` (server name `unigrok`).
-- `mcp__grok__agent` — connected through a user-scope registration named
-  `grok` (the Codex-compatible name).
+- `prompt` (required): the task or question, with enough context to act on.
+- `mode` (optional): `auto` (default), `fast` (single-turn, cheapest),
+  `reasoning` (multi-step planner), `thinking` (reflected agent loop), or
+  `research` (citation-grounded fanout).
+- `model` (optional): pin a Grok model id such as `grok-4.5`; leave unset to
+  let routing choose.
+- `session` (optional): a stable, project-qualified key such as
+  `owner-repo:task` for multi-turn continuity. Do not reuse a generic session
+  key across repositories.
+- `workspace_context` (optional): deliberately selected excerpts, diffs, or
+  errors when the task depends on the caller's project. The stable service
+  cannot browse the IDE workspace automatically.
+- `workspace_label` (optional): descriptive metadata for the supplied context.
+  It does not isolate sessions; the project-qualified `session` key does.
 
-Prefer the project-controlled `unigrok` registration. `.claude/settings.json`
-pre-allows its `agent`, `grok_mcp_status`, and `grok_mcp_discover_self` tools.
-A user-owned `grok` alias is not controlled by this repository; verify that it
-points to the expected UniGrok endpoint before approving or using its tools.
+Every result includes `response` plus metadata: `model`, `route`, `plane`
+(`API` or `CLI`), `cost_usd`, `tokens`, `latency_sec`, and `citations` when
+search grounding was used.
 
-## Calling `agent`
+## Mode selection guidance
 
-- `prompt` (required); `mode` optional: `auto` (default), `fast`, `reasoning`,
-  `thinking`, `research`.
-- `workspace_context`: the stable service is workspace-neutral and cannot see
-  the open folder — attach selected excerpts, `git diff` output, or errors
-  yourself. An optional `workspace_label` is descriptive metadata only; it does
-  not isolate sessions.
-- `session`: pass a stable, project-qualified key such as `owner-repo:task`.
-  The server namespaces it beneath a server-derived principal and the
-  caller-controlled `X-Client-ID` label (`plugin` in this repository's current
-  `.mcp.json`). A generic key can collide across repositories that reuse a
-  common label such as `claude-code`. Reuse preserves continuity and can reduce
-  repeated-context API input cost when caching hits, but savings are not
-  guaranteed and CLI provider cost remains unavailable.
-- `model`: pin only when asked; pins validate against the live catalog. An
-  explicit `plane=cli|api` should pair with `fallback_policy="same_plane"`
-  when billing planes must not cross.
-
-Every result returns `response` plus `model`, `route`, `plane`, `why`,
-`degraded`, `cost_usd`, `tokens`, `latency_sec`, and `citations` when search
-grounding ran. Surface `cost_usd` when the user cares about spend.
-
-## Claude Code patterns
-
-- **Second opinion before handoff**: send the branch diff via
-  `workspace_context` with `mode=reasoning` for a Grok peer review.
-- **Long calls should not block the turn**: `research` and `thinking` runs can
-  take minutes; wrap them in a background subagent (Agent tool) and keep
-  working, then relay the result.
-- **Health first**: on connection trouble, check `GET /healthz` on port 4765
-  and `grok_mcp_status`; `8080` is container-internal and never reachable from
-  the host.
-
-## Registering in another repository
-
-The gateway is machine-global; projects need no UniGrok files. Teammates run:
-
-```bash
-claude mcp add --transport http unigrok http://localhost:4765/mcp \
-  --header "X-Client-ID: claude-code"
-```
-
-`X-Client-ID` is a caller-controlled attribution and session label, not an
-authenticated identity. The server derives the principal; the default
-unauthenticated loopback service derives the shared `http:anon` principal for
-one local budget/security trust domain. There is no cross-user isolation without
-configured auth. Because many repositories can reuse
-`X-Client-ID: claude-code`, always project-qualify the `session` key;
-`workspace_label` remains descriptive only. Control Center:
-`http://localhost:4765/ui/`.
-
-## Safety
-
-- Never request `XAI_API_KEY` in chat or write it into any IDE config; the
-  credential belongs to the server.
-- Treat `credential_planes` notices from status or agent results as the source
-  of truth; ask the user before device authentication, installation, or secret
-  configuration.
-- Translate provider and transport errors into one concrete next action; the
-  user should not need to understand planes or JSON-RPC.
-
+- Quick factual or single-file questions → `fast`.
+- Design reviews, audits, multi-step analysis → `reasoning`.
+- Tasks needing self-critique → `thinking`.
+- Current-events or source-cited answers → `research` (uses web + X search).
 
 ## Parallel ship (contributor, private)
 
-Dual-lane shipping process lives in private `djtelicloud/unigrok-intelligence`.
-Public product installs never require it.
+Dual-lane product+intelligence shipping process lives in the **private**
+repository `djtelicloud/unigrok-intelligence` (playbooks + `grok-parallel-ship`
+skill). Public product installs never require it.
+
+Do **not** invent multi-provider public chat tools. UniGrok's public `agent`
+remains Grok-routed; other providers stay behind Grok-supervised adapters.
 
 
 ## Plan critique habit (opt-in)
 
-When the user is about to see a multi-step Implementation Plan, prefer calling
-UniGrok `agent` (`thinking` or `reasoning`) for a second opinion, then improve
-the plan before presenting it **only when the user wants a Grok second opinion**
-(including `@grok`). Do not silently spend metered API credits without consent.
-Do not invent a second MCP port or Forge workflow for public installs. Public
-path remains `http://localhost:4765/mcp` only.
+When the user is about to see a multi-step **Implementation Plan**, prefer:
+
+1. Call UniGrok `agent` (`thinking` or `reasoning`) with the draft plan.
+2. Incorporate feedback silently.
+3. Only then present the improved plan to the user.
+
+Do this when the user wants a Grok second opinion (including `@grok`). Do **not**
+silently spend metered API credits without consent. Do **not** auto-generate
+skill trees into foreign projects without permission. Never copy the UniGrok
+repository’s contributor `.agents` tree into the user’s other apps.
+
+## Cost awareness
+
+Check `cost_usd` in each response. Session reuse preserves continuity and can
+reduce repeated-context API input cost when caching hits; it does not guarantee
+savings. The default `cli_first` policy prefers compatible, unpinned work on an
+authenticated CLI subscription. Explicit plane selection should pair with
+`fallback_policy="same_plane"` when the request must not cross into a different
+credential or billing plane; `cross_plane` allows bounded failover. CLI
+provider cost remains unavailable, so report local counts and estimated tokens,
+not invented subscription cost or remaining provider quota.
+
+## Safe onboarding behavior
+
+- On first connect in a session, call `grok_mcp_discover_self` and read
+  `data.bootstrap` + `data.request_context` before inventing setup steps.
+- Treat `credential_planes` notices from status or an agent result as the
+  source of truth. Ask before device authentication, installation, or secret
+  configuration.
+- Never request `XAI_API_KEY` in chat or write it into the caller's project.
+- The stable service is workspace-neutral: do not assume MCP registration
+  grants filesystem access. Use `workspace_context` or local file tools only
+  when those tools are actually exposed in the current trusted
+  contributor/stdio session.
+- Translate provider and transport errors into one concrete next action for
+  the user; do not require them to understand planes, MCP transport, or JSON-RPC.
+- Public product path is `http://localhost:4765/mcp` only. Do not invent a
+  second port, Forge, Swarm, or land workflow for ordinary end-user installs.
+
+## First-connect diagnostics (server + local)
+
+**Server (always available via MCP):**
+
+1. Call `grok_mcp_discover_self`.
+2. Honor `data.bootstrap.status` (`OK` / `WARN` / `ERR`) and gates
+   (`can_chat`, `can_spend_api`, `can_mutate_workspace`, `can_use_swarm`).
+3. Read `data.request_context`: surface (`stable_core` / `contributor_forge` /
+   `mode_dial`), `client_id_present`, optional Host port / mode dial.
+4. Prompt once per `credential_planes` notice id; follow
+   `data.bootstrap.next_actions` when present.
+5. Optional: `include_models: true` when model routing matters.
+
+**Local IDE audit (only with user permission; report only):**
+
+UniGrok cannot read global IDE settings over HTTP. With consent, use local tools
+to check and **report** (never rewrite without explicit permission; never print
+secret values):
+
+- User MCP configs point daily chat at `http://localhost:4765/mcp`.
+- Stable `X-Client-ID` per IDE (claude-code, vscode, codex, cursor, antigravity).
+- No `XAI_API_KEY` (or other secrets) embedded in MCP JSON.
+- Project `.mcp.json` (if any) is dual HTTP for UniGrok worktrees, never
+  broken `unigrok-stdio` with `${PLUGIN_ROOT}`.
+- Optional `using-unigrok` skill present; do not copy contributor `.agents`
+  trees into foreign apps.
+- Unique leverage: which planes are ready, whether Forge tools appear only when
+  intentionally connected to the contributor surface, mode dials if enabled.
+
+Then one cheap verification: `agent` with `mode=fast` or `grok_mcp_status`.
+
+## Endpoint
+
+The shared gateway runs at `http://localhost:4765/mcp` (Streamable HTTP).
+Health: `GET /healthz`. Optional local Core UI: `http://localhost:4765/ui/`
+(trusted machine-owner test/control surface with a provider-calling agent
+playground). `X-Client-ID` is a caller-controlled
+attribution and session label beneath a server-derived principal; it is not
+authentication. The default unauthenticated loopback service derives the shared
+`http:anon` principal for one local budget/security trust domain, so there is
+no cross-user isolation without configured auth. Project-qualify every session
+key: a generic key can collide across repositories when the same client label
+is reused.

--- a/.github/skills/using-unigrok/SKILL.md
+++ b/.github/skills/using-unigrok/SKILL.md
@@ -1,95 +1,137 @@
 ---
 name: using-unigrok
-description: VS Code Copilot guidance for querying xAI Grok through the shared UniGrok MCP gateway. Activate when the user says "@grok", asks to query Grok, requests a Grok second opinion/peer review, wants web/X grounded research, or needs cross-repo UniGrok setup help.
+description: How to query xAI Grok through the UniGrok MCP gateway. Activate when the user says "@grok", asks to query Grok, wants a second-model opinion or peer review from Grok, or needs web/X search grounding.
 ---
 
-# Using UniGrok from VS Code Copilot
+# Using the UniGrok Grok Gateway
 
-This is the Copilot/VS Code adaptation of the canonical gateway skill at
-`skills/using-unigrok/SKILL.md`. Use it when working in this repository and
-also when helping users in other repositories that connect to the same local
-UniGrok MCP service.
+UniGrok exposes one headline MCP tool: `agent`. It self-routes across Grok
+models and two billing planes, and returns structured metadata with every
+answer. **Primary chat path for every project is IDE → UniGrok MCP**. The local
+browser UI is an optional trusted-loopback test/control surface whose agent
+playground can invoke providers and spend metered credits.
 
-## Tool resolution
+## The `agent` tool
 
-The core tool is `agent`, but the namespaced tool name depends on MCP server
-registration:
+Call `agent` with:
 
-- `mcp__unigrok__agent` when the server name is `unigrok` (common workspace
-  config).
-- `mcp__grok__agent` when user scope registers the same endpoint as `grok`.
+- `prompt` (required): the task or question, with enough context to act on.
+- `mode` (optional): `auto` (default), `fast` (single-turn, cheapest),
+  `reasoning` (multi-step planner), `thinking` (reflected agent loop), or
+  `research` (citation-grounded fanout).
+- `model` (optional): pin a Grok model id such as `grok-4.5`; leave unset to
+  let routing choose.
+- `session` (optional): a stable, project-qualified key such as
+  `owner-repo:task` for multi-turn continuity. Do not reuse a generic session
+  key across repositories.
+- `workspace_context` (optional): deliberately selected excerpts, diffs, or
+  errors when the task depends on the caller's project. The stable service
+  cannot browse the IDE workspace automatically.
+- `workspace_label` (optional): descriptive metadata for the supplied context.
+  It does not isolate sessions; the project-qualified `session` key does.
 
-Use whichever namespace exists in the active tool list.
+Every result includes `response` plus metadata: `model`, `route`, `plane`
+(`API` or `CLI`), `cost_usd`, `tokens`, `latency_sec`, and `citations` when
+search grounding was used.
 
-## Calling pattern
+## Mode selection guidance
 
-- `prompt` (required): the exact task/question.
-- `mode` (optional): `auto`, `fast`, `reasoning`, `thinking`, `research`.
-- `session` (optional): stable per-task session key (reuse for follow-ups).
-- `workspace_context` (optional): selected code snippets, diffs, logs, or
-  errors from the caller's repo.
-- `workspace_label` (optional): human-readable repo/project name.
-- `model` (optional): pin only when asked.
-- `plane` and `fallback_policy` (optional): use
-  `fallback_policy="same_plane"` when the request must not cross billing
-  planes.
-
-The stable service is workspace-neutral and cannot browse the caller's files
-automatically; attach only deliberate context via `workspace_context`.
-
-## Response handling
-
-Surface both `response` and key metadata when relevant:
-
-- `model`, `route`, `plane`, `why`, `degraded`
-- `cost_usd`, `tokens`, `latency_sec`
-- `citations` (when research grounding is used)
-
-If users are cost-sensitive, explicitly report `cost_usd` and encourage session
-reuse for follow-up questions.
-
-## VS Code team distribution
-
-- **Workspace-shared skill (git-backed):**
-  `.github/skills/using-unigrok/SKILL.md`
-- **Personal user-level skill (not in git):**
-  `~/.copilot/skills/using-unigrok/SKILL.md`
-
-Use the workspace path for team defaults. Use the personal path for individual
-defaults across unrelated repositories.
-
-Do not duplicate this skill under a repository-root `.copilot/skills`
-directory; that is not a default project discovery path. VS Code can opt into
-additional paths through `chat.agentSkillsLocations` when a deliberate
-nonstandard location is required.
-
-## MCP endpoint and identity
-
-Default endpoint: `http://localhost:4765/mcp`
-
-Every IDE config should send a stable `X-Client-ID` (for example `vscode`) so
-session namespaces and telemetry remain separated by client.
-
-## Safety and credential boundary
-
-- Never ask users to paste `XAI_API_KEY` into IDE MCP config; credentials live
-  server-side.
-- Treat `credential_planes` status in tool output as source of truth.
-- On failures, return one concrete next action (for example check `/healthz`,
-  authenticate CLI plane, or verify MCP registration).
-
+- Quick factual or single-file questions → `fast`.
+- Design reviews, audits, multi-step analysis → `reasoning`.
+- Tasks needing self-critique → `thinking`.
+- Current-events or source-cited answers → `research` (uses web + X search).
 
 ## Parallel ship (contributor, private)
 
-Dual-lane shipping process lives in private `djtelicloud/unigrok-intelligence`.
-Public product installs never require it.
+Dual-lane product+intelligence shipping process lives in the **private**
+repository `djtelicloud/unigrok-intelligence` (playbooks + `grok-parallel-ship`
+skill). Public product installs never require it.
+
+Do **not** invent multi-provider public chat tools. UniGrok's public `agent`
+remains Grok-routed; other providers stay behind Grok-supervised adapters.
 
 
 ## Plan critique habit (opt-in)
 
-When the user is about to see a multi-step Implementation Plan, prefer calling
-UniGrok `agent` (`thinking` or `reasoning`) for a second opinion, then improve
-the plan before presenting it **only when the user wants a Grok second opinion**
-(including `@grok`). Do not silently spend metered API credits without consent.
-Do not invent a second MCP port or Forge workflow for public installs. Public
-path remains `http://localhost:4765/mcp` only.
+When the user is about to see a multi-step **Implementation Plan**, prefer:
+
+1. Call UniGrok `agent` (`thinking` or `reasoning`) with the draft plan.
+2. Incorporate feedback silently.
+3. Only then present the improved plan to the user.
+
+Do this when the user wants a Grok second opinion (including `@grok`). Do **not**
+silently spend metered API credits without consent. Do **not** auto-generate
+skill trees into foreign projects without permission. Never copy the UniGrok
+repository’s contributor `.agents` tree into the user’s other apps.
+
+## Cost awareness
+
+Check `cost_usd` in each response. Session reuse preserves continuity and can
+reduce repeated-context API input cost when caching hits; it does not guarantee
+savings. The default `cli_first` policy prefers compatible, unpinned work on an
+authenticated CLI subscription. Explicit plane selection should pair with
+`fallback_policy="same_plane"` when the request must not cross into a different
+credential or billing plane; `cross_plane` allows bounded failover. CLI
+provider cost remains unavailable, so report local counts and estimated tokens,
+not invented subscription cost or remaining provider quota.
+
+## Safe onboarding behavior
+
+- On first connect in a session, call `grok_mcp_discover_self` and read
+  `data.bootstrap` + `data.request_context` before inventing setup steps.
+- Treat `credential_planes` notices from status or an agent result as the
+  source of truth. Ask before device authentication, installation, or secret
+  configuration.
+- Never request `XAI_API_KEY` in chat or write it into the caller's project.
+- The stable service is workspace-neutral: do not assume MCP registration
+  grants filesystem access. Use `workspace_context` or local file tools only
+  when those tools are actually exposed in the current trusted
+  contributor/stdio session.
+- Translate provider and transport errors into one concrete next action for
+  the user; do not require them to understand planes, MCP transport, or JSON-RPC.
+- Public product path is `http://localhost:4765/mcp` only. Do not invent a
+  second port, Forge, Swarm, or land workflow for ordinary end-user installs.
+
+## First-connect diagnostics (server + local)
+
+**Server (always available via MCP):**
+
+1. Call `grok_mcp_discover_self`.
+2. Honor `data.bootstrap.status` (`OK` / `WARN` / `ERR`) and gates
+   (`can_chat`, `can_spend_api`, `can_mutate_workspace`, `can_use_swarm`).
+3. Read `data.request_context`: surface (`stable_core` / `contributor_forge` /
+   `mode_dial`), `client_id_present`, optional Host port / mode dial.
+4. Prompt once per `credential_planes` notice id; follow
+   `data.bootstrap.next_actions` when present.
+5. Optional: `include_models: true` when model routing matters.
+
+**Local IDE audit (only with user permission; report only):**
+
+UniGrok cannot read global IDE settings over HTTP. With consent, use local tools
+to check and **report** (never rewrite without explicit permission; never print
+secret values):
+
+- User MCP configs point daily chat at `http://localhost:4765/mcp`.
+- Stable `X-Client-ID` per IDE (claude-code, vscode, codex, cursor, antigravity).
+- No `XAI_API_KEY` (or other secrets) embedded in MCP JSON.
+- Project `.mcp.json` (if any) is dual HTTP for UniGrok worktrees, never
+  broken `unigrok-stdio` with `${PLUGIN_ROOT}`.
+- Optional `using-unigrok` skill present; do not copy contributor `.agents`
+  trees into foreign apps.
+- Unique leverage: which planes are ready, whether Forge tools appear only when
+  intentionally connected to the contributor surface, mode dials if enabled.
+
+Then one cheap verification: `agent` with `mode=fast` or `grok_mcp_status`.
+
+## Endpoint
+
+The shared gateway runs at `http://localhost:4765/mcp` (Streamable HTTP).
+Health: `GET /healthz`. Optional local Core UI: `http://localhost:4765/ui/`
+(trusted machine-owner test/control surface with a provider-calling agent
+playground). `X-Client-ID` is a caller-controlled
+attribution and session label beneath a server-derived principal; it is not
+authentication. The default unauthenticated loopback service derives the shared
+`http:anon` principal for one local budget/security trust domain, so there is
+no cross-user isolation without configured auth. Project-qualify every session
+key: a generic key can collide across repositories when the same client label
+is reused.

--- a/.github/skills/using-unigrok/SKILL.md
+++ b/.github/skills/using-unigrok/SKILL.md
@@ -1,98 +1,79 @@
 ---
 name: using-unigrok
-description: How to query xAI Grok through the UniGrok MCP gateway. Activate when the user says "@grok", asks to query Grok, wants a second-model opinion or peer review from Grok, or needs web/X search grounding.
+description: VS Code Copilot guidance for querying xAI Grok through the shared UniGrok MCP gateway. Activate when the user says "@grok", asks to query Grok, requests a Grok second opinion/peer review, wants web/X grounded research, or needs cross-repo UniGrok setup help.
 ---
 
-# Using the UniGrok Grok Gateway
+# Using UniGrok from VS Code Copilot
 
-UniGrok exposes one headline MCP tool: `agent`. It self-routes across Grok
-models and two billing planes, and returns structured metadata with every
-answer. **Primary chat path for every project is IDE → UniGrok MCP**. The local
-browser UI is an optional trusted-loopback test/control surface whose agent
-playground can invoke providers and spend metered credits.
+This is the Copilot/VS Code adaptation of the canonical gateway skill at
+`skills/using-unigrok/SKILL.md`. Use it when working in this repository and
+also when helping users in other repositories that connect to the same local
+UniGrok MCP service.
 
-## The `agent` tool
+## Tool resolution
 
-Call `agent` with:
+The core tool is `agent`, but the namespaced tool name depends on MCP server
+registration:
 
-- `prompt` (required): the task or question, with enough context to act on.
-- `mode` (optional): `auto` (default), `fast` (single-turn, cheapest),
-  `reasoning` (multi-step planner), `thinking` (reflected agent loop), or
-  `research` (citation-grounded fanout).
-- `model` (optional): pin a Grok model id such as `grok-4.5`; leave unset to
-  let routing choose.
-- `session` (optional): a stable, project-qualified key such as
-  `owner-repo:task` for multi-turn continuity. Do not reuse a generic session
-  key across repositories.
-- `workspace_context` (optional): deliberately selected excerpts, diffs, or
-  errors when the task depends on the caller's project. The stable service
-  cannot browse the IDE workspace automatically.
-- `workspace_label` (optional): descriptive metadata for the supplied context.
-  It does not isolate sessions; the project-qualified `session` key does.
+- `mcp__unigrok__agent` when the server name is `unigrok` (common workspace
+  config).
+- `mcp__grok__agent` when user scope registers the same endpoint as `grok`.
 
-Every result includes `response` plus metadata: `model`, `route`, `plane`
-(`API` or `CLI`), `cost_usd`, `tokens`, `latency_sec`, and `citations` when
-search grounding was used.
+Use whichever namespace exists in the active tool list.
 
-## Mode selection guidance
+## Calling pattern
 
-- Quick factual or single-file questions → `fast`.
-- Design reviews, audits, multi-step analysis → `reasoning`.
-- Tasks needing self-critique → `thinking`.
-- Current-events or source-cited answers → `research` (uses web + X search).
+- `prompt` (required): the exact task/question.
+- `mode` (optional): `auto`, `fast`, `reasoning`, `thinking`, `research`.
+- `session` (optional): stable per-task session key (reuse for follow-ups).
+- `workspace_context` (optional): selected code snippets, diffs, logs, or
+  errors from the caller's repo.
+- `workspace_label` (optional): human-readable repo/project name.
+- `model` (optional): pin only when asked.
+- `plane` and `fallback_policy` (optional): use
+  `fallback_policy="same_plane"` when the request must not cross billing
+  planes.
 
-## Parallel ship (contributor, private)
+The stable service is workspace-neutral and cannot browse the caller's files
+automatically; attach only deliberate context via `workspace_context`.
 
-Dual-lane product+intelligence shipping process lives in the **private**
-repository `djtelicloud/unigrok-intelligence` (playbooks + `grok-parallel-ship`
-skill). Public product installs never require it.
+## Response handling
 
-Do **not** invent multi-provider public chat tools. UniGrok's public `agent`
-remains Grok-routed; other providers stay behind Grok-supervised adapters.
+Surface both `response` and key metadata when relevant:
 
+- `model`, `route`, `plane`, `why`, `degraded`
+- `cost_usd`, `tokens`, `latency_sec`
+- `citations` (when research grounding is used)
 
-## Plan critique habit (opt-in)
+If users are cost-sensitive, explicitly report `cost_usd` and encourage session
+reuse for follow-up questions.
 
-When the user is about to see a multi-step **Implementation Plan**, prefer:
+## VS Code team distribution
 
-1. Call UniGrok `agent` (`thinking` or `reasoning`) with the draft plan.
-2. Incorporate feedback silently.
-3. Only then present the improved plan to the user.
+- **Workspace-shared skill (git-backed):**
+  `.github/skills/using-unigrok/SKILL.md`
+- **Personal user-level skill (not in git):**
+  `~/.copilot/skills/using-unigrok/SKILL.md`
 
-Do this when the user wants a Grok second opinion (including `@grok`). Do **not**
-silently spend metered API credits without consent. Do **not** auto-generate
-skill trees into foreign projects without permission. Never copy the UniGrok
-repository’s contributor `.agents` tree into the user’s other apps.
+Use the workspace path for team defaults. Use the personal path for individual
+defaults across unrelated repositories.
 
-## Cost awareness
+Do not duplicate this skill under a repository-root `.copilot/skills`
+directory; that is not a default project discovery path. VS Code can opt into
+additional paths through `chat.agentSkillsLocations` when a deliberate
+nonstandard location is required.
 
-Check `cost_usd` in each response. Session reuse preserves continuity and can
-reduce repeated-context API input cost when caching hits; it does not guarantee
-savings. The default `cli_first` policy prefers compatible, unpinned work on an
-authenticated CLI subscription. Explicit plane selection should pair with
-`fallback_policy="same_plane"` when the request must not cross into a different
-credential or billing plane; `cross_plane` allows bounded failover. CLI
-provider cost remains unavailable, so report local counts and estimated tokens,
-not invented subscription cost or remaining provider quota.
+## MCP endpoint and identity
 
-## Safe onboarding behavior
+Default endpoint: `http://localhost:4765/mcp`
 
-- On first connect in a session, call `grok_mcp_discover_self` and read
-  `data.bootstrap` + `data.request_context` before inventing setup steps.
-- Treat `credential_planes` notices from status or an agent result as the
-  source of truth. Ask before device authentication, installation, or secret
-  configuration.
-- Never request `XAI_API_KEY` in chat or write it into the caller's project.
-- The stable service is workspace-neutral: do not assume MCP registration
-  grants filesystem access. Use `workspace_context` or local file tools only
-  when those tools are actually exposed in the current trusted
-  contributor/stdio session.
-- Translate provider and transport errors into one concrete next action for
-  the user; do not require them to understand planes, MCP transport, or JSON-RPC.
-- Public product path is `http://localhost:4765/mcp` only. Do not invent a
-  second port, Forge, Swarm, or land workflow for ordinary end-user installs.
+Every IDE config should send a stable `X-Client-ID` (for example `vscode`) so
+session namespaces and telemetry remain separated by client.
 
 ## First-connect diagnostics (server + local)
+
+On first connect in a session, call `grok_mcp_discover_self` and read
+`data.bootstrap` + `data.request_context` before inventing setup steps.
 
 **Server (always available via MCP):**
 
@@ -112,26 +93,35 @@ to check and **report** (never rewrite without explicit permission; never print
 secret values):
 
 - User MCP configs point daily chat at `http://localhost:4765/mcp`.
-- Stable `X-Client-ID` per IDE (claude-code, vscode, codex, cursor, antigravity).
+- Stable `X-Client-ID` per IDE (for VS Code: `vscode`).
 - No `XAI_API_KEY` (or other secrets) embedded in MCP JSON.
 - Project `.mcp.json` (if any) is dual HTTP for UniGrok worktrees, never
   broken `unigrok-stdio` with `${PLUGIN_ROOT}`.
 - Optional `using-unigrok` skill present; do not copy contributor `.agents`
   trees into foreign apps.
-- Unique leverage: which planes are ready, whether Forge tools appear only when
-  intentionally connected to the contributor surface, mode dials if enabled.
 
 Then one cheap verification: `agent` with `mode=fast` or `grok_mcp_status`.
 
-## Endpoint
+## Safety and credential boundary
 
-The shared gateway runs at `http://localhost:4765/mcp` (Streamable HTTP).
-Health: `GET /healthz`. Optional local Core UI: `http://localhost:4765/ui/`
-(trusted machine-owner test/control surface with a provider-calling agent
-playground). `X-Client-ID` is a caller-controlled
-attribution and session label beneath a server-derived principal; it is not
-authentication. The default unauthenticated loopback service derives the shared
-`http:anon` principal for one local budget/security trust domain, so there is
-no cross-user isolation without configured auth. Project-qualify every session
-key: a generic key can collide across repositories when the same client label
-is reused.
+- Never ask users to paste `XAI_API_KEY` into IDE MCP config; credentials live
+  server-side.
+- Treat `credential_planes` status in tool output as source of truth.
+- On failures, return one concrete next action (for example check `/healthz`,
+  authenticate CLI plane, or verify MCP registration).
+
+
+## Parallel ship (contributor, private)
+
+Dual-lane shipping process lives in private `djtelicloud/unigrok-intelligence`.
+Public product installs never require it.
+
+
+## Plan critique habit (opt-in)
+
+When the user is about to see a multi-step Implementation Plan, prefer calling
+UniGrok `agent` (`thinking` or `reasoning`) for a second opinion, then improve
+the plan before presenting it **only when the user wants a Grok second opinion**
+(including `@grok`). Do not silently spend metered API credits without consent.
+Do not invent a second MCP port or Forge workflow for public installs. Public
+path remains `http://localhost:4765/mcp` only.

--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -244,6 +244,36 @@ Test helper: clear the process-local cache after swapping fixture files.
 
 ## http_server.py {#http_server}
 
+### Function: `mode_dials_enabled` {#http_server-mode_dials_enabled}
+
+```python
+def mode_dials_enabled() -> bool
+```
+
+**Keywords:** mode, dials, enabled
+
+Public alias for whether phoneword mode-dial ports are enabled.
+
+### Function: `get_active_mode_dial` {#http_server-get_active_mode_dial}
+
+```python
+def get_active_mode_dial() -> Optional[tuple[int, str]]
+```
+
+**Keywords:** get, active, mode, dial
+
+Return the phoneword mode dial bound for this HTTP request, if any.
+
+### Function: `get_active_host_port` {#http_server-get_active_host_port}
+
+```python
+def get_active_host_port() -> Optional[int]
+```
+
+**Keywords:** get, active, host, port
+
+Return the Host header port for this HTTP request, when parseable.
+
 ### Class: `ModeDialContextMiddleware` {#http_server-modedialcontextmiddleware}
 
 ```python
@@ -538,6 +568,26 @@ def set_active_principal(principal: Optional[str])
 **Keywords:** set, active, principal
 
 Bind the authenticated security principal for the current request.
+
+### Function: `get_active_client_id` {#identity-get_active_client_id}
+
+```python
+def get_active_client_id() -> Optional[str]
+```
+
+**Keywords:** get, active, client, id
+
+Return the untrusted X-Client-ID label bound for this request, if any.
+
+### Function: `principal_kind` {#identity-principal_kind}
+
+```python
+def principal_kind(principal: Optional[str]=None) -> str
+```
+
+**Keywords:** principal, kind
+
+Classify the security principal without exposing raw identifiers.
 
 ### Function: `resolve_request_caller` {#identity-resolve_request_caller}
 

--- a/docs/okf/faq.md
+++ b/docs/okf/faq.md
@@ -172,10 +172,22 @@ composer model for coding.
 
 **Keywords:** credentials, missing api key, cli auth, install cli, permission
 
-On first connection, inspect `grok_mcp_discover_self.data.credential_planes`.
-Each notice has a stable id, severity, whether it blocks model work, and a
-bounded action. Prompt the user once per notice id and repeat only after the
-reported state changes.
+On first connection, call `grok_mcp_discover_self` and inspect:
+
+1. `data.bootstrap` — `status` (`OK`/`WARN`/`ERR`), gates (`can_chat`,
+   `can_spend_api`, `can_mutate_workspace`, `can_use_swarm`), warnings, and
+   `first_connect_checklist`.
+2. `data.request_context` — whether `X-Client-ID` is present, process surface
+   (`stable_core` vs `contributor_forge` vs phoneword `mode_dial`), and Host
+   port when the HTTP transport supplied one.
+3. `data.credential_planes` — each notice has a stable id, severity, whether it
+   blocks model work, and a bounded action. Prompt the user once per notice id
+   and repeat only after the reported state changes.
+
+`caller_config_audit` is `not_available_on_service` on purpose: UniGrok does not
+read global IDE MCP files or the caller's project. With permission, the IDE
+agent may audit those locally and report only (never rewrite without consent;
+never print secret values).
 
 - CLI missing or unauthenticated: ask permission before installing/rebuilding
   the CLI or running its interactive device-auth command. Continue on API when

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -244,6 +244,36 @@ Test helper: clear the process-local cache after swapping fixture files.
 
 ## http_server.py {#http_server}
 
+### Function: `mode_dials_enabled` {#http_server-mode_dials_enabled}
+
+```python
+def mode_dials_enabled() -> bool
+```
+
+**Keywords:** mode, dials, enabled
+
+Public alias for whether phoneword mode-dial ports are enabled.
+
+### Function: `get_active_mode_dial` {#http_server-get_active_mode_dial}
+
+```python
+def get_active_mode_dial() -> Optional[tuple[int, str]]
+```
+
+**Keywords:** get, active, mode, dial
+
+Return the phoneword mode dial bound for this HTTP request, if any.
+
+### Function: `get_active_host_port` {#http_server-get_active_host_port}
+
+```python
+def get_active_host_port() -> Optional[int]
+```
+
+**Keywords:** get, active, host, port
+
+Return the Host header port for this HTTP request, when parseable.
+
 ### Class: `ModeDialContextMiddleware` {#http_server-modedialcontextmiddleware}
 
 ```python
@@ -538,6 +568,26 @@ def set_active_principal(principal: Optional[str])
 **Keywords:** set, active, principal
 
 Bind the authenticated security principal for the current request.
+
+### Function: `get_active_client_id` {#identity-get_active_client_id}
+
+```python
+def get_active_client_id() -> Optional[str]
+```
+
+**Keywords:** get, active, client, id
+
+Return the untrusted X-Client-ID label bound for this request, if any.
+
+### Function: `principal_kind` {#identity-principal_kind}
+
+```python
+def principal_kind(principal: Optional[str]=None) -> str
+```
+
+**Keywords:** principal, kind
+
+Classify the security principal without exposing raw identifiers.
 
 ### Function: `resolve_request_caller` {#identity-resolve_request_caller}
 

--- a/sites/unigrok-control-center/public/docs/okf/faq.md
+++ b/sites/unigrok-control-center/public/docs/okf/faq.md
@@ -172,10 +172,22 @@ composer model for coding.
 
 **Keywords:** credentials, missing api key, cli auth, install cli, permission
 
-On first connection, inspect `grok_mcp_discover_self.data.credential_planes`.
-Each notice has a stable id, severity, whether it blocks model work, and a
-bounded action. Prompt the user once per notice id and repeat only after the
-reported state changes.
+On first connection, call `grok_mcp_discover_self` and inspect:
+
+1. `data.bootstrap` — `status` (`OK`/`WARN`/`ERR`), gates (`can_chat`,
+   `can_spend_api`, `can_mutate_workspace`, `can_use_swarm`), warnings, and
+   `first_connect_checklist`.
+2. `data.request_context` — whether `X-Client-ID` is present, process surface
+   (`stable_core` vs `contributor_forge` vs phoneword `mode_dial`), and Host
+   port when the HTTP transport supplied one.
+3. `data.credential_planes` — each notice has a stable id, severity, whether it
+   blocks model work, and a bounded action. Prompt the user once per notice id
+   and repeat only after the reported state changes.
+
+`caller_config_audit` is `not_available_on_service` on purpose: UniGrok does not
+read global IDE MCP files or the caller's project. With permission, the IDE
+agent may audit those locally and report only (never rewrite without consent;
+never print secret values).
 
 - CLI missing or unauthenticated: ask permission before installing/rebuilding
   the CLI or running its interactive device-auth command. Continue on API when

--- a/skills/using-unigrok/SKILL.md
+++ b/skills/using-unigrok/SKILL.md
@@ -77,6 +77,8 @@ not invented subscription cost or remaining provider quota.
 
 ## Safe onboarding behavior
 
+- On first connect in a session, call `grok_mcp_discover_self` and read
+  `data.bootstrap` + `data.request_context` before inventing setup steps.
 - Treat `credential_planes` notices from status or an agent result as the
   source of truth. Ask before device authentication, installation, or secret
   configuration.
@@ -89,6 +91,37 @@ not invented subscription cost or remaining provider quota.
   the user; do not require them to understand planes, MCP transport, or JSON-RPC.
 - Public product path is `http://localhost:4765/mcp` only. Do not invent a
   second port, Forge, Swarm, or land workflow for ordinary end-user installs.
+
+## First-connect diagnostics (server + local)
+
+**Server (always available via MCP):**
+
+1. Call `grok_mcp_discover_self`.
+2. Honor `data.bootstrap.status` (`OK` / `WARN` / `ERR`) and gates
+   (`can_chat`, `can_spend_api`, `can_mutate_workspace`, `can_use_swarm`).
+3. Read `data.request_context`: surface (`stable_core` / `contributor_forge` /
+   `mode_dial`), `client_id_present`, optional Host port / mode dial.
+4. Prompt once per `credential_planes` notice id; follow
+   `data.bootstrap.next_actions` when present.
+5. Optional: `include_models: true` when model routing matters.
+
+**Local IDE audit (only with user permission; report only):**
+
+UniGrok cannot read global IDE settings over HTTP. With consent, use local tools
+to check and **report** (never rewrite without explicit permission; never print
+secret values):
+
+- User MCP configs point daily chat at `http://localhost:4765/mcp`.
+- Stable `X-Client-ID` per IDE (claude-code, vscode, codex, cursor, antigravity).
+- No `XAI_API_KEY` (or other secrets) embedded in MCP JSON.
+- Project `.mcp.json` (if any) is dual HTTP for UniGrok worktrees, never
+  broken `unigrok-stdio` with `${PLUGIN_ROOT}`.
+- Optional `using-unigrok` skill present; do not copy contributor `.agents`
+  trees into foreign apps.
+- Unique leverage: which planes are ready, whether Forge tools appear only when
+  intentionally connected to the contributor surface, mode dials if enabled.
+
+Then one cheap verification: `agent` with `mode=fast` or `grok_mcp_status`.
 
 ## Endpoint
 

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -85,6 +85,9 @@ MODE_DIAL_PORTS: Dict[int, Literal["auto", "fast", "reasoning", "thinking", "res
 _ACTIVE_MODE_DIAL: contextvars.ContextVar[Optional[tuple[int, str]]] = contextvars.ContextVar(
     "unigrok_active_mode_dial", default=None
 )
+_ACTIVE_HOST_PORT: contextvars.ContextVar[Optional[int]] = contextvars.ContextVar(
+    "unigrok_active_host_port", default=None
+)
 
 
 def _json_error(message: str, status_code: int = 400, code: str = "invalid_request_error") -> JSONResponse:
@@ -372,6 +375,21 @@ def _mode_dials_enabled() -> bool:
     return os.environ.get("UNIGROK_MODE_DIALS", "").strip().lower() in ("1", "true", "yes")
 
 
+def mode_dials_enabled() -> bool:
+    """Public alias for whether phoneword mode-dial ports are enabled."""
+    return _mode_dials_enabled()
+
+
+def get_active_mode_dial() -> Optional[tuple[int, str]]:
+    """Return the phoneword mode dial bound for this HTTP request, if any."""
+    return _ACTIVE_MODE_DIAL.get()
+
+
+def get_active_host_port() -> Optional[int]:
+    """Return the Host header port for this HTTP request, when parseable."""
+    return _ACTIVE_HOST_PORT.get()
+
+
 def _host_port(scope: Dict[str, Any]) -> Optional[int]:
     host = (_scope_header(scope, b"host") or "").strip()
     if not host:
@@ -405,11 +423,13 @@ class ModeDialContextMiddleware:
         if scope["type"] != "http":
             await self.app(scope, receive, send)
             return
-        token = _ACTIVE_MODE_DIAL.set(_mode_dial_for_scope(scope))
+        host_token = _ACTIVE_HOST_PORT.set(_host_port(scope))
+        dial_token = _ACTIVE_MODE_DIAL.set(_mode_dial_for_scope(scope))
         try:
             await self.app(scope, receive, send)
         finally:
-            _ACTIVE_MODE_DIAL.reset(token)
+            _ACTIVE_MODE_DIAL.reset(dial_token)
+            _ACTIVE_HOST_PORT.reset(host_token)
 
 
 # These endpoints are deliberately safe for public health checks and agent

--- a/src/identity.py
+++ b/src/identity.py
@@ -106,6 +106,27 @@ def get_active_principal() -> Optional[str]:
     return _ACTIVE_PRINCIPAL.get()
 
 
+def get_active_client_id() -> Optional[str]:
+    """Return the untrusted X-Client-ID label bound for this request, if any."""
+    return _ACTIVE_CLIENT_ID.get()
+
+
+def principal_kind(principal: Optional[str] = None) -> str:
+    """Classify the security principal without exposing raw identifiers."""
+    value = principal if principal is not None else get_active_principal()
+    if not value:
+        return "none"
+    if value.startswith("oauth:"):
+        return "oauth"
+    if value.startswith("http:key-"):
+        return "api_key"
+    if value == "http:anon":
+        return "anon"
+    if value.startswith("stdio:"):
+        return "stdio"
+    return "other"
+
+
 def resolve_request_caller(caller: Optional[str]) -> Optional[str]:
     """Resolve attribution without letting HTTP metadata replace principal.
 

--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -45,7 +45,7 @@ from ..utils import (
 from xai_sdk.chat import user
 from xai_sdk.tools import code_execution, web_search as xai_web_search, x_search as xai_x_search
 
-from ..identity import scoped_session
+from ..identity import get_active_client_id, principal_kind, scoped_session
 
 logger = logging.getLogger("GrokMCP")
 
@@ -941,6 +941,161 @@ def load_okf_manifest() -> dict[str, Any]:
     return manifest
 
 
+def _swarm_policy() -> str:
+    """Return the process Swarm policy: off | dry_run | active."""
+    raw = os.environ.get("UNIGROK_SWARM", "off").strip().lower()
+    if raw in ("dry_run", "active"):
+        return raw
+    if raw in ("1", "true", "yes", "on"):
+        return "active"
+    return "off"
+
+
+def _build_discover_request_context(*, contributor: bool) -> dict[str, Any]:
+    """Assemble request-scoped onboarding identity without secrets."""
+    # Late imports avoid cycles: http_server registers these tools at import time.
+    from ..http_server import (
+        get_active_host_port,
+        get_active_mode_dial,
+        mode_dials_enabled,
+    )
+
+    client_id = get_active_client_id()
+    host_port = get_active_host_port()
+    dial = get_active_mode_dial()
+    dials_on = mode_dials_enabled()
+
+    if contributor:
+        surface = "contributor_forge"
+    elif dial is not None:
+        surface = "mode_dial"
+    else:
+        surface = "stable_core"
+
+    return {
+        "client_id_present": bool(client_id),
+        "client_id_normalized": client_id,
+        "principal_kind": principal_kind(),
+        "host_port": host_port,
+        "surface": surface,
+        "dial": (
+            {"port": dial[0], "default_mode": dial[1]}
+            if dial is not None
+            else None
+        ),
+        "mode_dials_enabled": dials_on,
+    }
+
+
+def _build_discover_bootstrap(
+    *,
+    contributor: bool,
+    workspace_attached: bool,
+    credential_planes: dict[str, Any],
+    request_context: dict[str, Any],
+) -> dict[str, Any]:
+    """GenFunc-style continuity gates for onboarding (no project assimilation)."""
+    warnings: list[dict[str, Any]] = []
+    next_actions: list[dict[str, Any]] = []
+
+    service_usable = bool(credential_planes.get("service_usable"))
+    degraded = bool(credential_planes.get("degraded"))
+    api = credential_planes.get("api") if isinstance(credential_planes.get("api"), dict) else {}
+    cli = credential_planes.get("cli") if isinstance(credential_planes.get("cli"), dict) else {}
+    swarm_policy = _swarm_policy()
+
+    can_chat = service_usable
+    can_spend_api = bool(api.get("available"))
+    can_mutate_workspace = bool(contributor and workspace_attached)
+    can_use_swarm = bool(contributor and swarm_policy in ("dry_run", "active"))
+
+    if not request_context.get("client_id_present"):
+        warnings.append(
+            {
+                "id": "missing_client_id",
+                "severity": "warn",
+                "message": (
+                    "X-Client-ID is absent. Set a stable IDE label "
+                    "(for example claude-code, vscode, codex, cursor, antigravity) "
+                    "for session separation and telemetry. It is not authentication."
+                ),
+            }
+        )
+
+    for notice in credential_planes.get("notices") or []:
+        if not isinstance(notice, dict):
+            continue
+        notice_id = notice.get("id") or "credential_notice"
+        severity = "error" if notice.get("blocking") else "warn"
+        warnings.append(
+            {
+                "id": str(notice_id),
+                "severity": severity,
+                "plane": notice.get("plane"),
+                "message": notice.get("message") or "Credential plane notice.",
+            }
+        )
+        action = notice.get("action") if isinstance(notice.get("action"), dict) else None
+        if action or notice.get("action_id"):
+            next_actions.append(
+                {
+                    "id": notice.get("action_id") or notice_id,
+                    "prompt_user": bool(notice.get("prompt_user", True)),
+                    "action": action,
+                }
+            )
+
+    if degraded and service_usable:
+        warnings.append(
+            {
+                "id": "credential_plane_degraded",
+                "severity": "warn",
+                "message": "Service is usable but one credential plane is degraded.",
+            }
+        )
+
+    if not can_chat:
+        status = "ERR"
+    elif warnings:
+        status = "WARN"
+    else:
+        status = "OK"
+
+    return {
+        "schema_version": 1,
+        "status": status,
+        "can_chat": can_chat,
+        "can_spend_api": can_spend_api,
+        "can_mutate_workspace": can_mutate_workspace,
+        "can_use_swarm": can_use_swarm,
+        "swarm_policy": swarm_policy if contributor else "off",
+        "warnings": warnings,
+        "next_actions": next_actions,
+        "caller_config_audit": "not_available_on_service",
+        "caller_config_audit_hint": (
+            "Stable UniGrok cannot read global IDE MCP files or the caller's project. "
+            "With user permission, the IDE agent should audit local configs "
+            "(user MCP JSON, project .mcp.json, skills) and report only; never rewrite "
+            "global settings without explicit consent. Never print secret values."
+        ),
+        "surfaces": {
+            "canonical_mcp": "http://localhost:4765/mcp",
+            "healthz": "http://localhost:4765/healthz",
+            "readyz": "http://localhost:4765/readyz",
+            "runtimez": "http://localhost:4765/runtimez",
+            "ui": "http://localhost:4765/ui/",
+        },
+        "first_connect_checklist": [
+            "Call grok_mcp_discover_self and read data.bootstrap + data.request_context.",
+            "Prompt once per credential_planes notice id; never ask for XAI_API_KEY in chat.",
+            "Confirm X-Client-ID is set for this IDE (data.request_context.client_id_present).",
+            "With permission, audit local IDE MCP configs for http://localhost:4765/mcp and no keys in JSON.",
+            "Optional: one cheap agent(mode=fast) or grok_mcp_status after planes are ready.",
+            "Public installs: do not invent a second product port, Swarm, or land workflow.",
+        ],
+    }
+
+
 async def grok_mcp_discover_self(include_models: bool = False) -> SystemResult:
     """Exposes OKF bundle information, WebMCP manifests, and tool schemas for zero-configuration agent onboarding."""
     async with GrokInvocationContext("utility", logger, append_signature=False) as ctx:
@@ -950,6 +1105,7 @@ async def grok_mcp_discover_self(include_models: bool = False) -> SystemResult:
 
         workspace = PathResolver.get_workspace_root()
         contributor = PathResolver.contributor_mode()
+        workspace_attached = workspace is not None
         try:
             cli_plane = await run_blocking(
                 grok_cli_plane_status,
@@ -965,6 +1121,13 @@ async def grok_mcp_discover_self(include_models: bool = False) -> SystemResult:
                 "setup_command": CLI_AUTH_SETUP_COMMAND,
             }
         credential_planes = credential_plane_contract(cli_plane)
+        request_context = _build_discover_request_context(contributor=contributor)
+        bootstrap = _build_discover_bootstrap(
+            contributor=contributor,
+            workspace_attached=workspace_attached,
+            credential_planes=credential_planes,
+            request_context=request_context,
+        )
         okf_manifest = load_okf_manifest()
         model_catalog = None
         if include_models:
@@ -1009,20 +1172,25 @@ async def grok_mcp_discover_self(include_models: bool = False) -> SystemResult:
             }
         manifest = {
             "okf_version": "0.1",
+            "schema_version": 2,
             "name": "uni-grok-mcp",
             "service_mode": "contributor" if contributor else "stable",
             "requires_project_files": False,
             "canonical_endpoint": "http://localhost:4765/mcp",
             "mode_dials": {
                 "optional": True,
+                "enabled": bool(request_context.get("mode_dials_enabled")),
                 "ports": {str(port): mode for port, mode in MODE_DIAL_PORTS.items()},
                 "precedence": "explicit mode > dialed port > auto",
+                "request_dial": request_context.get("dial"),
             },
             "workspace": {
-                "attached": workspace is not None,
+                "attached": workspace_attached,
                 "context_transport": "workspace_context",
                 "automatic_project_discovery": False,
             },
+            "request_context": request_context,
+            "bootstrap": bootstrap,
             "credential_planes": credential_planes,
             "contributor_features": {
                 "enabled": contributor,
@@ -1059,15 +1227,30 @@ async def grok_mcp_discover_self(include_models: bool = False) -> SystemResult:
                 "(not a second UniGrok to install). Prefer the canonical 4765 endpoint.\n"
             )
 
+        client_label = request_context.get("client_id_normalized") or "(missing)"
+        surface = request_context.get("surface") or "stable_core"
+        bootstrap_status = bootstrap.get("status") or "WARN"
+
         doc_text = (
             "# UniGrok MCP Discovery & Self-Description\n\n"
             "Zero-configuration onboarding for IDE agents. The primary product chat path is the "
             "UniGrok `agent` tool over MCP. The trusted-loopback UI is an optional test and control "
             "surface, not the primary daily chat path.\n\n"
+            "## Bootstrap (first connect)\n"
+            f"- Status: `{bootstrap_status}`. Surface: `{surface}`. "
+            f"Client label: `{client_label}`.\n"
+            f"- Gates: can_chat=`{bootstrap.get('can_chat')}`, "
+            f"can_spend_api=`{bootstrap.get('can_spend_api')}`, "
+            f"can_mutate_workspace=`{bootstrap.get('can_mutate_workspace')}`, "
+            f"can_use_swarm=`{bootstrap.get('can_use_swarm')}`.\n"
+            "- Read structured `data.bootstrap` and `data.request_context` for machine-usable gates.\n"
+            "- This service does **not** read global IDE settings or the caller's project files. "
+            "With user permission, audit those locally (report only; never rewrite without consent; "
+            "never print secret values).\n\n"
             "## Service and Project Boundary\n"
             "- UniGrok is a standalone MCP service; the caller's project needs no UniGrok namespace files.\n"
             f"- Service mode: `{'contributor' if contributor else 'stable'}`. "
-            f"Workspace attached: `{'yes' if workspace is not None else 'no'}`.\n"
+            f"Workspace attached: `{'yes' if workspace_attached else 'no'}`.\n"
             f"{boundary_extra}\n"
             "## Public product path\n"
             "- Canonical endpoint: `http://localhost:4765/mcp` (`4765` spells GROK).\n"

--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -951,6 +951,55 @@ def _swarm_policy() -> str:
     return "off"
 
 
+def _markdown_inline_label(value: Any) -> str:
+    """Escape untrusted labels for single-line Markdown inline code spans.
+
+    Client ids come from the untrusted ``X-Client-ID`` header. Strip backticks
+    and collapse control/whitespace so discover prose cannot break fencing or
+    inject misleading multi-line content.
+    """
+    text = str(value if value is not None else "")
+    text = text.replace("`", "").replace("\r", " ").replace("\n", " ")
+    text = " ".join(text.split())
+    return text or "(missing)"
+
+
+def _resolve_notice_action(
+    notice: dict[str, Any],
+    *,
+    api: dict[str, Any],
+    cli: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Resolve a credential notice to a full bounded action object.
+
+    Notices often carry only ``action_id``; the executable action lives on the
+    plane view (``credential_planes.api.action`` / ``cli.action``).
+    """
+    direct = notice.get("action")
+    if isinstance(direct, dict):
+        return direct
+
+    action_id = notice.get("action_id")
+    plane = str(notice.get("plane") or "").upper()
+    candidates: list[dict[str, Any]] = []
+    if plane == "API" and isinstance(api.get("action"), dict):
+        candidates.append(api["action"])
+    elif plane == "CLI" and isinstance(cli.get("action"), dict):
+        candidates.append(cli["action"])
+    else:
+        for view in (api, cli):
+            if isinstance(view.get("action"), dict):
+                candidates.append(view["action"])
+
+    if action_id:
+        for candidate in candidates:
+            if candidate.get("id") == action_id:
+                return candidate
+    if candidates:
+        return candidates[0]
+    return None
+
+
 def _build_discover_request_context(*, contributor: bool) -> dict[str, Any]:
     """Assemble request-scoped onboarding identity without secrets."""
     # Late imports avoid cycles: http_server registers these tools at import time.
@@ -1035,11 +1084,11 @@ def _build_discover_bootstrap(
                 "message": notice.get("message") or "Credential plane notice.",
             }
         )
-        action = notice.get("action") if isinstance(notice.get("action"), dict) else None
+        action = _resolve_notice_action(notice, api=api, cli=cli)
         if action or notice.get("action_id"):
             next_actions.append(
                 {
-                    "id": notice.get("action_id") or notice_id,
+                    "id": (action or {}).get("id") or notice.get("action_id") or notice_id,
                     "prompt_user": bool(notice.get("prompt_user", True)),
                     "action": action,
                 }
@@ -1227,9 +1276,11 @@ async def grok_mcp_discover_self(include_models: bool = False) -> SystemResult:
                 "(not a second UniGrok to install). Prefer the canonical 4765 endpoint.\n"
             )
 
-        client_label = request_context.get("client_id_normalized") or "(missing)"
-        surface = request_context.get("surface") or "stable_core"
-        bootstrap_status = bootstrap.get("status") or "WARN"
+        client_label = _markdown_inline_label(
+            request_context.get("client_id_normalized")
+        )
+        surface = _markdown_inline_label(request_context.get("surface") or "stable_core")
+        bootstrap_status = _markdown_inline_label(bootstrap.get("status") or "WARN")
 
         doc_text = (
             "# UniGrok MCP Discovery & Self-Description\n\n"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -398,13 +398,30 @@ async def test_discover_self_tool():
     assert res.finish_reason == "final_answer"
     assert res.route == "discovery"
     assert res.data["okf_version"] == "0.1"
+    assert res.data["schema_version"] == 2
     assert res.data["name"] == "uni-grok-mcp"
     assert "/docs/okf/index.md" in res.data["files"]
     assert "/docs/okf/api-reference.md" in res.data["files"]
     assert "UniGrok MCP Discovery" in res.response
+    assert "Bootstrap (first connect)" in res.response
     assert "credential_planes" in res.data
     assert res.data["credential_planes"]["preferred_plane"] in {"CLI", "API"}
     assert "local_usage" in res.data["credential_planes"]
+    assert "request_context" in res.data
+    assert "bootstrap" in res.data
+    bootstrap = res.data["bootstrap"]
+    assert bootstrap["schema_version"] == 1
+    assert bootstrap["status"] in {"OK", "WARN", "ERR"}
+    assert bootstrap["caller_config_audit"] == "not_available_on_service"
+    assert isinstance(bootstrap["first_connect_checklist"], list)
+    assert bootstrap["first_connect_checklist"]
+    assert res.data["request_context"]["surface"] in {
+        "stable_core",
+        "contributor_forge",
+        "mode_dial",
+    }
+    assert "can_chat" in bootstrap
+    assert "can_mutate_workspace" in bootstrap
 
 
 @pytest.mark.asyncio

--- a/tests/test_service_workspace_boundary.py
+++ b/tests/test_service_workspace_boundary.py
@@ -300,6 +300,90 @@ async def test_discover_self_bootstrap_ok_with_client_id(monkeypatch):
         assert result.data["bootstrap"]["status"] in {"OK", "WARN"}
 
 
+def test_markdown_inline_label_strips_backticks_and_control():
+    from src.tools.system import _markdown_inline_label
+
+    assert _markdown_inline_label("evil`break") == "evilbreak"
+    assert _markdown_inline_label("a\nb\rc") == "a b c"
+    assert _markdown_inline_label(None) == "(missing)"
+    assert _markdown_inline_label("  ok  ") == "ok"
+
+
+def test_resolve_notice_action_fills_from_plane_views():
+    from src.tools.system import _resolve_notice_action
+
+    api_action = {"id": "configure_xai_api_key", "kind": "configure_secret"}
+    cli_action = {"id": "authenticate_grok_cli", "kind": "authenticate_cli"}
+    api = {"action": api_action}
+    cli = {"action": cli_action}
+
+    resolved_api = _resolve_notice_action(
+        {"plane": "API", "action_id": "configure_xai_api_key"},
+        api=api,
+        cli=cli,
+    )
+    assert resolved_api == api_action
+
+    resolved_cli = _resolve_notice_action(
+        {"plane": "CLI", "action_id": "authenticate_grok_cli"},
+        api=api,
+        cli=cli,
+    )
+    assert resolved_cli == cli_action
+
+
+@pytest.mark.asyncio
+async def test_discover_self_bootstrap_next_actions_include_plane_actions(monkeypatch):
+    monkeypatch.setenv("UNIGROK_SERVICE_MODE", "stable")
+    monkeypatch.delenv("WORKSPACE_ROOT", raising=False)
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "src.tools.system.grok_cli_plane_status",
+        lambda timeout_sec=5.0: {
+            "state": "needs_auth",
+            "ready": False,
+            "binary": True,
+            "auth": "unauthenticated",
+            "setup_command": "docker exec … grok login --device-auth",
+        },
+    )
+    result = await grok_mcp_discover_self()
+    next_actions = result.data["bootstrap"]["next_actions"]
+    assert next_actions, "expected credential repair next_actions"
+    for item in next_actions:
+        assert item.get("action") is not None, f"null action for {item.get('id')}"
+        assert item["action"].get("id")
+        assert item["action"].get("instructions") or item["action"].get("command")
+
+
+@pytest.mark.asyncio
+async def test_discover_self_markdown_escapes_hostile_client_id(monkeypatch):
+    from src.identity import _ACTIVE_CLIENT_ID
+
+    monkeypatch.setenv("UNIGROK_SERVICE_MODE", "stable")
+    monkeypatch.delenv("WORKSPACE_ROOT", raising=False)
+    monkeypatch.setenv("XAI_API_KEY", "test-key-for-discover")
+    monkeypatch.setattr(
+        "src.tools.system.grok_cli_plane_status",
+        lambda timeout_sec=5.0: {
+            "state": "ready",
+            "ready": True,
+            "binary": True,
+            "auth": "oauth",
+            "setup_command": "unused",
+        },
+    )
+    token = _ACTIVE_CLIENT_ID.set("evil`break\ninject")
+    try:
+        result = await grok_mcp_discover_self()
+    finally:
+        _ACTIVE_CLIENT_ID.reset(token)
+
+    prose = (result.response or "") + "\n" + (result.text or "")
+    assert "evil`break" not in prose
+    assert "Client label: `evilbreak inject`" in prose
+
+
 @pytest.mark.asyncio
 async def test_public_mcp_instructions_prefer_core_endpoint_and_plan_critique():
     mcp = create_public_mcp()

--- a/tests/test_service_workspace_boundary.py
+++ b/tests/test_service_workspace_boundary.py
@@ -240,6 +240,64 @@ async def test_stable_discover_self_has_no_forge_connect_recipes(monkeypatch):
         assert token.lower() not in lowered, f"stable discover leaked {token!r}"
     assert "http://localhost:4765/mcp" in prose
     assert "plan critique" in lowered or "implementation plan" in lowered
+    assert result.data["service_mode"] == "stable"
+    assert result.data["request_context"]["surface"] == "stable_core"
+    assert result.data["bootstrap"]["can_mutate_workspace"] is False
+    assert result.data["bootstrap"]["can_use_swarm"] is False
+    # Structured surface names are fine; never coach a second product port in prose.
+    assert "4766" not in prose
+
+
+@pytest.mark.asyncio
+async def test_discover_self_bootstrap_warns_without_client_id(monkeypatch):
+    monkeypatch.setenv("UNIGROK_SERVICE_MODE", "stable")
+    monkeypatch.delenv("WORKSPACE_ROOT", raising=False)
+    monkeypatch.setattr(
+        "src.tools.system.grok_cli_plane_status",
+        lambda timeout_sec=5.0: {
+            "state": "ready",
+            "ready": True,
+            "binary": True,
+            "auth": "oauth",
+            "setup_command": "unused",
+        },
+    )
+    result = await grok_mcp_discover_self()
+    assert result.data["request_context"]["client_id_present"] is False
+    warning_ids = {w["id"] for w in result.data["bootstrap"]["warnings"]}
+    assert "missing_client_id" in warning_ids
+    assert result.data["bootstrap"]["status"] in {"WARN", "ERR"}
+
+
+@pytest.mark.asyncio
+async def test_discover_self_bootstrap_ok_with_client_id(monkeypatch):
+    from src.identity import _ACTIVE_CLIENT_ID
+
+    monkeypatch.setenv("UNIGROK_SERVICE_MODE", "stable")
+    monkeypatch.delenv("WORKSPACE_ROOT", raising=False)
+    monkeypatch.setenv("XAI_API_KEY", "test-key-for-discover")
+    monkeypatch.setattr(
+        "src.tools.system.grok_cli_plane_status",
+        lambda timeout_sec=5.0: {
+            "state": "ready",
+            "ready": True,
+            "binary": True,
+            "auth": "oauth",
+            "setup_command": "unused",
+        },
+    )
+    token = _ACTIVE_CLIENT_ID.set("claude-code")
+    try:
+        result = await grok_mcp_discover_self()
+    finally:
+        _ACTIVE_CLIENT_ID.reset(token)
+
+    assert result.data["request_context"]["client_id_present"] is True
+    assert result.data["request_context"]["client_id_normalized"] == "claude-code"
+    warning_ids = {w["id"] for w in result.data["bootstrap"]["warnings"]}
+    assert "missing_client_id" not in warning_ids
+    if result.data["bootstrap"]["can_chat"]:
+        assert result.data["bootstrap"]["status"] in {"OK", "WARN"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Extend `grok_mcp_discover_self` with **`request_context`** (X-Client-ID presence, Host port, surface, mode dial) and **`bootstrap`** (`OK`/`WARN`/`ERR`, can_chat / can_spend_api / can_mutate_workspace / can_use_swarm, warnings, first-connect checklist).
- Steal GenFunc’s continuity **contract**, not IDE hijack: service remains workspace-neutral; `caller_config_audit=not_available_on_service`.
- Stable prose still forbids Forge/4766/Swarm/land coaching (existing boundary tests).
- Document server + permissioned local IDE audit in `using-unigrok` skill variants and OKF FAQ.

## Why
IDE agents need a real initialization workflow after dual MCP registration. The gateway already had client id + Host port + credential planes but did not surface them as a bootstrap report.

## Test plan
- [x] `pytest` discover_self + workspace boundary suites (72 passed)
- [ ] After merge: rebuild stable/forge images so Docker picks up code
- [ ] Call `discover_self` from Claude/Codex/Copilot and confirm `bootstrap` + `request_context`