### PR TITLE
integrate: clear reviewed maintainer backlog

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -8,7 +8,7 @@
   **boot** / **where were we**, follow
   [`.agents/skills/session-rehydrate/SKILL.md`](skills/session-rehydrate/SKILL.md).
 - Continuity lives in git/disk: private
-  `unigrok-intelligence/codex/continuity/active-work-latest.md` (if present),
+  `../unigrok-intelligence/codex/continuity/active-work-latest.md` (if present),
   open PR notes, and `./scripts/land-status` — not chat memory.
 
 ## Communication discipline

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -7,6 +7,7 @@
 - **Grok Mentions**: Whenever the user mentions "@grok", "grok", or explicitly asks to query Grok, call the shared UniGrok MCP `agent` tool when it is available rather than answering directly using your own model weights or context.
 - **Code Peer Reviews**: Whenever the user asks to peer review code, audit architectural files, or perform quality checks in this repository, invoke the shared UniGrok MCP `agent` tool for Grok's direct feedback when the MCP service is available.
 - **Operational Source of Truth**: For installation snippets and IDE-specific config, use `docs/ide-setup.md`. For browser-based manual testing, open `http://localhost:4765/ui/`.
+- **Multi-Step Implementation Plans**: When asked for a multi-step Implementation Plan, obtain a UniGrok second opinion (using agent mode `thinking` or `reasoning`) and improve the plan before showing it. Only do this if the user explicitly asks for this habit; do not silently spend metered API credits without request.
 
 ## Multi-Agent Git Coordination
 - **PR-First Contribution Record**: Every change to `origin/main` goes through a pull request. After local verification, an authorized IDE agent may push only its own agent-prefixed task branch and open or update a draft pull request. If that agent lacks GitHub credentials, it hands Codex the exact commit so an authorized Codex session can publish the same branch and draft PR. A commit-only handoff is pre-PR evidence, not a substitute for the PR.

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,5 +1,25 @@
 # Workspace Rules
 
+## Session rehydrate (new chats)
+
+- **Start inside this product checkout** (or an agent worktree), not `$HOME`.
+  Home sessions miss these rules and feel “dumber.”
+- On first message after IDE reset, or when the user says **rehydrate** /
+  **boot** / **where were we**, follow
+  [`.agents/skills/session-rehydrate/SKILL.md`](skills/session-rehydrate/SKILL.md).
+- Continuity lives in git/disk: private
+  `unigrok-intelligence/codex/continuity/active-work-latest.md` (if present),
+  open PR notes, and `./scripts/land-status` — not chat memory.
+
+## Communication discipline
+
+- **Silent process, loud finish:** use tools and plan without narrating every
+  step. Deliver one concise end-state answer (tables, decisions, links, blockers).
+- Do not stream progress essays (“now I’ll check…”) unless the user asked for
+  a live play-by-play.
+- Prefer UniGrok MCP CLI/`fast` for cheap index-diff hive emits; keep visible
+  output tiny. Insider silent-think doctrine is private (not public default).
+
 ## Grok MCP Integration Rules
 - **Shared MCP Endpoint**: The host-facing shared service endpoint is `http://localhost:4765/mcp` (Streamable HTTP). Port `8080` is container-internal only. Start it with `docker compose up --build -d` from the primary checkout unless the user explicitly asks for stdio mode.
 - **Per-Agent Identity**: Every IDE/agent config should send `X-Client-ID` with a stable value such as `codex`, `claude-code`, `vscode`, or `antigravity`. This attributes telemetry and keeps sessions separate.

--- a/.agents/skills/session-rehydrate/SKILL.md
+++ b/.agents/skills/session-rehydrate/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: session-rehydrate
+description: >-
+  Boot a new IDE/agent session into full UniGrok product context. Activate on
+  "rehydrate", "boot", "where were we", "session start", first message after
+  IDE reset, or when the agent was started outside the product checkout.
+---
+
+# Session rehydrate (persist intelligence across chats)
+
+New Grok/Claude/Codex sessions do **not** inherit prior chat transcripts.
+Intelligence is rehydrated from **git + disk**, not model memory.
+
+## Communication discipline (same experience every session)
+
+Do this for the whole session after rehydrate:
+
+1. **Think and tool silently.** Prefer tool calls and internal planning over
+   step-by-step narration to the user.
+2. **One end-state answer.** Deliver a concise final report (status table,
+   decisions, links, next action). Do not stream a blog of intermediate work
+   unless the user asked for a live play-by-play.
+3. **No fake progress essays.** “I’m checking X… now Y…” is noise. Use tools;
+   then speak.
+4. **UniGrok second opinions:** when calling MCP `agent` for hard product
+   claims, prefer **CLI** + `mode=fast` for index-diff hive polls; keep
+   **visible emit tiny**. Insider silent-think doctrine lives in private
+   `unigrok-intelligence/playbooks/silent-think-harness.md` (not public default).
+5. **Exceptions:** user asks “explain as you go”, safety/permission prompts,
+   or a blocking question that needs a human.
+
+This is **session law** when this skill or `.agents/AGENTS.md` is loaded — not
+global Grok TUI settings alone. Start the agent **inside the product checkout**
+so these rules load.
+
+## Boot sequence (run once at session start)
+
+### 0. Workspace
+
+- Prefer cwd: product checkout `…/grok-mcp-server` or a named agent worktree.
+- If cwd is `$HOME` or unrelated, **say so once**, then rehydrate from absolute
+  product paths anyway (or ask to reopen the project folder).
+
+### 1. Product law
+
+Read (skim) when available:
+
+- `.agents/AGENTS.md` — multi-agent git, MCP endpoint, credentials boundary
+- Root `AGENTS.md` if present
+
+### 2. Continuity (private brain)
+
+If the private repo is present at a sibling path or known clone:
+
+```text
+../unigrok-intelligence/codex/continuity/active-work-latest.md
+```
+
+Also useful:
+
+```text
+../unigrok-intelligence/harvest/index-diff-hive/   # recent hive receipts
+../unigrok-intelligence/playbooks/index-diff-hive.md
+../unigrok-intelligence/playbooks/parallel-ship-dag.md
+```
+
+If private paths are missing, continue with public product only; do not invent
+hive/land authority for public installs.
+
+### 3. Live gates
+
+From product root:
+
+```bash
+./scripts/land-status
+```
+
+Note: visible main, worktrees, stable/forge readiness.  
+Primary shared checkout should stay on **clean `main`**. Implementation uses
+**agent-prefixed worktrees** only.
+
+### 4. Runtime (optional quick)
+
+```bash
+curl -sf http://127.0.0.1:4765/readyz
+```
+
+Do not print secrets. Credential plane details via Control Center or
+`grok_mcp_discover_self` when needed.
+
+### 5. UniGrok MCP session key (optional)
+
+For multi-turn `@grok` continuity this calendar day, reuse a project-qualified
+session such as:
+
+```text
+unigrok:ops:YYYY-MM-DD
+```
+
+Do not reuse a bare generic session key across unrelated repos.
+
+### 6. Emit to user (only this)
+
+A short **Rehydrated** block:
+
+| Field | Value |
+|-------|--------|
+| cwd / branch | … |
+| main / land-status | … |
+| continuity | loaded / missing |
+| open PRs you care about | … |
+| next action | … |
+
+Then wait for the user task — or continue if they already gave one.
+
+## What this skill does *not* do
+
+- Does not restore prior chat transcripts
+- Does not land `main` (Codex / `scripts/land` only)
+- Does not run Stage 1 live Needle gen without exact-head authorization
+- Does not teach public users Forge/hive as product defaults
+
+## Persistence checklist (end of meaningful work)
+
+Before leaving a session that produced decisions:
+
+1. Update private `active-work-latest.md` when continuity changed
+2. Put exact head + “ready for Codex land?” on the PR
+3. Leave primary checkout on clean `main`
+4. Hive receipts (if any) under private `harvest/index-diff-hive/`

--- a/.agents/skills/session-rehydrate/SKILL.md
+++ b/.agents/skills/session-rehydrate/SKILL.md
@@ -25,7 +25,7 @@ Do this for the whole session after rehydrate:
 4. **UniGrok second opinions:** when calling MCP `agent` for hard product
    claims, prefer **CLI** + `mode=fast` for index-diff hive polls; keep
    **visible emit tiny**. Insider silent-think doctrine lives in private
-   `unigrok-intelligence/playbooks/silent-think-harness.md` (not public default).
+   `../unigrok-intelligence/playbooks/silent-think-harness.md` (not public default).
 5. **Exceptions:** user asks “explain as you go”, safety/permission prompts,
    or a blocking question that needs a human.
 
@@ -75,7 +75,7 @@ From product root:
 ./scripts/land-status
 ```
 
-Note: visible main, worktrees, stable/forge readiness.  
+Note: visible main, worktrees, stable/forge readiness.
 Primary shared checkout should stay on **clean `main`**. Implementation uses
 **agent-prefixed worktrees** only.
 
@@ -94,7 +94,7 @@ For multi-turn `@grok` continuity this calendar day, reuse a project-qualified
 session such as:
 
 ```text
-unigrok:ops:YYYY-MM-DD
+djtelicloud-grok-mcp-server:ops:YYYY-MM-DD
 ```
 
 Do not reuse a bare generic session key across unrelated repos.

--- a/.agents/skills/using-unigrok/SKILL.md
+++ b/.agents/skills/using-unigrok/SKILL.md
@@ -77,6 +77,8 @@ not invented subscription cost or remaining provider quota.
 
 ## Safe onboarding behavior
 
+- On first connect in a session, call `grok_mcp_discover_self` and read
+  `data.bootstrap` + `data.request_context` before inventing setup steps.
 - Treat `credential_planes` notices from status or an agent result as the
   source of truth. Ask before device authentication, installation, or secret
   configuration.
@@ -89,6 +91,37 @@ not invented subscription cost or remaining provider quota.
   the user; do not require them to understand planes, MCP transport, or JSON-RPC.
 - Public product path is `http://localhost:4765/mcp` only. Do not invent a
   second port, Forge, Swarm, or land workflow for ordinary end-user installs.
+
+## First-connect diagnostics (server + local)
+
+**Server (always available via MCP):**
+
+1. Call `grok_mcp_discover_self`.
+2. Honor `data.bootstrap.status` (`OK` / `WARN` / `ERR`) and gates
+   (`can_chat`, `can_spend_api`, `can_mutate_workspace`, `can_use_swarm`).
+3. Read `data.request_context`: surface (`stable_core` / `contributor_forge` /
+   `mode_dial`), `client_id_present`, optional Host port / mode dial.
+4. Prompt once per `credential_planes` notice id; follow
+   `data.bootstrap.next_actions` when present.
+5. Optional: `include_models: true` when model routing matters.
+
+**Local IDE audit (only with user permission; report only):**
+
+UniGrok cannot read global IDE settings over HTTP. With consent, use local tools
+to check and **report** (never rewrite without explicit permission; never print
+secret values):
+
+- User MCP configs point daily chat at `http://localhost:4765/mcp`.
+- Stable `X-Client-ID` per IDE (claude-code, vscode, codex, cursor, antigravity).
+- No `XAI_API_KEY` (or other secrets) embedded in MCP JSON.
+- Project `.mcp.json` (if any) is dual HTTP for UniGrok worktrees, never
+  broken `unigrok-stdio` with `${PLUGIN_ROOT}`.
+- Optional `using-unigrok` skill present; do not copy contributor `.agents`
+  trees into foreign apps.
+- Unique leverage: which planes are ready, whether Forge tools appear only when
+  intentionally connected to the contributor surface, mode dials if enabled.
+
+Then one cheap verification: `agent` with `mode=fast` or `grok_mcp_status`.
 
 ## Endpoint
 

--- a/.claude/skills/session-rehydrate/SKILL.md
+++ b/.claude/skills/session-rehydrate/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: session-rehydrate
+description: >-
+  Boot a new IDE/agent session into full UniGrok product context. Activate on
+  "rehydrate", "boot", "where were we", "session start", first message after
+  IDE reset, or when the agent was started outside the product checkout.
+---
+
+# Session rehydrate (persist intelligence across chats)
+
+New Grok/Claude/Codex sessions do **not** inherit prior chat transcripts.
+Intelligence is rehydrated from **git + disk**, not model memory.
+
+## Communication discipline (same experience every session)
+
+Do this for the whole session after rehydrate:
+
+1. **Think and tool silently.** Prefer tool calls and internal planning over
+   step-by-step narration to the user.
+2. **One end-state answer.** Deliver a concise final report (status table,
+   decisions, links, next action). Do not stream a blog of intermediate work
+   unless the user asked for a live play-by-play.
+3. **No fake progress essays.** “I’m checking X… now Y…” is noise. Use tools;
+   then speak.
+4. **UniGrok second opinions:** when calling MCP `agent` for hard product
+   claims, prefer **CLI** + `mode=fast` for index-diff hive polls; keep
+   **visible emit tiny**. Insider silent-think doctrine lives in private
+   `unigrok-intelligence/playbooks/silent-think-harness.md` (not public default).
+5. **Exceptions:** user asks “explain as you go”, safety/permission prompts,
+   or a blocking question that needs a human.
+
+This is **session law** when this skill or `.agents/AGENTS.md` is loaded — not
+global Grok TUI settings alone. Start the agent **inside the product checkout**
+so these rules load.
+
+## Boot sequence (run once at session start)
+
+### 0. Workspace
+
+- Prefer cwd: product checkout `…/grok-mcp-server` or a named agent worktree.
+- If cwd is `$HOME` or unrelated, **say so once**, then rehydrate from absolute
+  product paths anyway (or ask to reopen the project folder).
+
+### 1. Product law
+
+Read (skim) when available:
+
+- `.agents/AGENTS.md` — multi-agent git, MCP endpoint, credentials boundary
+- Root `AGENTS.md` if present
+
+### 2. Continuity (private brain)
+
+If the private repo is present at a sibling path or known clone:
+
+```text
+../unigrok-intelligence/codex/continuity/active-work-latest.md
+```
+
+Also useful:
+
+```text
+../unigrok-intelligence/harvest/index-diff-hive/   # recent hive receipts
+../unigrok-intelligence/playbooks/index-diff-hive.md
+../unigrok-intelligence/playbooks/parallel-ship-dag.md
+```
+
+If private paths are missing, continue with public product only; do not invent
+hive/land authority for public installs.
+
+### 3. Live gates
+
+From product root:
+
+```bash
+./scripts/land-status
+```
+
+Note: visible main, worktrees, stable/forge readiness.  
+Primary shared checkout should stay on **clean `main`**. Implementation uses
+**agent-prefixed worktrees** only.
+
+### 4. Runtime (optional quick)
+
+```bash
+curl -sf http://127.0.0.1:4765/readyz
+```
+
+Do not print secrets. Credential plane details via Control Center or
+`grok_mcp_discover_self` when needed.
+
+### 5. UniGrok MCP session key (optional)
+
+For multi-turn `@grok` continuity this calendar day, reuse a project-qualified
+session such as:
+
+```text
+unigrok:ops:YYYY-MM-DD
+```
+
+Do not reuse a bare generic session key across unrelated repos.
+
+### 6. Emit to user (only this)
+
+A short **Rehydrated** block:
+
+| Field | Value |
+|-------|--------|
+| cwd / branch | … |
+| main / land-status | … |
+| continuity | loaded / missing |
+| open PRs you care about | … |
+| next action | … |
+
+Then wait for the user task — or continue if they already gave one.
+
+## What this skill does *not* do
+
+- Does not restore prior chat transcripts
+- Does not land `main` (Codex / `scripts/land` only)
+- Does not run Stage 1 live Needle gen without exact-head authorization
+- Does not teach public users Forge/hive as product defaults
+
+## Persistence checklist (end of meaningful work)
+
+Before leaving a session that produced decisions:
+
+1. Update private `active-work-latest.md` when continuity changed
+2. Put exact head + “ready for Codex land?” on the PR
+3. Leave primary checkout on clean `main`
+4. Hive receipts (if any) under private `harvest/index-diff-hive/`

--- a/.claude/skills/session-rehydrate/SKILL.md
+++ b/.claude/skills/session-rehydrate/SKILL.md
@@ -25,7 +25,7 @@ Do this for the whole session after rehydrate:
 4. **UniGrok second opinions:** when calling MCP `agent` for hard product
    claims, prefer **CLI** + `mode=fast` for index-diff hive polls; keep
    **visible emit tiny**. Insider silent-think doctrine lives in private
-   `unigrok-intelligence/playbooks/silent-think-harness.md` (not public default).
+   `../unigrok-intelligence/playbooks/silent-think-harness.md` (not public default).
 5. **Exceptions:** user asks “explain as you go”, safety/permission prompts,
    or a blocking question that needs a human.
 
@@ -46,6 +46,7 @@ so these rules load.
 Read (skim) when available:
 
 - `.agents/AGENTS.md` — multi-agent git, MCP endpoint, credentials boundary
+- Root `CLAUDE.md` if present — Claude MCP names, branch rules, and attribution
 - Root `AGENTS.md` if present
 
 ### 2. Continuity (private brain)
@@ -75,7 +76,7 @@ From product root:
 ./scripts/land-status
 ```
 
-Note: visible main, worktrees, stable/forge readiness.  
+Note: visible main, worktrees, stable/forge readiness.
 Primary shared checkout should stay on **clean `main`**. Implementation uses
 **agent-prefixed worktrees** only.
 
@@ -94,7 +95,7 @@ For multi-turn `@grok` continuity this calendar day, reuse a project-qualified
 session such as:
 
 ```text
