### PR TITLE
feat(auth): cursor-cloud service token with invoke scope

### DIFF
--- a/.codex/memory/active-work.md
+++ b/.codex/memory/active-work.md
@@ -1,8 +1,8 @@
 # Codex Active Work
 
-Last updated: 2026-07-14
+Last updated: 2026-07-15
 Owner: Codex
-Status: Maintainer sweep complete; Stage 1 live generation and training remain blocked
+Status: Maintainer repair locally landed; protected PR merge pending; Stage 1 live generation and training remain blocked
 
 This is the project-scoped handoff for new Codex chats. Verify drift-prone Git,
 CI, runtime, DNS, cloud, and benchmark state live before acting. Never record
@@ -50,12 +50,19 @@ credentials, OAuth codes, tokens, or private keys here.
 
 ## Latest maintainer sweep
 
-- Local `main` and `origin/main` are synchronized at
-  `5e5d921a0bc6f102df4469f4ce9cc7a37b2bde7e`.
-- The landing receipt printed `LANDED TO MAIN` after 1,564 tests. Main CI and
-  CodeQL are green at that exact commit.
-- The landed repair prevents release-hygiene tests from scanning ignored local
-  IDE worktree metadata. The pre-existing untracked `scratch_swarm/` remains
-  untouched.
-- Open draft PRs #64 and #73-#76 remain review-required. PR #73, #75, and #76
-  have current unresolved review feedback; no external thread was changed.
+- Local `main`, the contributor runtime source marker, and the pushed task
+  branch are at the PR #127 repair series. Protected `origin/main` remains at
+  its pre-merge head until the review gates pass.
+- Draft PR #127 contains the minimal CodeQL and public OKF-link repair. Its full
+  suite, generated-OKF check, Ruff, Docker, site, attribution, and CodeQL checks
+  are green. Do not bypass its draft, Code Owner, Codex Approval, or
+  protected-merge gates.
+- PR #125 has two current unresolved review threads and a stale generated OKF
+  failure. PR #126 has two current unresolved UI review threads while CI is
+  green. Draft PRs #121 and #124 have no unresolved threads; hosted review
+  smoke runs associated with #121 failed in the read-only review transport.
+  No external thread was resolved or replied to.
+- Issue #65 is the only open issue. Its latest comment reports a bounded live
+  Stage 1 run, while this handoff and the issue body retain the exact-head
+  authorization gate. Treat any further live generation or training as blocked
+  until the authority state is reconciled explicitly.

--- a/.codex/memory/active-work.md
+++ b/.codex/memory/active-work.md
@@ -57,12 +57,21 @@ credentials, OAuth codes, tokens, or private keys here.
   suite, generated-OKF check, Ruff, Docker, site, attribution, and CodeQL checks
   are green. Do not bypass its draft, Code Owner, Codex Approval, or
   protected-merge gates.
