### PR TITLE
feat(ui): Planes trust UX + Cursor as first-class host IDE

### DIFF
--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -117,9 +117,14 @@ OAuth-protected remote clients obtain a scoped access token through the
 published RFC 9728 metadata; they do not reuse an xAI key or a local static
 gateway token.
 
-## Cursor (`.cursor/mcp.json` in project root, or `~/.cursor/mcp.json`)
+## Cursor (first-class host IDE)
 
-With Cursor joining the xAI family, it's the natural first-class Grok IDE.
+**Cursor is UniGrok’s preferred host IDE** (xAI family). SuperGrok CLI remains a
+**credential plane** (subscription auth for Grok models), not the long-term IDE
+product surface. Use Cursor (or any MCP client) as the place you type; use
+UniGrok as the shared Grok gateway with dual-plane cost truth.
+
+Put config in `~/.cursor/mcp.json` (user-global) or project `.cursor/mcp.json`:
 
 ```json
 {
@@ -136,6 +141,21 @@ With Cursor joining the xAI family, it's the natural first-class Grok IDE.
 
 Cursor auto-detects HTTP servers from the `url` field. After saving, enable
 the server under Settings → MCP; the `agent` tool appears in Composer/chat.
+
+### Cursor multi-model vs UniGrok planes
+
+Cursor may list **non-Grok** models for native chat (Claude, GPT, etc.). Those
+paths are **Cursor-native billing and routing** — they are not UniGrok planes
+and will not appear on Control Center → **Planes**.
+
+| Path | Who bills / routes | Where you see models |
+|------|--------------------|----------------------|
+| Cursor native multi-model | Cursor / that provider | Cursor model picker |
+| UniGrok MCP `agent` | UniGrok CLI sub and/or xAI API key | Control Center **Planes** + MCP |
+
+Use UniGrok when you want shared Grok across every IDE, server-side keys,
+CLI-first policy, exact API cost, and `@grok` peer review. Use Cursor’s own
+picker when you intentionally want a non-Grok host model.
 
 ## Claude Code (CLI)
 

--- a/mcp_ui/app.js
+++ b/mcp_ui/app.js
@@ -237,11 +237,10 @@ const state = {
   credentialPlanes: null,
 };
 
+// Only static/fallback model lists — not operational unavailable/skipped sources.
 const FALLBACK_CATALOG_SOURCES = new Set([
   "cli-fallback",
   "xai_api_fallback",
-  "cloudrun-disabled",
-  "skipped",
 ]);
 
 // --- DOM Selector Helper ---
@@ -1305,7 +1304,14 @@ function updatePlaneControls() {
     hint.innerText = "Subscription first · cross-plane fallback may incur API charges";
     hint.classList.add("metered");
   }
-  syncModelOptions();
+  // Console plane pins filter from the dual-plane catalog. Startup only warms
+  // /v1/models (API). Load plane catalogs when the user changes plane before
+  // visiting Planes, so CLI pins are not API-only slugs with same_plane.
+  if (!state.modelCatalog && !state.modelCatalogLoading) {
+    loadPlaneModelCatalog(false);
+  } else {
+    syncModelOptions();
+  }
 }
 
 function readableCatalogSource(source) {

--- a/mcp_ui/app.js
+++ b/mcp_ui/app.js
@@ -233,7 +233,16 @@ const state = {
   metricsPeriod: "today",
   metricsSnapshot: null,
   modelCatalog: null,
+  modelCatalogLoading: false,
+  credentialPlanes: null,
 };
+
+const FALLBACK_CATALOG_SOURCES = new Set([
+  "cli-fallback",
+  "xai_api_fallback",
+  "cloudrun-disabled",
+  "skipped",
+]);
 
 // --- DOM Selector Helper ---
 const $ = (id) => document.getElementById(id);
@@ -324,7 +333,8 @@ function switchTab(tabId) {
       loadWebMcpManifest();
       checkWebMcpBridge();
     } else if (tabId === "tab-models") {
-      loadPlaneModelCatalog();
+      // Lazy-load expensive dual-plane discovery only when Planes is opened.
+      loadPlaneModelCatalog(false);
     } else if (tabId === "tab-metrics") {
       fetchLiveMetrics();
     }
@@ -949,11 +959,13 @@ function resolveMcpEndpoint() {
 }
 
 function genericMcpJson(endpoint) {
+  // Cursor is the first-class host IDE for UniGrok (xAI family). Other IDEs
+  // swap X-Client-ID (claude-code, vscode, codex, antigravity) the same way.
   return JSON.stringify({
     mcpServers: {
       unigrok: {
         url: endpoint,
-        headers: { "X-Client-ID": "ide" },
+        headers: { "X-Client-ID": "cursor" },
       },
     },
   }, null, 2);
@@ -963,9 +975,10 @@ function agentSetupPrompt(endpoint) {
   return [
     "Configure UniGrok MCP for this machine:",
     `- Streamable HTTP URL: ${endpoint}`,
-    "- Send a stable X-Client-ID header for this IDE (e.g. cursor, claude-code, vscode, codex)",
+    "- Preferred host IDE: Cursor (X-Client-ID: cursor). Also supported: claude-code, vscode, codex, antigravity",
     "- Never put XAI_API_KEY in IDE MCP settings; credentials stay in UniGrok's server .env",
-    "- After connecting, call tools/list and grok_mcp_discover_self",
+    "- Cursor may offer non-Grok models natively; UniGrok MCP is for shared Grok planes, cost truth, and @grok",
+    "- After connecting, call tools/list and grok_mcp_discover_self (read data.bootstrap when present)",
     "- Prefer the UniGrok agent tool when I say @grok or want a second opinion",
     "- When I ask for a multi-step Implementation Plan, get a UniGrok second opinion",
     "  (agent mode thinking or reasoning) and improve the plan before showing it —",
@@ -1128,6 +1141,9 @@ async function fetchRuntimeStatus() {
     const res = await fetch("/runtimez");
     if (!res.ok) throw new Error();
     const data = await res.json();
+    if (data.credential_planes) {
+      state.credentialPlanes = data.credential_planes;
+    }
     $("runtimeChip").innerText = `runtime: ${data.runtime || "unknown"}`;
     $("transportChip").innerText = `transport: ${data.transport || "unknown"}`;
     renderSurfaceModeBadge(data);
@@ -1295,36 +1311,130 @@ function updatePlaneControls() {
 function readableCatalogSource(source) {
   const labels = {
     grok_cli: "Live Grok CLI",
-    "cli-fallback": "Fallback list",
+    "cli-fallback": "Fallback list (not live)",
     "cloudrun-disabled": "Unavailable in Cloud Run",
     xai_api: "Live xAI API",
-    xai_api_fallback: "Fallback list",
+    xai_api_fallback: "Fallback list (not live)",
     skipped: "Not queried",
   };
   return labels[source] || String(source || "Unknown").replaceAll("_", " ");
 }
 
-function renderPlaneModels(planeName, plane, sharedIds) {
+function isFallbackCatalogSource(source) {
+  const key = String(source || "");
+  return FALLBACK_CATALOG_SOURCES.has(key) || key.includes("fallback");
+}
+
+function planePinSnippet(planeName, modelId) {
+  const plane = planeName === "CLI" ? "cli" : "api";
+  return [
+    `model=${modelId}`,
+    `plane=${plane}`,
+    "fallback_policy=same_plane",
+    `# UniGrok agent pin — ${planeName} credential plane only`,
+  ].join("\n");
+}
+
+function clearPlaneModelLists(message) {
+  for (const prefix of ["cli", "api"]) {
+    const list = $(`${prefix}ModelList`);
+    if (!list) continue;
+    list.replaceChildren();
+    const empty = document.createElement("span");
+    empty.className = "empty-cell";
+    empty.innerText = message;
+    list.appendChild(empty);
+  }
+}
+
+function renderPlaneRepair(prefix, planeKey, contract) {
+  const host = $(`${prefix}PlaneRepair`);
+  if (!host) return;
+  host.replaceChildren();
+  host.classList.add("hidden");
+  if (!contract) return;
+
+  const plane = planeKey === "CLI" ? contract.cli : contract.api;
+  const notices = (contract.notices || []).filter(
+    (notice) => notice && String(notice.plane || "").toUpperCase() === planeKey,
+  );
+  const notice = notices.find((item) => item.prompt_user) || notices[0];
+  const action = (plane && plane.action) || (notice && notice.action) || null;
+  const needsRepair = plane && plane.available === false;
+  if (!needsRepair && !notice) return;
+
+  host.classList.remove("hidden");
+  const title = document.createElement("strong");
+  title.innerText = notice?.blocking
+    ? `${planeKey} plane blocked`
+    : `${planeKey} plane needs attention`;
+  const message = document.createElement("p");
+  message.innerText = notice?.message
+    || (planeKey === "CLI"
+      ? "CLI subscription plane is not ready. Device-login on the gateway host, then refresh."
+      : "API plane is not ready. Configure XAI_API_KEY in the UniGrok server .env (never in IDE MCP JSON).");
+  host.append(title, message);
+
+  const command = typeof action?.command === "string" ? action.command : "";
+  if (command) {
+    const pre = document.createElement("pre");
+    pre.className = "plane-repair-command";
+    pre.textContent = command;
+    const copyBtn = document.createElement("button");
+    copyBtn.type = "button";
+    copyBtn.className = "small-btn-glow";
+    copyBtn.innerText = "Copy repair command";
+    copyBtn.addEventListener("click", () => copyTextToClipboard(command, copyBtn));
+    host.append(pre, copyBtn);
+  }
+}
+
+function renderCatalogTrustBanner(prefix, plane) {
+  const banner = $(`${prefix}CatalogTrust`);
+  if (!banner) return;
+  const source = plane?.source;
+  if (isFallbackCatalogSource(source) || (plane?.credential_available && !plane?.catalog_available)) {
+    banner.classList.remove("hidden");
+    banner.innerText = "Not live — static fallback catalog. Do not treat pins as verified on this plane until source is Live.";
+    return;
+  }
+  banner.classList.add("hidden");
+  banner.innerText = "";
+}
+
+function renderPlaneModels(planeName, plane, sharedIds, contract) {
   const prefix = planeName === "CLI" ? "cli" : "api";
   const stateChip = $(`${prefix}ModelPlaneState`);
   const source = $(`${prefix}ModelSource`);
   const economics = $(`${prefix}ModelEconomics`);
   const list = $(`${prefix}ModelList`);
   const models = Array.isArray(plane?.models) ? plane.models : [];
+  const fallback = isFallbackCatalogSource(plane?.source)
+    || (plane?.credential_available && !plane?.catalog_available);
 
   const planeState = plane?.available
     ? "Ready"
-    : plane?.credential_available && !plane?.catalog_available
+    : fallback
       ? "Catalog fallback"
       : String(plane?.credential_state || "Unavailable").replaceAll("_", " ");
-  stateChip.innerText = planeState;
-  stateChip.className = `state-chip ${plane?.available ? "ready" : ""}`;
-  source.innerText = readableCatalogSource(plane?.source);
-  economics.innerText = plane?.economics || "Usage terms unavailable.";
-  if (prefix === "cli") {
+  if (stateChip) {
+    stateChip.innerText = planeState;
+    stateChip.className = `state-chip ${plane?.available ? "ready" : ""} ${fallback ? "fallback" : ""}`;
+  }
+  if (source) source.innerText = readableCatalogSource(plane?.source);
+  if (economics) economics.innerText = plane?.economics || "Usage terms unavailable.";
+  if (prefix === "cli" && $("cliDefaultModel")) {
     $("cliDefaultModel").innerText = plane?.default_model || "Not reported";
   }
+  if (prefix === "api" && $("apiDefaultModel")) {
+    $("apiDefaultModel").innerText = plane?.default_model
+      || "No single default — agent auto-routes (planning/coding aliases)";
+  }
 
+  renderCatalogTrustBanner(prefix, plane);
+  renderPlaneRepair(prefix, planeName, contract);
+
+  if (!list) return;
   list.replaceChildren();
   if (!models.length) {
     const empty = document.createElement("span");
@@ -1337,7 +1447,7 @@ function renderPlaneModels(planeName, plane, sharedIds) {
   for (const model of models) {
     const id = String(model?.id || "unknown");
     const card = document.createElement("article");
-    card.className = "provider-model-card";
+    card.className = `provider-model-card${fallback ? " fallback-catalog" : ""}`;
 
     const identity = document.createElement("div");
     const name = document.createElement("strong");
@@ -1350,6 +1460,13 @@ function renderPlaneModels(planeName, plane, sharedIds) {
     planeBadge.className = `model-badge ${prefix}`;
     planeBadge.innerText = planeName === "CLI" ? "CLI subscription" : "API metered";
     badges.appendChild(planeBadge);
+
+    if (fallback) {
+      const fallbackBadge = document.createElement("span");
+      fallbackBadge.className = "model-badge fallback";
+      fallbackBadge.innerText = "Fallback";
+      badges.appendChild(fallbackBadge);
+    }
 
     if (model?.default || id === plane?.default_model) {
       const defaultBadge = document.createElement("span");
@@ -1375,66 +1492,113 @@ function renderPlaneModels(planeName, plane, sharedIds) {
     copyButton.type = "button";
     copyButton.className = "small-btn model-copy-btn";
     copyButton.innerText = "Copy pin";
-    copyButton.setAttribute("aria-label", `Copy ${id} model pin`);
-    copyButton.addEventListener("click", () => copyTextToClipboard(id, copyButton));
+    copyButton.setAttribute("aria-label", `Copy ${planeName} plane pin for ${id}`);
+    copyButton.title = "Copies plane-qualified pin (model + plane + same_plane)";
+    const pin = planePinSnippet(planeName, id);
+    copyButton.addEventListener("click", () => copyTextToClipboard(pin, copyButton));
 
     card.append(identity, copyButton);
     list.appendChild(card);
   }
 }
 
-function renderPlaneModelCatalog(catalog) {
+function renderPlaneModelCatalog(catalog, contract = null) {
   const routing = catalog?.routing || {};
   const planes = catalog?.planes || {};
   const sharedIds = new Set(catalog?.shared_model_ids || []);
+  const planesContract = contract || state.credentialPlanes;
   state.modelCatalog = catalog;
+  if (contract) state.credentialPlanes = contract;
   syncModelOptions();
 
-  $("modelsRoutingPolicy").innerText = String(routing.policy || "unknown").replaceAll("_", " ");
-  $("modelsPreferredPlane").innerText = `Preferred: ${routing.preferred_plane || "none"}`;
-  $("modelsEffectivePlane").innerText = `Effective now: ${routing.effective_plane || "none"}`;
-  $("modelsRoutingRule").innerText = routing.rule || "Model and credential-plane selection are separate routing decisions.";
+  if ($("modelsRoutingPolicy")) {
+    $("modelsRoutingPolicy").innerText = String(routing.policy || "unknown").replaceAll("_", " ");
+  }
+  if ($("modelsPreferredPlane")) {
+    $("modelsPreferredPlane").innerText = `Preferred: ${routing.preferred_plane || "none"}`;
+  }
+  if ($("modelsEffectivePlane")) {
+    $("modelsEffectivePlane").innerText = `Effective now: ${routing.effective_plane || "none"}`;
+  }
+  if ($("modelsRoutingRule")) {
+    $("modelsRoutingRule").innerText = routing.rule
+      || "Model and credential-plane selection are separate routing decisions. Host IDEs (Cursor, etc.) may list non-Grok models natively — those are outside UniGrok.";
+  }
 
-  renderPlaneModels("CLI", planes.CLI || {}, sharedIds);
-  renderPlaneModels("API", planes.API || {}, sharedIds);
+  renderPlaneModels("CLI", planes.CLI || {}, sharedIds, planesContract);
+  renderPlaneModels("API", planes.API || {}, sharedIds, planesContract);
 
   const total = (planes.CLI?.models?.length || 0) + (planes.API?.models?.length || 0);
   const generated = catalog?.generated_at ? new Date(catalog.generated_at).toLocaleString() : "just now";
-  $("modelsStatus").innerText = `${total} plane-specific model entr${total === 1 ? "y" : "ies"} • refreshed ${generated}`;
+  if ($("modelsStatus")) {
+    $("modelsStatus").innerText = `${total} plane-specific model entr${total === 1 ? "y" : "ies"} • refreshed ${generated}`;
+  }
 
   const sharedNote = $("sharedModelsNote");
-  if (sharedIds.size) {
-    sharedNote.classList.remove("hidden");
-    sharedNote.innerText = `${[...sharedIds].join(", ")} ${sharedIds.size === 1 ? "exists" : "exist"} on both planes. These are shown twice intentionally because authentication, availability, and usage accounting differ.`;
-  } else {
-    sharedNote.classList.add("hidden");
-    sharedNote.innerText = "";
+  if (sharedNote) {
+    if (sharedIds.size) {
+      sharedNote.classList.remove("hidden");
+      sharedNote.innerText = `${[...sharedIds].join(", ")} ${sharedIds.size === 1 ? "exists" : "exist"} on both UniGrok planes. Shown twice intentionally — authentication, availability, and usage accounting differ. Copy pin is plane-qualified.`;
+    } else {
+      sharedNote.classList.add("hidden");
+      sharedNote.innerText = "";
+    }
   }
 
   const warningList = $("modelCatalogWarnings");
-  warningList.replaceChildren();
-  const warnings = Array.isArray(catalog?.warnings) ? catalog.warnings : [];
-  warningList.classList.toggle("hidden", warnings.length === 0);
-  for (const warning of warnings) {
-    const item = document.createElement("p");
-    item.innerText = warning;
-    warningList.appendChild(item);
+  if (warningList) {
+    warningList.replaceChildren();
+    const warnings = Array.isArray(catalog?.warnings) ? catalog.warnings : [];
+    warningList.classList.toggle("hidden", warnings.length === 0);
+    for (const warning of warnings) {
+      const item = document.createElement("p");
+      item.innerText = warning;
+      warningList.appendChild(item);
+    }
   }
 }
 
-async function loadPlaneModelCatalog() {
+async function loadPlaneModelCatalog(force = true) {
+  // Cache successful catalogs until the user forces refresh or opens Planes
+  // after a prior failure.
+  if (!force && state.modelCatalog && !state.modelCatalogLoading) {
+    renderPlaneModelCatalog(state.modelCatalog, state.credentialPlanes);
+    return;
+  }
+  if (state.modelCatalogLoading) return;
+
   const refreshButton = $("refreshModelsBtn");
   if (refreshButton) refreshButton.disabled = true;
-  $("modelsStatus").innerText = "Refreshing live CLI and API catalogs through MCP discovery…";
+  state.modelCatalogLoading = true;
+  if ($("modelsStatus")) {
+    $("modelsStatus").innerText = "Refreshing live CLI and API catalogs through MCP discovery…";
+  }
   try {
     const res = await fetchMcpCall("grok_mcp_discover_self", { include_models: true });
     const payload = extractToolPayload(res);
     const catalog = payload?.data?.model_catalog;
+    const contract = payload?.data?.credential_planes || state.credentialPlanes;
     if (!catalog) throw new Error("Discovery response did not include a model catalog.");
-    renderPlaneModelCatalog(catalog);
+    renderPlaneModelCatalog(catalog, contract);
   } catch (err) {
-    $("modelsStatus").innerText = `Model catalog unavailable: ${err.message}`;
+    if ($("modelsStatus")) {
+      $("modelsStatus").innerText = `Model catalog unavailable: ${err.message}`;
+    }
+    clearPlaneModelLists(`Failed to load catalog: ${err.message}`);
+    for (const prefix of ["cli", "api"]) {
+      const chip = $(`${prefix}ModelPlaneState`);
+      if (chip) {
+        chip.innerText = "Error";
+        chip.className = "state-chip";
+      }
+      const banner = $(`${prefix}CatalogTrust`);
+      if (banner) {
+        banner.classList.remove("hidden");
+        banner.innerText = "Catalog request failed. Fix MCP connectivity or credentials, then Refresh.";
+      }
+    }
   } finally {
+    state.modelCatalogLoading = false;
     if (refreshButton) refreshButton.disabled = false;
   }
 }
@@ -2362,7 +2526,7 @@ function init() {
   setupCredentialActions();
   setupMetricsControls();
 
-  $("refreshModelsBtn").addEventListener("click", loadPlaneModelCatalog);
+  $("refreshModelsBtn")?.addEventListener("click", () => loadPlaneModelCatalog(true));
 
   // Onboarding actions
   $("copyDiscoverBtn").addEventListener("click", runDiscoverSelfOnboarding);
@@ -2416,10 +2580,14 @@ function init() {
   setTimeout(async () => {
     const ready = await runStartupCheck();
     const runtime = await fetchRuntimeStatus();
+    if (runtime?.credential_planes) {
+      state.credentialPlanes = runtime.credential_planes;
+    }
     renderSetupStatus(runtime, ready, gatewayReadiness.detail);
     switchTab("tab-onboarding");
+    // Keep OpenAI-compat model list warm for any residual consumers; dual-plane
+    // Planes catalog is lazy-loaded only when the Planes tab opens.
     await loadModelsList();
-    await loadPlaneModelCatalog();
     await fetchMcpListTools();
     await fetchLiveMetrics();
     // WebMCP browser registration is optional/experimental; skip on Core glass.

--- a/mcp_ui/index.html
+++ b/mcp_ui/index.html
@@ -202,12 +202,12 @@
             <div class="panel-header">
               <div>
                 <h2>Models &amp; Credential Planes</h2>
-                <p class="panel-desc">Live provider catalogs kept separate so a model name never hides how the request is authenticated or billed.</p>
+                <p class="panel-desc">UniGrok’s two <strong>Grok</strong> credential planes (subscription CLI vs metered API). Host IDEs such as <strong>Cursor</strong> may offer other models outside UniGrok — those stay on the IDE side; this tab only shows what UniGrok can pin and bill.</p>
               </div>
               <button id="refreshModelsBtn" type="button" class="small-btn-glow">Refresh catalogs</button>
             </div>
 
-            <div id="modelsStatus" class="metrics-status">Loading model catalogs through MCP discovery…</div>
+            <div id="modelsStatus" class="metrics-status">Open this tab or press Refresh to load live catalogs…</div>
 
             <section class="routing-policy-card" aria-label="Current plane routing policy">
               <div>
@@ -231,12 +231,14 @@
                   </div>
                   <span id="cliModelPlaneState" class="state-chip">Checking</span>
                 </div>
+                <p id="cliCatalogTrust" class="catalog-trust-banner hidden" role="status"></p>
                 <p id="cliModelEconomics" class="plane-economics">Subscription activity is tracked locally; provider quota and cost are not exposed.</p>
+                <div id="cliPlaneRepair" class="plane-repair hidden"></div>
                 <dl class="plane-facts">
                   <div><dt>Catalog</dt><dd id="cliModelSource">—</dd></div>
                   <div><dt>Default</dt><dd id="cliDefaultModel">—</dd></div>
                 </dl>
-                <div id="cliModelList" class="model-card-list"><span class="empty-cell">Loading CLI models…</span></div>
+                <div id="cliModelList" class="model-card-list"><span class="empty-cell">Catalog not loaded yet.</span></div>
               </section>
 
               <section id="apiModelPlane" class="model-plane-card api-plane">
@@ -247,17 +249,20 @@
                   </div>
                   <span id="apiModelPlaneState" class="state-chip">Checking</span>
                 </div>
+                <p id="apiCatalogTrust" class="catalog-trust-banner hidden" role="status"></p>
                 <p id="apiModelEconomics" class="plane-economics">Exact response cost is tracked locally when the provider returns it.</p>
+                <div id="apiPlaneRepair" class="plane-repair hidden"></div>
                 <dl class="plane-facts">
                   <div><dt>Catalog</dt><dd id="apiModelSource">—</dd></div>
+                  <div><dt>Default</dt><dd id="apiDefaultModel">Agent auto-routes</dd></div>
                   <div><dt>Billing</dt><dd>Per API usage</dd></div>
                 </dl>
-                <div id="apiModelList" class="model-card-list"><span class="empty-cell">Loading API models…</span></div>
+                <div id="apiModelList" class="model-card-list"><span class="empty-cell">Catalog not loaded yet.</span></div>
               </section>
             </div>
 
             <div id="sharedModelsNote" class="coverage-note hidden"></div>
-            <div class="coverage-note">Grok Build is the coding-agent product. <code>grok-build-0.1</code> is its exact metered API model slug; the current CLI catalog advertises different selectable model IDs.</div>
+            <div class="coverage-note">Grok Build is the coding-agent product. <code>grok-build-0.1</code> is its exact metered API model slug; the current CLI catalog advertises different selectable model IDs. Cursor (and other multi-model IDEs) may list non-Grok models for native chat — those are not UniGrok planes.</div>
             <div id="modelCatalogWarnings" class="model-warning-list hidden" aria-live="polite"></div>
           </div>
 
@@ -446,12 +451,13 @@ docker compose up --build -d</code></pre>
             <section class="connect-panel" aria-label="IDE connect snippets">
               <div class="panel-header compact">
                 <h3>Connect your IDE</h3>
-                <span class="panel-header-hint">Never put XAI_API_KEY in IDE MCP settings</span>
+                <span class="panel-header-hint">Cursor is first-class · Never put XAI_API_KEY in IDE MCP settings</span>
               </div>
               <p class="connect-endpoint">Endpoint <code id="mcpEndpointDisplay">http://localhost:4765/mcp</code></p>
+              <p class="connect-partner-note">Preferred host IDE: <strong>Cursor</strong> (xAI family). UniGrok still serves Claude Code, VS Code/Copilot, Codex, and Gemini the same way — one gateway, stable <code>X-Client-ID</code> per client. Non-Grok models inside Cursor stay Cursor-native; use UniGrok MCP for shared Grok planes, cost truth, and <code>@grok</code>.</p>
               <div class="connect-snippet-block">
                 <div class="connect-snippet-header">
-                  <span class="section-kicker">Generic MCP JSON</span>
+                  <span class="section-kicker">Cursor MCP JSON (first-class)</span>
                   <button id="copyMcpJsonBtn" type="button" class="small-btn-glow">Copy</button>
                 </div>
                 <pre class="connect-snippet" tabindex="0"><code id="mcpJsonSnippet">{ }</code></pre>

--- a/mcp_ui/styles.css
+++ b/mcp_ui/styles.css
@@ -1320,6 +1320,77 @@ pre {
 .model-plane-card.cli-plane { border-top: 3px solid var(--teal); }
 .model-plane-card.api-plane { border-top: 3px solid var(--orange); }
 
+.catalog-trust-banner {
+  margin-top: 10px;
+  border: 1px dashed rgba(255, 180, 60, 0.55);
+  border-radius: var(--radius-sm);
+  padding: 8px 10px;
+  background: rgba(255, 160, 40, 0.08);
+  color: var(--orange);
+  font-size: 11px;
+  line-height: 1.45;
+  font-weight: 600;
+}
+
+.plane-repair {
+  margin-top: 12px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.plane-repair strong {
+  display: block;
+  color: var(--orange);
+  font-size: 12px;
+}
+
+.plane-repair p {
+  margin: 6px 0 8px;
+  color: var(--ink-soft);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.plane-repair-command {
+  margin: 0 0 8px;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  background: rgba(0, 0, 0, 0.35);
+  color: var(--cyan);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.state-chip.fallback {
+  border-color: rgba(255, 160, 40, 0.45);
+  color: var(--orange);
+}
+
+.provider-model-card.fallback-catalog {
+  border-style: dashed;
+  opacity: 0.92;
+}
+
+.model-badge.fallback {
+  border-color: rgba(255, 160, 40, 0.45);
+  color: var(--orange);
+}
+
+.connect-partner-note {
+  margin: 0 0 12px;
+  color: var(--ink-soft);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.connect-partner-note code {
+  font-size: 11px;
+}
+
 .model-plane-header {
   display: flex;
   align-items: flex-start;

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -169,6 +169,12 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert "renderPlaneRepair" in script.text
     assert "clearPlaneModelLists" in script.text
     assert "loadPlaneModelCatalog(false)" in script.text
+    # Operational unavailable sources must not be styled as static fallback catalogs.
+    fallback_set = script.text.split("FALLBACK_CATALOG_SOURCES")[1].split("];")[0]
+    assert '"cloudrun-disabled"' not in fallback_set
+    assert '"skipped"' not in fallback_set
+    # Plane selector must warm dual-plane catalog, not only /v1/models.
+    assert "if (!state.modelCatalog && !state.modelCatalogLoading)" in script.text
     assert 'headers: { "X-Client-ID": "cursor" }' in script.text
     assert "Cursor is the first-class host IDE" in script.text
     assert 'id="cliCatalogTrust"' in index.text

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -163,6 +163,21 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert "CLI subscription" in script.text
     assert "API metered" in script.text
     assert "list.replaceChildren()" in script.text
+    assert "planePinSnippet" in script.text
+    assert "fallback_policy=same_plane" in script.text
+    assert "isFallbackCatalogSource" in script.text
+    assert "renderPlaneRepair" in script.text
+    assert "clearPlaneModelLists" in script.text
+    assert "loadPlaneModelCatalog(false)" in script.text
+    assert 'headers: { "X-Client-ID": "cursor" }' in script.text
+    assert "Cursor is the first-class host IDE" in script.text
+    assert 'id="cliCatalogTrust"' in index.text
+    assert 'id="apiCatalogTrust"' in index.text
+    assert 'id="cliPlaneRepair"' in index.text
+    assert 'id="apiPlaneRepair"' in index.text
+    assert "Cursor is first-class" in index.text
+    assert "catalog-trust-banner" in styles.text
+    assert ".plane-repair" in styles.text
     assert "routing?.why_detail" in script.text
     assert styles.status_code == 200
     assert ".console-grid" in styles.text


### PR DESCRIPTION
## Summary
- **Planes tab trust UX:** lazy-load dual-plane catalogs, fallback watermarks, plane-qualified copy pins (`model` + `plane` + `same_plane`), per-plane repair CTAs, error empty states (no stuck Loading…), API default “auto-routes” fact.
- **Cursor first-class seat:** Connect panel + pasteable MCP JSON use `X-Client-ID: cursor`; ide-setup documents Cursor as preferred host IDE and explicitly separates Cursor-native multi-model from UniGrok Grok planes.

## Product stance
- UniGrok = dual **Grok** credential planes (CLI sub + API key), multi-IDE MCP host.
- Cursor = preferred **IDE surface** (xAI family); its non-Grok models stay Cursor-native and do not become a third UniGrok plane.
- SuperGrok CLI = credential plane, not the long-term IDE product.

## Test plan
- [x] `pytest tests/test_mcp_ui.py` (27 passed)
- [ ] Hard-refresh `http://localhost:4765/ui/` after rebuild/static reload
- [ ] Open Planes → catalogs load only then; Refresh works; fallback/error paths readable