-unigrok:ops:YYYY-MM-DD
+djtelicloud-grok-mcp-server:ops:YYYY-MM-DD
 ```
 
 Do not reuse a bare generic session key across unrelated repos.

--- a/.claude/skills/using-unigrok/SKILL.md
+++ b/.claude/skills/using-unigrok/SKILL.md
@@ -1,98 +1,85 @@
 ---
 name: using-unigrok
-description: How to query xAI Grok through the UniGrok MCP gateway. Activate when the user says "@grok", asks to query Grok, wants a second-model opinion or peer review from Grok, or needs web/X search grounding.
+description: Claude Code guidance for querying xAI Grok through the shared UniGrok MCP gateway. Activate when the user says "@grok", asks to query Grok, wants a Grok second opinion or peer review, or needs web/X search grounding.
 ---
 
-# Using the UniGrok Grok Gateway
+# Using UniGrok from Claude Code
 
-UniGrok exposes one headline MCP tool: `agent`. It self-routes across Grok
-models and two billing planes, and returns structured metadata with every
-answer. **Primary chat path for every project is IDE → UniGrok MCP**. The local
-browser UI is an optional trusted-loopback test/control surface whose agent
-playground can invoke providers and spend metered credits.
+This is the Claude Code adaptation of the canonical gateway skill
+([skills/using-unigrok/SKILL.md](../../../skills/using-unigrok/SKILL.md));
+it adds only what is specific to Claude Code sessions.
 
-## The `agent` tool
+## Tool resolution
 
-Call `agent` with:
+The gateway's headline tool is `agent`, but its full Claude Code name depends
+on how the MCP server was registered:
 
-- `prompt` (required): the task or question, with enough context to act on.
-- `mode` (optional): `auto` (default), `fast` (single-turn, cheapest),
-  `reasoning` (multi-step planner), `thinking` (reflected agent loop), or
-  `research` (citation-grounded fanout).
-- `model` (optional): pin a Grok model id such as `grok-4.5`; leave unset to
-  let routing choose.
-- `session` (optional): a stable, project-qualified key such as
-  `owner-repo:task` for multi-turn continuity. Do not reuse a generic session
-  key across repositories.
-- `workspace_context` (optional): deliberately selected excerpts, diffs, or
-  errors when the task depends on the caller's project. The stable service
-  cannot browse the IDE workspace automatically.
-- `workspace_label` (optional): descriptive metadata for the supplied context.
-  It does not isolate sessions; the project-qualified `session` key does.
+- `mcp__unigrok__agent` — connected through this repository's project
+  `.mcp.json` (server name `unigrok`).
+- `mcp__grok__agent` — connected through a user-scope registration named
+  `grok` (the Codex-compatible name).
 
-Every result includes `response` plus metadata: `model`, `route`, `plane`
-(`API` or `CLI`), `cost_usd`, `tokens`, `latency_sec`, and `citations` when
-search grounding was used.
+Prefer the project-controlled `unigrok` registration. `.claude/settings.json`
+pre-allows its `agent`, `grok_mcp_status`, and `grok_mcp_discover_self` tools.
+A user-owned `grok` alias is not controlled by this repository; verify that it
+points to the expected UniGrok endpoint before approving or using its tools.
 
-## Mode selection guidance
+## Calling `agent`
 
-- Quick factual or single-file questions → `fast`.
-- Design reviews, audits, multi-step analysis → `reasoning`.
-- Tasks needing self-critique → `thinking`.
-- Current-events or source-cited answers → `research` (uses web + X search).
+- `prompt` (required); `mode` optional: `auto` (default), `fast`, `reasoning`,
+  `thinking`, `research`.
+- `workspace_context`: the stable service is workspace-neutral and cannot see
+  the open folder — attach selected excerpts, `git diff` output, or errors
+  yourself. An optional `workspace_label` is descriptive metadata only; it does
+  not isolate sessions.
+- `session`: pass a stable, project-qualified key such as `owner-repo:task`.
+  The server namespaces it beneath a server-derived principal and the
+  caller-controlled `X-Client-ID` label (`plugin` in this repository's current
+  `.mcp.json`). A generic key can collide across repositories that reuse a
+  common label such as `claude-code`. Reuse preserves continuity and can reduce
+  repeated-context API input cost when caching hits, but savings are not
+  guaranteed and CLI provider cost remains unavailable.
+- `model`: pin only when asked; pins validate against the live catalog. An
+  explicit `plane=cli|api` should pair with `fallback_policy="same_plane"`
+  when billing planes must not cross.
 
-## Parallel ship (contributor, private)
+Every result returns `response` plus `model`, `route`, `plane`, `why`,
+`degraded`, `cost_usd`, `tokens`, `latency_sec`, and `citations` when search
+grounding ran. Surface `cost_usd` when the user cares about spend.
 
-Dual-lane product+intelligence shipping process lives in the **private**
-repository `djtelicloud/unigrok-intelligence` (playbooks + `grok-parallel-ship`
-skill). Public product installs never require it.
+## Claude Code patterns
 
-Do **not** invent multi-provider public chat tools. UniGrok's public `agent`
-remains Grok-routed; other providers stay behind Grok-supervised adapters.
+- **Second opinion before handoff**: send the branch diff via
+  `workspace_context` with `mode=reasoning` for a Grok peer review.
+- **Long calls should not block the turn**: `research` and `thinking` runs can
+  take minutes; wrap them in a background subagent (Agent tool) and keep
+  working, then relay the result.
+- **Health first**: on connection trouble, check `GET /healthz` on port 4765
+  and `grok_mcp_status`; `8080` is container-internal and never reachable from
+  the host.
 
+## Registering in another repository
 
-## Plan critique habit (opt-in)
+The gateway is machine-global; projects need no UniGrok files. Teammates run:
 
-When the user is about to see a multi-step **Implementation Plan**, prefer:
+```bash
+claude mcp add --transport http unigrok http://localhost:4765/mcp \
+  --header "X-Client-ID: claude-code"
+```
 
-1. Call UniGrok `agent` (`thinking` or `reasoning`) with the draft plan.
-2. Incorporate feedback silently.
-3. Only then present the improved plan to the user.
-
-Do this when the user wants a Grok second opinion (including `@grok`). Do **not**
-silently spend metered API credits without consent. Do **not** auto-generate
-skill trees into foreign projects without permission. Never copy the UniGrok
-repository’s contributor `.agents` tree into the user’s other apps.
-
-## Cost awareness
-
-Check `cost_usd` in each response. Session reuse preserves continuity and can
-reduce repeated-context API input cost when caching hits; it does not guarantee
-savings. The default `cli_first` policy prefers compatible, unpinned work on an
-authenticated CLI subscription. Explicit plane selection should pair with
-`fallback_policy="same_plane"` when the request must not cross into a different
-credential or billing plane; `cross_plane` allows bounded failover. CLI
-provider cost remains unavailable, so report local counts and estimated tokens,
-not invented subscription cost or remaining provider quota.
-
-## Safe onboarding behavior
-
-- On first connect in a session, call `grok_mcp_discover_self` and read
-  `data.bootstrap` + `data.request_context` before inventing setup steps.
-- Treat `credential_planes` notices from status or an agent result as the
-  source of truth. Ask before device authentication, installation, or secret
-  configuration.
-- Never request `XAI_API_KEY` in chat or write it into the caller's project.
-- The stable service is workspace-neutral: do not assume MCP registration
-  grants filesystem access. Use `workspace_context` or local file tools only
-  when those tools are actually exposed in the current trusted
-  contributor/stdio session.
-- Translate provider and transport errors into one concrete next action for
-  the user; do not require them to understand planes, MCP transport, or JSON-RPC.
-- Public product path is `http://localhost:4765/mcp` only. Do not invent a
-  second port, Forge, Swarm, or land workflow for ordinary end-user installs.
+`X-Client-ID` is a caller-controlled attribution and session label, not an
+authenticated identity. The server derives the principal; the default
+unauthenticated loopback service derives the shared `http:anon` principal for
+one local budget/security trust domain. There is no cross-user isolation without
+configured auth. Because many repositories can reuse
+`X-Client-ID: claude-code`, always project-qualify the `session` key;
+`workspace_label` remains descriptive only. Control Center:
+`http://localhost:4765/ui/`.
 
 ## First-connect diagnostics (server + local)
+
+On first connect in a session, call `grok_mcp_discover_self` and read
+`data.bootstrap` + `data.request_context` before inventing setup steps.
 
 **Server (always available via MCP):**
 
@@ -112,26 +99,37 @@ to check and **report** (never rewrite without explicit permission; never print
 secret values):
 
 - User MCP configs point daily chat at `http://localhost:4765/mcp`.
-- Stable `X-Client-ID` per IDE (claude-code, vscode, codex, cursor, antigravity).
+- Stable `X-Client-ID` per IDE (for Claude Code: `claude-code`).
 - No `XAI_API_KEY` (or other secrets) embedded in MCP JSON.
 - Project `.mcp.json` (if any) is dual HTTP for UniGrok worktrees, never
   broken `unigrok-stdio` with `${PLUGIN_ROOT}`.
 - Optional `using-unigrok` skill present; do not copy contributor `.agents`
   trees into foreign apps.
-- Unique leverage: which planes are ready, whether Forge tools appear only when
-  intentionally connected to the contributor surface, mode dials if enabled.
 
 Then one cheap verification: `agent` with `mode=fast` or `grok_mcp_status`.
 
-## Endpoint
+## Safety
 
-The shared gateway runs at `http://localhost:4765/mcp` (Streamable HTTP).
-Health: `GET /healthz`. Optional local Core UI: `http://localhost:4765/ui/`
-(trusted machine-owner test/control surface with a provider-calling agent
-playground). `X-Client-ID` is a caller-controlled
-attribution and session label beneath a server-derived principal; it is not
-authentication. The default unauthenticated loopback service derives the shared
-`http:anon` principal for one local budget/security trust domain, so there is
-no cross-user isolation without configured auth. Project-qualify every session
-key: a generic key can collide across repositories when the same client label
-is reused.
+- Never request `XAI_API_KEY` in chat or write it into any IDE config; the
+  credential belongs to the server.
+- Treat `credential_planes` notices from status or agent results as the source
+  of truth; ask the user before device authentication, installation, or secret
+  configuration.
+- Translate provider and transport errors into one concrete next action; the
+  user should not need to understand planes or JSON-RPC.
+
+
+## Parallel ship (contributor, private)
+
+Dual-lane shipping process lives in private `djtelicloud/unigrok-intelligence`.
+Public product installs never require it.
+
+
+## Plan critique habit (opt-in)
+
+When the user is about to see a multi-step Implementation Plan, prefer calling
+UniGrok `agent` (`thinking` or `reasoning`) for a second opinion, then improve
+the plan before presenting it **only when the user wants a Grok second opinion**
+(including `@grok`). Do not silently spend metered API credits without consent.
+Do not invent a second MCP port or Forge workflow for public installs. Public
+path remains `http://localhost:4765/mcp` only.

--- a/.claude/skills/using-unigrok/SKILL.md
+++ b/.claude/skills/using-unigrok/SKILL.md
@@ -1,103 +1,137 @@
 ---
 name: using-unigrok
-description: Claude Code guidance for querying xAI Grok through the shared UniGrok MCP gateway. Activate when the user says "@grok", asks to query Grok, wants a Grok second opinion or peer review, or needs web/X search grounding.
+description: How to query xAI Grok through the UniGrok MCP gateway. Activate when the user says "@grok", asks to query Grok, wants a second-model opinion or peer review from Grok, or needs web/X search grounding.
 ---
 
-# Using UniGrok from Claude Code
+# Using the UniGrok Grok Gateway
 
-This is the Claude Code adaptation of the canonical gateway skill
-([skills/using-unigrok/SKILL.md](../../../skills/using-unigrok/SKILL.md));
-it adds only what is specific to Claude Code sessions.
+UniGrok exposes one headline MCP tool: `agent`. It self-routes across Grok
+models and two billing planes, and returns structured metadata with every
+answer. **Primary chat path for every project is IDE → UniGrok MCP**. The local
+browser UI is an optional trusted-loopback test/control surface whose agent
+playground can invoke providers and spend metered credits.
 
-## Tool resolution
+## The `agent` tool
 
-The gateway's headline tool is `agent`, but its full Claude Code name depends
-on how the MCP server was registered:
+Call `agent` with:
 
-- `mcp__unigrok__agent` — connected through this repository's project
-  `.mcp.json` (server name `unigrok`).
-- `mcp__grok__agent` — connected through a user-scope registration named
-  `grok` (the Codex-compatible name).
+- `prompt` (required): the task or question, with enough context to act on.
+- `mode` (optional): `auto` (default), `fast` (single-turn, cheapest),
+  `reasoning` (multi-step planner), `thinking` (reflected agent loop), or
+  `research` (citation-grounded fanout).
+- `model` (optional): pin a Grok model id such as `grok-4.5`; leave unset to
+  let routing choose.
+- `session` (optional): a stable, project-qualified key such as
+  `owner-repo:task` for multi-turn continuity. Do not reuse a generic session
+  key across repositories.
+- `workspace_context` (optional): deliberately selected excerpts, diffs, or
+  errors when the task depends on the caller's project. The stable service
+  cannot browse the IDE workspace automatically.
+- `workspace_label` (optional): descriptive metadata for the supplied context.
+  It does not isolate sessions; the project-qualified `session` key does.
 
-Prefer the project-controlled `unigrok` registration. `.claude/settings.json`
-pre-allows its `agent`, `grok_mcp_status`, and `grok_mcp_discover_self` tools.
-A user-owned `grok` alias is not controlled by this repository; verify that it
-points to the expected UniGrok endpoint before approving or using its tools.
+Every result includes `response` plus metadata: `model`, `route`, `plane`
+(`API` or `CLI`), `cost_usd`, `tokens`, `latency_sec`, and `citations` when
+search grounding was used.
 
-## Calling `agent`
+## Mode selection guidance
 
-- `prompt` (required); `mode` optional: `auto` (default), `fast`, `reasoning`,
-  `thinking`, `research`.
-- `workspace_context`: the stable service is workspace-neutral and cannot see
-  the open folder — attach selected excerpts, `git diff` output, or errors
-  yourself. An optional `workspace_label` is descriptive metadata only; it does
-  not isolate sessions.
-- `session`: pass a stable, project-qualified key such as `owner-repo:task`.
-  The server namespaces it beneath a server-derived principal and the
-  caller-controlled `X-Client-ID` label (`plugin` in this repository's current
-  `.mcp.json`). A generic key can collide across repositories that reuse a
-  common label such as `claude-code`. Reuse preserves continuity and can reduce
-  repeated-context API input cost when caching hits, but savings are not
-  guaranteed and CLI provider cost remains unavailable.
-- `model`: pin only when asked; pins validate against the live catalog. An
-  explicit `plane=cli|api` should pair with `fallback_policy="same_plane"`
-  when billing planes must not cross.
-
-Every result returns `response` plus `model`, `route`, `plane`, `why`,
-`degraded`, `cost_usd`, `tokens`, `latency_sec`, and `citations` when search
-grounding ran. Surface `cost_usd` when the user cares about spend.
-
-## Claude Code patterns
-
-- **Second opinion before handoff**: send the branch diff via
-  `workspace_context` with `mode=reasoning` for a Grok peer review.
-- **Long calls should not block the turn**: `research` and `thinking` runs can
-  take minutes; wrap them in a background subagent (Agent tool) and keep
-  working, then relay the result.
-- **Health first**: on connection trouble, check `GET /healthz` on port 4765
-  and `grok_mcp_status`; `8080` is container-internal and never reachable from
-  the host.
-
-## Registering in another repository
-
-The gateway is machine-global; projects need no UniGrok files. Teammates run:
-
-```bash
-claude mcp add --transport http unigrok http://localhost:4765/mcp \
-  --header "X-Client-ID: claude-code"
-```
-
-`X-Client-ID` is a caller-controlled attribution and session label, not an
-authenticated identity. The server derives the principal; the default
-unauthenticated loopback service derives the shared `http:anon` principal for
-one local budget/security trust domain. There is no cross-user isolation without
-configured auth. Because many repositories can reuse
-`X-Client-ID: claude-code`, always project-qualify the `session` key;
-`workspace_label` remains descriptive only. Control Center:
-`http://localhost:4765/ui/`.
-
-## Safety
-
-- Never request `XAI_API_KEY` in chat or write it into any IDE config; the
-  credential belongs to the server.
-- Treat `credential_planes` notices from status or agent results as the source
-  of truth; ask the user before device authentication, installation, or secret
-  configuration.
-- Translate provider and transport errors into one concrete next action; the
-  user should not need to understand planes or JSON-RPC.
-
+- Quick factual or single-file questions → `fast`.
+- Design reviews, audits, multi-step analysis → `reasoning`.
+- Tasks needing self-critique → `thinking`.
+- Current-events or source-cited answers → `research` (uses web + X search).
 
 ## Parallel ship (contributor, private)
 
-Dual-lane shipping process lives in private `djtelicloud/unigrok-intelligence`.
-Public product installs never require it.
+Dual-lane product+intelligence shipping process lives in the **private**
+repository `djtelicloud/unigrok-intelligence` (playbooks + `grok-parallel-ship`
+skill). Public product installs never require it.
+
+Do **not** invent multi-provider public chat tools. UniGrok's public `agent`
+remains Grok-routed; other providers stay behind Grok-supervised adapters.
 
 
 ## Plan critique habit (opt-in)
 
