### PR TITLE
chore(deps): enable bounded Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,75 @@
+version: 2
+
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    groups:
+      python-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: "/sites/unigrok-control-center"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    groups:
+      control-center-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "docker"
+    directory: "/sites/unigrok-control-center"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "America/New_York"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"

--- a/tests/test_release_hygiene.py
+++ b/tests/test_release_hygiene.py
@@ -24,6 +24,16 @@ def test_release_version_is_aligned_across_package_runtime_and_ui():
     assert plugin["version"] == __version__
 
 
+def test_dependabot_covers_every_shipped_dependency_surface():
+    config = (ROOT / ".github" / "dependabot.yml").read_text(encoding="utf-8")
+
+    assert 'package-ecosystem: "uv"' in config
+    assert 'package-ecosystem: "npm"' in config
+    assert 'package-ecosystem: "github-actions"' in config
+    assert config.count('package-ecosystem: "docker"') == 2
+    assert 'directory: "/sites/unigrok-control-center"' in config
+
+
 def test_public_runtime_files_do_not_embed_a_developer_home_path():
     paths = [
         ROOT / "docker-compose.yml",


### PR DESCRIPTION
## Summary

Enable bounded weekly Dependabot version updates for every shipped dependency surface:
- uv at the repository root
- npm in the Contributor Control site
- GitHub Actions
- the gateway and Control Cloud Run Dockerfiles

Minor/patch Python and npm updates are grouped to reduce PR churn. No update is auto-merged, and each ecosystem is capped at five open PRs.

## Exact head

`ec924177d4497d4b7911b7c18f0636a97a9fa5cb`

## Changed paths

- `.github/dependabot.yml`
- `tests/test_release_hygiene.py`

## Verification

- Dependabot YAML parsed and asserted against all five ecosystem roots
- `uv run pytest -q tests/test_release_hygiene.py` — 15 passed
- `uv run pytest -q` — 1,988 passed
- Control site: npm audit, lint, typecheck, verified build, and 66 unit tests passed
- Python `pip-audit` and npm audit — zero known vulnerabilities
- `git diff --check`, Ruff, and attribution check passed
- `./scripts/land` printed `LANDED TO MAIN: ec924177d4497d4b7911b7c18f0636a97a9fa5cb`

## Risk

Dependabot may open update PRs on its next scheduled run. Changes still require normal protected-branch review and CI; this does not enable auto-merge or weaken protection.

Human sponsor: David Johnston

Ready for Codex land: yes

Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=implementation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/release-hygiene and GitHub automation only; future Dependabot PRs still go through normal review and do not auto-merge.
> 
> **Overview**
> Adds **`.github/dependabot.yml`** so dependency updates run on a **weekly Monday** schedule (America/New_York) with **`dependencies`** labels and **at most five open PRs** per ecosystem.
> 
> Coverage matches shipped surfaces: **uv** at repo root, **npm** under `sites/unigrok-control-center`, **GitHub Actions**, and **two Docker** roots (gateway at `/` and control center). **Minor/patch** Python and npm bumps are **grouped** to cut PR noise; Actions are grouped together. There is **no auto-merge** in this config.
> 
> **`tests/test_release_hygiene.py`** gains **`test_dependabot_covers_every_shipped_dependency_surface`**, which asserts the config includes uv, npm, github-actions, two docker entries, and the control-center directory path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec924177d4497d4b7911b7c18f0636a97a9fa5cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->