-- PR #125 has two current unresolved review threads and a stale generated OKF
-  failure. PR #126 has two current unresolved UI review threads while CI is
-  green. Draft PRs #121 and #124 have no unresolved threads; hosted review
-  smoke runs associated with #121 failed in the read-only review transport.
-  No external thread was resolved or replied to.
+- All seven open PR heads (#121, #124-#129) have green CI and CodeQL. PR #125
+  has two newly actionable onboarding threads plus one addressed-but-unresolved
+  thread. PR #126 has one newly actionable UI cache thread plus one
+  addressed-but-unresolved thread. PR #128 has four current skill/documentation
+  threads and diff whitespace. Draft PRs #121, #124, and #129 have no review
+  threads. No external thread was resolved or replied to.
+- Hosted review smoke runs associated with #121 failed in the read-only MCP
+  transport; no later successful hosted review run exists. Do not silently
+  rerun the API-plane workflow because it may spend metered provider credits.
 - Issue #65 is the only open issue. Its latest comment reports a bounded live
   Stage 1 run, while this handoff and the issue body retain the exact-head
   authorization gate. Treat any further live generation or training as blocked
   until the authority state is reconciled explicitly.
+- Repository metadata, dependency/security automation, release 0.6.0, public
+  endpoints, ports, and agent/plugin metadata were rechecked. The empty GitHub
+  Wiki feature remains enabled even though the product docs explicitly forbid a
+  separate Wiki surface; changing that repository setting needs an explicit
+  maintainer decision.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ binding path. That control plane does not replace local UniGrok MCP on
 | You are… | Use |
 |---|---|
 | Installing / connecting an IDE | This README |
-| An agent needing schemas and operations | [OKF knowledge bundle](https://grokmcp.org/docs/okf/) (also via `discover_self` and local `/docs/okf/`) |
+| An agent needing schemas and operations | [OKF knowledge bundle](https://grokmcp.org/docs/okf/index.md) (also via `discover_self` and local `/docs/okf/`) |
 | Changing UniGrok itself | [CONTRIBUTING.md](CONTRIBUTING.md) |
 
 There is **no** separate GitHub Wiki product surface. Prefer these three paths
@@ -158,7 +158,7 @@ over any Wiki tab so public install and agent knowledge stay one source of truth
 | I want… | Go here |
 |---|---|
 | More IDE examples | [docs/ide-setup.md](docs/ide-setup.md) |
-| Agent knowledge (OKF) | [https://grokmcp.org/docs/okf/](https://grokmcp.org/docs/okf/) |
+| Agent knowledge (OKF) | [https://grokmcp.org/docs/okf/index.md](https://grokmcp.org/docs/okf/index.md) |
 | Architecture | [architecture.md](architecture.md) |
 | Security reporting | [SECURITY.md](SECURITY.md) |
 | **Contribute to UniGrok itself** | [CONTRIBUTING.md](CONTRIBUTING.md) |

--- a/docs/cursor-cloud-mcp.md
+++ b/docs/cursor-cloud-mcp.md
@@ -1,0 +1,48 @@
+# Cursor Cloud → UniGrok twin
+
+One secret. Remote MCP. No local server.
+
+## Operator (you)
+
+```bash
+export UNIGROK_MCP_TOKEN_SECRET='…same as Control MCP_TOKEN_SECRET…'
+export UNIGROK_SERVICE_NAME=cursor-cloud
+export UNIGROK_SERVICE_SCOPE=unigrok:invoke
+# optional TTL max 600
+uv run python scripts/mint_mcp_service_token.py
+```
+
+Copy the printed token into Cursor Cloud secret: **`UNIGROK_ACCESS_TOKEN`**.
+
+Token lasts **10 minutes**. Re-mint when it expires.
+
+Requires Control Center deployed with `service:cursor-cloud` allowlist (this PR).
+
+## Cursor Cloud agent paste
+
+```
+Secret UNIGROK_ACCESS_TOKEN is set.
+
+Use MCP https://mcp.grokmcp.org/mcp
+Header Authorization: Bearer $UNIGROK_ACCESS_TOKEN
+Header X-Client-ID: cursor-cloud
+
+Call grok_mcp_discover_self then agent(mode=fast, prompt="ping", plane=api, fallback_policy=same_plane).
+Never ask for XAI_API_KEY. Do not land main. No Stage 1 live gen.
+```
+
+## MCP JSON (if the UI has a config field)
+
+```json
+{
+  "mcpServers": {
+    "unigrok": {
+      "url": "https://mcp.grokmcp.org/mcp",
+      "headers": {
+        "Authorization": "Bearer ${UNIGROK_ACCESS_TOKEN}",
+        "X-Client-ID": "cursor-cloud"
+      }
+    }
+  }
+}
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "mcp[cli]>=1.26,<1.27",
     "httpx>=0.28.1",
     "google-auth[requests]>=2.40,<3",
+    "cryptography>=49,<50",
     "python-dotenv>=1.2.2",
     "pydantic>=2.9.0",
     "pydantic-settings>=2.14.2",

--- a/scripts/mint_mcp_service_token.py
+++ b/scripts/mint_mcp_service_token.py
@@ -25,13 +25,14 @@ from __future__ import annotations
 
 import argparse
 import base64
-import hmac
 import json
 import os
 import secrets
 import sys
 import time
 from typing import Any, Mapping, Optional
+
+from cryptography.hazmat.primitives import hashes, hmac
 
 TOKEN_PREFIX = "ugtoken."
 DEFAULT_TTL = 120
@@ -66,11 +67,9 @@ def sign_cookie_payload(payload: Mapping[str, Any], secret: str) -> str:
     body = _b64url(json.dumps(payload, separators=(",", ":"), ensure_ascii=True).encode("utf-8"))
     if len(body) > 4_096:
         raise ValueError("cookie payload is too large")
-    signature = hmac.digest(
-        secret.encode("utf-8"),
-        body.encode("utf-8"),
-        "sha256",
-    )
+    signer = hmac.HMAC(secret.encode("utf-8"), hashes.SHA256())
+    signer.update(body.encode("utf-8"))
+    signature = signer.finalize()
     return f"{body}.{_b64url(signature)}"
 
 

--- a/scripts/mint_mcp_service_token.py
+++ b/scripts/mint_mcp_service_token.py
@@ -5,8 +5,8 @@ Matches Control Center ``createServiceAccessToken``:
 HMAC-SHA256 over base64url(JSON claims), token prefix ``ugtoken.``.
 
 Production remote MCP validates via Control introspection — never install a
-long-lived static client key on Cloud Run. This script only produces ~120s
-tokens for GitHub Actions / ops smoke.
+long-lived static client key on Cloud Run. This script only produces short-lived
+tokens for GitHub Actions, Cursor Cloud agents, and ops smoke.
 
 Environment (required):
   UNIGROK_MCP_TOKEN_SECRET  — same value as Control ``MCP_TOKEN_SECRET``
@@ -14,9 +14,9 @@ Environment (required):
   UNIGROK_MCP_RESOURCE_URL  — e.g. https://mcp.grokmcp.org/mcp
 
 Optional:
-  UNIGROK_SERVICE_NAME      — default github-review-broker
-  UNIGROK_SERVICE_SCOPE     — default unigrok:review
-  UNIGROK_TOKEN_TTL_SECONDS — default 120 (max 600)
+  UNIGROK_SERVICE_NAME      — github-review-broker | cursor-cloud
+  UNIGROK_SERVICE_SCOPE     — review (broker) | invoke (cursor-cloud)
+  UNIGROK_TOKEN_TTL_SECONDS — default per service (max 600)
 
 Prints the bearer token to stdout only (no logs of the secret).
 """
@@ -35,7 +35,6 @@ from typing import Any, Mapping, Optional
 from cryptography.hazmat.primitives import hashes, hmac
 
 TOKEN_PREFIX = "ugtoken."
-DEFAULT_TTL = 120
 MAX_TTL = 600
 ALLOWED_SCOPES = frozenset(
     {
@@ -46,7 +45,23 @@ ALLOWED_SCOPES = frozenset(
         "unigrok:status",
     }
 )
-ALLOWED_SERVICES = frozenset({"github-review-broker"})
+
+# service → primary capability scope (connect is always included)
+SERVICE_SPECS: dict[str, dict[str, Any]] = {
+    "github-review-broker": {
+        "scopes": frozenset({"unigrok:review"}),
+        "default_scope": "unigrok:review",
+        "default_ttl": 120,
+        "max_ttl": 120,
+    },
+    # Cursor Cloud / headless IDE agents: invoke + status (discover/status tools).
+    "cursor-cloud": {
+        "scopes": frozenset({"unigrok:invoke", "unigrok:status"}),
+        "default_scope": "unigrok:invoke",
+        "default_ttl": 600,
+        "max_ttl": 600,
+    },
+}
 
 
 def _b64url(data: bytes) -> str:
@@ -79,31 +94,40 @@ def mint_service_access_token(
     issuer: str,
     resource: str,
     service: str = "github-review-broker",
-    scope: str = "unigrok:review",
-    ttl_seconds: int = DEFAULT_TTL,
+    scope: Optional[str] = None,
+    ttl_seconds: Optional[int] = None,
     now: Optional[int] = None,
     jti: Optional[str] = None,
 ) -> str:
-    if service not in ALLOWED_SERVICES:
+    if service not in SERVICE_SPECS:
         raise ValueError(f"service not allowed: {service}")
-    # Service mint is review-only; invoke/chat/status stay for user OAuth.
-    if scope != "unigrok:review":
-        raise ValueError(f"scope not allowed for service mint: {scope}")
+    spec = SERVICE_SPECS[service]
+    primary = (scope or spec["default_scope"]).strip()
+    if primary not in spec["scopes"]:
+        raise ValueError(f"scope not allowed for service {service}: {primary}")
     if not issuer.startswith("https://") or issuer.endswith("/"):
         raise ValueError("issuer must be an https origin without trailing slash")
     if not resource.startswith("https://") or not resource.endswith("/mcp"):
         raise ValueError("resource must be https://…/mcp")
-    if not (1 <= int(ttl_seconds) <= MAX_TTL):
-        raise ValueError(f"ttl_seconds must be 1..{MAX_TTL}")
+    ttl = int(ttl_seconds if ttl_seconds is not None else spec["default_ttl"])
+    max_ttl = int(spec["max_ttl"])
+    if not (1 <= ttl <= min(max_ttl, MAX_TTL)):
+        raise ValueError(f"ttl_seconds must be 1..{min(max_ttl, MAX_TTL)} for {service}")
     iat = int(now if now is not None else time.time())
+    # Always grant connect + capability. cursor-cloud is a fixed package so
+    # discover/status + agent work without a second mint.
+    if service == "cursor-cloud":
+        granted = ["unigrok:connect", "unigrok:invoke", "unigrok:status"]
+    else:
+        granted = ["unigrok:connect", primary]
     claims = {
         "aud": resource,
-        "exp": iat + int(ttl_seconds),
+        "exp": iat + ttl,
         "iat": iat,
         "iss": issuer,
         "jti": jti or _b64url(secrets.token_bytes(24)),
         "kind": "service",
-        "scope": ["unigrok:connect", scope],
+        "scope": granted,
         "sub": f"service:{service}",
         "v": 1,
     }
@@ -123,9 +147,10 @@ def main(argv: Optional[list[str]] = None) -> int:
     issuer = os.environ.get("UNIGROK_OAUTH_ISSUER", "https://control.grokmcp.org").strip()
     resource = os.environ.get("UNIGROK_MCP_RESOURCE_URL", "https://mcp.grokmcp.org/mcp").strip()
     service = os.environ.get("UNIGROK_SERVICE_NAME", "github-review-broker").strip()
-    scope = os.environ.get("UNIGROK_SERVICE_SCOPE", "unigrok:review").strip()
+    scope = os.environ.get("UNIGROK_SERVICE_SCOPE", "").strip() or None
+    raw_ttl = os.environ.get("UNIGROK_TOKEN_TTL_SECONDS", "").strip()
     try:
-        ttl = int(os.environ.get("UNIGROK_TOKEN_TTL_SECONDS", str(DEFAULT_TTL)))
+        ttl = int(raw_ttl) if raw_ttl else None
     except ValueError as exc:
         raise SystemExit("UNIGROK_TOKEN_TTL_SECONDS must be an integer") from exc
 
@@ -140,12 +165,14 @@ def main(argv: Optional[list[str]] = None) -> int:
         now=issued_at,
     )
     if args.print_claims:
-        # Report independently constructed, non-secret metadata. Never decode
-        # or log any value derived from the signed bearer token.
+        body = token[len(TOKEN_PREFIX) :].split(".", 1)[0]
+        pad = "=" * (-len(body) % 4)
+        # Decode only for operator metadata after we minted it; never log secret.
+        claims = json.loads(base64.urlsafe_b64decode(body + pad))
         claims_metadata = {
-            "exp": issued_at + ttl,
-            "scope": ["unigrok:connect", scope],
-            "sub": f"service:{service}",
+            "exp": claims["exp"],
+            "scope": claims["scope"],
+            "sub": claims["sub"],
         }
         print(json.dumps(claims_metadata, sort_keys=True), file=sys.stderr)
     sys.stdout.write(token)

--- a/scripts/mint_mcp_service_token.py
+++ b/scripts/mint_mcp_service_token.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 
 import argparse
 import base64
-import hashlib
 import hmac
 import json
 import os
@@ -67,7 +66,11 @@ def sign_cookie_payload(payload: Mapping[str, Any], secret: str) -> str:
     body = _b64url(json.dumps(payload, separators=(",", ":"), ensure_ascii=True).encode("utf-8"))
     if len(body) > 4_096:
         raise ValueError("cookie payload is too large")
-    signature = hmac.new(secret.encode("utf-8"), body.encode("utf-8"), hashlib.sha256).digest()
+    signature = hmac.digest(
+        secret.encode("utf-8"),
+        body.encode("utf-8"),
+        "sha256",
+    )
     return f"{body}.{_b64url(signature)}"
 
 
@@ -127,6 +130,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     except ValueError as exc:
         raise SystemExit("UNIGROK_TOKEN_TTL_SECONDS must be an integer") from exc
 
+    issued_at = int(time.time())
     token = mint_service_access_token(
         secret=secret,
         issuer=issuer,
@@ -134,13 +138,17 @@ def main(argv: Optional[list[str]] = None) -> int:
         service=service,
         scope=scope,
         ttl_seconds=ttl,
+        now=issued_at,
     )
     if args.print_claims:
-        # Decode payload segment only for operator debugging (no secret).
-        body = token[len(TOKEN_PREFIX) :].split(".", 1)[0]
-        pad = "=" * (-len(body) % 4)
-        claims = json.loads(base64.urlsafe_b64decode(body + pad))
-        print(json.dumps({"sub": claims["sub"], "exp": claims["exp"], "scope": claims["scope"]}, sort_keys=True), file=sys.stderr)
+        # Report independently constructed, non-secret metadata. Never decode
+        # or log any value derived from the signed bearer token.
+        claims_metadata = {
+            "exp": issued_at + ttl,
+            "scope": ["unigrok:connect", scope],
+            "sub": f"service:{service}",
+        }
+        print(json.dumps(claims_metadata, sort_keys=True), file=sys.stderr)
     sys.stdout.write(token)
     if sys.stdout.isatty():
         sys.stdout.write("\n")

--- a/sites/unigrok-control-center/app/lib/mcp-oauth.ts
+++ b/sites/unigrok-control-center/app/lib/mcp-oauth.ts
@@ -195,21 +195,44 @@ export async function exchangeAuthorizationCode(
   };
 }
 
+/** Allowed headless services and the capability scopes they may hold. */
+export const MCP_SERVICE_SPECS = Object.freeze({
+  "github-review-broker": {
+    scopes: Object.freeze(["unigrok:review"] as const),
+    ttlSeconds: 120,
+  },
+  "cursor-cloud": {
+    scopes: Object.freeze(["unigrok:invoke", "unigrok:status"] as const),
+    ttlSeconds: TOKEN_TTL_SECONDS,
+  },
+} as const);
+
+export type McpServiceName = keyof typeof MCP_SERVICE_SPECS;
+
 export async function createServiceAccessToken(
   config: McpOAuthConfig,
-  service: "github-review-broker",
-  scope: "unigrok:review",
+  service: McpServiceName,
+  scope: "unigrok:review" | "unigrok:invoke" | "unigrok:status",
   now = Date.now(),
 ): Promise<string> {
+  const spec = MCP_SERVICE_SPECS[service];
+  if (!spec || !(spec.scopes as readonly string[]).includes(scope)) {
+    throw new McpOAuthError("invalid_scope");
+  }
   const iat = Math.floor(now / 1_000);
+  // cursor-cloud always gets invoke+status so discover/status + agent work.
+  const granted =
+    service === "cursor-cloud"
+      ? ["unigrok:connect", "unigrok:invoke", "unigrok:status"]
+      : ["unigrok:connect", scope];
   const claims: McpAccessClaims = {
     aud: config.resource,
-    exp: iat + 120,
+    exp: iat + spec.ttlSeconds,
     iat,
     iss: config.issuer,
     jti: randomBase64Url(24),
     kind: "service",
-    scope: ["unigrok:connect", scope],
+    scope: granted,
     sub: `service:${service}`,
     v: 1,
   };
@@ -268,7 +291,30 @@ function isAccessClaims(value: unknown, config: McpOAuthConfig, now: number): va
     !Array.isArray(record.scope) ||
     record.scope.some((scope) => typeof scope !== "string" || !MCP_OAUTH_SCOPES.includes(scope))
   ) return false;
-  if (record.kind === "service") return record.sub === "service:github-review-broker";
+  if (record.kind === "service") {
+    if (record.sub === "service:github-review-broker") {
+      return (
+        Array.isArray(record.scope) &&
+        record.scope.includes("unigrok:connect") &&
+        record.scope.includes("unigrok:review") &&
+        record.scope.every((scope) => scope === "unigrok:connect" || scope === "unigrok:review")
+      );
+    }
+    if (record.sub === "service:cursor-cloud") {
+      return (
+        Array.isArray(record.scope) &&
+        record.scope.includes("unigrok:connect") &&
+        record.scope.includes("unigrok:invoke") &&
+        record.scope.every(
+          (scope) =>
+            scope === "unigrok:connect" ||
+            scope === "unigrok:invoke" ||
+            scope === "unigrok:status",
+        )
+      );
+    }
+    return false;
+  }
   return Number.isSafeInteger(record.githubId) && record.sub === `github:${record.githubId}` && typeof record.githubLogin === "string";
 }
 

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -2406,11 +2406,11 @@ def _log_cli_plane_availability():
         logger.info(f"local CLI plane: ready ({cli_path}; verified grok.com OAuth).")
     elif status["binary"]:
         logger.warning(
-            "local CLI plane: %s (%s). Authenticate the global service with `%s`; "
-            "API-plane service remains available.",
+            "local CLI plane: %s (%s). Use grok_mcp_discover_self or the "
+            "Control Center for the bounded authentication action; API-plane "
+            "service remains available.",
             status["state"],
             status["auth"],
-            status["setup_command"],
         )
     else:
         logger.warning(

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -18,6 +18,7 @@ from src.http_server import (
     StaticAssetCacheMiddleware,
     _ACTIVE_MODE_DIAL,
     _derive_http_caller,
+    _log_cli_plane_availability,
     _message_content_size,
     _resolve_bind_host,
     _resolve_bind_port,
@@ -1177,6 +1178,30 @@ def test_resolve_bind_port_explicit_argument_wins(monkeypatch):
     monkeypatch.setenv("PORT", "$PORT")
 
     assert _resolve_bind_port(9090) == 9090
+
+
+def test_cli_plane_warning_never_logs_setup_command(monkeypatch, caplog):
+    marker = "do-not-log-credential-adjacent-command"
+    monkeypatch.setattr(
+        "src.http_server.PathResolver.get_grok_cli_path",
+        lambda: "/usr/local/bin/grok",
+    )
+    monkeypatch.setattr(
+        "src.http_server.grok_cli_plane_status",
+        lambda **_: {
+            "state": "auth_required",
+            "ready": False,
+            "binary": True,
+            "auth": "missing",
+            "setup_command": marker,
+        },
+    )
+
+    with caplog.at_level("WARNING", logger="GrokMCP"):
+        _log_cli_plane_availability()
+
+    assert "grok_mcp_discover_self" in caplog.text
+    assert marker not in caplog.text
 
 
 def test_run_http_server_rejects_exposed_without_auth(monkeypatch):

--- a/tests/test_mint_mcp_service_token.py
+++ b/tests/test_mint_mcp_service_token.py
@@ -6,7 +6,6 @@ import base64
 import hashlib
 import hmac
 import json
-import os
 from pathlib import Path
 
 import pytest
@@ -89,3 +88,26 @@ def test_cli_prints_token_only(capsys: pytest.CaptureFixture[str], monkeypatch: 
     out = capsys.readouterr().out.strip()
     assert out.startswith(TOKEN_PREFIX)
     assert "\n" not in out or out.endswith("\n") is False or True
+
+
+def test_cli_print_claims_uses_independent_non_secret_metadata(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    secret = "do-not-log-this-signing-key" * 2
+    monkeypatch.setenv("UNIGROK_MCP_TOKEN_SECRET", secret)
+    monkeypatch.setenv("UNIGROK_OAUTH_ISSUER", "https://control.grokmcp.org")
+    monkeypatch.setenv("UNIGROK_MCP_RESOURCE_URL", "https://mcp.grokmcp.org/mcp")
+    monkeypatch.setattr("scripts.mint_mcp_service_token.time.time", lambda: 1_700_000_000)
+
+    import scripts.mint_mcp_service_token as mod
+
+    assert mod.main(["--print-claims"]) == 0
+    captured = capsys.readouterr()
+    assert captured.out.startswith(TOKEN_PREFIX)
+    assert json.loads(captured.err) == {
+        "exp": 1_700_000_120,
+        "scope": ["unigrok:connect", "unigrok:review"],
+        "sub": "service:github-review-broker",
+    }
+    assert secret not in captured.out
+    assert secret not in captured.err

--- a/tests/test_mint_mcp_service_token.py
+++ b/tests/test_mint_mcp_service_token.py
@@ -59,6 +59,28 @@ def test_mint_service_access_token_shape_and_claims() -> None:
     assert signed == sign_cookie_payload(claims, secret)
 
 
+def test_mint_cursor_cloud_token_grants_invoke_and_status() -> None:
+    secret = "s" * 48
+    token = mint_service_access_token(
+        secret=secret,
+        issuer="https://control.grokmcp.org",
+        resource="https://mcp.grokmcp.org/mcp",
+        service="cursor-cloud",
+        now=1_700_000_000,
+        jti="cursor-jti-fixed-value-24bxx",
+    )
+    body = token[len(TOKEN_PREFIX) :].split(".", 1)[0]
+    pad = "=" * (-len(body) % 4)
+    claims = json.loads(base64.urlsafe_b64decode(body + pad))
+    assert claims["sub"] == "service:cursor-cloud"
+    assert claims["scope"] == [
+        "unigrok:connect",
+        "unigrok:invoke",
+        "unigrok:status",
+    ]
+    assert claims["exp"] - claims["iat"] == 600
+
+
 def test_mint_rejects_disallowed_service_and_scope() -> None:
     secret = "s" * 48
     with pytest.raises(ValueError, match="service not allowed"):
@@ -73,7 +95,16 @@ def test_mint_rejects_disallowed_service_and_scope() -> None:
             secret=secret,
             issuer="https://control.grokmcp.org",
             resource="https://mcp.grokmcp.org/mcp",
+            service="github-review-broker",
             scope="unigrok:invoke",
+        )
+    with pytest.raises(ValueError, match="scope not allowed"):
+        mint_service_access_token(
+            secret=secret,
+            issuer="https://control.grokmcp.org",
+            resource="https://mcp.grokmcp.org/mcp",
+            service="cursor-cloud",
+            scope="unigrok:review",
         )
 
 
@@ -111,3 +142,24 @@ def test_cli_print_claims_uses_independent_non_secret_metadata(
     }
     assert secret not in captured.out
     assert secret not in captured.err
+
+
+def test_cli_cursor_cloud_env(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    secret = "cursor-cloud-signing-key-value-ok" * 2
+    monkeypatch.setenv("UNIGROK_MCP_TOKEN_SECRET", secret)
+    monkeypatch.setenv("UNIGROK_SERVICE_NAME", "cursor-cloud")
+    monkeypatch.setenv("UNIGROK_SERVICE_SCOPE", "unigrok:invoke")
+    monkeypatch.setenv("UNIGROK_OAUTH_ISSUER", "https://control.grokmcp.org")
+    monkeypatch.setenv("UNIGROK_MCP_RESOURCE_URL", "https://mcp.grokmcp.org/mcp")
+    monkeypatch.setattr("scripts.mint_mcp_service_token.time.time", lambda: 1_700_000_000)
+
+    import scripts.mint_mcp_service_token as mod
+
+    assert mod.main(["--print-claims"]) == 0
+    captured = capsys.readouterr()
+    meta = json.loads(captured.err)
+    assert meta["sub"] == "service:cursor-cloud"
+    assert "unigrok:invoke" in meta["scope"]
+    assert secret not in captured.out

--- a/tests/test_public_mcp_transport_security.py
+++ b/tests/test_public_mcp_transport_security.py
@@ -16,5 +16,5 @@ def test_public_mcp_transport_security_includes_public_hostname() -> None:
     settings = public_mcp_transport_security(
         public_mcp_url="https://mcp.grokmcp.org/mcp",
     )
-    assert "mcp.grokmcp.org" in settings.allowed_hosts
-    assert "https://mcp.grokmcp.org" in settings.allowed_origins
+    assert settings.allowed_hosts[-1] == "mcp.grokmcp.org"
+    assert settings.allowed_origins[-1] == "https://mcp.grokmcp.org"

--- a/tests/test_release_hygiene.py
+++ b/tests/test_release_hygiene.py
@@ -153,7 +153,7 @@ def test_public_docs_surfaces_exclude_github_wiki_as_product():
     )
 
     assert "## 8. Where docs live" in readme
-    assert "https://grokmcp.org/docs/okf/" in readme
+    assert "https://grokmcp.org/docs/okf/index.md" in readme
     assert "There is **no** separate GitHub Wiki product surface" in readme
     assert "GitHub Wiki is not a product surface" in contributing
     assert "Do not hand-edit it as source of" in contributing

--- a/uv.lock
+++ b/uv.lock
@@ -896,6 +896,7 @@ version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
+    { name = "cryptography" },
     { name = "google-auth", extra = ["requests"] },
     { name = "httpx" },
     { name = "jsonschema" },
@@ -934,6 +935,7 @@ dev = [
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "coverage", marker = "extra == 'forge'", specifier = ">=7.6" },
+    { name = "cryptography", specifier = ">=49,<50" },
     { name = "google-auth", extras = ["requests"], specifier = ">=2.40,<3" },
     { name = "google-genai", marker = "extra == 'campaign'", specifier = ">=1.25,<2" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
## Summary
- Mint + Control allow `service:cursor-cloud` with `connect`+`invoke`+`status` (10 min TTL).
- Review broker unchanged (review-only).
- Docs: `docs/cursor-cloud-mcp.md` — one secret for Cursor Cloud.

## Exact head
`b6a78cc`

## Tests
- `uv run pytest tests/test_mint_mcp_service_token.py` — 7 passed
- Control `npx tsx --test tests/oauth-control.test.ts` — 5 passed

## Deploy gate
**Control Center must be redeployed** for production introspection to accept `service:cursor-cloud`. MCP twin itself needs no change.

## Ready for Codex land?
After CI green + Control redeploy.

Human-Sponsor: djtelicloud
Agent-Assisted-By: xAI Grok | model=grok-4.5 | surface=Grok Build CLI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Expands authentication to a new service principal with invoke/status capabilities on remote MCP; misconfiguration or incomplete Control deploy could allow or block headless agent access incorrectly.
> 
> **Overview**
> Adds a **`cursor-cloud`** headless service identity so Cursor Cloud agents can call remote MCP at `https://mcp.grokmcp.org/mcp` with short-lived bearer tokens instead of a local gateway.
> 
> **Control Center** (`mcp-oauth.ts`) now allowlists `service:cursor-cloud` with a fixed scope bundle (`connect`, `invoke`, `status`) and a 10-minute TTL; **`github-review-broker`** stays review-only at 120s. The Python **`mint_mcp_service_token.py`** script mirrors the same service specs, switches signing to **`cryptography`** HMAC-SHA256, and documents env vars for minting `UNIGROK_ACCESS_TOKEN`.
> 
> New **`docs/cursor-cloud-mcp.md`** covers operator mint steps and agent paste/MCP JSON. README and release-hygiene tests point OKF links at **`index.md`**. Startup CLI warnings no longer log credential-adjacent setup commands; tests cover minting and that logging behavior.
> 
> **Deploy note:** Control Center must be redeployed before production introspection accepts `cursor-cloud` tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6a78cc3902550fc7d907e563f8a7f94166c17f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->