-When the user is about to see a multi-step Implementation Plan, prefer calling
-UniGrok `agent` (`thinking` or `reasoning`) for a second opinion, then improve
-the plan before presenting it **only when the user wants a Grok second opinion**
-(including `@grok`). Do not silently spend metered API credits without consent.
-Do not invent a second MCP port or Forge workflow for public installs. Public
-path remains `http://localhost:4765/mcp` only.
+When the user is about to see a multi-step **Implementation Plan**, prefer:
+
+1. Call UniGrok `agent` (`thinking` or `reasoning`) with the draft plan.
+2. Incorporate feedback silently.
+3. Only then present the improved plan to the user.
+
+Do this when the user wants a Grok second opinion (including `@grok`). Do **not**
+silently spend metered API credits without consent. Do **not** auto-generate
+skill trees into foreign projects without permission. Never copy the UniGrok
+repository’s contributor `.agents` tree into the user’s other apps.
+
+## Cost awareness
+
+Check `cost_usd` in each response. Session reuse preserves continuity and can
+reduce repeated-context API input cost when caching hits; it does not guarantee
+savings. The default `cli_first` policy prefers compatible, unpinned work on an
+authenticated CLI subscription. Explicit plane selection should pair with
+`fallback_policy="same_plane"` when the request must not cross into a different
+credential or billing plane; `cross_plane` allows bounded failover. CLI
+provider cost remains unavailable, so report local counts and estimated tokens,
+not invented subscription cost or remaining provider quota.
+
+## Safe onboarding behavior
+
+- On first connect in a session, call `grok_mcp_discover_self` and read
+  `data.bootstrap` + `data.request_context` before inventing setup steps.
+- Treat `credential_planes` notices from status or an agent result as the
+  source of truth. Ask before device authentication, installation, or secret
+  configuration.
+- Never request `XAI_API_KEY` in chat or write it into the caller's project.
+- The stable service is workspace-neutral: do not assume MCP registration
+  grants filesystem access. Use `workspace_context` or local file tools only
+  when those tools are actually exposed in the current trusted
+  contributor/stdio session.
+- Translate provider and transport errors into one concrete next action for
+  the user; do not require them to understand planes, MCP transport, or JSON-RPC.
+- Public product path is `http://localhost:4765/mcp` only. Do not invent a
+  second port, Forge, Swarm, or land workflow for ordinary end-user installs.
+
+## First-connect diagnostics (server + local)
+
+**Server (always available via MCP):**
+
+1. Call `grok_mcp_discover_self`.
+2. Honor `data.bootstrap.status` (`OK` / `WARN` / `ERR`) and gates
+   (`can_chat`, `can_spend_api`, `can_mutate_workspace`, `can_use_swarm`).
+3. Read `data.request_context`: surface (`stable_core` / `contributor_forge` /
+   `mode_dial`), `client_id_present`, optional Host port / mode dial.
+4. Prompt once per `credential_planes` notice id; follow
+   `data.bootstrap.next_actions` when present.
+5. Optional: `include_models: true` when model routing matters.
+
+**Local IDE audit (only with user permission; report only):**
+
+UniGrok cannot read global IDE settings over HTTP. With consent, use local tools
+to check and **report** (never rewrite without explicit permission; never print
+secret values):
+
+- User MCP configs point daily chat at `http://localhost:4765/mcp`.
+- Stable `X-Client-ID` per IDE (claude-code, vscode, codex, cursor, antigravity).
+- No `XAI_API_KEY` (or other secrets) embedded in MCP JSON.
+- Project `.mcp.json` (if any) is dual HTTP for UniGrok worktrees, never
+  broken `unigrok-stdio` with `${PLUGIN_ROOT}`.
+- Optional `using-unigrok` skill present; do not copy contributor `.agents`
+  trees into foreign apps.
+- Unique leverage: which planes are ready, whether Forge tools appear only when
+  intentionally connected to the contributor surface, mode dials if enabled.
+
+Then one cheap verification: `agent` with `mode=fast` or `grok_mcp_status`.
+
+## Endpoint
+
+The shared gateway runs at `http://localhost:4765/mcp` (Streamable HTTP).
+Health: `GET /healthz`. Optional local Core UI: `http://localhost:4765/ui/`
+(trusted machine-owner test/control surface with a provider-calling agent
+playground). `X-Client-ID` is a caller-controlled
+attribution and session label beneath a server-derived principal; it is not
+authentication. The default unauthenticated loopback service derives the shared
+`http:anon` principal for one local budget/security trust domain, so there is
+no cross-user isolation without configured auth. Project-qualify every session
+key: a generic key can collide across repositories when the same client label
+is reused.

--- a/.github/skills/using-unigrok/SKILL.md
+++ b/.github/skills/using-unigrok/SKILL.md
@@ -1,95 +1,137 @@
 ---
 name: using-unigrok
-description: VS Code Copilot guidance for querying xAI Grok through the shared UniGrok MCP gateway. Activate when the user says "@grok", asks to query Grok, requests a Grok second opinion/peer review, wants web/X grounded research, or needs cross-repo UniGrok setup help.
+description: How to query xAI Grok through the UniGrok MCP gateway. Activate when the user says "@grok", asks to query Grok, wants a second-model opinion or peer review from Grok, or needs web/X search grounding.
 ---
 
-# Using UniGrok from VS Code Copilot
+# Using the UniGrok Grok Gateway
 
-This is the Copilot/VS Code adaptation of the canonical gateway skill at
-`skills/using-unigrok/SKILL.md`. Use it when working in this repository and
-also when helping users in other repositories that connect to the same local
-UniGrok MCP service.
+UniGrok exposes one headline MCP tool: `agent`. It self-routes across Grok
+models and two billing planes, and returns structured metadata with every
+answer. **Primary chat path for every project is IDE → UniGrok MCP**. The local
+browser UI is an optional trusted-loopback test/control surface whose agent
+playground can invoke providers and spend metered credits.
 
-## Tool resolution
+## The `agent` tool
 
-The core tool is `agent`, but the namespaced tool name depends on MCP server
-registration:
+Call `agent` with:
 
-- `mcp__unigrok__agent` when the server name is `unigrok` (common workspace
-  config).
-- `mcp__grok__agent` when user scope registers the same endpoint as `grok`.
+- `prompt` (required): the task or question, with enough context to act on.
+- `mode` (optional): `auto` (default), `fast` (single-turn, cheapest),
+  `reasoning` (multi-step planner), `thinking` (reflected agent loop), or
+  `research` (citation-grounded fanout).
+- `model` (optional): pin a Grok model id such as `grok-4.5`; leave unset to
+  let routing choose.
+- `session` (optional): a stable, project-qualified key such as
+  `owner-repo:task` for multi-turn continuity. Do not reuse a generic session
+  key across repositories.
+- `workspace_context` (optional): deliberately selected excerpts, diffs, or
+  errors when the task depends on the caller's project. The stable service
+  cannot browse the IDE workspace automatically.
+- `workspace_label` (optional): descriptive metadata for the supplied context.
+  It does not isolate sessions; the project-qualified `session` key does.
 
-Use whichever namespace exists in the active tool list.
+Every result includes `response` plus metadata: `model`, `route`, `plane`
+(`API` or `CLI`), `cost_usd`, `tokens`, `latency_sec`, and `citations` when
+search grounding was used.
 
-## Calling pattern
+## Mode selection guidance
 
-- `prompt` (required): the exact task/question.
-- `mode` (optional): `auto`, `fast`, `reasoning`, `thinking`, `research`.
-- `session` (optional): stable per-task session key (reuse for follow-ups).
-- `workspace_context` (optional): selected code snippets, diffs, logs, or
-  errors from the caller's repo.
-- `workspace_label` (optional): human-readable repo/project name.
-- `model` (optional): pin only when asked.
-- `plane` and `fallback_policy` (optional): use
-  `fallback_policy="same_plane"` when the request must not cross billing
-  planes.
-
-The stable service is workspace-neutral and cannot browse the caller's files
-automatically; attach only deliberate context via `workspace_context`.
-
-## Response handling
-
-Surface both `response` and key metadata when relevant:
-
-- `model`, `route`, `plane`, `why`, `degraded`
-- `cost_usd`, `tokens`, `latency_sec`
-- `citations` (when research grounding is used)
-
-If users are cost-sensitive, explicitly report `cost_usd` and encourage session
-reuse for follow-up questions.
-
-## VS Code team distribution
-
-- **Workspace-shared skill (git-backed):**
-  `.github/skills/using-unigrok/SKILL.md`
-- **Personal user-level skill (not in git):**
-  `~/.copilot/skills/using-unigrok/SKILL.md`
-
-Use the workspace path for team defaults. Use the personal path for individual
-defaults across unrelated repositories.
-
-Do not duplicate this skill under a repository-root `.copilot/skills`
-directory; that is not a default project discovery path. VS Code can opt into
-additional paths through `chat.agentSkillsLocations` when a deliberate
-nonstandard location is required.
-
-## MCP endpoint and identity
-
-Default endpoint: `http://localhost:4765/mcp`
-
-Every IDE config should send a stable `X-Client-ID` (for example `vscode`) so
-session namespaces and telemetry remain separated by client.
-
-## Safety and credential boundary
-
-- Never ask users to paste `XAI_API_KEY` into IDE MCP config; credentials live
-  server-side.
-- Treat `credential_planes` status in tool output as source of truth.
-- On failures, return one concrete next action (for example check `/healthz`,
-  authenticate CLI plane, or verify MCP registration).
-
+- Quick factual or single-file questions → `fast`.
+- Design reviews, audits, multi-step analysis → `reasoning`.
+- Tasks needing self-critique → `thinking`.
+- Current-events or source-cited answers → `research` (uses web + X search).
 
 ## Parallel ship (contributor, private)
 
-Dual-lane shipping process lives in private `djtelicloud/unigrok-intelligence`.
-Public product installs never require it.
+Dual-lane product+intelligence shipping process lives in the **private**
+repository `djtelicloud/unigrok-intelligence` (playbooks + `grok-parallel-ship`
+skill). Public product installs never require it.
+
+Do **not** invent multi-provider public chat tools. UniGrok's public `agent`
+remains Grok-routed; other providers stay behind Grok-supervised adapters.
 
 
 ## Plan critique habit (opt-in)
 
-When the user is about to see a multi-step Implementation Plan, prefer calling
-UniGrok `agent` (`thinking` or `reasoning`) for a second opinion, then improve
-the plan before presenting it **only when the user wants a Grok second opinion**
-(including `@grok`). Do not silently spend metered API credits without consent.
-Do not invent a second MCP port or Forge workflow for public installs. Public
-path remains `http://localhost:4765/mcp` only.
+When the user is about to see a multi-step **Implementation Plan**, prefer:
+
+1. Call UniGrok `agent` (`thinking` or `reasoning`) with the draft plan.
+2. Incorporate feedback silently.
+3. Only then present the improved plan to the user.
+
+Do this when the user wants a Grok second opinion (including `@grok`). Do **not**
+silently spend metered API credits without consent. Do **not** auto-generate
+skill trees into foreign projects without permission. Never copy the UniGrok
+repository’s contributor `.agents` tree into the user’s other apps.
+
+## Cost awareness
+
+Check `cost_usd` in each response. Session reuse preserves continuity and can
+reduce repeated-context API input cost when caching hits; it does not guarantee
+savings. The default `cli_first` policy prefers compatible, unpinned work on an
+authenticated CLI subscription. Explicit plane selection should pair with
+`fallback_policy="same_plane"` when the request must not cross into a different
+credential or billing plane; `cross_plane` allows bounded failover. CLI
+provider cost remains unavailable, so report local counts and estimated tokens,
+not invented subscription cost or remaining provider quota.
+
+## Safe onboarding behavior
+
+- On first connect in a session, call `grok_mcp_discover_self` and read
+  `data.bootstrap` + `data.request_context` before inventing setup steps.
+- Treat `credential_planes` notices from status or an agent result as the
+  source of truth. Ask before device authentication, installation, or secret
+  configuration.
+- Never request `XAI_API_KEY` in chat or write it into the caller's project.
+- The stable service is workspace-neutral: do not assume MCP registration
+  grants filesystem access. Use `workspace_context` or local file tools only
+  when those tools are actually exposed in the current trusted
+  contributor/stdio session.
+- Translate provider and transport errors into one concrete next action for
+  the user; do not require them to understand planes, MCP transport, or JSON-RPC.
+- Public product path is `http://localhost:4765/mcp` only. Do not invent a
+  second port, Forge, Swarm, or land workflow for ordinary end-user installs.
+
+## First-connect diagnostics (server + local)
+
+**Server (always available via MCP):**
+
+1. Call `grok_mcp_discover_self`.
+2. Honor `data.bootstrap.status` (`OK` / `WARN` / `ERR`) and gates
+   (`can_chat`, `can_spend_api`, `can_mutate_workspace`, `can_use_swarm`).
+3. Read `data.request_context`: surface (`stable_core` / `contributor_forge` /
+   `mode_dial`), `client_id_present`, optional Host port / mode dial.
+4. Prompt once per `credential_planes` notice id; follow
+   `data.bootstrap.next_actions` when present.
+5. Optional: `include_models: true` when model routing matters.
+
+**Local IDE audit (only with user permission; report only):**
+
+UniGrok cannot read global IDE settings over HTTP. With consent, use local tools
+to check and **report** (never rewrite without explicit permission; never print
+secret values):
+
+- User MCP configs point daily chat at `http://localhost:4765/mcp`.
+- Stable `X-Client-ID` per IDE (claude-code, vscode, codex, cursor, antigravity).
+- No `XAI_API_KEY` (or other secrets) embedded in MCP JSON.
+- Project `.mcp.json` (if any) is dual HTTP for UniGrok worktrees, never
+  broken `unigrok-stdio` with `${PLUGIN_ROOT}`.
+- Optional `using-unigrok` skill present; do not copy contributor `.agents`
+  trees into foreign apps.
+- Unique leverage: which planes are ready, whether Forge tools appear only when
+  intentionally connected to the contributor surface, mode dials if enabled.
+
+Then one cheap verification: `agent` with `mode=fast` or `grok_mcp_status`.
+
+## Endpoint
+
+The shared gateway runs at `http://localhost:4765/mcp` (Streamable HTTP).
+Health: `GET /healthz`. Optional local Core UI: `http://localhost:4765/ui/`
+(trusted machine-owner test/control surface with a provider-calling agent
+playground). `X-Client-ID` is a caller-controlled
+attribution and session label beneath a server-derived principal; it is not
+authentication. The default unauthenticated loopback service derives the shared
+`http:anon` principal for one local budget/security trust domain, so there is
+no cross-user isolation without configured auth. Project-qualify every session
+key: a generic key can collide across repositories when the same client label
+is reused.

--- a/.github/skills/using-unigrok/SKILL.md
+++ b/.github/skills/using-unigrok/SKILL.md
@@ -1,98 +1,79 @@
 ---
 name: using-unigrok
-description: How to query xAI Grok through the UniGrok MCP gateway. Activate when the user says "@grok", asks to query Grok, wants a second-model opinion or peer review from Grok, or needs web/X search grounding.
+description: VS Code Copilot guidance for querying xAI Grok through the shared UniGrok MCP gateway. Activate when the user says "@grok", asks to query Grok, requests a Grok second opinion/peer review, wants web/X grounded research, or needs cross-repo UniGrok setup help.
 ---
 
-# Using the UniGrok Grok Gateway
+# Using UniGrok from VS Code Copilot
 
-UniGrok exposes one headline MCP tool: `agent`. It self-routes across Grok
-models and two billing planes, and returns structured metadata with every
-answer. **Primary chat path for every project is IDE → UniGrok MCP**. The local
-browser UI is an optional trusted-loopback test/control surface whose agent
-playground can invoke providers and spend metered credits.
+This is the Copilot/VS Code adaptation of the canonical gateway skill at
+`skills/using-unigrok/SKILL.md`. Use it when working in this repository and
+also when helping users in other repositories that connect to the same local
+UniGrok MCP service.
 
-## The `agent` tool
+## Tool resolution
 
-Call `agent` with:
+The core tool is `agent`, but the namespaced tool name depends on MCP server
+registration:
 
-- `prompt` (required): the task or question, with enough context to act on.
-- `mode` (optional): `auto` (default), `fast` (single-turn, cheapest),
-  `reasoning` (multi-step planner), `thinking` (reflected agent loop), or
-  `research` (citation-grounded fanout).
-- `model` (optional): pin a Grok model id such as `grok-4.5`; leave unset to
-  let routing choose.
-- `session` (optional): a stable, project-qualified key such as
-  `owner-repo:task` for multi-turn continuity. Do not reuse a generic session
-  key across repositories.
-- `workspace_context` (optional): deliberately selected excerpts, diffs, or
-  errors when the task depends on the caller's project. The stable service
-  cannot browse the IDE workspace automatically.
-- `workspace_label` (optional): descriptive metadata for the supplied context.
-  It does not isolate sessions; the project-qualified `session` key does.
+- `mcp__unigrok__agent` when the server name is `unigrok` (common workspace
+  config).
+- `mcp__grok__agent` when user scope registers the same endpoint as `grok`.
 
-Every result includes `response` plus metadata: `model`, `route`, `plane`
-(`API` or `CLI`), `cost_usd`, `tokens`, `latency_sec`, and `citations` when
-search grounding was used.
+Use whichever namespace exists in the active tool list.
 
-## Mode selection guidance
+## Calling pattern
 
-- Quick factual or single-file questions → `fast`.
-- Design reviews, audits, multi-step analysis → `reasoning`.
-- Tasks needing self-critique → `thinking`.
-- Current-events or source-cited answers → `research` (uses web + X search).
+- `prompt` (required): the exact task/question.
+- `mode` (optional): `auto`, `fast`, `reasoning`, `thinking`, `research`.
+- `session` (optional): stable per-task session key (reuse for follow-ups).
+- `workspace_context` (optional): selected code snippets, diffs, logs, or
+  errors from the caller's repo.
+- `workspace_label` (optional): human-readable repo/project name.
+- `model` (optional): pin only when asked.
+- `plane` and `fallback_policy` (optional): use
+  `fallback_policy="same_plane"` when the request must not cross billing
+  planes.
 
-## Parallel ship (contributor, private)
+The stable service is workspace-neutral and cannot browse the caller's files
+automatically; attach only deliberate context via `workspace_context`.
 
-Dual-lane product+intelligence shipping process lives in the **private**
-repository `djtelicloud/unigrok-intelligence` (playbooks + `grok-parallel-ship`
-skill). Public product installs never require it.
+## Response handling
 
-Do **not** invent multi-provider public chat tools. UniGrok's public `agent`
-remains Grok-routed; other providers stay behind Grok-supervised adapters.
+Surface both `response` and key metadata when relevant:
 
+- `model`, `route`, `plane`, `why`, `degraded`
+- `cost_usd`, `tokens`, `latency_sec`
+- `citations` (when research grounding is used)
 
-## Plan critique habit (opt-in)
+If users are cost-sensitive, explicitly report `cost_usd` and encourage session
+reuse for follow-up questions.
 
-When the user is about to see a multi-step **Implementation Plan**, prefer:
+## VS Code team distribution
 
-1. Call UniGrok `agent` (`thinking` or `reasoning`) with the draft plan.
-2. Incorporate feedback silently.
-3. Only then present the improved plan to the user.
+- **Workspace-shared skill (git-backed):**
+  `.github/skills/using-unigrok/SKILL.md`
+- **Personal user-level skill (not in git):**
+  `~/.copilot/skills/using-unigrok/SKILL.md`
 
-Do this when the user wants a Grok second opinion (including `@grok`). Do **not**
-silently spend metered API credits without consent. Do **not** auto-generate
-skill trees into foreign projects without permission. Never copy the UniGrok
-repository’s contributor `.agents` tree into the user’s other apps.
+Use the workspace path for team defaults. Use the personal path for individual
+defaults across unrelated repositories.
 
-## Cost awareness
+Do not duplicate this skill under a repository-root `.copilot/skills`
+directory; that is not a default project discovery path. VS Code can opt into
+additional paths through `chat.agentSkillsLocations` when a deliberate
+nonstandard location is required.
 
