### PR TITLE
Support reviewed MCP 1.28 session registry

### DIFF
--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -950,15 +950,15 @@ class SessionRuntimeRevoker
 
 Revokes all session-owned callback/effect authority before teardown.
 
-### Class: `MCP126SessionTransportRegistry` {#mcp_session_guard-mcp126sessiontransportregistry}
+### Class: `MCP128SessionTransportRegistry` {#mcp_session_guard-mcp128sessiontransportregistry}
 
 ```python
-class MCP126SessionTransportRegistry
+class MCP128SessionTransportRegistry
 ```
 
-**Keywords:** mcp, 126, session, transport, registry
+**Keywords:** mcp, 128, session, transport, registry
 
-Version-checked adapter over MCP SDK 1.26 private session state.
+Version-checked adapter over MCP SDK 1.28 private session state.
 
 This adapter is intentionally constructed with one exact session manager;
 it never discovers or mutates a module-global manager.  A future SDK minor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 dependencies = [
     # Stateful session cleanup uses a narrowly isolated, version-checked SDK
     # 1.26 private registry adapter. Review that adapter before widening this.
-    "mcp[cli]>=1.26,<1.27",
+    "mcp[cli]>=1.28.1,<1.29",
     "httpx>=0.28.1",
     "google-auth[requests]>=2.40,<3",
     "cryptography>=49,<50",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 dependencies = [
     # Stateful session cleanup uses a narrowly isolated, version-checked SDK
-    # 1.26 private registry adapter. Review that adapter before widening this.
+    # 1.28 private registry adapter. Review that adapter before widening this.
     "mcp[cli]>=1.28.1,<1.29",
     "httpx>=0.28.1",
     "google-auth[requests]>=2.40,<3",

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -950,15 +950,15 @@ class SessionRuntimeRevoker
 
 Revokes all session-owned callback/effect authority before teardown.
 
-### Class: `MCP126SessionTransportRegistry` {#mcp_session_guard-mcp126sessiontransportregistry}
+### Class: `MCP128SessionTransportRegistry` {#mcp_session_guard-mcp128sessiontransportregistry}
 
 ```python
-class MCP126SessionTransportRegistry
+class MCP128SessionTransportRegistry
 ```
 
-**Keywords:** mcp, 126, session, transport, registry
+**Keywords:** mcp, 128, session, transport, registry
 
-Version-checked adapter over MCP SDK 1.26 private session state.
+Version-checked adapter over MCP SDK 1.28 private session state.
 
 This adapter is intentionally constructed with one exact session manager;
 it never discovers or mutates a module-global manager.  A future SDK minor

--- a/src/mcp_session_guard.py
+++ b/src/mcp_session_guard.py
@@ -31,7 +31,7 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 MCP_SESSION_ID_HEADER = b"mcp-session-id"
 MCP_SESSION_BINDING_SCOPE_KEY = "unigrok.mcp_session.binding"
 
-_SDK_PRIVATE_INTERFACE_MINOR = (1, 26)
+_SDK_PRIVATE_INTERFACE_MINOR = (1, 28)
 _SESSION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._~-]{0,127}$")
 _CLIENT_ID_RE = re.compile(rb"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 _SINGLETON_SECURITY_HEADERS = frozenset(
@@ -66,8 +66,8 @@ class SessionRuntimeRevoker(Protocol):
     async def revoke_session(self, session_id: str) -> None: ...
 
 
-class MCP126SessionTransportRegistry:
-    """Version-checked adapter over MCP SDK 1.26 private session state.
+class MCP128SessionTransportRegistry:
+    """Version-checked adapter over MCP SDK 1.28 private session state.
 
     This adapter is intentionally constructed with one exact session manager;
     it never discovers or mutates a module-global manager.  A future SDK minor
@@ -87,14 +87,18 @@ class MCP126SessionTransportRegistry:
             )
 
         instances = getattr(manager, "_server_instances", None)
+        owners = getattr(manager, "_session_owners", None)
         creation_lock = getattr(manager, "_session_creation_lock", None)
         if not isinstance(instances, MutableMapping):
             raise RuntimeError("MCP SDK session registry shape changed")
+        if not isinstance(owners, MutableMapping):
+            raise RuntimeError("MCP SDK session owner registry shape changed")
         if not callable(getattr(creation_lock, "__aenter__", None)) or not callable(
             getattr(creation_lock, "__aexit__", None)
         ):
             raise RuntimeError("MCP SDK session creation lock shape changed")
         self._instances = instances
+        self._owners = owners
         self._creation_lock = creation_lock
 
     async def contains(self, session_id: str) -> bool:
@@ -108,8 +112,9 @@ class MCP126SessionTransportRegistry:
     async def remove_and_terminate(self, session_id: str) -> bool:
         async with self._creation_lock:
             transport = self._instances.get(session_id)
-        if transport is None:
-            return False
+            if transport is None:
+                self._owners.pop(session_id, None)
+                return False
         terminate = getattr(transport, "terminate", None)
         if not callable(terminate):
             raise RuntimeError("MCP SDK transport termination interface changed")
@@ -120,6 +125,7 @@ class MCP126SessionTransportRegistry:
                 self._instances.pop(session_id, None)
             elif current is not None:
                 raise RuntimeError("MCP SDK session transport changed during cleanup")
+            self._owners.pop(session_id, None)
         return True
 
 

--- a/tests/test_mcp_session_guard.py
+++ b/tests/test_mcp_session_guard.py
@@ -10,7 +10,7 @@ import pytest
 
 from src.mcp_session_guard import (
     MCP_SESSION_BINDING_SCOPE_KEY,
-    MCP126SessionTransportRegistry,
+    MCP128SessionTransportRegistry,
     MCPSessionBinding,
     StatefulMCPSessionGuard,
 )
@@ -1257,23 +1257,37 @@ async def test_sdk_private_registry_is_instance_scoped_and_terminates_after_remo
     manager = StreamableHTTPSessionManager(app=object())
     transport = FakeTransport("session-a", events)
     manager._server_instances["session-a"] = transport
-    registry = MCP126SessionTransportRegistry(manager)
+    manager._session_owners["session-a"] = object()
+    registry = MCP128SessionTransportRegistry(manager)
 
     assert await registry.session_ids() == frozenset({"session-a"})
     assert await registry.contains("session-a") is True
     assert await registry.remove_and_terminate("session-a") is True
     assert manager._server_instances == {}
+    assert manager._session_owners == {}
     assert events == ["terminate:session-a"]
 
 
 @pytest.mark.asyncio
-async def test_guard_interoperates_with_real_mcp_126_stateful_asgi():
+async def test_sdk_private_registry_removes_orphaned_session_owner():
+    from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+
+    manager = StreamableHTTPSessionManager(app=object())
+    manager._session_owners["orphaned-session"] = object()
+    registry = MCP128SessionTransportRegistry(manager)
+
+    assert await registry.remove_and_terminate("orphaned-session") is False
+    assert manager._session_owners == {}
+
+
+@pytest.mark.asyncio
+async def test_guard_interoperates_with_real_mcp_128_stateful_asgi():
     from mcp.server.fastmcp import FastMCP
 
     events: list[str] = []
     mcp = FastMCP("guard-integration", stateless_http=False)
     mcp_app = mcp.streamable_http_app()
-    registry = MCP126SessionTransportRegistry(mcp.session_manager)
+    registry = MCP128SessionTransportRegistry(mcp.session_manager)
     guard = StatefulMCPSessionGuard(
         mcp_app,
         registry=registry,
@@ -1318,8 +1332,8 @@ async def test_guard_interoperates_with_real_mcp_126_stateful_asgi():
 def test_sdk_private_registry_rejects_unreviewed_minor(monkeypatch):
     from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
 
-    monkeypatch.setattr("src.mcp_session_guard.metadata.version", lambda _: "1.27.0")
+    monkeypatch.setattr("src.mcp_session_guard.metadata.version", lambda _: "1.29.0")
     manager = StreamableHTTPSessionManager(app=object())
 
     with pytest.raises(RuntimeError, match="explicit SDK minor review"):
-        MCP126SessionTransportRegistry(manager)
+        MCP128SessionTransportRegistry(manager)

--- a/uv.lock
+++ b/uv.lock
@@ -861,7 +861,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.26.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -879,9 +879,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [package.optional-dependencies]
@@ -940,7 +940,7 @@ requires-dist = [
     { name = "google-genai", marker = "extra == 'campaign'", specifier = ">=1.25,<2" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "jsonschema", specifier = ">=4.23,<5" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.26,<1.27" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.28.1,<1.29" },
     { name = "pydantic", specifier = ">=2.9.0" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pytest", marker = "extra == 'forge'", specifier = ">=9.1.1" },


### PR DESCRIPTION
## Summary

- update `mcp[cli]` from reviewed SDK minor 1.26 to 1.28.1
- extend the fail-closed private session-registry adapter to validate and clean the SDK's new credential-owner map
- regenerate the public OKF API reference
- supersede failing Dependabot PR #142 with the required compatibility repair
- correct the adjacent SDK review marker identified during PR review

## Exact scope

- Reviewed head: `2d6375fbcf7f2ccffeeb04543ef31d7c508940b4`
- Changed paths:
  - `pyproject.toml`
  - `uv.lock`
  - `src/mcp_session_guard.py`
  - `tests/test_mcp_session_guard.py`
  - `docs/okf/api-reference.md`
  - `sites/unigrok-control-center/public/docs/okf/api-reference.md`

## Verification

- focused MCP session-guard suite: 47 passed
- Ruff on changed Python paths: passed
- full suite after review fix: 1,989 passed
- Docker image rebuilt and runtime smoke-tested
- `./scripts/land`: `LANDED TO MAIN: 2d6375fbcf7f2ccffeeb04543ef31d7c508940b4`

## Risk and safety

The adapter still depends on SDK-private state. It accepts only MCP minor 1.28, validates the transport map, owner map, and creation lock at construction, and fails closed on any future minor or shape change. Cleanup terminates the exact transport and removes both transport and credential-owner state under the SDK lock.

## Ownership and provenance

- Human sponsor / accountable contributor: `djtelicloud`
- Agent assistance: OpenAI Codex, GPT-5, provider-session, Codex Desktop, implementation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Relies on SDK-private `_server_instances` and `_session_owners` with a narrow 1.28 version gate; incorrect cleanup could affect stateful MCP session teardown.
> 
> **Overview**
> Bumps the **`mcp[cli]`** dependency from the reviewed **1.26** line to **1.28.1** and renames the fail-closed private registry adapter to **`MCP128SessionTransportRegistry`**, which only accepts MCP minor **1.28**.
> 
> The adapter now validates the SDK’s **`_session_owners`** map at construction and clears owner entries during **`remove_and_terminate`** (including orphaned owners when no transport exists), keeping session teardown aligned with MCP 1.28’s private session manager shape. OKF API reference docs and session-guard tests are updated accordingly; unreviewed minors (e.g. **1.29**) still fail closed at adapter init.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d6375fbcf7f2ccffeeb04543ef31d7c508940b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->