### PR TITLE
docs: Cursor Cloud setup notes for grok-mcp-server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,3 +137,15 @@ new chat does not resume obsolete steps.
 ## Public vs private intelligence
 
 Process IP and harvest live in private `djtelicloud/unigrok-intelligence`. See [docs/design/public-private-git-split.md](docs/design/public-private-git-split.md).
+
+## Cursor Cloud specific instructions
+
+**Repo identity:** the GitHub repository is `djtelicloud/grok-mcp-server`. Product brand is UniGrok; Python package name is `mcp-grok`; CLI entrypoint is `unigrok-mcp`. The string `uni-grok-mcp` appears in agent docs/skills as an internal nickname only — do not treat it as the repo or package name.
+
+**Stable gateway (dev):** prefer `uv run python main.py --http` (binds `127.0.0.1:4765`). `docker compose up --build -d` is the documented shared-service path and is required for the baked Grok CLI binary / `grok-cli-auth` volume; pure HTTP-local cloud sessions do not need Docker for API-plane work.
+
+**Credential planes:** live `agent` inference needs `XAI_API_KEY` in the server `.env` and/or an authenticated CLI plane. Placeholder `your_xai_api_key_here` is treated as missing by the app (see `src/utils.py`), but `GET /readyz` only checks that the env var is non-empty — use `grok_mcp_status` / `grok_mcp_discover_self` (or a real `agent` call) as the usable-plane gate, not `/readyz` alone.
+
+**Commands:** dependency sync and tests/lint gates are in [CONTRIBUTING.md](CONTRIBUTING.md) / [README.md](README.md) (`uv sync`, `uv run pytest`, `uv run python -m compileall -q src evals main.py`). Ruff is available via the `dev` dependency group but is not the required land gate; the suite currently has many pre-existing ruff findings.
+
+**UI:** Control Center test bench at `http://localhost:4765/ui/`; core product path remains MCP at `http://localhost:4765/mcp`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` so future cloud agents remember:

- Authoritative GitHub repo name is **`djtelicloud/grok-mcp-server`** (UniGrok is the product brand; `uni-grok-mcp` is only an internal docs nickname)
- Prefer `uv run python main.py --http` for local cloud-agent development on `:4765`
- `/readyz` can look ready with a placeholder `XAI_API_KEY`; use `grok_mcp_status` / a real `agent` call for usable-plane readiness
- Pointers to existing CONTRIBUTING/README commands instead of duplicating them

## Changes

- Append Cursor Cloud notes to `AGENTS.md`

## Head and handoff evidence

- Exact head SHA: `7df7c474772d36517f1470bfe3374cb8f5d9d7d4`
- Submitting branch: `cursor/cloud-env-setup-5b67`
- Changed paths: `AGENTS.md`
- Known follow-up: live `agent` inference needs cloud secret `XAI_API_KEY` (or CLI OAuth)

## Fact-check checklist

- [x] Endpoints: `/healthz`, `/mcp`, `/ui/` verified live
- [x] Compose service name `grok-mcp` left unchanged (docs only; Docker not required for API-plane HTTP-local)
- [x] Env vars referenced (`XAI_API_KEY`) exist in `example.env` / code
- [x] No destructive commands

## Testing

- [x] `uv run pytest -q` — **1972 passed** on this environment (pre-docs commit; docs-only delta)
- [x] `uv run python -m compileall -q src evals main.py` — OK
- [x] `uv run python main.py --http` — healthy; MCP `discover_self` / `status` / `agent` exercised
- [x] Results apply to docs head `7df7c47` (docs-only change)

## Security

- [x] No secrets in the diff (`.env` gitignored)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d8922f3-04aa-4e80-a3e2-8c8feba15b67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d8922f3-04aa-4e80-a3e2-8c8feba15b67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