-Check `cost_usd` in each response. Session reuse preserves continuity and can
-reduce repeated-context API input cost when caching hits; it does not guarantee
-savings. The default `cli_first` policy prefers compatible, unpinned work on an
-authenticated CLI subscription. Explicit plane selection should pair with
-`fallback_policy="same_plane"` when the request must not cross into a different
-credential or billing plane; `cross_plane` allows bounded failover. CLI
-provider cost remains unavailable, so report local counts and estimated tokens,
-not invented subscription cost or remaining provider quota.
+## MCP endpoint and identity
 
-## Safe onboarding behavior
+Default endpoint: `http://localhost:4765/mcp`
 
-- On first connect in a session, call `grok_mcp_discover_self` and read
-  `data.bootstrap` + `data.request_context` before inventing setup steps.
-- Treat `credential_planes` notices from status or an agent result as the
-  source of truth. Ask before device authentication, installation, or secret
-  configuration.
-- Never request `XAI_API_KEY` in chat or write it into the caller's project.
-- The stable service is workspace-neutral: do not assume MCP registration
-  grants filesystem access. Use `workspace_context` or local file tools only
-  when those tools are actually exposed in the current trusted
-  contributor/stdio session.
-- Translate provider and transport errors into one concrete next action for
-  the user; do not require them to understand planes, MCP transport, or JSON-RPC.
-- Public product path is `http://localhost:4765/mcp` only. Do not invent a
-  second port, Forge, Swarm, or land workflow for ordinary end-user installs.
+Every IDE config should send a stable `X-Client-ID` (for example `vscode`) so
+session namespaces and telemetry remain separated by client.
 
 ## First-connect diagnostics (server + local)
+
+On first connect in a session, call `grok_mcp_discover_self` and read
+`data.bootstrap` + `data.request_context` before inventing setup steps.
 
 **Server (always available via MCP):**
 
@@ -112,26 +93,35 @@ to check and **report** (never rewrite without explicit permission; never print
 secret values):
 
 - User MCP configs point daily chat at `http://localhost:4765/mcp`.
-- Stable `X-Client-ID` per IDE (claude-code, vscode, codex, cursor, antigravity).
+- Stable `X-Client-ID` per IDE (for VS Code: `vscode`).
 - No `XAI_API_KEY` (or other secrets) embedded in MCP JSON.
 - Project `.mcp.json` (if any) is dual HTTP for UniGrok worktrees, never
   broken `unigrok-stdio` with `${PLUGIN_ROOT}`.
 - Optional `using-unigrok` skill present; do not copy contributor `.agents`
   trees into foreign apps.
-- Unique leverage: which planes are ready, whether Forge tools appear only when
-  intentionally connected to the contributor surface, mode dials if enabled.
 
 Then one cheap verification: `agent` with `mode=fast` or `grok_mcp_status`.
 
-## Endpoint
+## Safety and credential boundary
 
-The shared gateway runs at `http://localhost:4765/mcp` (Streamable HTTP).
-Health: `GET /healthz`. Optional local Core UI: `http://localhost:4765/ui/`
-(trusted machine-owner test/control surface with a provider-calling agent
-playground). `X-Client-ID` is a caller-controlled
-attribution and session label beneath a server-derived principal; it is not
-authentication. The default unauthenticated loopback service derives the shared
-`http:anon` principal for one local budget/security trust domain, so there is
-no cross-user isolation without configured auth. Project-qualify every session
-key: a generic key can collide across repositories when the same client label
-is reused.
+- Never ask users to paste `XAI_API_KEY` into IDE MCP config; credentials live
+  server-side.
+- Treat `credential_planes` status in tool output as source of truth.
+- On failures, return one concrete next action (for example check `/healthz`,
+  authenticate CLI plane, or verify MCP registration).
+
+
+## Parallel ship (contributor, private)
+
+Dual-lane shipping process lives in private `djtelicloud/unigrok-intelligence`.
+Public product installs never require it.
+
+
+## Plan critique habit (opt-in)
+
+When the user is about to see a multi-step Implementation Plan, prefer calling
+UniGrok `agent` (`thinking` or `reasoning`) for a second opinion, then improve
+the plan before presenting it **only when the user wants a Grok second opinion**
+(including `@grok`). Do not silently spend metered API credits without consent.
+Do not invent a second MCP port or Forge workflow for public installs. Public
+path remains `http://localhost:4765/mcp` only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,3 +137,15 @@ new chat does not resume obsolete steps.
 ## Public vs private intelligence
 
 Process IP and harvest live in private `djtelicloud/unigrok-intelligence`. See [docs/design/public-private-git-split.md](docs/design/public-private-git-split.md).
+
+## Cursor Cloud specific instructions
+
+**Repo identity:** the GitHub repository is `djtelicloud/grok-mcp-server`. Product brand is UniGrok; Python package name is `mcp-grok`; CLI entrypoint is `unigrok-mcp`. The string `uni-grok-mcp` appears in agent docs/skills as an internal nickname only — do not treat it as the repo or package name.
+
+**Stable gateway (dev):** prefer `uv run python main.py --http` (binds `127.0.0.1:4765`). `docker compose up --build -d` is the documented shared-service path and is required for the baked Grok CLI binary / `grok-cli-auth` volume; pure HTTP-local cloud sessions do not need Docker for API-plane work.
+
+**Credential planes:** live `agent` inference needs `XAI_API_KEY` in the server `.env` and/or an authenticated CLI plane. Placeholder `your_xai_api_key_here` is treated as missing by the app (see `src/utils.py`), but `GET /readyz` only checks that the env var is non-empty — use `grok_mcp_status` / `grok_mcp_discover_self` (or a real `agent` call) as the usable-plane gate, not `/readyz` alone.
+
+**Commands:** dependency sync and tests/lint gates are in [CONTRIBUTING.md](CONTRIBUTING.md) / [README.md](README.md) (`uv sync`, `uv run pytest`, `uv run python -m compileall -q src evals main.py`). Ruff is available via the `dev` dependency group but is not the required land gate; the suite currently has many pre-existing ruff findings.
+
+**UI:** Control Center test bench at `http://localhost:4765/ui/`; core product path remains MCP at `http://localhost:4765/mcp`.

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -117,9 +117,14 @@ OAuth-protected remote clients obtain a scoped access token through the
 published RFC 9728 metadata; they do not reuse an xAI key or a local static
 gateway token.
 
-## Cursor (`.cursor/mcp.json` in project root, or `~/.cursor/mcp.json`)
+## Cursor (first-class host IDE)
 
-With Cursor joining the xAI family, it's the natural first-class Grok IDE.
+**Cursor is UniGrok’s preferred host IDE** (xAI family). SuperGrok CLI remains a
+**credential plane** (subscription auth for Grok models), not the long-term IDE
+product surface. Use Cursor (or any MCP client) as the place you type; use
+UniGrok as the shared Grok gateway with dual-plane cost truth.
+
+Put config in `~/.cursor/mcp.json` (user-global) or project `.cursor/mcp.json`:
 
 ```json
 {
@@ -136,6 +141,21 @@ With Cursor joining the xAI family, it's the natural first-class Grok IDE.
 
 Cursor auto-detects HTTP servers from the `url` field. After saving, enable
 the server under Settings → MCP; the `agent` tool appears in Composer/chat.
+
+### Cursor multi-model vs UniGrok planes
+
+Cursor may list **non-Grok** models for native chat (Claude, GPT, etc.). Those
+paths are **Cursor-native billing and routing** — they are not UniGrok planes
+and will not appear on Control Center → **Planes**.
+
+| Path | Who bills / routes | Where you see models |
+|------|--------------------|----------------------|
+| Cursor native multi-model | Cursor / that provider | Cursor model picker |
+| UniGrok MCP `agent` | UniGrok CLI sub and/or xAI API key | Control Center **Planes** + MCP |
+
+Use UniGrok when you want shared Grok across every IDE, server-side keys,
+CLI-first policy, exact API cost, and `@grok` peer review. Use Cursor’s own
+picker when you intentionally want a non-Grok host model.
 
 ## Claude Code (CLI)
 

--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -244,6 +244,36 @@ Test helper: clear the process-local cache after swapping fixture files.
 
 ## http_server.py {#http_server}
 
+### Function: `mode_dials_enabled` {#http_server-mode_dials_enabled}
+
+```python
+def mode_dials_enabled() -> bool
+```
+
+**Keywords:** mode, dials, enabled
+
+Public alias for whether phoneword mode-dial ports are enabled.
+
+### Function: `get_active_mode_dial` {#http_server-get_active_mode_dial}
+
+```python
+def get_active_mode_dial() -> Optional[tuple[int, str]]
+```
+
+**Keywords:** get, active, mode, dial
+
+Return the phoneword mode dial bound for this HTTP request, if any.
+
+### Function: `get_active_host_port` {#http_server-get_active_host_port}
+
+```python
+def get_active_host_port() -> Optional[int]
+```
+
+**Keywords:** get, active, host, port
+
+Return the Host header port for this HTTP request, when parseable.
+
 ### Class: `ModeDialContextMiddleware` {#http_server-modedialcontextmiddleware}
 
 ```python
@@ -538,6 +568,26 @@ def set_active_principal(principal: Optional[str])
 **Keywords:** set, active, principal
 
 Bind the authenticated security principal for the current request.
+
+### Function: `get_active_client_id` {#identity-get_active_client_id}
+
+```python
+def get_active_client_id() -> Optional[str]
+```
+
+**Keywords:** get, active, client, id
+
+Return the untrusted X-Client-ID label bound for this request, if any.
+
+### Function: `principal_kind` {#identity-principal_kind}
+
+```python
+def principal_kind(principal: Optional[str]=None) -> str
+```
+
+**Keywords:** principal, kind
+
+Classify the security principal without exposing raw identifiers.
 
 ### Function: `resolve_request_caller` {#identity-resolve_request_caller}
 

--- a/docs/okf/faq.md
+++ b/docs/okf/faq.md
@@ -172,10 +172,22 @@ composer model for coding.
 
 **Keywords:** credentials, missing api key, cli auth, install cli, permission
 
-On first connection, inspect `grok_mcp_discover_self.data.credential_planes`.
-Each notice has a stable id, severity, whether it blocks model work, and a
-bounded action. Prompt the user once per notice id and repeat only after the
-reported state changes.
+On first connection, call `grok_mcp_discover_self` and inspect:
+
+1. `data.bootstrap` — `status` (`OK`/`WARN`/`ERR`), gates (`can_chat`,
+   `can_spend_api`, `can_mutate_workspace`, `can_use_swarm`), warnings, and
+   `first_connect_checklist`.
+2. `data.request_context` — whether `X-Client-ID` is present, process surface
+   (`stable_core` vs `contributor_forge` vs phoneword `mode_dial`), and Host
+   port when the HTTP transport supplied one.
+3. `data.credential_planes` — each notice has a stable id, severity, whether it
+   blocks model work, and a bounded action. Prompt the user once per notice id
+   and repeat only after the reported state changes.
+
+`caller_config_audit` is `not_available_on_service` on purpose: UniGrok does not
+read global IDE MCP files or the caller's project. With permission, the IDE
+agent may audit those locally and report only (never rewrite without consent;
+never print secret values).
 
 - CLI missing or unauthenticated: ask permission before installing/rebuilding
   the CLI or running its interactive device-auth command. Continue on API when

--- a/mcp_ui/app.js
+++ b/mcp_ui/app.js
@@ -237,11 +237,10 @@ const state = {
   credentialPlanes: null,
 };
 
+// Only static/fallback model lists — not operational unavailable/skipped sources.
 const FALLBACK_CATALOG_SOURCES = new Set([
   "cli-fallback",
   "xai_api_fallback",
-  "cloudrun-disabled",
-  "skipped",
 ]);
 
 // --- DOM Selector Helper ---
@@ -1305,7 +1304,14 @@ function updatePlaneControls() {
     hint.innerText = "Subscription first · cross-plane fallback may incur API charges";
     hint.classList.add("metered");
   }
-  syncModelOptions();
+  // Console plane pins filter from the dual-plane catalog. Startup only warms
+  // /v1/models (API). Load plane catalogs when the user changes plane before
+  // visiting Planes, so CLI pins are not API-only slugs with same_plane.
+  if (!state.modelCatalog && !state.modelCatalogLoading) {
+    loadPlaneModelCatalog(false);
+  } else {
+    syncModelOptions();
+  }
 }
 
 function readableCatalogSource(source) {

--- a/mcp_ui/app.js
+++ b/mcp_ui/app.js
@@ -1135,12 +1135,39 @@ function renderSurfaceModeBadge(data) {
   }
 }
 
