### PR TITLE
fix(auth): harden Cursor Cloud service tokens

### DIFF
--- a/docs/cursor-cloud-mcp.md
+++ b/docs/cursor-cloud-mcp.md
@@ -1,0 +1,48 @@
+# Cursor Cloud → UniGrok twin
+
+One secret. Remote MCP. No local server.
+
+## Operator (you)
+
+```bash
+export UNIGROK_MCP_TOKEN_SECRET='…same as Control MCP_TOKEN_SECRET…'
+export UNIGROK_SERVICE_NAME=cursor-cloud
+export UNIGROK_SERVICE_SCOPE=unigrok:invoke
+# optional TTL max 600
+uv run python scripts/mint_mcp_service_token.py
+```
+
+Copy the printed token into Cursor Cloud secret: **`UNIGROK_ACCESS_TOKEN`**.
+
+Token lasts **10 minutes**. Re-mint when it expires.
+
+Requires Control Center deployed with `service:cursor-cloud` allowlist (this PR).
+
+## Cursor Cloud agent paste
+
+```
+Secret UNIGROK_ACCESS_TOKEN is set.
+
+Use MCP https://mcp.grokmcp.org/mcp
+Header Authorization: Bearer $UNIGROK_ACCESS_TOKEN
+Header X-Client-ID: cursor-cloud
+
+Call grok_mcp_discover_self then agent(mode=fast, prompt="ping", plane=api, fallback_policy=same_plane).
+Never ask for XAI_API_KEY. Do not land main. No Stage 1 live gen.
+```
+
+## MCP JSON (if the UI has a config field)
+
+```json
+{
+  "mcpServers": {
+    "unigrok": {
+      "url": "https://mcp.grokmcp.org/mcp",
+      "headers": {
+        "Authorization": "Bearer ${UNIGROK_ACCESS_TOKEN}",
+        "X-Client-ID": "cursor-cloud"
+      }
+    }
+  }
+}
+```

--- a/scripts/mint_mcp_service_token.py
+++ b/scripts/mint_mcp_service_token.py
@@ -15,7 +15,7 @@ Environment (required):
 
 Optional:
   UNIGROK_SERVICE_NAME      — github-review-broker | cursor-cloud
-  UNIGROK_SERVICE_SCOPE     — review (broker) | invoke (cursor-cloud)
+  UNIGROK_SERVICE_SCOPE     — unigrok:review (broker) | unigrok:invoke (cursor-cloud)
   UNIGROK_TOKEN_TTL_SECONDS — default per service (max 600)
 
 Prints the bearer token to stdout only (no logs of the secret).