+function credentialPlaneCatalogSignature(contract) {
+  const plane = (name) => {
+    const view = contract?.[name] || {};
+    return {
+      available: Boolean(view.available),
+      state: String(view.state || ""),
+      auth: String(view.auth || ""),
+      binary: Boolean(view.binary),
+    };
+  };
+  return JSON.stringify({
+    policy: String(contract?.policy || ""),
+    effectivePlane: String(contract?.effective_plane || ""),
+    serviceUsable: Boolean(contract?.service_usable),
+    degraded: Boolean(contract?.degraded),
+    api: plane("api"),
+    cli: plane("cli"),
+  });
+}
+
 async function fetchRuntimeStatus() {
   try {
     const res = await fetch("/runtimez");
     if (!res.ok) throw new Error();
     const data = await res.json();
     if (data.credential_planes) {
+      const priorSignature = credentialPlaneCatalogSignature(state.credentialPlanes);
+      const nextSignature = credentialPlaneCatalogSignature(data.credential_planes);
+      if (state.modelCatalog && priorSignature !== nextSignature) {
+        // Catalog availability/source is credential-dependent. Force the next
+        // Planes render to discover a fresh snapshot after Recheck changes it.
+        state.modelCatalog = null;
+      }
       state.credentialPlanes = data.credential_planes;
     }
     $("runtimeChip").innerText = `runtime: ${data.runtime || "unknown"}`;

--- a/mcp_ui/app.js
+++ b/mcp_ui/app.js
@@ -233,7 +233,16 @@ const state = {
   metricsPeriod: "today",
   metricsSnapshot: null,
   modelCatalog: null,
+  modelCatalogLoading: false,
+  credentialPlanes: null,
 };
+
+const FALLBACK_CATALOG_SOURCES = new Set([
+  "cli-fallback",
+  "xai_api_fallback",
+  "cloudrun-disabled",
+  "skipped",
+]);
 
 // --- DOM Selector Helper ---
 const $ = (id) => document.getElementById(id);
@@ -324,7 +333,8 @@ function switchTab(tabId) {
       loadWebMcpManifest();
       checkWebMcpBridge();
     } else if (tabId === "tab-models") {
-      loadPlaneModelCatalog();
+      // Lazy-load expensive dual-plane discovery only when Planes is opened.
+      loadPlaneModelCatalog(false);
     } else if (tabId === "tab-metrics") {
       fetchLiveMetrics();
     }
@@ -949,11 +959,13 @@ function resolveMcpEndpoint() {
 }
 
 function genericMcpJson(endpoint) {
+  // Cursor is the first-class host IDE for UniGrok (xAI family). Other IDEs
+  // swap X-Client-ID (claude-code, vscode, codex, antigravity) the same way.
   return JSON.stringify({
     mcpServers: {
       unigrok: {
         url: endpoint,
-        headers: { "X-Client-ID": "ide" },
+        headers: { "X-Client-ID": "cursor" },
       },
     },
   }, null, 2);
@@ -963,9 +975,10 @@ function agentSetupPrompt(endpoint) {
   return [
     "Configure UniGrok MCP for this machine:",
     `- Streamable HTTP URL: ${endpoint}`,
-    "- Send a stable X-Client-ID header for this IDE (e.g. cursor, claude-code, vscode, codex)",
+    "- Preferred host IDE: Cursor (X-Client-ID: cursor). Also supported: claude-code, vscode, codex, antigravity",
     "- Never put XAI_API_KEY in IDE MCP settings; credentials stay in UniGrok's server .env",
-    "- After connecting, call tools/list and grok_mcp_discover_self",
+    "- Cursor may offer non-Grok models natively; UniGrok MCP is for shared Grok planes, cost truth, and @grok",
+    "- After connecting, call tools/list and grok_mcp_discover_self (read data.bootstrap when present)",
     "- Prefer the UniGrok agent tool when I say @grok or want a second opinion",
     "- When I ask for a multi-step Implementation Plan, get a UniGrok second opinion",
     "  (agent mode thinking or reasoning) and improve the plan before showing it —",
@@ -1128,6 +1141,9 @@ async function fetchRuntimeStatus() {
     const res = await fetch("/runtimez");
     if (!res.ok) throw new Error();
     const data = await res.json();
+    if (data.credential_planes) {
+      state.credentialPlanes = data.credential_planes;
+    }
     $("runtimeChip").innerText = `runtime: ${data.runtime || "unknown"}`;
     $("transportChip").innerText = `transport: ${data.transport || "unknown"}`;
     renderSurfaceModeBadge(data);
@@ -1295,36 +1311,130 @@ function updatePlaneControls() {
 function readableCatalogSource(source) {
   const labels = {
     grok_cli: "Live Grok CLI",
-    "cli-fallback": "Fallback list",
+    "cli-fallback": "Fallback list (not live)",
     "cloudrun-disabled": "Unavailable in Cloud Run",
     xai_api: "Live xAI API",
-    xai_api_fallback: "Fallback list",
+    xai_api_fallback: "Fallback list (not live)",
     skipped: "Not queried",
   };
   return labels[source] || String(source || "Unknown").replaceAll("_", " ");
 }
 
-function renderPlaneModels(planeName, plane, sharedIds) {
+function isFallbackCatalogSource(source) {
+  const key = String(source || "");
+  return FALLBACK_CATALOG_SOURCES.has(key) || key.includes("fallback");
+}
+
+function planePinSnippet(planeName, modelId) {
+  const plane = planeName === "CLI" ? "cli" : "api";
+  return [
+    `model=${modelId}`,
+    `plane=${plane}`,
+    "fallback_policy=same_plane",
+    `# UniGrok agent pin — ${planeName} credential plane only`,
+  ].join("\n");
+}
+
+function clearPlaneModelLists(message) {
+  for (const prefix of ["cli", "api"]) {
+    const list = $(`${prefix}ModelList`);
+    if (!list) continue;
+    list.replaceChildren();
+    const empty = document.createElement("span");
+    empty.className = "empty-cell";
+    empty.innerText = message;
+    list.appendChild(empty);
+  }
+}
+
+function renderPlaneRepair(prefix, planeKey, contract) {
+  const host = $(`${prefix}PlaneRepair`);
+  if (!host) return;
+  host.replaceChildren();
+  host.classList.add("hidden");
+  if (!contract) return;
+
+  const plane = planeKey === "CLI" ? contract.cli : contract.api;
+  const notices = (contract.notices || []).filter(
+    (notice) => notice && String(notice.plane || "").toUpperCase() === planeKey,
+  );
+  const notice = notices.find((item) => item.prompt_user) || notices[0];
+  const action = (plane && plane.action) || (notice && notice.action) || null;
+  const needsRepair = plane && plane.available === false;
+  if (!needsRepair && !notice) return;
+
+  host.classList.remove("hidden");
+  const title = document.createElement("strong");
+  title.innerText = notice?.blocking
+    ? `${planeKey} plane blocked`
+    : `${planeKey} plane needs attention`;
+  const message = document.createElement("p");
+  message.innerText = notice?.message
+    || (planeKey === "CLI"
+      ? "CLI subscription plane is not ready. Device-login on the gateway host, then refresh."
+      : "API plane is not ready. Configure XAI_API_KEY in the UniGrok server .env (never in IDE MCP JSON).");
+  host.append(title, message);
+
+  const command = typeof action?.command === "string" ? action.command : "";
+  if (command) {
+    const pre = document.createElement("pre");
+    pre.className = "plane-repair-command";
+    pre.textContent = command;
+    const copyBtn = document.createElement("button");
+    copyBtn.type = "button";
+    copyBtn.className = "small-btn-glow";
+    copyBtn.innerText = "Copy repair command";
+    copyBtn.addEventListener("click", () => copyTextToClipboard(command, copyBtn));
+    host.append(pre, copyBtn);
+  }
+}
+
+function renderCatalogTrustBanner(prefix, plane) {
+  const banner = $(`${prefix}CatalogTrust`);
+  if (!banner) return;
+  const source = plane?.source;
+  if (isFallbackCatalogSource(source) || (plane?.credential_available && !plane?.catalog_available)) {
+    banner.classList.remove("hidden");
+    banner.innerText = "Not live — static fallback catalog. Do not treat pins as verified on this plane until source is Live.";
+    return;
+  }
+  banner.classList.add("hidden");
+  banner.innerText = "";
+}
+
+function renderPlaneModels(planeName, plane, sharedIds, contract) {
   const prefix = planeName === "CLI" ? "cli" : "api";
   const stateChip = $(`${prefix}ModelPlaneState`);
   const source = $(`${prefix}ModelSource`);
   const economics = $(`${prefix}ModelEconomics`);
   const list = $(`${prefix}ModelList`);
   const models = Array.isArray(plane?.models) ? plane.models : [];
+  const fallback = isFallbackCatalogSource(plane?.source)
+    || (plane?.credential_available && !plane?.catalog_available);
 
   const planeState = plane?.available
     ? "Ready"
-    : plane?.credential_available && !plane?.catalog_available
+    : fallback
       ? "Catalog fallback"
       : String(plane?.credential_state || "Unavailable").replaceAll("_", " ");
-  stateChip.innerText = planeState;
-  stateChip.className = `state-chip ${plane?.available ? "ready" : ""}`;
-  source.innerText = readableCatalogSource(plane?.source);
-  economics.innerText = plane?.economics || "Usage terms unavailable.";
-  if (prefix === "cli") {
+  if (stateChip) {
+    stateChip.innerText = planeState;
+    stateChip.className = `state-chip ${plane?.available ? "ready" : ""} ${fallback ? "fallback" : ""}`;
+  }
+  if (source) source.innerText = readableCatalogSource(plane?.source);
+  if (economics) economics.innerText = plane?.economics || "Usage terms unavailable.";
+  if (prefix === "cli" && $("cliDefaultModel")) {
     $("cliDefaultModel").innerText = plane?.default_model || "Not reported";
   }
+  if (prefix === "api" && $("apiDefaultModel")) {
+    $("apiDefaultModel").innerText = plane?.default_model
+      || "No single default — agent auto-routes (planning/coding aliases)";
+  }
 
+  renderCatalogTrustBanner(prefix, plane);
+  renderPlaneRepair(prefix, planeName, contract);
+
+  if (!list) return;
   list.replaceChildren();
   if (!models.length) {
     const empty = document.createElement("span");
@@ -1337,7 +1447,7 @@ function renderPlaneModels(planeName, plane, sharedIds) {
   for (const model of models) {
     const id = String(model?.id || "unknown");
     const card = document.createElement("article");
-    card.className = "provider-model-card";
+    card.className = `provider-model-card${fallback ? " fallback-catalog" : ""}`;
 
     const identity = document.createElement("div");
     const name = document.createElement("strong");
@@ -1350,6 +1460,13 @@ function renderPlaneModels(planeName, plane, sharedIds) {
     planeBadge.className = `model-badge ${prefix}`;
     planeBadge.innerText = planeName === "CLI" ? "CLI subscription" : "API metered";
     badges.appendChild(planeBadge);
+
+    if (fallback) {
+      const fallbackBadge = document.createElement("span");
+      fallbackBadge.className = "model-badge fallback";
+      fallbackBadge.innerText = "Fallback";
+      badges.appendChild(fallbackBadge);
+    }
 
     if (model?.default || id === plane?.default_model) {
       const defaultBadge = document.createElement("span");
@@ -1375,66 +1492,113 @@ function renderPlaneModels(planeName, plane, sharedIds) {
     copyButton.type = "button";
     copyButton.className = "small-btn model-copy-btn";
     copyButton.innerText = "Copy pin";
-    copyButton.setAttribute("aria-label", `Copy ${id} model pin`);
-    copyButton.addEventListener("click", () => copyTextToClipboard(id, copyButton));
+    copyButton.setAttribute("aria-label", `Copy ${planeName} plane pin for ${id}`);
+    copyButton.title = "Copies plane-qualified pin (model + plane + same_plane)";
+    const pin = planePinSnippet(planeName, id);
+    copyButton.addEventListener("click", () => copyTextToClipboard(pin, copyButton));
 
     card.append(identity, copyButton);
     list.appendChild(card);
   }
 }
 
-function renderPlaneModelCatalog(catalog) {
+function renderPlaneModelCatalog(catalog, contract = null) {
   const routing = catalog?.routing || {};
   const planes = catalog?.planes || {};
   const sharedIds = new Set(catalog?.shared_model_ids || []);
+  const planesContract = contract || state.credentialPlanes;
   state.modelCatalog = catalog;
+  if (contract) state.credentialPlanes = contract;
   syncModelOptions();
 
-  $("modelsRoutingPolicy").innerText = String(routing.policy || "unknown").replaceAll("_", " ");
-  $("modelsPreferredPlane").innerText = `Preferred: ${routing.preferred_plane || "none"}`;
-  $("modelsEffectivePlane").innerText = `Effective now: ${routing.effective_plane || "none"}`;
-  $("modelsRoutingRule").innerText = routing.rule || "Model and credential-plane selection are separate routing decisions.";
+  if ($("modelsRoutingPolicy")) {
+    $("modelsRoutingPolicy").innerText = String(routing.policy || "unknown").replaceAll("_", " ");
+  }
+  if ($("modelsPreferredPlane")) {
+    $("modelsPreferredPlane").innerText = `Preferred: ${routing.preferred_plane || "none"}`;
+  }
+  if ($("modelsEffectivePlane")) {
+    $("modelsEffectivePlane").innerText = `Effective now: ${routing.effective_plane || "none"}`;
+  }
+  if ($("modelsRoutingRule")) {
+    $("modelsRoutingRule").innerText = routing.rule
+      || "Model and credential-plane selection are separate routing decisions. Host IDEs (Cursor, etc.) may list non-Grok models natively — those are outside UniGrok.";
+  }
 
-  renderPlaneModels("CLI", planes.CLI || {}, sharedIds);
-  renderPlaneModels("API", planes.API || {}, sharedIds);
+  renderPlaneModels("CLI", planes.CLI || {}, sharedIds, planesContract);
+  renderPlaneModels("API", planes.API || {}, sharedIds, planesContract);
 
   const total = (planes.CLI?.models?.length || 0) + (planes.API?.models?.length || 0);
   const generated = catalog?.generated_at ? new Date(catalog.generated_at).toLocaleString() : "just now";
-  $("modelsStatus").innerText = `${total} plane-specific model entr${total === 1 ? "y" : "ies"} • refreshed ${generated}`;
+  if ($("modelsStatus")) {
+    $("modelsStatus").innerText = `${total} plane-specific model entr${total === 1 ? "y" : "ies"} • refreshed ${generated}`;
+  }
 
   const sharedNote = $("sharedModelsNote");
-  if (sharedIds.size) {
-    sharedNote.classList.remove("hidden");
-    sharedNote.innerText = `${[...sharedIds].join(", ")} ${sharedIds.size === 1 ? "exists" : "exist"} on both planes. These are shown twice intentionally because authentication, availability, and usage accounting differ.`;
-  } else {
-    sharedNote.classList.add("hidden");
-    sharedNote.innerText = "";
+  if (sharedNote) {
+    if (sharedIds.size) {
+      sharedNote.classList.remove("hidden");
+      sharedNote.innerText = `${[...sharedIds].join(", ")} ${sharedIds.size === 1 ? "exists" : "exist"} on both UniGrok planes. Shown twice intentionally — authentication, availability, and usage accounting differ. Copy pin is plane-qualified.`;
+    } else {
+      sharedNote.classList.add("hidden");
+      sharedNote.innerText = "";
+    }
   }
 
   const warningList = $("modelCatalogWarnings");
-  warningList.replaceChildren();
-  const warnings = Array.isArray(catalog?.warnings) ? catalog.warnings : [];
-  warningList.classList.toggle("hidden", warnings.length === 0);
-  for (const warning of warnings) {
-    const item = document.createElement("p");
-    item.innerText = warning;
-    warningList.appendChild(item);
+  if (warningList) {
+    warningList.replaceChildren();
+    const warnings = Array.isArray(catalog?.warnings) ? catalog.warnings : [];
+    warningList.classList.toggle("hidden", warnings.length === 0);
+    for (const warning of warnings) {
+      const item = document.createElement("p");
+      item.innerText = warning;
+      warningList.appendChild(item);
+    }
   }
 }
 
-async function loadPlaneModelCatalog() {
+async function loadPlaneModelCatalog(force = true) {
+  // Cache successful catalogs until the user forces refresh or opens Planes
+  // after a prior failure.
+  if (!force && state.modelCatalog && !state.modelCatalogLoading) {
+    renderPlaneModelCatalog(state.modelCatalog, state.credentialPlanes);
+    return;
+  }
+  if (state.modelCatalogLoading) return;
+
   const refreshButton = $("refreshModelsBtn");
   if (refreshButton) refreshButton.disabled = true;
-  $("modelsStatus").innerText = "Refreshing live CLI and API catalogs through MCP discovery…";
+  state.modelCatalogLoading = true;
+  if ($("modelsStatus")) {
+    $("modelsStatus").innerText = "Refreshing live CLI and API catalogs through MCP discovery…";
+  }
   try {
     const res = await fetchMcpCall("grok_mcp_discover_self", { include_models: true });
     const payload = extractToolPayload(res);
     const catalog = payload?.data?.model_catalog;
+    const contract = payload?.data?.credential_planes || state.credentialPlanes;
     if (!catalog) throw new Error("Discovery response did not include a model catalog.");
-    renderPlaneModelCatalog(catalog);
+    renderPlaneModelCatalog(catalog, contract);
   } catch (err) {
-    $("modelsStatus").innerText = `Model catalog unavailable: ${err.message}`;
+    if ($("modelsStatus")) {
+      $("modelsStatus").innerText = `Model catalog unavailable: ${err.message}`;
+    }
+    clearPlaneModelLists(`Failed to load catalog: ${err.message}`);
+    for (const prefix of ["cli", "api"]) {
+      const chip = $(`${prefix}ModelPlaneState`);
+      if (chip) {
+        chip.innerText = "Error";
+        chip.className = "state-chip";
+      }
+      const banner = $(`${prefix}CatalogTrust`);
+      if (banner) {
+        banner.classList.remove("hidden");
+        banner.innerText = "Catalog request failed. Fix MCP connectivity or credentials, then Refresh.";
+      }
+    }
   } finally {
+    state.modelCatalogLoading = false;
     if (refreshButton) refreshButton.disabled = false;
   }
 }
@@ -2362,7 +2526,7 @@ function init() {
   setupCredentialActions();
   setupMetricsControls();
 
-  $("refreshModelsBtn").addEventListener("click", loadPlaneModelCatalog);
+  $("refreshModelsBtn")?.addEventListener("click", () => loadPlaneModelCatalog(true));
 
   // Onboarding actions
   $("copyDiscoverBtn").addEventListener("click", runDiscoverSelfOnboarding);
@@ -2416,10 +2580,14 @@ function init() {
   setTimeout(async () => {
     const ready = await runStartupCheck();
     const runtime = await fetchRuntimeStatus();
+    if (runtime?.credential_planes) {
+      state.credentialPlanes = runtime.credential_planes;
+    }
     renderSetupStatus(runtime, ready, gatewayReadiness.detail);
     switchTab("tab-onboarding");
+    // Keep OpenAI-compat model list warm for any residual consumers; dual-plane
+    // Planes catalog is lazy-loaded only when the Planes tab opens.
     await loadModelsList();
-    await loadPlaneModelCatalog();
     await fetchMcpListTools();
     await fetchLiveMetrics();
     // WebMCP browser registration is optional/experimental; skip on Core glass.

--- a/mcp_ui/app.js
+++ b/mcp_ui/app.js
@@ -234,6 +234,7 @@ const state = {
   metricsSnapshot: null,
   modelCatalog: null,
   modelCatalogLoading: false,
+  modelCatalogGeneration: 0,
   credentialPlanes: null,
 };
 
@@ -1163,12 +1164,18 @@ async function fetchRuntimeStatus() {
     if (data.credential_planes) {
       const priorSignature = credentialPlaneCatalogSignature(state.credentialPlanes);
       const nextSignature = credentialPlaneCatalogSignature(data.credential_planes);
-      if (state.modelCatalog && priorSignature !== nextSignature) {
-        // Catalog availability/source is credential-dependent. Force the next
-        // Planes render to discover a fresh snapshot after Recheck changes it.
-        state.modelCatalog = null;
-      }
       state.credentialPlanes = data.credential_planes;
+      if (priorSignature !== nextSignature) {
+        // Catalog availability/source is credential-dependent. Invalidate any
+        // cached or in-flight snapshot and remove stale plane/model choices.
+        state.modelCatalog = null;
+        state.modelCatalogGeneration += 1;
+        clearPlaneModelLists("Credentials changed. Refreshing model catalog…");
+        clearModelOptions("auto route");
+        if (state.activeTab === "tab-models") {
+          void loadPlaneModelCatalog(true);
+        }
+      }
     }
     $("runtimeChip").innerText = `runtime: ${data.runtime || "unknown"}`;
     $("transportChip").innerText = `transport: ${data.transport || "unknown"}`;
@@ -1262,15 +1269,8 @@ async function loadModelsList() {
     if (!res.ok) throw new Error();
     const data = await res.json();
     state.models = data.data || [];
-
-    const select = $("modelInput");
-    select.innerHTML = '<option value="">auto (Recommended)</option>';
-    state.models.forEach((m) => {
-      const opt = document.createElement("option");
-      opt.value = m.id;
-      opt.innerText = m.id;
-      select.appendChild(opt);
-    });
+    // /v1/models is API-compatible and intentionally does not own the plane-
+    // aware selector. grok_mcp_discover_self is the only source for that UI.
   } catch (err) {
     console.error("Failed to load models list: ", err);
   }
@@ -1312,6 +1312,16 @@ function syncModelOptions() {
     if (group.children.length) select.appendChild(group);
   }
   select.value = seen.has(previous) ? previous : "";
+}
+
+function clearModelOptions(label = "auto route") {
+  const select = $("modelInput");
+  if (!select) return;
+  select.replaceChildren();
+  const automatic = document.createElement("option");
+  automatic.value = "";
+  automatic.innerText = label;
+  select.appendChild(automatic);
 }
 
 function updatePlaneControls() {
@@ -1600,6 +1610,8 @@ async function loadPlaneModelCatalog(force = true) {
   }
   if (state.modelCatalogLoading) return;
 
+  const generation = state.modelCatalogGeneration;
+
   const refreshButton = $("refreshModelsBtn");
   if (refreshButton) refreshButton.disabled = true;
   state.modelCatalogLoading = true;
@@ -1612,8 +1624,12 @@ async function loadPlaneModelCatalog(force = true) {
     const catalog = payload?.data?.model_catalog;
     const contract = payload?.data?.credential_planes || state.credentialPlanes;
     if (!catalog) throw new Error("Discovery response did not include a model catalog.");
+    if (generation !== state.modelCatalogGeneration) return;
     renderPlaneModelCatalog(catalog, contract);
   } catch (err) {
+    if (generation !== state.modelCatalogGeneration) return;
+    state.modelCatalog = null;
+    clearModelOptions("auto route");
     if ($("modelsStatus")) {
       $("modelsStatus").innerText = `Model catalog unavailable: ${err.message}`;
     }
@@ -1633,6 +1649,11 @@ async function loadPlaneModelCatalog(force = true) {
   } finally {
     state.modelCatalogLoading = false;
     if (refreshButton) refreshButton.disabled = false;
+    if (generation !== state.modelCatalogGeneration && !state.modelCatalog) {
+      // A credential recheck invalidated this in-flight response. Start one
+      // fresh request after releasing the single-flight guard.
+      void loadPlaneModelCatalog(false);
+    }
   }
 }
 

--- a/mcp_ui/index.html
+++ b/mcp_ui/index.html
@@ -202,12 +202,12 @@
             <div class="panel-header">
               <div>
                 <h2>Models &amp; Credential Planes</h2>
-                <p class="panel-desc">Live provider catalogs kept separate so a model name never hides how the request is authenticated or billed.</p>
+                <p class="panel-desc">UniGrok’s two <strong>Grok</strong> credential planes (subscription CLI vs metered API). Host IDEs such as <strong>Cursor</strong> may offer other models outside UniGrok — those stay on the IDE side; this tab only shows what UniGrok can pin and bill.</p>
               </div>
               <button id="refreshModelsBtn" type="button" class="small-btn-glow">Refresh catalogs</button>
             </div>
 
-            <div id="modelsStatus" class="metrics-status">Loading model catalogs through MCP discovery…</div>
+            <div id="modelsStatus" class="metrics-status">Open this tab or press Refresh to load live catalogs…</div>
 
             <section class="routing-policy-card" aria-label="Current plane routing policy">
               <div>
@@ -231,12 +231,14 @@
                   </div>
                   <span id="cliModelPlaneState" class="state-chip">Checking</span>
                 </div>
+                <p id="cliCatalogTrust" class="catalog-trust-banner hidden" role="status"></p>
                 <p id="cliModelEconomics" class="plane-economics">Subscription activity is tracked locally; provider quota and cost are not exposed.</p>
+                <div id="cliPlaneRepair" class="plane-repair hidden"></div>
                 <dl class="plane-facts">
                   <div><dt>Catalog</dt><dd id="cliModelSource">—</dd></div>
                   <div><dt>Default</dt><dd id="cliDefaultModel">—</dd></div>
                 </dl>
-                <div id="cliModelList" class="model-card-list"><span class="empty-cell">Loading CLI models…</span></div>
+                <div id="cliModelList" class="model-card-list"><span class="empty-cell">Catalog not loaded yet.</span></div>
               </section>
 
               <section id="apiModelPlane" class="model-plane-card api-plane">
@@ -247,17 +249,20 @@
                   </div>
                   <span id="apiModelPlaneState" class="state-chip">Checking</span>
                 </div>
+                <p id="apiCatalogTrust" class="catalog-trust-banner hidden" role="status"></p>
                 <p id="apiModelEconomics" class="plane-economics">Exact response cost is tracked locally when the provider returns it.</p>
+                <div id="apiPlaneRepair" class="plane-repair hidden"></div>
                 <dl class="plane-facts">
                   <div><dt>Catalog</dt><dd id="apiModelSource">—</dd></div>
+                  <div><dt>Default</dt><dd id="apiDefaultModel">Agent auto-routes</dd></div>
                   <div><dt>Billing</dt><dd>Per API usage</dd></div>
                 </dl>
-                <div id="apiModelList" class="model-card-list"><span class="empty-cell">Loading API models…</span></div>
+                <div id="apiModelList" class="model-card-list"><span class="empty-cell">Catalog not loaded yet.</span></div>
               </section>
             </div>
 
             <div id="sharedModelsNote" class="coverage-note hidden"></div>
-            <div class="coverage-note">Grok Build is the coding-agent product. <code>grok-build-0.1</code> is its exact metered API model slug; the current CLI catalog advertises different selectable model IDs.</div>
+            <div class="coverage-note">Grok Build is the coding-agent product. <code>grok-build-0.1</code> is its exact metered API model slug; the current CLI catalog advertises different selectable model IDs. Cursor (and other multi-model IDEs) may list non-Grok models for native chat — those are not UniGrok planes.</div>
             <div id="modelCatalogWarnings" class="model-warning-list hidden" aria-live="polite"></div>
           </div>
 
@@ -446,12 +451,13 @@ docker compose up --build -d</code></pre>
             <section class="connect-panel" aria-label="IDE connect snippets">
               <div class="panel-header compact">
                 <h3>Connect your IDE</h3>
-                <span class="panel-header-hint">Never put XAI_API_KEY in IDE MCP settings</span>
+                <span class="panel-header-hint">Cursor is first-class · Never put XAI_API_KEY in IDE MCP settings</span>
               </div>
               <p class="connect-endpoint">Endpoint <code id="mcpEndpointDisplay">http://localhost:4765/mcp</code></p>
+              <p class="connect-partner-note">Preferred host IDE: <strong>Cursor</strong> (xAI family). UniGrok still serves Claude Code, VS Code/Copilot, Codex, and Gemini the same way — one gateway, stable <code>X-Client-ID</code> per client. Non-Grok models inside Cursor stay Cursor-native; use UniGrok MCP for shared Grok planes, cost truth, and <code>@grok</code>.</p>
               <div class="connect-snippet-block">
                 <div class="connect-snippet-header">
-                  <span class="section-kicker">Generic MCP JSON</span>
+                  <span class="section-kicker">Cursor MCP JSON (first-class)</span>
                   <button id="copyMcpJsonBtn" type="button" class="small-btn-glow">Copy</button>
                 </div>
                 <pre class="connect-snippet" tabindex="0"><code id="mcpJsonSnippet">{ }</code></pre>

--- a/mcp_ui/styles.css
+++ b/mcp_ui/styles.css
@@ -1320,6 +1320,77 @@ pre {
 .model-plane-card.cli-plane { border-top: 3px solid var(--teal); }
 .model-plane-card.api-plane { border-top: 3px solid var(--orange); }
 
+.catalog-trust-banner {
+  margin-top: 10px;
+  border: 1px dashed rgba(255, 180, 60, 0.55);
+  border-radius: var(--radius-sm);
+  padding: 8px 10px;
+  background: rgba(255, 160, 40, 0.08);
+  color: var(--orange);
+  font-size: 11px;
+  line-height: 1.45;
+  font-weight: 600;
+}
+
+.plane-repair {
+  margin-top: 12px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.plane-repair strong {
+  display: block;
+  color: var(--orange);
+  font-size: 12px;
+}
+
+.plane-repair p {
+  margin: 6px 0 8px;
+  color: var(--ink-soft);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.plane-repair-command {
+  margin: 0 0 8px;
+  padding: 8px 10px;
+  border-radius: var(--radius-sm);
+  background: rgba(0, 0, 0, 0.35);
+  color: var(--cyan);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.state-chip.fallback {
+  border-color: rgba(255, 160, 40, 0.45);
+  color: var(--orange);
+}
+
+.provider-model-card.fallback-catalog {
+  border-style: dashed;
+  opacity: 0.92;
+}
+
+.model-badge.fallback {
+  border-color: rgba(255, 160, 40, 0.45);
+  color: var(--orange);
+}
+
+.connect-partner-note {
+  margin: 0 0 12px;
+  color: var(--ink-soft);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.connect-partner-note code {
+  font-size: 11px;
+}
+
 .model-plane-header {
   display: flex;
   align-items: flex-start;

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -244,6 +244,36 @@ Test helper: clear the process-local cache after swapping fixture files.
 
 ## http_server.py {#http_server}
 
+### Function: `mode_dials_enabled` {#http_server-mode_dials_enabled}
+
+```python
+def mode_dials_enabled() -> bool
+```
+
+**Keywords:** mode, dials, enabled
+
+Public alias for whether phoneword mode-dial ports are enabled.
+
+### Function: `get_active_mode_dial` {#http_server-get_active_mode_dial}
+
+```python
+def get_active_mode_dial() -> Optional[tuple[int, str]]
+```
+
+**Keywords:** get, active, mode, dial
+
+Return the phoneword mode dial bound for this HTTP request, if any.
+
+### Function: `get_active_host_port` {#http_server-get_active_host_port}
+
+```python
+def get_active_host_port() -> Optional[int]
+```
+
+**Keywords:** get, active, host, port
+
+Return the Host header port for this HTTP request, when parseable.
+
 ### Class: `ModeDialContextMiddleware` {#http_server-modedialcontextmiddleware}
 
 ```python
@@ -538,6 +568,26 @@ def set_active_principal(principal: Optional[str])
 **Keywords:** set, active, principal
 
 Bind the authenticated security principal for the current request.
+
+### Function: `get_active_client_id` {#identity-get_active_client_id}
+
+```python
+def get_active_client_id() -> Optional[str]
+```
+
+**Keywords:** get, active, client, id
+
+Return the untrusted X-Client-ID label bound for this request, if any.
+
+### Function: `principal_kind` {#identity-principal_kind}
+
+```python
+def principal_kind(principal: Optional[str]=None) -> str
+```
+
+**Keywords:** principal, kind
+
+Classify the security principal without exposing raw identifiers.
 
 ### Function: `resolve_request_caller` {#identity-resolve_request_caller}
 

--- a/sites/unigrok-control-center/public/docs/okf/faq.md
+++ b/sites/unigrok-control-center/public/docs/okf/faq.md
@@ -172,10 +172,22 @@ composer model for coding.
 
 **Keywords:** credentials, missing api key, cli auth, install cli, permission
 
-On first connection, inspect `grok_mcp_discover_self.data.credential_planes`.
-Each notice has a stable id, severity, whether it blocks model work, and a
-bounded action. Prompt the user once per notice id and repeat only after the
-reported state changes.
+On first connection, call `grok_mcp_discover_self` and inspect:
+
+1. `data.bootstrap` — `status` (`OK`/`WARN`/`ERR`), gates (`can_chat`,
+   `can_spend_api`, `can_mutate_workspace`, `can_use_swarm`), warnings, and
+   `first_connect_checklist`.
+2. `data.request_context` — whether `X-Client-ID` is present, process surface
+   (`stable_core` vs `contributor_forge` vs phoneword `mode_dial`), and Host
+   port when the HTTP transport supplied one.
+3. `data.credential_planes` — each notice has a stable id, severity, whether it
+   blocks model work, and a bounded action. Prompt the user once per notice id
+   and repeat only after the reported state changes.
+
+`caller_config_audit` is `not_available_on_service` on purpose: UniGrok does not
+read global IDE MCP files or the caller's project. With permission, the IDE
+agent may audit those locally and report only (never rewrite without consent;
+never print secret values).
 
 - CLI missing or unauthenticated: ask permission before installing/rebuilding
   the CLI or running its interactive device-auth command. Continue on API when

--- a/skills/using-unigrok/SKILL.md
+++ b/skills/using-unigrok/SKILL.md
@@ -77,6 +77,8 @@ not invented subscription cost or remaining provider quota.
 
 ## Safe onboarding behavior
 
+- On first connect in a session, call `grok_mcp_discover_self` and read
+  `data.bootstrap` + `data.request_context` before inventing setup steps.
 - Treat `credential_planes` notices from status or an agent result as the
   source of truth. Ask before device authentication, installation, or secret
   configuration.
@@ -89,6 +91,37 @@ not invented subscription cost or remaining provider quota.
   the user; do not require them to understand planes, MCP transport, or JSON-RPC.
 - Public product path is `http://localhost:4765/mcp` only. Do not invent a
   second port, Forge, Swarm, or land workflow for ordinary end-user installs.
+
+## First-connect diagnostics (server + local)
+
+**Server (always available via MCP):**
+
+1. Call `grok_mcp_discover_self`.
+2. Honor `data.bootstrap.status` (`OK` / `WARN` / `ERR`) and gates
+   (`can_chat`, `can_spend_api`, `can_mutate_workspace`, `can_use_swarm`).
+3. Read `data.request_context`: surface (`stable_core` / `contributor_forge` /
+   `mode_dial`), `client_id_present`, optional Host port / mode dial.
+4. Prompt once per `credential_planes` notice id; follow
+   `data.bootstrap.next_actions` when present.
+5. Optional: `include_models: true` when model routing matters.
+
+**Local IDE audit (only with user permission; report only):**
+
+UniGrok cannot read global IDE settings over HTTP. With consent, use local tools
+to check and **report** (never rewrite without explicit permission; never print
+secret values):
+
+- User MCP configs point daily chat at `http://localhost:4765/mcp`.
+- Stable `X-Client-ID` per IDE (claude-code, vscode, codex, cursor, antigravity).
+- No `XAI_API_KEY` (or other secrets) embedded in MCP JSON.
+- Project `.mcp.json` (if any) is dual HTTP for UniGrok worktrees, never
+  broken `unigrok-stdio` with `${PLUGIN_ROOT}`.
+- Optional `using-unigrok` skill present; do not copy contributor `.agents`
+  trees into foreign apps.
+- Unique leverage: which planes are ready, whether Forge tools appear only when
+  intentionally connected to the contributor surface, mode dials if enabled.
+
+Then one cheap verification: `agent` with `mode=fast` or `grok_mcp_status`.
 
 ## Endpoint
 

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -85,6 +85,9 @@ MODE_DIAL_PORTS: Dict[int, Literal["auto", "fast", "reasoning", "thinking", "res
 _ACTIVE_MODE_DIAL: contextvars.ContextVar[Optional[tuple[int, str]]] = contextvars.ContextVar(
     "unigrok_active_mode_dial", default=None
 )
+_ACTIVE_HOST_PORT: contextvars.ContextVar[Optional[int]] = contextvars.ContextVar(
+    "unigrok_active_host_port", default=None
+)
 
 
 def _json_error(message: str, status_code: int = 400, code: str = "invalid_request_error") -> JSONResponse:
@@ -372,6 +375,21 @@ def _mode_dials_enabled() -> bool:
     return os.environ.get("UNIGROK_MODE_DIALS", "").strip().lower() in ("1", "true", "yes")
 
 
+def mode_dials_enabled() -> bool:
+    """Public alias for whether phoneword mode-dial ports are enabled."""
+    return _mode_dials_enabled()
+
+
+def get_active_mode_dial() -> Optional[tuple[int, str]]:
+    """Return the phoneword mode dial bound for this HTTP request, if any."""
+    return _ACTIVE_MODE_DIAL.get()
+
+
+def get_active_host_port() -> Optional[int]:
+    """Return the Host header port for this HTTP request, when parseable."""
+    return _ACTIVE_HOST_PORT.get()
+
+
 def _host_port(scope: Dict[str, Any]) -> Optional[int]:
     host = (_scope_header(scope, b"host") or "").strip()
     if not host:
@@ -405,11 +423,13 @@ class ModeDialContextMiddleware:
         if scope["type"] != "http":
             await self.app(scope, receive, send)
             return
-        token = _ACTIVE_MODE_DIAL.set(_mode_dial_for_scope(scope))
+        host_token = _ACTIVE_HOST_PORT.set(_host_port(scope))
+        dial_token = _ACTIVE_MODE_DIAL.set(_mode_dial_for_scope(scope))
         try:
             await self.app(scope, receive, send)
         finally:
-            _ACTIVE_MODE_DIAL.reset(token)
+            _ACTIVE_MODE_DIAL.reset(dial_token)
+            _ACTIVE_HOST_PORT.reset(host_token)
 
 
 # These endpoints are deliberately safe for public health checks and agent

--- a/src/identity.py
+++ b/src/identity.py
@@ -106,6 +106,27 @@ def get_active_principal() -> Optional[str]:
     return _ACTIVE_PRINCIPAL.get()
 
 
+def get_active_client_id() -> Optional[str]:
+    """Return the untrusted X-Client-ID label bound for this request, if any."""
+    return _ACTIVE_CLIENT_ID.get()
+
+
+def principal_kind(principal: Optional[str] = None) -> str:
+    """Classify the security principal without exposing raw identifiers."""
+    value = principal if principal is not None else get_active_principal()
+    if not value:
+        return "none"
+    if value.startswith("oauth:"):
+        return "oauth"
+    if value.startswith("http:key-"):
+        return "api_key"
+    if value == "http:anon":
+        return "anon"
+    if value.startswith("stdio:"):
+        return "stdio"
+    return "other"
+
+
 def resolve_request_caller(caller: Optional[str]) -> Optional[str]:
     """Resolve attribution without letting HTTP metadata replace principal.
 

--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -45,7 +45,7 @@ from ..utils import (
 from xai_sdk.chat import user
 from xai_sdk.tools import code_execution, web_search as xai_web_search, x_search as xai_x_search
 
-from ..identity import scoped_session
+from ..identity import get_active_client_id, principal_kind, scoped_session
 
 logger = logging.getLogger("GrokMCP")
 
@@ -941,6 +941,161 @@ def load_okf_manifest() -> dict[str, Any]:
     return manifest
 
 
+def _swarm_policy() -> str:
+    """Return the process Swarm policy: off | dry_run | active."""
+    raw = os.environ.get("UNIGROK_SWARM", "off").strip().lower()
+    if raw in ("dry_run", "active"):
+        return raw
+    if raw in ("1", "true", "yes", "on"):
+        return "active"
+    return "off"
+
+
+def _build_discover_request_context(*, contributor: bool) -> dict[str, Any]:
+    """Assemble request-scoped onboarding identity without secrets."""
+    # Late imports avoid cycles: http_server registers these tools at import time.
+    from ..http_server import (
+        get_active_host_port,
+        get_active_mode_dial,
+        mode_dials_enabled,
+    )
+
+    client_id = get_active_client_id()
+    host_port = get_active_host_port()
+    dial = get_active_mode_dial()
+    dials_on = mode_dials_enabled()
+
+    if contributor:
+        surface = "contributor_forge"
+    elif dial is not None:
+        surface = "mode_dial"
+    else:
+        surface = "stable_core"
+
+    return {
+        "client_id_present": bool(client_id),
+        "client_id_normalized": client_id,
+        "principal_kind": principal_kind(),
+        "host_port": host_port,
+        "surface": surface,
+        "dial": (
+            {"port": dial[0], "default_mode": dial[1]}
+            if dial is not None
+            else None
+        ),
+        "mode_dials_enabled": dials_on,
+    }
+
+
+def _build_discover_bootstrap(
+    *,
+    contributor: bool,
+    workspace_attached: bool,
+    credential_planes: dict[str, Any],
+    request_context: dict[str, Any],
+) -> dict[str, Any]:
+    """GenFunc-style continuity gates for onboarding (no project assimilation)."""
+    warnings: list[dict[str, Any]] = []
+    next_actions: list[dict[str, Any]] = []
+
+    service_usable = bool(credential_planes.get("service_usable"))
+    degraded = bool(credential_planes.get("degraded"))
+    api = credential_planes.get("api") if isinstance(credential_planes.get("api"), dict) else {}
+    cli = credential_planes.get("cli") if isinstance(credential_planes.get("cli"), dict) else {}
+    swarm_policy = _swarm_policy()
+
+    can_chat = service_usable
+    can_spend_api = bool(api.get("available"))
+    can_mutate_workspace = bool(contributor and workspace_attached)
+    can_use_swarm = bool(contributor and swarm_policy in ("dry_run", "active"))
+
+    if not request_context.get("client_id_present"):
+        warnings.append(
+            {
+                "id": "missing_client_id",
+                "severity": "warn",
+                "message": (
+                    "X-Client-ID is absent. Set a stable IDE label "
+                    "(for example claude-code, vscode, codex, cursor, antigravity) "
+                    "for session separation and telemetry. It is not authentication."
+                ),
+            }
+        )
+
+    for notice in credential_planes.get("notices") or []:
+        if not isinstance(notice, dict):
+            continue
+        notice_id = notice.get("id") or "credential_notice"
+        severity = "error" if notice.get("blocking") else "warn"
+        warnings.append(
+            {
+                "id": str(notice_id),
+                "severity": severity,
+                "plane": notice.get("plane"),
+                "message": notice.get("message") or "Credential plane notice.",
+            }
+        )
+        action = notice.get("action") if isinstance(notice.get("action"), dict) else None
+        if action or notice.get("action_id"):
+            next_actions.append(
+                {
+                    "id": notice.get("action_id") or notice_id,
+                    "prompt_user": bool(notice.get("prompt_user", True)),
+                    "action": action,
+                }
+            )
+
+    if degraded and service_usable:
+        warnings.append(
+            {
+                "id": "credential_plane_degraded",
+                "severity": "warn",
+                "message": "Service is usable but one credential plane is degraded.",
+            }
+        )
+
+    if not can_chat:
+        status = "ERR"
+    elif warnings:
+        status = "WARN"
+    else:
+        status = "OK"
+
+    return {
+        "schema_version": 1,
+        "status": status,
+        "can_chat": can_chat,
+        "can_spend_api": can_spend_api,
+        "can_mutate_workspace": can_mutate_workspace,
+        "can_use_swarm": can_use_swarm,
+        "swarm_policy": swarm_policy if contributor else "off",
+        "warnings": warnings,
+        "next_actions": next_actions,
+        "caller_config_audit": "not_available_on_service",
+        "caller_config_audit_hint": (
+            "Stable UniGrok cannot read global IDE MCP files or the caller's project. "
+            "With user permission, the IDE agent should audit local configs "
+            "(user MCP JSON, project .mcp.json, skills) and report only; never rewrite "
+            "global settings without explicit consent. Never print secret values."
+        ),
+        "surfaces": {
+            "canonical_mcp": "http://localhost:4765/mcp",
+            "healthz": "http://localhost:4765/healthz",
+            "readyz": "http://localhost:4765/readyz",
+            "runtimez": "http://localhost:4765/runtimez",
+            "ui": "http://localhost:4765/ui/",
+        },
+        "first_connect_checklist": [
+            "Call grok_mcp_discover_self and read data.bootstrap + data.request_context.",
+            "Prompt once per credential_planes notice id; never ask for XAI_API_KEY in chat.",
+            "Confirm X-Client-ID is set for this IDE (data.request_context.client_id_present).",
+            "With permission, audit local IDE MCP configs for http://localhost:4765/mcp and no keys in JSON.",
+            "Optional: one cheap agent(mode=fast) or grok_mcp_status after planes are ready.",
+            "Public installs: do not invent a second product port, Swarm, or land workflow.",
+        ],
+    }
+
+
 async def grok_mcp_discover_self(include_models: bool = False) -> SystemResult:
     """Exposes OKF bundle information, WebMCP manifests, and tool schemas for zero-configuration agent onboarding."""
     async with GrokInvocationContext("utility", logger, append_signature=False) as ctx:
@@ -950,6 +1105,7 @@ async def grok_mcp_discover_self(include_models: bool = False) -> SystemResult:
 
         workspace = PathResolver.get_workspace_root()
         contributor = PathResolver.contributor_mode()
+        workspace_attached = workspace is not None
         try:
             cli_plane = await run_blocking(
                 grok_cli_plane_status,
@@ -965,6 +1121,13 @@ async def grok_mcp_discover_self(include_models: bool = False) -> SystemResult:
                 "setup_command": CLI_AUTH_SETUP_COMMAND,
             }
         credential_planes = credential_plane_contract(cli_plane)
+        request_context = _build_discover_request_context(contributor=contributor)
+        bootstrap = _build_discover_bootstrap(
+            contributor=contributor,
+            workspace_attached=workspace_attached,
+            credential_planes=credential_planes,
+            request_context=request_context,
+        )
         okf_manifest = load_okf_manifest()
         model_catalog = None
         if include_models:
@@ -1009,20 +1172,25 @@ async def grok_mcp_discover_self(include_models: bool = False) -> SystemResult:
             }
         manifest = {
             "okf_version": "0.1",
+            "schema_version": 2,
             "name": "uni-grok-mcp",
             "service_mode": "contributor" if contributor else "stable",
             "requires_project_files": False,
             "canonical_endpoint": "http://localhost:4765/mcp",
             "mode_dials": {
                 "optional": True,
+                "enabled": bool(request_context.get("mode_dials_enabled")),
                 "ports": {str(port): mode for port, mode in MODE_DIAL_PORTS.items()},
                 "precedence": "explicit mode > dialed port > auto",
+                "request_dial": request_context.get("dial"),
             },
             "workspace": {
-                "attached": workspace is not None,
+                "attached": workspace_attached,
                 "context_transport": "workspace_context",
                 "automatic_project_discovery": False,
             },
+            "request_context": request_context,
+            "bootstrap": bootstrap,
             "credential_planes": credential_planes,
             "contributor_features": {
                 "enabled": contributor,
@@ -1059,15 +1227,30 @@ async def grok_mcp_discover_self(include_models: bool = False) -> SystemResult:
                 "(not a second UniGrok to install). Prefer the canonical 4765 endpoint.\n"
             )
 
+        client_label = request_context.get("client_id_normalized") or "(missing)"
+        surface = request_context.get("surface") or "stable_core"
+        bootstrap_status = bootstrap.get("status") or "WARN"
+
         doc_text = (
             "# UniGrok MCP Discovery & Self-Description\n\n"
             "Zero-configuration onboarding for IDE agents. The primary product chat path is the "
             "UniGrok `agent` tool over MCP. The trusted-loopback UI is an optional test and control "
             "surface, not the primary daily chat path.\n\n"
+            "## Bootstrap (first connect)\n"
+            f"- Status: `{bootstrap_status}`. Surface: `{surface}`. "
+            f"Client label: `{client_label}`.\n"
+            f"- Gates: can_chat=`{bootstrap.get('can_chat')}`, "
+            f"can_spend_api=`{bootstrap.get('can_spend_api')}`, "
+            f"can_mutate_workspace=`{bootstrap.get('can_mutate_workspace')}`, "
+            f"can_use_swarm=`{bootstrap.get('can_use_swarm')}`.\n"
+            "- Read structured `data.bootstrap` and `data.request_context` for machine-usable gates.\n"
+            "- This service does **not** read global IDE settings or the caller's project files. "
+            "With user permission, audit those locally (report only; never rewrite without consent; "
+            "never print secret values).\n\n"
             "## Service and Project Boundary\n"
             "- UniGrok is a standalone MCP service; the caller's project needs no UniGrok namespace files.\n"
             f"- Service mode: `{'contributor' if contributor else 'stable'}`. "
-            f"Workspace attached: `{'yes' if workspace is not None else 'no'}`.\n"
+            f"Workspace attached: `{'yes' if workspace_attached else 'no'}`.\n"
             f"{boundary_extra}\n"
             "## Public product path\n"
             "- Canonical endpoint: `http://localhost:4765/mcp` (`4765` spells GROK).\n"

--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -943,12 +943,9 @@ def load_okf_manifest() -> dict[str, Any]:
 
 def _swarm_policy() -> str:
     """Return the process Swarm policy: off | dry_run | active."""
-    raw = os.environ.get("UNIGROK_SWARM", "off").strip().lower()
-    if raw in ("dry_run", "active"):
-        return raw
-    if raw in ("1", "true", "yes", "on"):
-        return "active"
-    return "off"
+    from ..swarm.config import swarm_mode
+
+    return swarm_mode()
 
 
 def _markdown_inline_label(value: Any) -> str:
@@ -1149,7 +1146,7 @@ def _build_discover_bootstrap(
             "Call grok_mcp_discover_self and read data.bootstrap + data.request_context.",
             "Prompt once per credential_planes notice id; never ask for XAI_API_KEY in chat.",
             "Confirm X-Client-ID is set for this IDE (data.request_context.client_id_present).",
-            "With permission, audit local IDE MCP configs for http://localhost:4765/mcp and no keys in JSON.",
+            f"With permission, audit local IDE MCP configs for {local_surface}/mcp and no keys in JSON.",
             "Optional: one cheap agent(mode=fast) or grok_mcp_status after planes are ready.",
             "Public installs: do not invent a second product port, Swarm, or land workflow.",
         ],
@@ -1236,7 +1233,7 @@ async def grok_mcp_discover_self(include_models: bool = False) -> SystemResult:
             "name": "uni-grok-mcp",
             "service_mode": "contributor" if contributor else "stable",
             "requires_project_files": False,
-            "canonical_endpoint": "http://localhost:4765/mcp",
+            "canonical_endpoint": bootstrap["surfaces"]["canonical_mcp"],
             "mode_dials": {
                 "optional": True,
                 "enabled": bool(request_context.get("mode_dials_enabled")),

--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -1261,6 +1261,8 @@ async def grok_mcp_discover_self(include_models: bool = False) -> SystemResult:
         if model_catalog is not None:
             manifest["model_catalog"] = model_catalog
 
+        canonical_endpoint = bootstrap["surfaces"]["canonical_mcp"]
+        ui_endpoint = bootstrap["surfaces"]["ui"]
         if contributor:
             boundary_extra = (
                 "- Contributor mode may attach the UniGrok checkout and enable insider-only "
@@ -1281,7 +1283,7 @@ async def grok_mcp_discover_self(include_models: bool = False) -> SystemResult:
             )
             dial_extra = (
                 "- Optional phoneword ports, when enabled, are aliases of this same Core service "
-                "(not a second UniGrok to install). Prefer the canonical 4765 endpoint.\n"
+                f"(not a second UniGrok to install). Prefer the connected endpoint `{canonical_endpoint}`.\n"
             )
 
         client_label = _markdown_inline_label(
@@ -1312,9 +1314,9 @@ async def grok_mcp_discover_self(include_models: bool = False) -> SystemResult:
             f"Workspace attached: `{'yes' if workspace_attached else 'no'}`.\n"
             f"{boundary_extra}\n"
             "## Public product path\n"
-            "- Canonical endpoint: `http://localhost:4765/mcp` (`4765` spells GROK).\n"
+            f"- Connected MCP endpoint: `{canonical_endpoint}`. The default Core port is `4765` (GROK).\n"
             "- Health: `GET /healthz`. Readiness: `GET /readyz`. Optional local Core UI: "
-            "`http://localhost:4765/ui/` (trusted machine-owner test/control surface with an "
+            f"`{ui_endpoint}` (trusted machine-owner test/control surface with an "
             "agent playground that can invoke providers and spend metered credits; not GitHub-gated).\n"
             f"{dial_extra}"
             "- An explicit `agent.mode` always overrides a dialed-port default.\n\n"

--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -1052,11 +1052,14 @@ def _build_discover_bootstrap(
     api = credential_planes.get("api") if isinstance(credential_planes.get("api"), dict) else {}
     cli = credential_planes.get("cli") if isinstance(credential_planes.get("cli"), dict) else {}
     swarm_policy = _swarm_policy()
+    cloudrun = is_cloudrun_runtime()
 
     can_chat = service_usable
     can_spend_api = bool(api.get("available"))
-    can_mutate_workspace = bool(contributor and workspace_attached)
-    can_use_swarm = bool(contributor and swarm_policy in ("dry_run", "active"))
+    can_mutate_workspace = bool(contributor and workspace_attached and not cloudrun)
+    can_use_swarm = bool(
+        contributor and not cloudrun and swarm_policy in ("dry_run", "active")
+    )
 
     if not request_context.get("client_id_present"):
         warnings.append(
@@ -1110,6 +1113,14 @@ def _build_discover_bootstrap(
     else:
         status = "OK"
 
+    connected_port = request_context.get("host_port")
+    surface_port = (
+        connected_port
+        if isinstance(connected_port, int) and not isinstance(connected_port, bool)
+        else 4765
+    )
+    local_surface = f"http://localhost:{surface_port}"
+
     return {
         "schema_version": 1,
         "status": status,
@@ -1128,11 +1139,11 @@ def _build_discover_bootstrap(
             "global settings without explicit consent. Never print secret values."
         ),
         "surfaces": {
-            "canonical_mcp": "http://localhost:4765/mcp",
-            "healthz": "http://localhost:4765/healthz",
-            "readyz": "http://localhost:4765/readyz",
-            "runtimez": "http://localhost:4765/runtimez",
-            "ui": "http://localhost:4765/ui/",
+            "canonical_mcp": f"{local_surface}/mcp",
+            "healthz": f"{local_surface}/healthz",
+            "readyz": f"{local_surface}/readyz",
+            "runtimez": f"{local_surface}/runtimez",
+            "ui": f"{local_surface}/ui/",
         },
         "first_connect_checklist": [
             "Call grok_mcp_discover_self and read data.bootstrap + data.request_context.",

--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -951,6 +951,55 @@ def _swarm_policy() -> str:
     return "off"
 
 
+def _markdown_inline_label(value: Any) -> str:
+    """Escape untrusted labels for single-line Markdown inline code spans.
+
+    Client ids come from the untrusted ``X-Client-ID`` header. Strip backticks
+    and collapse control/whitespace so discover prose cannot break fencing or
+    inject misleading multi-line content.
+    """
+    text = str(value if value is not None else "")
+    text = text.replace("`", "").replace("\r", " ").replace("\n", " ")
+    text = " ".join(text.split())
+    return text or "(missing)"
+
+
+def _resolve_notice_action(
+    notice: dict[str, Any],
+    *,
+    api: dict[str, Any],
+    cli: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Resolve a credential notice to a full bounded action object.
+
+    Notices often carry only ``action_id``; the executable action lives on the
+    plane view (``credential_planes.api.action`` / ``cli.action``).
+    """
+    direct = notice.get("action")
+    if isinstance(direct, dict):
+        return direct
+
+    action_id = notice.get("action_id")
+    plane = str(notice.get("plane") or "").upper()
+    candidates: list[dict[str, Any]] = []
+    if plane == "API" and isinstance(api.get("action"), dict):
+        candidates.append(api["action"])
+    elif plane == "CLI" and isinstance(cli.get("action"), dict):
+        candidates.append(cli["action"])
+    else:
+        for view in (api, cli):
+            if isinstance(view.get("action"), dict):
+                candidates.append(view["action"])
+
+    if action_id:
+        for candidate in candidates:
+            if candidate.get("id") == action_id:
+                return candidate
+    if candidates:
+        return candidates[0]
+    return None
+
+
 def _build_discover_request_context(*, contributor: bool) -> dict[str, Any]:
     """Assemble request-scoped onboarding identity without secrets."""
     # Late imports avoid cycles: http_server registers these tools at import time.
@@ -1035,11 +1084,11 @@ def _build_discover_bootstrap(
                 "message": notice.get("message") or "Credential plane notice.",
             }
         )
-        action = notice.get("action") if isinstance(notice.get("action"), dict) else None
+        action = _resolve_notice_action(notice, api=api, cli=cli)
         if action or notice.get("action_id"):
             next_actions.append(
                 {
-                    "id": notice.get("action_id") or notice_id,
+                    "id": (action or {}).get("id") or notice.get("action_id") or notice_id,
                     "prompt_user": bool(notice.get("prompt_user", True)),
                     "action": action,
                 }
@@ -1227,9 +1276,11 @@ async def grok_mcp_discover_self(include_models: bool = False) -> SystemResult:
                 "(not a second UniGrok to install). Prefer the canonical 4765 endpoint.\n"
             )
 
-        client_label = request_context.get("client_id_normalized") or "(missing)"
-        surface = request_context.get("surface") or "stable_core"
-        bootstrap_status = bootstrap.get("status") or "WARN"
+        client_label = _markdown_inline_label(
+            request_context.get("client_id_normalized")
+        )
+        surface = _markdown_inline_label(request_context.get("surface") or "stable_core")
+        bootstrap_status = _markdown_inline_label(bootstrap.get("status") or "WARN")
 
         doc_text = (
             "# UniGrok MCP Discovery & Self-Description\n\n"

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -169,6 +169,12 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert "renderPlaneRepair" in script.text
     assert "clearPlaneModelLists" in script.text
     assert "loadPlaneModelCatalog(false)" in script.text
+    # Operational unavailable sources must not be styled as static fallback catalogs.
+    fallback_set = script.text.split("FALLBACK_CATALOG_SOURCES")[1].split("];")[0]
+    assert '"cloudrun-disabled"' not in fallback_set
+    assert '"skipped"' not in fallback_set
+    # Plane selector must warm dual-plane catalog, not only /v1/models.
+    assert "if (!state.modelCatalog && !state.modelCatalogLoading)" in script.text
     assert 'headers: { "X-Client-ID": "cursor" }' in script.text
     assert "Cursor is the first-class host IDE" in script.text
     assert 'id="cliCatalogTrust"' in index.text

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -175,6 +175,10 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert '"skipped"' not in fallback_set
     # Plane selector must warm dual-plane catalog, not only /v1/models.
     assert "if (!state.modelCatalog && !state.modelCatalogLoading)" in script.text
+    # Credential rechecks must invalidate credential-dependent catalog snapshots.
+    assert "credentialPlaneCatalogSignature" in script.text
+    assert "priorSignature !== nextSignature" in script.text
+    assert "state.modelCatalog = null" in script.text
     assert 'headers: { "X-Client-ID": "cursor" }' in script.text
     assert "Cursor is the first-class host IDE" in script.text
     assert 'id="cliCatalogTrust"' in index.text

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -163,6 +163,21 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert "CLI subscription" in script.text
     assert "API metered" in script.text
     assert "list.replaceChildren()" in script.text
+    assert "planePinSnippet" in script.text
+    assert "fallback_policy=same_plane" in script.text
+    assert "isFallbackCatalogSource" in script.text
+    assert "renderPlaneRepair" in script.text
+    assert "clearPlaneModelLists" in script.text
+    assert "loadPlaneModelCatalog(false)" in script.text
+    assert 'headers: { "X-Client-ID": "cursor" }' in script.text
+    assert "Cursor is the first-class host IDE" in script.text
+    assert 'id="cliCatalogTrust"' in index.text
+    assert 'id="apiCatalogTrust"' in index.text
+    assert 'id="cliPlaneRepair"' in index.text
+    assert 'id="apiPlaneRepair"' in index.text
+    assert "Cursor is first-class" in index.text
+    assert "catalog-trust-banner" in styles.text
+    assert ".plane-repair" in styles.text
     assert "routing?.why_detail" in script.text
     assert styles.status_code == 200
     assert ".console-grid" in styles.text

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -179,6 +179,14 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert "credentialPlaneCatalogSignature" in script.text
     assert "priorSignature !== nextSignature" in script.text
     assert "state.modelCatalog = null" in script.text
+    assert "state.modelCatalogGeneration += 1" in script.text
+    assert 'state.activeTab === "tab-models"' in script.text
+    assert 'clearModelOptions("auto route")' in script.text
+    assert "generation !== state.modelCatalogGeneration" in script.text
+    legacy_loader = script.text.split("async function loadModelsList()", 1)[1].split(
+        "function syncModelOptions()", 1
+    )[0]
+    assert '$("modelInput")' not in legacy_loader
     assert 'headers: { "X-Client-ID": "cursor" }' in script.text
     assert "Cursor is the first-class host IDE" in script.text
     assert 'id="cliCatalogTrust"' in index.text

--- a/tests/test_release_hygiene.py
+++ b/tests/test_release_hygiene.py
@@ -144,6 +144,24 @@ def test_public_setup_surfaces_use_the_grok_phoneword_endpoint():
         assert "http://localhost:8080" not in text, path
 
 
+def test_session_rehydrate_skills_use_project_qualified_continuity():
+    agent_skill = (ROOT / ".agents" / "skills" / "session-rehydrate" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    claude_skill = (ROOT / ".claude" / "skills" / "session-rehydrate" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    shared_rules = (ROOT / ".agents" / "AGENTS.md").read_text(encoding="utf-8")
+
+    for text in (agent_skill, claude_skill, shared_rules):
+        assert "../unigrok-intelligence/" in text
+        assert "`unigrok-intelligence/" not in text
+    for text in (agent_skill, claude_skill):
+        assert "djtelicloud-grok-mcp-server:ops:YYYY-MM-DD" in text
+        assert "unigrok:ops:YYYY-MM-DD" not in text
+    assert "Root `CLAUDE.md` if present" in claude_skill
+
+
 def test_public_docs_surfaces_exclude_github_wiki_as_product():
     """Public knowledge is README + OKF; GitHub Wiki is not a second tree."""
     readme = (ROOT / "README.md").read_text(encoding="utf-8")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -398,13 +398,30 @@ async def test_discover_self_tool():
     assert res.finish_reason == "final_answer"
     assert res.route == "discovery"
     assert res.data["okf_version"] == "0.1"
+    assert res.data["schema_version"] == 2
     assert res.data["name"] == "uni-grok-mcp"
     assert "/docs/okf/index.md" in res.data["files"]
     assert "/docs/okf/api-reference.md" in res.data["files"]
     assert "UniGrok MCP Discovery" in res.response
+    assert "Bootstrap (first connect)" in res.response
     assert "credential_planes" in res.data
     assert res.data["credential_planes"]["preferred_plane"] in {"CLI", "API"}
     assert "local_usage" in res.data["credential_planes"]
+    assert "request_context" in res.data
+    assert "bootstrap" in res.data
+    bootstrap = res.data["bootstrap"]
+    assert bootstrap["schema_version"] == 1
+    assert bootstrap["status"] in {"OK", "WARN", "ERR"}
+    assert bootstrap["caller_config_audit"] == "not_available_on_service"
+    assert isinstance(bootstrap["first_connect_checklist"], list)
+    assert bootstrap["first_connect_checklist"]
+    assert res.data["request_context"]["surface"] in {
+        "stable_core",
+        "contributor_forge",
+        "mode_dial",
+    }
+    assert "can_chat" in bootstrap
+    assert "can_mutate_workspace" in bootstrap
 
 
 @pytest.mark.asyncio

--- a/tests/test_service_workspace_boundary.py
+++ b/tests/test_service_workspace_boundary.py
@@ -332,6 +332,54 @@ def test_resolve_notice_action_fills_from_plane_views():
     assert resolved_cli == cli_action
 
 
+def test_discover_bootstrap_surfaces_follow_connected_port(monkeypatch):
+    from src.tools.system import _build_discover_bootstrap
+
+    monkeypatch.setenv("UNIGROK_RUNTIME", "local")
+    bootstrap = _build_discover_bootstrap(
+        contributor=False,
+        workspace_attached=False,
+        credential_planes={
+            "service_usable": True,
+            "degraded": False,
+            "api": {"available": True},
+            "cli": {"available": True},
+            "notices": [],
+        },
+        request_context={"client_id_present": True, "host_port": 9090},
+    )
+
+    assert bootstrap["surfaces"] == {
+        "canonical_mcp": "http://localhost:9090/mcp",
+        "healthz": "http://localhost:9090/healthz",
+        "readyz": "http://localhost:9090/readyz",
+        "runtimez": "http://localhost:9090/runtimez",
+        "ui": "http://localhost:9090/ui/",
+    }
+
+
+def test_discover_bootstrap_disables_workspace_mutation_in_cloudrun(monkeypatch):
+    from src.tools.system import _build_discover_bootstrap
+
+    monkeypatch.setenv("UNIGROK_RUNTIME", "cloudrun")
+    monkeypatch.setenv("UNIGROK_SWARM", "active")
+    bootstrap = _build_discover_bootstrap(
+        contributor=True,
+        workspace_attached=True,
+        credential_planes={
+            "service_usable": True,
+            "degraded": False,
+            "api": {"available": True},
+            "cli": {"available": False},
+            "notices": [],
+        },
+        request_context={"client_id_present": True, "host_port": None},
+    )
+
+    assert bootstrap["can_mutate_workspace"] is False
+    assert bootstrap["can_use_swarm"] is False
+
+
 @pytest.mark.asyncio
 async def test_discover_self_bootstrap_next_actions_include_plane_actions(monkeypatch):
     monkeypatch.setenv("UNIGROK_SERVICE_MODE", "stable")

--- a/tests/test_service_workspace_boundary.py
+++ b/tests/test_service_workspace_boundary.py
@@ -300,6 +300,90 @@ async def test_discover_self_bootstrap_ok_with_client_id(monkeypatch):
         assert result.data["bootstrap"]["status"] in {"OK", "WARN"}
 
 
+def test_markdown_inline_label_strips_backticks_and_control():
+    from src.tools.system import _markdown_inline_label
+
+    assert _markdown_inline_label("evil`break") == "evilbreak"
+    assert _markdown_inline_label("a\nb\rc") == "a b c"
+    assert _markdown_inline_label(None) == "(missing)"
+    assert _markdown_inline_label("  ok  ") == "ok"
+
+
+def test_resolve_notice_action_fills_from_plane_views():
+    from src.tools.system import _resolve_notice_action
+
+    api_action = {"id": "configure_xai_api_key", "kind": "configure_secret"}
+    cli_action = {"id": "authenticate_grok_cli", "kind": "authenticate_cli"}
+    api = {"action": api_action}
+    cli = {"action": cli_action}
+
+    resolved_api = _resolve_notice_action(
+        {"plane": "API", "action_id": "configure_xai_api_key"},
+        api=api,
+        cli=cli,
+    )
+    assert resolved_api == api_action
+
+    resolved_cli = _resolve_notice_action(
+        {"plane": "CLI", "action_id": "authenticate_grok_cli"},
+        api=api,
+        cli=cli,
+    )
+    assert resolved_cli == cli_action
+
+
+@pytest.mark.asyncio
+async def test_discover_self_bootstrap_next_actions_include_plane_actions(monkeypatch):
+    monkeypatch.setenv("UNIGROK_SERVICE_MODE", "stable")
+    monkeypatch.delenv("WORKSPACE_ROOT", raising=False)
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.setattr(
+        "src.tools.system.grok_cli_plane_status",
+        lambda timeout_sec=5.0: {
+            "state": "needs_auth",
+            "ready": False,
+            "binary": True,
+            "auth": "unauthenticated",
+            "setup_command": "docker exec … grok login --device-auth",
+        },
+    )
+    result = await grok_mcp_discover_self()
+    next_actions = result.data["bootstrap"]["next_actions"]
+    assert next_actions, "expected credential repair next_actions"
+    for item in next_actions:
+        assert item.get("action") is not None, f"null action for {item.get('id')}"
+        assert item["action"].get("id")
+        assert item["action"].get("instructions") or item["action"].get("command")
+
+
+@pytest.mark.asyncio
+async def test_discover_self_markdown_escapes_hostile_client_id(monkeypatch):
+    from src.identity import _ACTIVE_CLIENT_ID
+
+    monkeypatch.setenv("UNIGROK_SERVICE_MODE", "stable")
+    monkeypatch.delenv("WORKSPACE_ROOT", raising=False)
+    monkeypatch.setenv("XAI_API_KEY", "test-key-for-discover")
+    monkeypatch.setattr(
+        "src.tools.system.grok_cli_plane_status",
+        lambda timeout_sec=5.0: {
+            "state": "ready",
+            "ready": True,
+            "binary": True,
+            "auth": "oauth",
+            "setup_command": "unused",
+        },
+    )
+    token = _ACTIVE_CLIENT_ID.set("evil`break\ninject")
+    try:
+        result = await grok_mcp_discover_self()
+    finally:
+        _ACTIVE_CLIENT_ID.reset(token)
+
+    prose = (result.response or "") + "\n" + (result.text or "")
+    assert "evil`break" not in prose
+    assert "Client label: `evilbreak inject`" in prose
+
+
 @pytest.mark.asyncio
 async def test_public_mcp_instructions_prefer_core_endpoint_and_plan_critique():
     mcp = create_public_mcp()

--- a/tests/test_service_workspace_boundary.py
+++ b/tests/test_service_workspace_boundary.py
@@ -240,6 +240,64 @@ async def test_stable_discover_self_has_no_forge_connect_recipes(monkeypatch):
         assert token.lower() not in lowered, f"stable discover leaked {token!r}"
     assert "http://localhost:4765/mcp" in prose
     assert "plan critique" in lowered or "implementation plan" in lowered
+    assert result.data["service_mode"] == "stable"
+    assert result.data["request_context"]["surface"] == "stable_core"
+    assert result.data["bootstrap"]["can_mutate_workspace"] is False
+    assert result.data["bootstrap"]["can_use_swarm"] is False
+    # Structured surface names are fine; never coach a second product port in prose.
+    assert "4766" not in prose
+
+
+@pytest.mark.asyncio
+async def test_discover_self_bootstrap_warns_without_client_id(monkeypatch):
+    monkeypatch.setenv("UNIGROK_SERVICE_MODE", "stable")
+    monkeypatch.delenv("WORKSPACE_ROOT", raising=False)
+    monkeypatch.setattr(
+        "src.tools.system.grok_cli_plane_status",
+        lambda timeout_sec=5.0: {
+            "state": "ready",
+            "ready": True,
+            "binary": True,
+            "auth": "oauth",
+            "setup_command": "unused",
+        },
+    )
+    result = await grok_mcp_discover_self()
+    assert result.data["request_context"]["client_id_present"] is False
+    warning_ids = {w["id"] for w in result.data["bootstrap"]["warnings"]}
+    assert "missing_client_id" in warning_ids
+    assert result.data["bootstrap"]["status"] in {"WARN", "ERR"}
+
+
+@pytest.mark.asyncio
+async def test_discover_self_bootstrap_ok_with_client_id(monkeypatch):
+    from src.identity import _ACTIVE_CLIENT_ID
+
+    monkeypatch.setenv("UNIGROK_SERVICE_MODE", "stable")
+    monkeypatch.delenv("WORKSPACE_ROOT", raising=False)
+    monkeypatch.setenv("XAI_API_KEY", "test-key-for-discover")
+    monkeypatch.setattr(
+        "src.tools.system.grok_cli_plane_status",
+        lambda timeout_sec=5.0: {
+            "state": "ready",
+            "ready": True,
+            "binary": True,
+            "auth": "oauth",
+            "setup_command": "unused",
+        },
+    )
+    token = _ACTIVE_CLIENT_ID.set("claude-code")
+    try:
+        result = await grok_mcp_discover_self()
+    finally:
+        _ACTIVE_CLIENT_ID.reset(token)
+
+    assert result.data["request_context"]["client_id_present"] is True
+    assert result.data["request_context"]["client_id_normalized"] == "claude-code"
+    warning_ids = {w["id"] for w in result.data["bootstrap"]["warnings"]}
+    assert "missing_client_id" not in warning_ids
+    if result.data["bootstrap"]["can_chat"]:
+        assert result.data["bootstrap"]["status"] in {"OK", "WARN"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_service_workspace_boundary.py
+++ b/tests/test_service_workspace_boundary.py
@@ -356,6 +356,49 @@ def test_discover_bootstrap_surfaces_follow_connected_port(monkeypatch):
         "runtimez": "http://localhost:9090/runtimez",
         "ui": "http://localhost:9090/ui/",
     }
+    assert any(
+        "http://localhost:9090/mcp" in step
+        for step in bootstrap["first_connect_checklist"]
+    )
+
+
+def test_discover_bootstrap_swarm_policy_matches_runtime_parser(monkeypatch):
+    from src.tools.system import _build_discover_bootstrap
+
+    monkeypatch.setenv("UNIGROK_RUNTIME", "local")
+    credentials = {
+        "service_usable": True,
+        "degraded": False,
+        "api": {"available": True},
+        "cli": {"available": True},
+        "notices": [],
+    }
+
+    for configured, expected, usable in (
+        ("active", "active", True),
+        ("dry_run", "dry_run", True),
+        ("on", "off", False),
+        ("true", "off", False),
+    ):
+        monkeypatch.setenv("UNIGROK_SWARM", configured)
+        bootstrap = _build_discover_bootstrap(
+            contributor=True,
+            workspace_attached=True,
+            credential_planes=credentials,
+            request_context={"client_id_present": True, "host_port": 4766},
+        )
+        assert bootstrap["swarm_policy"] == expected
+        assert bootstrap["can_use_swarm"] is usable
+
+
+@pytest.mark.asyncio
+async def test_discover_manifest_endpoint_follows_connected_port(monkeypatch):
+    monkeypatch.setattr("src.http_server.get_active_host_port", lambda: 9090)
+
+    result = await grok_mcp_discover_self()
+
+    assert result.data["canonical_endpoint"] == "http://localhost:9090/mcp"
+    assert result.data["bootstrap"]["surfaces"]["canonical_mcp"] == result.data["canonical_endpoint"]
 
 
 def test_discover_bootstrap_disables_workspace_mutation_in_cloudrun(monkeypatch):

--- a/tests/test_service_workspace_boundary.py
+++ b/tests/test_service_workspace_boundary.py
@@ -399,6 +399,8 @@ async def test_discover_manifest_endpoint_follows_connected_port(monkeypatch):
 
     assert result.data["canonical_endpoint"] == "http://localhost:9090/mcp"
     assert result.data["bootstrap"]["surfaces"]["canonical_mcp"] == result.data["canonical_endpoint"]
+    assert "`http://localhost:9090/mcp`" in result.response
+    assert "`http://localhost:9090/ui/`" in result.response
 
 
 def test_discover_bootstrap_disables_workspace_mutation_in_cloudrun(monkeypatch):


### PR DESCRIPTION
## Summary
- integrate the reviewed work from PRs #124, #125, #126, #128, and #129 on current protected main
- preserve the opt-in UniGrok plan-review habit, port-aware first-connect bootstrap, Planes trust UX, session rehydrate skill, and Cursor Cloud guidance
- close every outstanding actionable review gap before integration

## Review fixes included
- derive bootstrap MCP/health/UI links from the connected Host port
- keep workspace mutation and Swarm gates false in Cloud Run
- invalidate credential-dependent plane-catalog cache after credential changes
- use sibling private-continuity paths and a project-qualified MCP session key
- make the Claude rehydrate skill load root `CLAUDE.md`
- remove trailing whitespace in both rehydrate skill copies

## Exact handoff
- Head: `4b708b0e507a34cb45f9745061416a19e17f348f`
- Branch: `codex/integrate-maintainer-backlog`
- Supersedes after merge: #124, #125, #126, #128, #129
- Changed paths: 23 files across agent guidance, onboarding/bootstrap, Control Center UI, generated OKF mirrors, and tests

## Verification
- focused onboarding/UI/release suite: 232 passed
- JavaScript syntax check: passed
- changed-path Ruff (excluding two documented pre-existing F841 findings in `src/tools/system.py`): passed
- deterministic OKF generation: passed
- attribution check: passed
- full landing suite: 1,983 passed
- final receipt: `LANDED TO MAIN: 4b708b0e507a34cb45f9745061416a19e17f348f`
- contributor runtime: restarted and smoke-tested
- workspace-memory landing evidence: synced

## Risk
Moderate but bounded. This consolidates already-reviewed contributor PRs and adds focused fixes for their current review threads. No credentials, release tags, branch-protection settings, provider calls, dataset writes, or destructive worktree cleanup are included.

## Attribution
- Human sponsor: `djtelicloud`
- Integration: OpenAI Codex, GPT-5, Codex Desktop
- Original contributor commits and canonical trailers are preserved.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches onboarding bootstrap and Control Center model/credential UX that agents and users rely on at first connect; changes are documentation-heavy and test-backed but span server discovery, UI cache invalidation, and multi-surface agent skills.
> 
> **Overview**
> This PR **consolidates maintainer backlog** into one integration: first-connect onboarding, agent guidance, Control Center UI, and targeted review fixes.
> 
> **`grok_mcp_discover_self` (schema v2)** now returns **`data.bootstrap`** (OK/WARN/ERR, capability gates, warnings, `next_actions`) and **`data.request_context`** (surface, `X-Client-ID`, Host port). MCP/health/UI URLs follow the **connected Host port**; Cloud Run keeps workspace mutation and Swarm gates false. Discover prose **sanitizes untrusted client labels** for Markdown.
> 
> **Agent docs** add **session-rehydrate** skills (`.agents` / `.claude`), **communication discipline**, **first-connect diagnostics** via `grok_mcp_discover_self`, sibling private continuity paths, and **Cursor Cloud** notes in root `AGENTS.md`. **IDE setup** positions Cursor as the preferred host and separates Cursor-native models from UniGrok planes.
> 
> **Control Center (`mcp_ui`)** lazy-loads dual-plane catalogs, **invalidates** model cache when credentials change, adds fallback/trust banners and plane repair UI, **plane-qualified** copy pins, and Cursor-first connect snippets.
> 
> **HTTP/identity** expose `get_active_host_port`, mode-dial helpers, `get_active_client_id`, and `principal_kind`. OKF FAQ/docs and tests mirror the bootstrap contract and stable discover boundaries (no Forge/4766 coaching).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 144b84d2e97858a8606b4a2341879a2b635de07f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->