@@ -56,7 +56,8 @@ SERVICE_SPECS: dict[str, dict[str, Any]] = {
     },
     # Cursor Cloud / headless IDE agents: invoke + status (discover/status tools).
     "cursor-cloud": {
-        "scopes": frozenset({"unigrok:invoke", "unigrok:status"}),
+        # Status is granted only inside the fixed cursor-cloud bundle below.
+        "scopes": frozenset({"unigrok:invoke"}),
         "default_scope": "unigrok:invoke",
         "default_ttl": 600,
         "max_ttl": 600,
@@ -88,6 +89,29 @@ def sign_cookie_payload(payload: Mapping[str, Any], secret: str) -> str:
     return f"{body}.{_b64url(signature)}"
 
 
+def _service_token_parameters(
+    service: str,
+    scope: Optional[str],
+    ttl_seconds: Optional[int],
+) -> tuple[str, int, list[str]]:
+    """Validate a service request and return its exact scope/TTL bundle."""
+    if service not in SERVICE_SPECS:
+        raise ValueError(f"service not allowed: {service}")
+    spec = SERVICE_SPECS[service]
+    primary = (scope or spec["default_scope"]).strip()
+    if primary not in spec["scopes"]:
+        raise ValueError(f"scope not allowed for service {service}: {primary}")
+    ttl = int(ttl_seconds if ttl_seconds is not None else spec["default_ttl"])
+    max_ttl = int(spec["max_ttl"])
+    if not (1 <= ttl <= min(max_ttl, MAX_TTL)):
+        raise ValueError(f"ttl_seconds must be 1..{min(max_ttl, MAX_TTL)} for {service}")
+    if service == "cursor-cloud":
+        granted = ["unigrok:connect", "unigrok:invoke", "unigrok:status"]
+    else:
+        granted = ["unigrok:connect", primary]
+    return primary, ttl, granted
+
+
 def mint_service_access_token(
     *,
     secret: str,
@@ -99,27 +123,12 @@ def mint_service_access_token(
     now: Optional[int] = None,
     jti: Optional[str] = None,
 ) -> str:
-    if service not in SERVICE_SPECS:
-        raise ValueError(f"service not allowed: {service}")
-    spec = SERVICE_SPECS[service]
-    primary = (scope or spec["default_scope"]).strip()
-    if primary not in spec["scopes"]:
-        raise ValueError(f"scope not allowed for service {service}: {primary}")
+    _primary, ttl, granted = _service_token_parameters(service, scope, ttl_seconds)
     if not issuer.startswith("https://") or issuer.endswith("/"):
         raise ValueError("issuer must be an https origin without trailing slash")
     if not resource.startswith("https://") or not resource.endswith("/mcp"):
         raise ValueError("resource must be https://…/mcp")
-    ttl = int(ttl_seconds if ttl_seconds is not None else spec["default_ttl"])
-    max_ttl = int(spec["max_ttl"])
-    if not (1 <= ttl <= min(max_ttl, MAX_TTL)):
-        raise ValueError(f"ttl_seconds must be 1..{min(max_ttl, MAX_TTL)} for {service}")
     iat = int(now if now is not None else time.time())
-    # Always grant connect + capability. cursor-cloud is a fixed package so
-    # discover/status + agent work without a second mint.
-    if service == "cursor-cloud":
-        granted = ["unigrok:connect", "unigrok:invoke", "unigrok:status"]
-    else:
-        granted = ["unigrok:connect", primary]
     claims = {
         "aud": resource,
         "exp": iat + ttl,
@@ -155,6 +164,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         raise SystemExit("UNIGROK_TOKEN_TTL_SECONDS must be an integer") from exc
 
     issued_at = int(time.time())
+    _primary, resolved_ttl, granted = _service_token_parameters(service, scope, ttl)
     token = mint_service_access_token(
         secret=secret,
         issuer=issuer,
@@ -165,14 +175,10 @@ def main(argv: Optional[list[str]] = None) -> int:
         now=issued_at,
     )
     if args.print_claims:
-        body = token[len(TOKEN_PREFIX) :].split(".", 1)[0]
-        pad = "=" * (-len(body) % 4)
-        # Decode only for operator metadata after we minted it; never log secret.
-        claims = json.loads(base64.urlsafe_b64decode(body + pad))
         claims_metadata = {
-            "exp": claims["exp"],
-            "scope": claims["scope"],
-            "sub": claims["sub"],
+            "exp": issued_at + resolved_ttl,
+            "scope": granted,
+            "sub": f"service:{service}",
         }
         print(json.dumps(claims_metadata, sort_keys=True), file=sys.stderr)
     sys.stdout.write(token)

--- a/scripts/mint_mcp_service_token.py
+++ b/scripts/mint_mcp_service_token.py
@@ -5,8 +5,8 @@ Matches Control Center ``createServiceAccessToken``:
 HMAC-SHA256 over base64url(JSON claims), token prefix ``ugtoken.``.
 
 Production remote MCP validates via Control introspection — never install a
-long-lived static client key on Cloud Run. This script only produces ~120s
-tokens for GitHub Actions / ops smoke.
+long-lived static client key on Cloud Run. This script only produces short-lived
+tokens for GitHub Actions, Cursor Cloud agents, and ops smoke.
 
 Environment (required):
   UNIGROK_MCP_TOKEN_SECRET  — same value as Control ``MCP_TOKEN_SECRET``
@@ -14,9 +14,9 @@ Environment (required):
   UNIGROK_MCP_RESOURCE_URL  — e.g. https://mcp.grokmcp.org/mcp
 
 Optional:
-  UNIGROK_SERVICE_NAME      — default github-review-broker
-  UNIGROK_SERVICE_SCOPE     — default unigrok:review
-  UNIGROK_TOKEN_TTL_SECONDS — default 120 (max 600)
+  UNIGROK_SERVICE_NAME      — github-review-broker | cursor-cloud
+  UNIGROK_SERVICE_SCOPE     — review (broker) | invoke (cursor-cloud)
+  UNIGROK_TOKEN_TTL_SECONDS — default per service (max 600)
 
 Prints the bearer token to stdout only (no logs of the secret).
 """
@@ -35,7 +35,6 @@ from typing import Any, Mapping, Optional
 from cryptography.hazmat.primitives import hashes, hmac
 
 TOKEN_PREFIX = "ugtoken."
-DEFAULT_TTL = 120
 MAX_TTL = 600
 ALLOWED_SCOPES = frozenset(
     {
@@ -46,7 +45,23 @@ ALLOWED_SCOPES = frozenset(
         "unigrok:status",
     }
 )
-ALLOWED_SERVICES = frozenset({"github-review-broker"})
+
+# service → primary capability scope (connect is always included)
+SERVICE_SPECS: dict[str, dict[str, Any]] = {
+    "github-review-broker": {
+        "scopes": frozenset({"unigrok:review"}),
+        "default_scope": "unigrok:review",
+        "default_ttl": 120,
+        "max_ttl": 120,
+    },
+    # Cursor Cloud / headless IDE agents: invoke + status (discover/status tools).
+    "cursor-cloud": {
+        "scopes": frozenset({"unigrok:invoke", "unigrok:status"}),
+        "default_scope": "unigrok:invoke",
+        "default_ttl": 600,
+        "max_ttl": 600,
+    },
+}
 
 
 def _b64url(data: bytes) -> str:
@@ -79,31 +94,40 @@ def mint_service_access_token(
     issuer: str,
     resource: str,
     service: str = "github-review-broker",
-    scope: str = "unigrok:review",
-    ttl_seconds: int = DEFAULT_TTL,
+    scope: Optional[str] = None,
+    ttl_seconds: Optional[int] = None,
     now: Optional[int] = None,
     jti: Optional[str] = None,
 ) -> str:
-    if service not in ALLOWED_SERVICES:
+    if service not in SERVICE_SPECS:
         raise ValueError(f"service not allowed: {service}")
-    # Service mint is review-only; invoke/chat/status stay for user OAuth.
-    if scope != "unigrok:review":
-        raise ValueError(f"scope not allowed for service mint: {scope}")
+    spec = SERVICE_SPECS[service]
+    primary = (scope or spec["default_scope"]).strip()
+    if primary not in spec["scopes"]:
+        raise ValueError(f"scope not allowed for service {service}: {primary}")
     if not issuer.startswith("https://") or issuer.endswith("/"):
         raise ValueError("issuer must be an https origin without trailing slash")
     if not resource.startswith("https://") or not resource.endswith("/mcp"):
         raise ValueError("resource must be https://…/mcp")
-    if not (1 <= int(ttl_seconds) <= MAX_TTL):
-        raise ValueError(f"ttl_seconds must be 1..{MAX_TTL}")
+    ttl = int(ttl_seconds if ttl_seconds is not None else spec["default_ttl"])
+    max_ttl = int(spec["max_ttl"])
+    if not (1 <= ttl <= min(max_ttl, MAX_TTL)):
+        raise ValueError(f"ttl_seconds must be 1..{min(max_ttl, MAX_TTL)} for {service}")
     iat = int(now if now is not None else time.time())
+    # Always grant connect + capability. cursor-cloud is a fixed package so
+    # discover/status + agent work without a second mint.
+    if service == "cursor-cloud":
+        granted = ["unigrok:connect", "unigrok:invoke", "unigrok:status"]
+    else:
+        granted = ["unigrok:connect", primary]
     claims = {
         "aud": resource,
-        "exp": iat + int(ttl_seconds),
+        "exp": iat + ttl,
         "iat": iat,
         "iss": issuer,
         "jti": jti or _b64url(secrets.token_bytes(24)),
         "kind": "service",
-        "scope": ["unigrok:connect", scope],
+        "scope": granted,
         "sub": f"service:{service}",
         "v": 1,
     }
@@ -123,9 +147,10 @@ def main(argv: Optional[list[str]] = None) -> int:
     issuer = os.environ.get("UNIGROK_OAUTH_ISSUER", "https://control.grokmcp.org").strip()
     resource = os.environ.get("UNIGROK_MCP_RESOURCE_URL", "https://mcp.grokmcp.org/mcp").strip()
     service = os.environ.get("UNIGROK_SERVICE_NAME", "github-review-broker").strip()
-    scope = os.environ.get("UNIGROK_SERVICE_SCOPE", "unigrok:review").strip()
+    scope = os.environ.get("UNIGROK_SERVICE_SCOPE", "").strip() or None
+    raw_ttl = os.environ.get("UNIGROK_TOKEN_TTL_SECONDS", "").strip()
     try:
-        ttl = int(os.environ.get("UNIGROK_TOKEN_TTL_SECONDS", str(DEFAULT_TTL)))
+        ttl = int(raw_ttl) if raw_ttl else None
     except ValueError as exc:
         raise SystemExit("UNIGROK_TOKEN_TTL_SECONDS must be an integer") from exc
 
@@ -140,12 +165,14 @@ def main(argv: Optional[list[str]] = None) -> int:
         now=issued_at,
     )
     if args.print_claims:
-        # Report independently constructed, non-secret metadata. Never decode
-        # or log any value derived from the signed bearer token.
+        body = token[len(TOKEN_PREFIX) :].split(".", 1)[0]
+        pad = "=" * (-len(body) % 4)
+        # Decode only for operator metadata after we minted it; never log secret.
+        claims = json.loads(base64.urlsafe_b64decode(body + pad))
         claims_metadata = {
-            "exp": issued_at + ttl,
-            "scope": ["unigrok:connect", scope],
-            "sub": f"service:{service}",
+            "exp": claims["exp"],
+            "scope": claims["scope"],
+            "sub": claims["sub"],
         }
         print(json.dumps(claims_metadata, sort_keys=True), file=sys.stderr)
     sys.stdout.write(token)

--- a/scripts/mint_mcp_service_token.py
+++ b/scripts/mint_mcp_service_token.py
@@ -36,15 +36,6 @@ from cryptography.hazmat.primitives import hashes, hmac
 
 TOKEN_PREFIX = "ugtoken."
 MAX_TTL = 600
-ALLOWED_SCOPES = frozenset(
-    {
-        "unigrok:connect",
-        "unigrok:invoke",
-        "unigrok:review",
-        "unigrok:chat",
-        "unigrok:status",
-    }
-)
 
 # service → primary capability scope (connect is always included)
 SERVICE_SPECS: dict[str, dict[str, Any]] = {

--- a/sites/unigrok-control-center/app/lib/mcp-oauth.ts
+++ b/sites/unigrok-control-center/app/lib/mcp-oauth.ts
@@ -202,7 +202,8 @@ export const MCP_SERVICE_SPECS = Object.freeze({
     ttlSeconds: 120,
   },
   "cursor-cloud": {
-    scopes: Object.freeze(["unigrok:invoke", "unigrok:status"] as const),
+    // Status is granted only inside the fixed cursor-cloud bundle below.
+    scopes: Object.freeze(["unigrok:invoke"] as const),
     ttlSeconds: TOKEN_TTL_SECONDS,
   },
 } as const);
@@ -295,6 +296,7 @@ function isAccessClaims(value: unknown, config: McpOAuthConfig, now: number): va
     if (record.sub === "service:github-review-broker") {
       return (
         Array.isArray(record.scope) &&
+        record.scope.length === 2 &&
         record.scope.includes("unigrok:connect") &&
         record.scope.includes("unigrok:review") &&
         record.scope.every((scope) => scope === "unigrok:connect" || scope === "unigrok:review")
@@ -303,8 +305,10 @@ function isAccessClaims(value: unknown, config: McpOAuthConfig, now: number): va
     if (record.sub === "service:cursor-cloud") {
       return (
         Array.isArray(record.scope) &&
+        record.scope.length === 3 &&
         record.scope.includes("unigrok:connect") &&
         record.scope.includes("unigrok:invoke") &&
+        record.scope.includes("unigrok:status") &&
         record.scope.every(
           (scope) =>
             scope === "unigrok:connect" ||

--- a/sites/unigrok-control-center/app/lib/mcp-oauth.ts
+++ b/sites/unigrok-control-center/app/lib/mcp-oauth.ts
@@ -195,21 +195,44 @@ export async function exchangeAuthorizationCode(
   };
 }
 
+/** Allowed headless services and the capability scopes they may hold. */
+export const MCP_SERVICE_SPECS = Object.freeze({
+  "github-review-broker": {
+    scopes: Object.freeze(["unigrok:review"] as const),
+    ttlSeconds: 120,
+  },
+  "cursor-cloud": {
+    scopes: Object.freeze(["unigrok:invoke", "unigrok:status"] as const),
+    ttlSeconds: TOKEN_TTL_SECONDS,
+  },
+} as const);
+
+export type McpServiceName = keyof typeof MCP_SERVICE_SPECS;
+
 export async function createServiceAccessToken(
   config: McpOAuthConfig,
-  service: "github-review-broker",
-  scope: "unigrok:review",
+  service: McpServiceName,
+  scope: "unigrok:review" | "unigrok:invoke" | "unigrok:status",
   now = Date.now(),
 ): Promise<string> {
+  const spec = MCP_SERVICE_SPECS[service];
+  if (!spec || !(spec.scopes as readonly string[]).includes(scope)) {
+    throw new McpOAuthError("invalid_scope");
+  }
   const iat = Math.floor(now / 1_000);
+  // cursor-cloud always gets invoke+status so discover/status + agent work.
+  const granted =
+    service === "cursor-cloud"
+      ? ["unigrok:connect", "unigrok:invoke", "unigrok:status"]
+      : ["unigrok:connect", scope];
   const claims: McpAccessClaims = {
     aud: config.resource,
-    exp: iat + 120,
+    exp: iat + spec.ttlSeconds,
     iat,
     iss: config.issuer,
     jti: randomBase64Url(24),
     kind: "service",
-    scope: ["unigrok:connect", scope],
+    scope: granted,
     sub: `service:${service}`,
     v: 1,
   };
@@ -268,7 +291,30 @@ function isAccessClaims(value: unknown, config: McpOAuthConfig, now: number): va
     !Array.isArray(record.scope) ||
     record.scope.some((scope) => typeof scope !== "string" || !MCP_OAUTH_SCOPES.includes(scope))
   ) return false;
-  if (record.kind === "service") return record.sub === "service:github-review-broker";
+  if (record.kind === "service") {
+    if (record.sub === "service:github-review-broker") {
+      return (
+        Array.isArray(record.scope) &&
+        record.scope.includes("unigrok:connect") &&
+        record.scope.includes("unigrok:review") &&
+        record.scope.every((scope) => scope === "unigrok:connect" || scope === "unigrok:review")
+      );
+    }
+    if (record.sub === "service:cursor-cloud") {
+      return (
+        Array.isArray(record.scope) &&
+        record.scope.includes("unigrok:connect") &&
+        record.scope.includes("unigrok:invoke") &&
+        record.scope.every(
+          (scope) =>
+            scope === "unigrok:connect" ||
+            scope === "unigrok:invoke" ||
+            scope === "unigrok:status",
+        )
+      );
+    }
+    return false;
+  }
   return Number.isSafeInteger(record.githubId) && record.sub === `github:${record.githubId}` && typeof record.githubLogin === "string";
 }
 

--- a/sites/unigrok-control-center/tests/oauth-control.test.ts
+++ b/sites/unigrok-control-center/tests/oauth-control.test.ts
@@ -14,13 +14,15 @@ import {
 } from "../app/lib/landing-receipt";
 import {
   createAuthorizationCode,
+  createServiceAccessToken,
   exchangeAuthorizationCode,
+  McpOAuthError,
   normalizeScopes,
   readAccessToken,
   registerOAuthClient,
   type McpOAuthConfig,
 } from "../app/lib/mcp-oauth";
-import { sha256Base64Url } from "../app/lib/signed-cookie";
+import { sha256Base64Url, signCookiePayload } from "../app/lib/signed-cookie";
 
 const oauth: McpOAuthConfig = {
   issuer: "https://control.grokmcp.org",
@@ -62,6 +64,43 @@ test("dynamic OAuth client, PKCE code, and scoped token round trip", async () =>
   await assert.rejects(() => exchangeAuthorizationCode(oauth, { ...input, verifier: "x".repeat(64) }, 1_800_000_001_000));
   assert.equal(await readAccessToken(oauth, first.access_token, 1_800_000_800_000), null);
   assert.throws(() => normalizeScopes("unigrok:review repository:write"));
+});
+
+test("cursor-cloud service tokens require the exact fixed scope bundle", async () => {
+  const now = 1_800_000_000_000;
+  const token = await createServiceAccessToken(
+    oauth,
+    "cursor-cloud",
+    "unigrok:invoke",
+    now,
+  );
+  const claims = await readAccessToken(oauth, token, now + 1_000);
+  assert.equal(claims?.sub, "service:cursor-cloud");
+  assert.deepEqual(claims?.scope, [
+    "unigrok:connect",
+    "unigrok:invoke",
+    "unigrok:status",
+  ]);
+  await assert.rejects(
+    () => createServiceAccessToken(oauth, "cursor-cloud", "unigrok:status", now),
+    (error: unknown) =>
+      error instanceof McpOAuthError && error.oauthCode === "invalid_scope",
+  );
+
+  const iat = Math.floor(now / 1_000);
+  const missingStatus = {
+    aud: oauth.resource,
+    exp: iat + 600,
+    iat,
+    iss: oauth.issuer,
+    jti: "missing-status-scope-test",
+    kind: "service",
+    scope: ["unigrok:connect", "unigrok:invoke"],
+    sub: "service:cursor-cloud",
+    v: 1,
+  };
+  const malformed = `ugtoken.${await signCookiePayload(missingStatus, oauth.secret)}`;
+  assert.equal(await readAccessToken(oauth, malformed, now + 1_000), null);
 });
 
 test("authorization requires same-origin explicit consent before issuing a code", async () => {

--- a/tests/test_mint_mcp_service_token.py
+++ b/tests/test_mint_mcp_service_token.py
@@ -59,6 +59,28 @@ def test_mint_service_access_token_shape_and_claims() -> None:
     assert signed == sign_cookie_payload(claims, secret)
 
 
+def test_mint_cursor_cloud_token_grants_invoke_and_status() -> None:
+    secret = "s" * 48
+    token = mint_service_access_token(
+        secret=secret,
+        issuer="https://control.grokmcp.org",
+        resource="https://mcp.grokmcp.org/mcp",
+        service="cursor-cloud",
+        now=1_700_000_000,
+        jti="cursor-jti-fixed-value-24bxx",
+    )
+    body = token[len(TOKEN_PREFIX) :].split(".", 1)[0]
+    pad = "=" * (-len(body) % 4)
+    claims = json.loads(base64.urlsafe_b64decode(body + pad))
+    assert claims["sub"] == "service:cursor-cloud"
+    assert claims["scope"] == [
+        "unigrok:connect",
+        "unigrok:invoke",
+        "unigrok:status",
+    ]
+    assert claims["exp"] - claims["iat"] == 600
+
+
 def test_mint_rejects_disallowed_service_and_scope() -> None:
     secret = "s" * 48
     with pytest.raises(ValueError, match="service not allowed"):
@@ -73,7 +95,16 @@ def test_mint_rejects_disallowed_service_and_scope() -> None:
             secret=secret,
             issuer="https://control.grokmcp.org",
             resource="https://mcp.grokmcp.org/mcp",
+            service="github-review-broker",
             scope="unigrok:invoke",
+        )
+    with pytest.raises(ValueError, match="scope not allowed"):
+        mint_service_access_token(
+            secret=secret,
+            issuer="https://control.grokmcp.org",
+            resource="https://mcp.grokmcp.org/mcp",
+            service="cursor-cloud",
+            scope="unigrok:review",
         )
 
 
@@ -111,3 +142,24 @@ def test_cli_print_claims_uses_independent_non_secret_metadata(
     }
     assert secret not in captured.out
     assert secret not in captured.err
+
+
+def test_cli_cursor_cloud_env(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    secret = "cursor-cloud-signing-key-value-ok" * 2
+    monkeypatch.setenv("UNIGROK_MCP_TOKEN_SECRET", secret)
+    monkeypatch.setenv("UNIGROK_SERVICE_NAME", "cursor-cloud")
+    monkeypatch.setenv("UNIGROK_SERVICE_SCOPE", "unigrok:invoke")
+    monkeypatch.setenv("UNIGROK_OAUTH_ISSUER", "https://control.grokmcp.org")
+    monkeypatch.setenv("UNIGROK_MCP_RESOURCE_URL", "https://mcp.grokmcp.org/mcp")
+    monkeypatch.setattr("scripts.mint_mcp_service_token.time.time", lambda: 1_700_000_000)
+
+    import scripts.mint_mcp_service_token as mod
+
+    assert mod.main(["--print-claims"]) == 0
+    captured = capsys.readouterr()
+    meta = json.loads(captured.err)
+    assert meta["sub"] == "service:cursor-cloud"
+    assert "unigrok:invoke" in meta["scope"]
+    assert secret not in captured.out

--- a/tests/test_mint_mcp_service_token.py
+++ b/tests/test_mint_mcp_service_token.py
@@ -106,6 +106,14 @@ def test_mint_rejects_disallowed_service_and_scope() -> None:
             service="cursor-cloud",
             scope="unigrok:review",
         )
+    with pytest.raises(ValueError, match="scope not allowed"):
+        mint_service_access_token(
+            secret=secret,
+            issuer="https://control.grokmcp.org",
+            resource="https://mcp.grokmcp.org/mcp",
+            service="cursor-cloud",
+            scope="unigrok:status",
+        )
 
 
 def test_cli_prints_token_only(capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
@@ -116,9 +124,9 @@ def test_cli_prints_token_only(capsys: pytest.CaptureFixture[str], monkeypatch: 
     import scripts.mint_mcp_service_token as mod
 
     assert mod.main([]) == 0
-    out = capsys.readouterr().out.strip()
+    out = capsys.readouterr().out
     assert out.startswith(TOKEN_PREFIX)
-    assert "\n" not in out or out.endswith("\n") is False or True
+    assert "\n" not in out
 
 
 def test_cli_print_claims_uses_independent_non_secret_metadata(
@@ -132,6 +140,11 @@ def test_cli_print_claims_uses_independent_non_secret_metadata(
 
     import scripts.mint_mcp_service_token as mod
 
+    monkeypatch.setattr(
+        mod,
+        "mint_service_access_token",
+        lambda **_: f"{TOKEN_PREFIX}opaque-non-json-token",
+    )
     assert mod.main(["--print-claims"]) == 0
     captured = capsys.readouterr()
     assert captured.out.startswith(TOKEN_PREFIX)


### PR DESCRIPTION
Supersedes #130 with the reviewed implementation and security fixes.

Exact head: `4f830191b6ef886f14daa7a089aa10906d07f2c7`

Changed paths:
- `docs/cursor-cloud-mcp.md`
- `scripts/mint_mcp_service_token.py`
- `sites/unigrok-control-center/app/lib/mcp-oauth.ts`
- `sites/unigrok-control-center/tests/oauth-control.test.ts`
- `tests/test_mint_mcp_service_token.py`

What changed:
- Enforces the exact Cursor Cloud `connect + invoke + status` service bundle.
- Rejects status-only mint requests instead of silently escalating them.
- Requires exact-scope Control introspection.
- Makes `--print-claims` metadata independent of secret-derived token bytes, closing the clear-text logging finding.
- Keeps `SERVICE_SPECS` as the single authoritative scope source and replaces tautological coverage with behavior assertions.

Verification:
- `./scripts/land` — 1,987 tests passed; branch synchronized with protected `main`; `LANDED TO MAIN: 4f830191b6ef886f14daa7a089aa10906d07f2c7`.
- Focused Python auth/security tests: 136 passed.
- Token mint tests: 7 passed.
- Control OAuth tests: 6 passed.
- TypeScript typecheck, production dependency audit, Ruff, attribution, and deterministic OKF checks passed.

Risk and rollout:
- Security-sensitive auth change. Do not deploy Control until this exact head passes GitHub CI, CodeQL, Bugbot, independent security review, and exact-head approval.
- No credentials or token values are logged or committed.

Human-Sponsor: djtelicloud

Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=user-reported | surface=Codex Desktop | role=integration