### PR TITLE
fix: harden maintainer integration surfaces

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -48,7 +48,7 @@ promote an OpenAI, Anthropic, or Google result to final output.
 
 The three xAI credential roles are separate. Grok CLI OAuth and `XAI_API_KEY`
 authorize their respective inference planes. The optional xAI
-business/management credential (`XAI_MANAGEMENT_API_KEY`) is non-inference
+business/management credential (`XAI_MANAGEMENT_API_KEY`) is a non-inference
 management authority: configuring it neither enables inference nor chooses
 which administrative operations are allowed. Each management operation still
 requires its own explicit authorization boundary.

--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -1493,7 +1493,7 @@ def provider_result_matches_start(start: ProviderAttemptStart, result: ProviderA
 
 **Keywords:** provider, result, matches, start
 
-Return whether one normalized result is bound to its exact v2 start.
+Return whether one normalized result is bound to its exact v3 start.
 
 ### Function: `is_safe_model_id` {#providers-contracts-is_safe_model_id}
 
@@ -3995,6 +3995,16 @@ def xai_management_key_configured() -> bool
 **Keywords:** xai, management, key, configured
 
 Return whether one unambiguous xAI management credential is configured.
+
+### Function: `xai_management_key_state` {#utils-xai_management_key_state}
+
+```python
+def xai_management_key_state() -> str
+```
+
+**Keywords:** xai, management, key, state
+
+Return configured, missing, or conflict without exposing either secret.
 
 ### Function: `get_xai_inference_client` {#utils-get_xai_inference_client}
 

--- a/mcp_ui/app.js
+++ b/mcp_ui/app.js
@@ -1003,9 +1003,6 @@ function syncPrimaryCta(ready, detailText = null) {
   if (offline) {
     btn.textContent = "Copy install commands";
     btn.dataset.cta = "install";
-  } else if (!ready && detailText) {
-    btn.textContent = "Copy IDE MCP config";
-    btn.dataset.cta = "mcp";
   } else {
     btn.textContent = "Copy IDE MCP config";
     btn.dataset.cta = "mcp";
@@ -1110,7 +1107,9 @@ function renderSetupStatus(data, ready = true, detailText = null) {
 
   if (target) {
     const t = document.createElement("strong");
-    t.textContent = ready ? "Gateway is live." : "Gateway needs attention.";
+    t.textContent = ready
+      ? "Gateway is live."
+      : (detailText ? "Gateway needs attention." : "Gateway offline.");
     const d = document.createElement("span");
     d.textContent = ready
       ? ` Runtime: ${runtime} · active credential plane: ${effective}.${attention ? ` ${attention}` : ""}`
@@ -2044,14 +2043,6 @@ function genSessionId() {
   return `console-${token}`;
 }
 
-function resetConversation() {
-  const conversation = $("conversation");
-  if (conversation) conversation.innerHTML = "";
-  const sessionInput = $("sessionInput");
-  if (sessionInput && !sessionInput.value.trim()) sessionInput.value = genSessionId();
-  addMessageBubble("system", "Session started. Ready to execute prompts.");
-}
-
 // Clear History rotates to a fresh session so the next turn starts clean; the
 // prior server-side session is retained under its own id, not deleted here.
 function clearConversation() {
@@ -2625,7 +2616,6 @@ function init() {
     loadWebMcpManifest();
   });
 
-  resetConversation();
   switchTab("tab-onboarding");
 
   window.parseMcpResponse = parseMcpResponse;

--- a/mcp_ui/index.html
+++ b/mcp_ui/index.html
@@ -458,14 +458,14 @@ docker compose up --build -d</code></pre>
               <div class="connect-snippet-block">
                 <div class="connect-snippet-header">
                   <span class="section-kicker">Cursor MCP JSON (first-class)</span>
-                  <button id="copyMcpJsonBtn" type="button" class="small-btn-glow">Copy</button>
+                  <button id="copyMcpJsonBtn" type="button" class="small-btn-glow" aria-label="Copy Cursor MCP JSON">Copy</button>
                 </div>
                 <pre class="connect-snippet" tabindex="0"><code id="mcpJsonSnippet">{ }</code></pre>
               </div>
               <div class="connect-snippet-block">
                 <div class="connect-snippet-header">
                   <span class="section-kicker">Agent setup prompt</span>
-                  <button id="copyAgentPromptBtn" type="button" class="small-btn-glow">Copy</button>
+                  <button id="copyAgentPromptBtn" type="button" class="small-btn-glow" aria-label="Copy agent setup prompt">Copy</button>
                 </div>
                 <pre class="connect-snippet connect-snippet-prompt" tabindex="0"><code id="agentPromptSnippet">…</code></pre>
               </div>

--- a/mcp_ui/styles.css
+++ b/mcp_ui/styles.css
@@ -1926,6 +1926,7 @@ pre {
   border-radius: var(--radius-sm);
   background: rgba(3, 6, 9, 0.55);
   overflow-x: auto;
+  overflow-y: auto;
   font-size: 12px;
   line-height: 1.55;
   color: var(--ink-soft);

--- a/scripts/github-grok-review.py
+++ b/scripts/github-grok-review.py
@@ -136,19 +136,16 @@ def _workflow_run_url(repository: str) -> str | None:
 
 
 def _gateway_bearer_token() -> str:
-    """Resolve MCP auth: static token override, else mint a ~120s service token.
+    """Resolve MCP auth: mint when possible, else use the static fallback.
 
     Production twin validates via Control introspection. Long-lived static
     client keys must not be installed on Cloud Run. When
     ``UNIGROK_MCP_TOKEN_SECRET`` is set (same as Control ``MCP_TOKEN_SECRET``),
     mint ``service:github-review-broker`` with ``unigrok:review``.
     """
-    static = os.environ.get("UNIGROK_CLIENT_TOKEN", "").strip()
-    if static:
-        return static
     secret = os.environ.get("UNIGROK_MCP_TOKEN_SECRET", "").strip()
     if not secret:
-        return ""
+        return os.environ.get("UNIGROK_CLIENT_TOKEN", "").strip()
     # Import path works when run as ``uv run python scripts/github-grok-review.py``
     # with repo root on sys.path (uv / Actions checkout default).
     try:
@@ -167,12 +164,18 @@ def _gateway_bearer_token() -> str:
     if not resource.endswith("/mcp"):
         if resource.endswith(".org") or resource.endswith(".com"):
             resource = f"{resource}/mcp"
+    raw_ttl = os.environ.get("UNIGROK_TOKEN_TTL_SECONDS", "").strip()
+    try:
+        ttl_seconds = int(raw_ttl) if raw_ttl else None
+    except ValueError as exc:
+        raise ValueError("UNIGROK_TOKEN_TTL_SECONDS must be an integer") from exc
     return mint_service_access_token(
         secret=secret,
         issuer=issuer,
         resource=resource,
         service=os.environ.get("UNIGROK_SERVICE_NAME", "github-review-broker").strip(),
         scope=os.environ.get("UNIGROK_SERVICE_SCOPE", "unigrok:review").strip(),
+        ttl_seconds=ttl_seconds,
     )
 
 
@@ -182,7 +185,8 @@ async def _call_unigrok(arguments: dict[str, Any]) -> dict[str, Any]:
     gateway_token = _gateway_bearer_token()
     if gateway_token:
         headers["Authorization"] = f"Bearer {gateway_token}"
-    async with httpx.AsyncClient(headers=headers, timeout=540.0) as client:
+    timeout = httpx.Timeout(connect=15.0, read=540.0, write=30.0, pool=15.0)
+    async with httpx.AsyncClient(headers=headers, timeout=timeout) as client:
         async with streamable_http_client(url, http_client=client) as (read, write, _):
             async with ClientSession(read, write, read_timeout_seconds=timedelta(seconds=540)) as session:
                 await session.initialize()
@@ -330,7 +334,9 @@ def _format_exc(exc: BaseException) -> str:
     if isinstance(exc, BaseExceptionGroup):
         for i, sub in enumerate(exc.exceptions, 1):
             parts.append(f"  [{i}] {_format_exc(sub)}")
-    cause = exc.__cause__ or exc.__context__
+    cause = exc.__cause__
+    if cause is None and not exc.__suppress_context__:
+        cause = exc.__context__
     if cause is not None and cause is not exc:
         parts.append(f"  caused by: {_format_exc(cause)}")
     return "\n".join(parts)

--- a/scripts/mint_mcp_service_token.py
+++ b/scripts/mint_mcp_service_token.py
@@ -42,8 +42,10 @@ SERVICE_SPECS: dict[str, dict[str, Any]] = {
     "github-review-broker": {
         "scopes": frozenset({"unigrok:review"}),
         "default_scope": "unigrok:review",
-        "default_ttl": 120,
-        "max_ttl": 120,
+        # Hosted review allows a 9-minute model read. Keep one bounded token
+        # valid for that stream instead of expiring mid-response.
+        "default_ttl": 600,
+        "max_ttl": 600,
     },
     # Cursor Cloud / headless IDE agents: invoke + status (discover/status tools).
     "cursor-cloud": {
@@ -103,6 +105,59 @@ def _service_token_parameters(
     return primary, ttl, granted
 
 
+def _service_access_claims(
+    *,
+    issuer: str,
+    resource: str,
+    service: str = "github-review-broker",
+    scope: Optional[str] = None,
+    ttl_seconds: Optional[int] = None,
+    now: Optional[int] = None,
+    jti: Optional[str] = None,
+) -> dict[str, Any]:
+    _primary, ttl, granted = _service_token_parameters(service, scope, ttl_seconds)
+    if not issuer.startswith("https://") or issuer.endswith("/"):
+        raise ValueError("issuer must be an https origin without trailing slash")
+    if not resource.startswith("https://") or not resource.endswith("/mcp"):
+        raise ValueError("resource must be https://…/mcp")
+    iat = int(now if now is not None else time.time())
+    return {
+        "aud": resource,
+        "exp": iat + ttl,
+        "iat": iat,
+        "iss": issuer,
+        "jti": jti or _b64url(secrets.token_bytes(24)),
+        "kind": "service",
+        "scope": granted,
+        "sub": f"service:{service}",
+        "v": 1,
+    }
+
+
+def _mint_service_access_token_with_claims(
+    *,
+    secret: str,
+    issuer: str,
+    resource: str,
+    service: str = "github-review-broker",
+    scope: Optional[str] = None,
+    ttl_seconds: Optional[int] = None,
+    now: Optional[int] = None,
+    jti: Optional[str] = None,
+) -> tuple[str, dict[str, Any]]:
+    claims = _service_access_claims(
+        issuer=issuer,
+        resource=resource,
+        service=service,
+        scope=scope,
+        ttl_seconds=ttl_seconds,
+        now=now,
+        jti=jti,
+    )
+    token = f"{TOKEN_PREFIX}{sign_cookie_payload(claims, secret)}"
+    return token, claims
+
+
 def mint_service_access_token(
     *,
     secret: str,
@@ -114,24 +169,17 @@ def mint_service_access_token(
     now: Optional[int] = None,
     jti: Optional[str] = None,
 ) -> str:
-    _primary, ttl, granted = _service_token_parameters(service, scope, ttl_seconds)
-    if not issuer.startswith("https://") or issuer.endswith("/"):
-        raise ValueError("issuer must be an https origin without trailing slash")
-    if not resource.startswith("https://") or not resource.endswith("/mcp"):
-        raise ValueError("resource must be https://…/mcp")
-    iat = int(now if now is not None else time.time())
-    claims = {
-        "aud": resource,
-        "exp": iat + ttl,
-        "iat": iat,
-        "iss": issuer,
-        "jti": jti or _b64url(secrets.token_bytes(24)),
-        "kind": "service",
-        "scope": granted,
-        "sub": f"service:{service}",
-        "v": 1,
-    }
-    return f"{TOKEN_PREFIX}{sign_cookie_payload(claims, secret)}"
+    token, _claims = _mint_service_access_token_with_claims(
+        secret=secret,
+        issuer=issuer,
+        resource=resource,
+        service=service,
+        scope=scope,
+        ttl_seconds=ttl_seconds,
+        now=now,
+        jti=jti,
+    )
+    return token
 
 
 def main(argv: Optional[list[str]] = None) -> int:
@@ -154,22 +202,19 @@ def main(argv: Optional[list[str]] = None) -> int:
     except ValueError as exc:
         raise SystemExit("UNIGROK_TOKEN_TTL_SECONDS must be an integer") from exc
 
-    issued_at = int(time.time())
-    _primary, resolved_ttl, granted = _service_token_parameters(service, scope, ttl)
-    token = mint_service_access_token(
+    token, claims = _mint_service_access_token_with_claims(
         secret=secret,
         issuer=issuer,
         resource=resource,
         service=service,
         scope=scope,
         ttl_seconds=ttl,
-        now=issued_at,
     )
     if args.print_claims:
         claims_metadata = {
-            "exp": issued_at + resolved_ttl,
-            "scope": granted,
-            "sub": f"service:{service}",
+            "exp": claims["exp"],
+            "scope": claims["scope"],
+            "sub": claims["sub"],
         }
         print(json.dumps(claims_metadata, sort_keys=True), file=sys.stderr)
     output = token.encode("ascii")

--- a/sites/unigrok-control-center/Dockerfile.cloudrun
+++ b/sites/unigrok-control-center/Dockerfile.cloudrun
@@ -1,21 +1,19 @@
 # syntax=docker/dockerfile:1
 
-ARG NODE_IMAGE=node:22.22.0-bookworm-slim@sha256:dd9d21971ec4395903fa6143c2b9267d048ae01ca6d3ea96f16cb30df6187d94
-
-FROM ${NODE_IMAGE} AS dependencies
+FROM node:22.22.0-bookworm-slim@sha256:dd9d21971ec4395903fa6143c2b9267d048ae01ca6d3ea96f16cb30df6187d94 AS dependencies
 WORKDIR /workspace
 ENV NEXT_TELEMETRY_DISABLED=1
 COPY package.json package-lock.json .npmrc ./
 RUN npm ci --ignore-scripts
 
-FROM ${NODE_IMAGE} AS builder
+FROM node:22.22.0-bookworm-slim@sha256:dd9d21971ec4395903fa6143c2b9267d048ae01ca6d3ea96f16cb30df6187d94 AS builder
 WORKDIR /workspace
 ENV NEXT_TELEMETRY_DISABLED=1
 COPY --from=dependencies /workspace/node_modules ./node_modules
 COPY . .
 RUN npm run build:standalone
 
-FROM ${NODE_IMAGE} AS runtime
+FROM node:22.22.0-bookworm-slim@sha256:dd9d21971ec4395903fa6143c2b9267d048ae01ca6d3ea96f16cb30df6187d94 AS runtime
 WORKDIR /app
 
 ENV HOSTNAME=0.0.0.0 \

--- a/sites/unigrok-control-center/app/lib/grok-review-surface.ts
+++ b/sites/unigrok-control-center/app/lib/grok-review-surface.ts
@@ -24,14 +24,6 @@ export function deriveGrokReviewSurface(input: GrokReviewSurfaceInput): GrokRevi
   const completed = unigrokChecks.filter(
     (check) => check.status === "completed" || (check.conclusion !== null && check.conclusion !== ""),
   );
-  const success = completed.find((check) => check.conclusion === "success");
-  if (success) {
-    return surface(
-      "ready",
-      `Latest UniGrok review check succeeded on PR #${success.pullNumber}. Score and findings appear only when the review broker returns structured content.`,
-      "Check passed",
-    );
-  }
   const failure = completed.find((check) =>
     check.conclusion === "failure" ||
     check.conclusion === "cancelled" ||
@@ -41,8 +33,16 @@ export function deriveGrokReviewSurface(input: GrokReviewSurfaceInput): GrokRevi
   if (failure) {
     return surface(
       "error",
-      `Latest UniGrok review check on PR #${failure.pullNumber} concluded ${failure.conclusion}. No synthetic score is shown.`,
+      `A UniGrok review check on PR #${failure.pullNumber} concluded ${failure.conclusion}. No synthetic score is shown.`,
       null,
+    );
+  }
+  const success = completed.find((check) => check.conclusion === "success");
+  if (success) {
+    return surface(
+      "ready",
+      `A UniGrok review check succeeded on PR #${success.pullNumber}. Score and findings appear only when the review broker returns structured content.`,
+      "Check passed",
     );
   }
   if (input.oauthConfigured) {

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -1493,7 +1493,7 @@ def provider_result_matches_start(start: ProviderAttemptStart, result: ProviderA
 
 **Keywords:** provider, result, matches, start
 
-Return whether one normalized result is bound to its exact v2 start.
+Return whether one normalized result is bound to its exact v3 start.
 
 ### Function: `is_safe_model_id` {#providers-contracts-is_safe_model_id}
 
@@ -3995,6 +3995,16 @@ def xai_management_key_configured() -> bool
 **Keywords:** xai, management, key, configured
 
 Return whether one unambiguous xAI management credential is configured.
+
+### Function: `xai_management_key_state` {#utils-xai_management_key_state}
+
+```python
+def xai_management_key_state() -> str
+```
+
+**Keywords:** xai, management, key, state
+
+Return configured, missing, or conflict without exposing either secret.
 
 ### Function: `get_xai_inference_client` {#utils-get_xai_inference_client}
 

--- a/sites/unigrok-control-center/tests/grok-review-surface.test.ts
+++ b/sites/unigrok-control-center/tests/grok-review-surface.test.ts
@@ -66,6 +66,29 @@ test("deriveGrokReviewSurface surfaces failed checks as error without a score", 
   assert.match(surface.message, /failure/);
 });
 
+test("deriveGrokReviewSurface gives failures precedence without claiming recency", () => {
+  const surface = deriveGrokReviewSurface({
+    oauthConfigured: true,
+    reviewChecks: [
+      {
+        conclusion: "success",
+        name: "UniGrok review",
+        pullNumber: 114,
+        status: "completed",
+      },
+      {
+        conclusion: "timed_out",
+        name: "UniGrok review",
+        pullNumber: 115,
+        status: "completed",
+      },
+    ],
+  });
+  assert.equal(surface.state, "error");
+  assert.match(surface.message, /PR #115/);
+  assert.doesNotMatch(surface.message, /Latest/);
+});
+
 test("mcpOAuthConfigured is injectable and fail-closed", () => {
   assert.equal(
     mcpOAuthConfigured(() => {

--- a/src/completion_envelope.py
+++ b/src/completion_envelope.py
@@ -367,7 +367,12 @@ def _json_boundary(payload: Mapping[str, Any] | str | bytes | bytearray) -> str:
 
     if not isinstance(payload, Mapping):
         raise CompletionContractError("completion payload must be a JSON object")
-    require_json(payload)
+    try:
+        require_json(payload)
+    except RecursionError as exc:
+        raise CompletionContractError(
+            "completion payload exceeds the maximum nesting depth"
+        ) from exc
     try:
         encoded = json.dumps(
             payload,
@@ -496,21 +501,24 @@ def _rebase_local_refs(value: Any, root_pointer: str) -> Any:
     if isinstance(value, bool):
         return value
     rebound = deepcopy(value)
-    reference = value.get("$ref")
-    if reference is not None:
-        suffix = "" if reference == "#" else reference[1:]
-        rebound["$ref"] = f"{root_pointer}{suffix}"
-    for keyword in _DIRECT_SUBSCHEMA_KEYWORDS.intersection(value):
-        rebound[keyword] = _rebase_local_refs(value[keyword], root_pointer)
-    for keyword in _ARRAY_SUBSCHEMA_KEYWORDS.intersection(value):
-        rebound[keyword] = [
-            _rebase_local_refs(child, root_pointer) for child in value[keyword]
-        ]
-    for keyword in _MAPPING_SUBSCHEMA_KEYWORDS.intersection(value):
-        rebound[keyword] = {
-            name: _rebase_local_refs(child, root_pointer)
-            for name, child in value[keyword].items()
-        }
+
+    def rebase_in_place(current: Any) -> None:
+        if not isinstance(current, dict):
+            return
+        reference = current.get("$ref")
+        if reference is not None:
+            suffix = "" if reference == "#" else reference[1:]
+            current["$ref"] = f"{root_pointer}{suffix}"
+        for keyword in _DIRECT_SUBSCHEMA_KEYWORDS.intersection(current):
+            rebase_in_place(current[keyword])
+        for keyword in _ARRAY_SUBSCHEMA_KEYWORDS.intersection(current):
+            for child in current[keyword]:
+                rebase_in_place(child)
+        for keyword in _MAPPING_SUBSCHEMA_KEYWORDS.intersection(current):
+            for child in current[keyword].values():
+                rebase_in_place(child)
+
+    rebase_in_place(rebound)
     return rebound
 
 
@@ -623,7 +631,12 @@ def validate_evidence_refs(
         if len(by_id) >= MAX_EVIDENCE_REFS:
             raise EvidenceResolutionError("too many supplied evidence receipts")
         if not isinstance(receipt, EvidenceReceipt):
-            receipt = EvidenceReceipt.model_validate(receipt)
+            try:
+                receipt = EvidenceReceipt.model_validate(receipt)
+            except (TypeError, ValueError, RecursionError) as exc:
+                raise EvidenceResolutionError(
+                    "supplied evidence receipt violates its contract"
+                ) from exc
         if receipt.receipt_id in by_id:
             raise EvidenceResolutionError("supplied receipt IDs must be unique")
         by_id[receipt.receipt_id] = receipt

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -962,7 +962,10 @@ def _validated_https_url(value: str) -> Optional[str]:
 
 
 def _public_mcp_resource() -> Optional[str]:
-    return _validated_https_url(os.environ.get("UNIGROK_PUBLIC_MCP_URL", ""))
+    resource = _validated_https_url(os.environ.get("UNIGROK_PUBLIC_MCP_URL", ""))
+    if resource and not urlsplit(resource).path:
+        return f"{resource}/mcp"
+    return resource
 
 
 def _oauth_authorization_servers() -> List[str]:

--- a/src/mcp_session_guard.py
+++ b/src/mcp_session_guard.py
@@ -110,22 +110,24 @@ class MCP128SessionTransportRegistry:
             return frozenset(self._instances)
 
     async def remove_and_terminate(self, session_id: str) -> bool:
+        owner_missing = object()
         async with self._creation_lock:
-            transport = self._instances.get(session_id)
+            transport = self._instances.pop(session_id, None)
+            owner = self._owners.pop(session_id, owner_missing)
             if transport is None:
-                self._owners.pop(session_id, None)
                 return False
-        terminate = getattr(transport, "terminate", None)
-        if not callable(terminate):
-            raise RuntimeError("MCP SDK transport termination interface changed")
-        await terminate()
-        async with self._creation_lock:
-            current = self._instances.get(session_id)
-            if current is transport:
-                self._instances.pop(session_id, None)
-            elif current is not None:
-                raise RuntimeError("MCP SDK session transport changed during cleanup")
-            self._owners.pop(session_id, None)
+        try:
+            terminate = getattr(transport, "terminate", None)
+            if not callable(terminate):
+                raise RuntimeError("MCP SDK transport termination interface changed")
+            await terminate()
+        except BaseException:
+            async with self._creation_lock:
+                if session_id not in self._instances:
+                    self._instances[session_id] = transport
+                    if owner is not owner_missing:
+                        self._owners[session_id] = owner
+            raise
         return True
 
 

--- a/src/provider_harvest.py
+++ b/src/provider_harvest.py
@@ -261,8 +261,10 @@ class _ProviderHarvestEffectAuthority:
     def until(cls, deadline_monotonic: float) -> "_ProviderHarvestEffectAuthority":
         deadline = float(deadline_monotonic)
         remaining = deadline - time.monotonic()
-        if not math.isfinite(deadline) or not 0 < remaining <= 300.0:
+        if not math.isfinite(deadline) or remaining > 300.0:
             raise ValueError("provider harvest effect deadline is out of bounds")
+        if remaining <= 0:
+            raise TimeoutError("provider harvest effect deadline expired")
         return cls(expires_monotonic=deadline)
 
     def revoke(self) -> None:
@@ -380,7 +382,10 @@ class XAIWorkerEpisodeUploader:
 
     @staticmethod
     def _default_unavailable_reason() -> str | None:
-        if not _utils.xai_management_key_configured():
+        management_state = _utils.xai_management_key_state()
+        if management_state == "conflict":
+            return "management_key_conflict"
+        if management_state == "missing":
             return "management_key_missing"
         if not str(_utils.XAI_API_KEY or "").strip():
             return "inference_client_missing"
@@ -761,7 +766,7 @@ class ProviderAttemptHarvester:
                             row["attempt_id"],
                             lease_id,
                             self._safe_error(exc),
-                            self._retry_delay(int(row["harvest_attempts"])),
+                            self._retry_delay(int(row.get("harvest_attempts") or 0)),
                         )
                     except Exception:
                         # The row remains leased and becomes retryable on expiry.

--- a/src/providers/broker.py
+++ b/src/providers/broker.py
@@ -1150,7 +1150,9 @@ class GrokWorkerBroker:
             if not callable(inspector):
                 return True
             claimed = inspector()
-        except BaseException:
+        except asyncio.CancelledError:
+            return True
+        except Exception:
             return True
         return claimed if type(claimed) is bool else True
 
@@ -2227,6 +2229,8 @@ class GrokWorkerBroker:
             row_ttl = datetime.fromisoformat(str(row.get("ttl_expires_at")))
         except (TypeError, ValueError) as exc:
             raise ValueError("stored attempt TTL projection is malformed") from exc
+        if row_ttl.tzinfo is None:
+            row_ttl = row_ttl.replace(tzinfo=UTC)
         if row_ttl != supervision.ttl_expires_at:
             raise ValueError("stored attempt TTL projection changed")
         return start
@@ -2910,14 +2914,6 @@ class GrokWorkerBroker:
                     delegation=delegation,
                     plane=CredentialPlane.SUBSCRIPTION,
                 )
-                api = (
-                    self._select_channel(
-                        delegation=delegation,
-                        plane=CredentialPlane.METERED_API,
-                    )
-                    if delegation.fallback.max_metered_api_attempts == 1
-                    else None
-                )
             except Exception:
                 return BrokerDelegationResult(
                     delegation_id=delegation_id,
@@ -2928,6 +2924,7 @@ class GrokWorkerBroker:
                     reason="registry_contract_invalid",
                     attempts=(),
                 )
+            api_authorized = delegation.fallback.max_metered_api_attempts == 1
 
             attempts: list[BrokerAttemptEvidence] = []
             if subscription is not None:
@@ -2977,6 +2974,24 @@ class GrokWorkerBroker:
                         attempts=tuple(attempts),
                     )
 
+            api = None
+            if api_authorized:
+                try:
+                    api = self._select_channel(
+                        delegation=delegation,
+                        plane=CredentialPlane.METERED_API,
+                    )
+                except Exception:
+                    if not attempts:
+                        return BrokerDelegationResult(
+                            delegation_id=delegation_id,
+                            delegation_key=delegation.delegation_key,
+                            provider=delegation.provider,
+                            route=delegation.route,
+                            status="indeterminate",
+                            reason="registry_contract_invalid",
+                            attempts=(),
+                        )
             if api is None:
                 status: Literal["failed", "unavailable"] = (
                     "failed" if attempts else "unavailable"

--- a/src/providers/contracts.py
+++ b/src/providers/contracts.py
@@ -806,7 +806,7 @@ def provider_result_matches_start(
     start: ProviderAttemptStart,
     result: ProviderAttemptResult,
 ) -> bool:
-    """Return whether one normalized result is bound to its exact v2 start."""
+    """Return whether one normalized result is bound to its exact v3 start."""
 
     execution = start.execution
     receipt = result.response.receipt if result.response is not None else result.failure

--- a/src/providers/subscription.py
+++ b/src/providers/subscription.py
@@ -244,9 +244,14 @@ async def _write_stdin(
 async def _kill_and_reap(process: asyncio.subprocess.Process) -> None:
     try:
         pid = getattr(process, "pid", None)
-        if isinstance(pid, int) and pid > 0:
-            os.killpg(pid, signal.SIGKILL)
-        else:
+        used_process_group = False
+        if isinstance(pid, int) and pid > 0 and hasattr(os, "killpg"):
+            try:
+                os.killpg(pid, signal.SIGKILL)
+                used_process_group = True
+            except AttributeError:
+                pass
+        if not used_process_group:
             process.kill()
     except (ProcessLookupError, OSError):
         pass
@@ -584,7 +589,7 @@ class ClaudeCLIAdapter(HTTPProviderAdapter):
             requested_model=model,
             resolved_model=resolved_model,
             model_source=model_source,
-            response_id=wrapper.uuid,
+            response_id=self._response_id(wrapper.uuid),
             duration_ms=result.duration_ms,
             usage=usage,
             region="host_subscription",
@@ -706,6 +711,17 @@ def _snapshot_sampling_capability_descriptor(
         )
     except (AttributeError, TypeError, ValueError, ValidationError):
         raise ValueError("sampling capability descriptor is invalid") from None
+    client_identity = snapshot.client_identity or ""
+    capability_digest = (
+        f"sha256:{client_identity.removeprefix('mcp-')}"
+        if re.fullmatch(r"mcp-[0-9a-f]{64}", client_identity)
+        else ""
+    )
+    expected_transport_identity = (
+        transport_resource_identity("mcp_sampling_capability", capability_digest)
+        if capability_digest
+        else None
+    )
     if (
         snapshot.provider != provider
         or snapshot.channel != channel
@@ -715,7 +731,8 @@ def _snapshot_sampling_capability_descriptor(
         or snapshot.credential_kind != "mcp_client_subscription"
         or snapshot.billing_class != "subscription"
         or snapshot.client_identity != capability.client_id
-        or snapshot.transport_resource_identity is None
+        or snapshot.display_name != f"{provider.value} IDE subscription"
+        or snapshot.transport_resource_identity != expected_transport_identity
         or snapshot.credential_env_names
         or snapshot.credential_state != CredentialState.DEFERRED
         or snapshot.models != models

--- a/src/rag.py
+++ b/src/rag.py
@@ -46,6 +46,7 @@ from .utils import (
     get_xai_management_client,
     run_blocking,
     xai_management_key_configured,
+    xai_management_key_state,
 )
 
 _LOGGER = "GrokMCP"
@@ -334,11 +335,16 @@ class TaskMemoryMirror:
         if task_rag_mode() == "off":
             self.last_known_ready = False
             return False
-        if not has_management_key():
+        management_state = xai_management_key_state()
+        if management_state != "configured":
             # Not an error: the mirror is an optional boost. Report the
             # reason without burning a probe or tripping failure backoff.
             self.last_known_ready = False
-            self._last_error = "xAI management key not set (cloud mirror is optional)"
+            self._last_error = (
+                "xAI management key aliases conflict; cloud mirror is disabled"
+                if management_state == "conflict"
+                else "xAI management key not set (cloud mirror is optional)"
+            )
             return False
 
         def _probe():
@@ -816,6 +822,13 @@ async def _rag_status(store: Any, out: TextIO) -> int:
     if mode == "off":
         print("cloud mirror: off (UNIGROK_TASK_RAG=off)", file=out)
         print("ready: no (UNIGROK_TASK_RAG=off)", file=out)
+    elif xai_management_key_state() == "conflict":
+        print(
+            "cloud mirror: disabled — XAI_MANAGEMENT_API_KEY and "
+            "XAI_MANAGEMENT_KEY conflict",
+            file=out,
+        )
+        print("ready: no (xAI management key aliases conflict)", file=out)
     elif not has_management_key():
         print(
             "cloud mirror: disabled — optional; set XAI_MANAGEMENT_API_KEY "
@@ -860,14 +873,22 @@ async def _rag_backfill(
     if mode == "off":
         print("UNIGROK_TASK_RAG=off — nothing to backfill.", file=out)
         return 1
-    if not has_management_key() and not dry_run:
+    management_state = xai_management_key_state()
+    if management_state != "configured" and not dry_run:
         # --dry-run stays available keyless (purely local outbox inspection).
-        print(
-            "The cloud mirror needs XAI_MANAGEMENT_API_KEY (or SDK alias "
-            "XAI_MANAGEMENT_KEY), separate from the inference key. It is "
-            "OPTIONAL: local semantic routing evidence already works without it.",
-            file=out,
-        )
+        if management_state == "conflict":
+            print(
+                "XAI_MANAGEMENT_API_KEY and XAI_MANAGEMENT_KEY conflict. "
+                "Make the aliases identical or configure only one before backfill.",
+                file=out,
+            )
+        else:
+            print(
+                "The cloud mirror needs XAI_MANAGEMENT_API_KEY (or SDK alias "
+                "XAI_MANAGEMENT_KEY), separate from the inference key. It is "
+                "OPTIONAL: local semantic routing evidence already works without it.",
+                file=out,
+            )
         return 1
     mirror = get_task_memory_mirror()
 

--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -11,7 +11,6 @@ import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Optional, List, Literal
-from urllib.parse import urlsplit
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 from ..models.results import SystemResult
@@ -1125,15 +1124,9 @@ def _build_discover_bootstrap(
         from ..http_server import _public_mcp_resource
 
         public_resource = _public_mcp_resource()
-        if public_resource:
-            if public_resource.endswith("/mcp"):
-                canonical_mcp = public_resource
-                surface_root = public_resource.removesuffix("/mcp")
-            elif not urlsplit(public_resource).path:
-                # Accept a validated bare origin as a deployment convenience,
-                # while keeping non-standard resource paths fail-closed.
-                surface_root = public_resource
-                canonical_mcp = f"{public_resource}/mcp"
+        if public_resource and public_resource.endswith("/mcp"):
+            canonical_mcp = public_resource
+            surface_root = public_resource.removesuffix("/mcp")
 
     return {
         "schema_version": 1,

--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -1116,7 +1116,17 @@ def _build_discover_bootstrap(
         if isinstance(connected_port, int) and not isinstance(connected_port, bool)
         else 4765
     )
-    local_surface = f"http://localhost:{surface_port}"
+    surface_root = f"http://localhost:{surface_port}"
+    canonical_mcp = f"{surface_root}/mcp"
+    if cloudrun:
+        # Cloud Run has no caller-local surface. Reuse the same validated public
+        # resource that protects OAuth metadata and DNS-rebinding configuration.
+        from ..http_server import _public_mcp_resource
+
+        public_resource = _public_mcp_resource()
+        if public_resource and public_resource.endswith("/mcp"):
+            canonical_mcp = public_resource
+            surface_root = public_resource.removesuffix("/mcp")
 
     return {
         "schema_version": 1,
@@ -1136,17 +1146,17 @@ def _build_discover_bootstrap(
             "global settings without explicit consent. Never print secret values."
         ),
         "surfaces": {
-            "canonical_mcp": f"{local_surface}/mcp",
-            "healthz": f"{local_surface}/healthz",
-            "readyz": f"{local_surface}/readyz",
-            "runtimez": f"{local_surface}/runtimez",
-            "ui": f"{local_surface}/ui/",
+            "canonical_mcp": canonical_mcp,
+            "healthz": f"{surface_root}/healthz",
+            "readyz": f"{surface_root}/readyz",
+            "runtimez": f"{surface_root}/runtimez",
+            "ui": f"{surface_root}/ui/",
         },
         "first_connect_checklist": [
             "Call grok_mcp_discover_self and read data.bootstrap + data.request_context.",
             "Prompt once per credential_planes notice id; never ask for XAI_API_KEY in chat.",
             "Confirm X-Client-ID is set for this IDE (data.request_context.client_id_present).",
-            f"With permission, audit local IDE MCP configs for {local_surface}/mcp and no keys in JSON.",
+            f"With permission, audit local IDE MCP configs for {canonical_mcp} and no keys in JSON.",
             "Optional: one cheap agent(mode=fast) or grok_mcp_status after planes are ready.",
             "Public installs: do not invent a second product port, Swarm, or land workflow.",
         ],

--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -11,6 +11,7 @@ import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Optional, List, Literal
+from urllib.parse import urlsplit
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 from ..models.results import SystemResult
@@ -1124,9 +1125,15 @@ def _build_discover_bootstrap(
         from ..http_server import _public_mcp_resource
 
         public_resource = _public_mcp_resource()
-        if public_resource and public_resource.endswith("/mcp"):
-            canonical_mcp = public_resource
-            surface_root = public_resource.removesuffix("/mcp")
+        if public_resource:
+            if public_resource.endswith("/mcp"):
+                canonical_mcp = public_resource
+                surface_root = public_resource.removesuffix("/mcp")
+            elif not urlsplit(public_resource).path:
+                # Accept a validated bare origin as a deployment convenience,
+                # while keeping non-standard resource paths fail-closed.
+                surface_root = public_resource
+                canonical_mcp = f"{public_resource}/mcp"
 
     return {
         "schema_version": 1,

--- a/src/utils.py
+++ b/src/utils.py
@@ -42,7 +42,10 @@ from .credentials import (
     build_credential_plane_contract,
     credential_plane_policy,
 )
-from .xai_credentials import _require_xai_management_key
+from .xai_credentials import (
+    _require_xai_management_key,
+    _xai_management_key_state,
+)
 from .identity import (
     _ACTIVE_CALLER,
     _ACTIVE_CLIENT_ID,
@@ -1282,7 +1285,13 @@ def _redact_provider_episode_text(
 
 
 def _canonical_json_text(value: Any) -> str:
-    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
 
 
 def _content_sha256(text: str) -> str:
@@ -1920,7 +1929,10 @@ class _CollectionsOnlyXAIManagementClient:
         collections = getattr(delegate, "collections", None)
         close = getattr(delegate, "close", None)
         if collections is None or not callable(close):
-            raise RuntimeError("xAI management client interface changed")
+            raise RuntimeError(
+                "xAI management client interface changed: expected collections "
+                "and callable close"
+            )
         object.__setattr__(self, "_collections", collections)
         object.__setattr__(self, "_close_callback", close)
 
@@ -1933,6 +1945,12 @@ class _CollectionsOnlyXAIManagementClient:
 
     def __dir__(self) -> list[str]:
         return ["close", "collections"]
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        raise AttributeError("xAI management facade is read-only")
+
+    def __delattr__(self, name: str) -> None:
+        raise AttributeError("xAI management facade is read-only")
 
     @property
     def collections(self) -> Any:
@@ -1951,11 +1969,13 @@ def _resolve_xai_management_key() -> str:
 def xai_management_key_configured() -> bool:
     """Return whether one unambiguous xAI management credential is configured."""
 
-    try:
-        _resolve_xai_management_key()
-    except ValueError:
-        return False
-    return True
+    return xai_management_key_state() == "configured"
+
+
+def xai_management_key_state() -> str:
+    """Return configured, missing, or conflict without exposing either secret."""
+
+    return _xai_management_key_state()
 
 
 def get_xai_inference_client():
@@ -2680,10 +2700,12 @@ class GrokSessionStore:
                 row = await cursor.fetchone()
                 version = int(row[0])
             if version < 0 or version > _SESSION_STORE_SCHEMA_HEAD:
-                raise RuntimeError(
+                message = (
                     f"unsupported session-store schema version {version}; "
                     f"expected 0..{_SESSION_STORE_SCHEMA_HEAD}"
                 )
+                await self._reset_connection_unlocked()
+                raise RuntimeError(message)
             await self._conn.execute("PRAGMA journal_mode=WAL;")
             await self._conn.execute("PRAGMA synchronous=NORMAL;")
             await self._conn.execute("PRAGMA busy_timeout=30000;")
@@ -5663,7 +5685,7 @@ class GrokSessionStore:
                             """
                             UPDATE provider_attempts SET
                                 harvest_status = 'retry_wait',
-                                harvest_attempts = harvest_attempts + 1,
+                                harvest_attempts = COALESCE(harvest_attempts, 0) + 1,
                                 harvest_next_at = ?, harvest_lease_id = NULL,
                                 harvest_lease_expires_at = NULL,
                                 harvest_error = ?, remote_file_id = NULL,
@@ -5697,7 +5719,7 @@ class GrokSessionStore:
                         """
                         UPDATE provider_attempts SET
                             harvest_status = 'leased',
-                            harvest_attempts = harvest_attempts + 1,
+                            harvest_attempts = COALESCE(harvest_attempts, 0) + 1,
                             harvest_next_at = NULL,
                             harvest_lease_id = ?,
                             harvest_lease_expires_at = ?,
@@ -11110,6 +11132,32 @@ async def _select_routing_model(
                     f"Model '{model}' is not available on the xAI developer API plane."
                 )
             catalog_source = api_source
+        else:
+            cli_status = grok_cli_plane_status()
+            cli_models = {
+                str(item) for item in cli_status.get("models", []) if str(item)
+            }
+            cli_contains = bool(cli_status.get("ready")) and model in cli_models
+            api_models, api_source, api_available = (
+                await _MODEL_RESOLVER.catalog_snapshot()
+            )
+            api_contains = api_available and model in set(api_models)
+            policy = credential_plane_policy(cloudrun=is_cloudrun_runtime())
+            if policy == "cli_first" and cli_contains:
+                catalog_source = "grok_cli_live"
+            elif api_contains:
+                catalog_source = api_source
+            elif cli_contains:
+                catalog_source = "grok_cli_live"
+            elif not cli_status.get("ready") and not api_available:
+                raise ValueError(
+                    f"Cannot verify explicit model '{model}' because neither live "
+                    "xAI catalog is available."
+                )
+            else:
+                raise ValueError(
+                    f"Model '{model}' is unavailable on both live xAI credential planes."
+                )
         receipt = make_routing_receipt(
             mode=mode,
             route_class="pinned",
@@ -11502,7 +11550,11 @@ async def orchestrate(
                 routing_receipt={
                     "provider": "xai",
                     "authority": "grok",
-                    "requested_plane": requested_plane.upper(),
+                    "requested_plane": (
+                        requested_plane.upper()
+                        if requested_plane != "auto"
+                        else "auto"
+                    ),
                     "resolved_plane": None,
                     "fallback_policy": fallback_policy,
                     "fallback_occurred": True,

--- a/src/xai_credentials.py
+++ b/src/xai_credentials.py
@@ -9,6 +9,25 @@ from __future__ import annotations
 
 import os
 from collections.abc import Mapping
+from typing import Literal
+
+
+XAIManagementKeyState = Literal["configured", "missing", "conflict"]
+
+
+def _xai_management_key_state(
+    environ: Mapping[str, str] | None = None,
+) -> XAIManagementKeyState:
+    """Return secret-safe management credential configuration state."""
+
+    source = os.environ if environ is None else environ
+    canonical = str(source.get("XAI_MANAGEMENT_API_KEY") or "").strip()
+    sdk_alias = str(source.get("XAI_MANAGEMENT_KEY") or "").strip()
+    if canonical and sdk_alias and canonical != sdk_alias:
+        return "conflict"
+    if canonical or sdk_alias:
+        return "configured"
+    return "missing"
 
 
 def _resolve_optional_xai_management_key(
@@ -17,9 +36,9 @@ def _resolve_optional_xai_management_key(
     """Return one unambiguous management key without logging its value."""
 
     source = os.environ if environ is None else environ
-    canonical = str(source.get("XAI_MANAGEMENT_API_KEY", "")).strip()
-    sdk_alias = str(source.get("XAI_MANAGEMENT_KEY", "")).strip()
-    if canonical and sdk_alias and canonical != sdk_alias:
+    canonical = str(source.get("XAI_MANAGEMENT_API_KEY") or "").strip()
+    sdk_alias = str(source.get("XAI_MANAGEMENT_KEY") or "").strip()
+    if _xai_management_key_state(source) == "conflict":
         raise ValueError(
             "XAI_MANAGEMENT_API_KEY and XAI_MANAGEMENT_KEY are both configured "
             "with different values."

--- a/tests/test_completion_envelope.py
+++ b/tests/test_completion_envelope.py
@@ -715,3 +715,19 @@ def test_unwrap_binds_model_envelope_to_authoritative_attempt_and_ttl():
             receipts=[],
             now=NOW,
         )
+
+
+def test_recursive_mapping_is_normalized_to_completion_contract_error():
+    recursive: dict[str, object] = {}
+    recursive["self"] = recursive
+    with pytest.raises(CompletionContractError, match="nesting depth"):
+        parse_completion_envelope(recursive)
+
+
+def test_invalid_supplied_receipt_is_normalized_to_evidence_error():
+    with pytest.raises(EvidenceResolutionError, match="violates its contract"):
+        validate_evidence_refs(
+            _complete(),
+            [{"receipt_id": "not-a-complete-receipt"}],
+            now=NOW,
+        )

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -309,6 +309,83 @@ async def test_strict_plane_pin_uses_matching_live_catalog(monkeypatch):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("policy", "expected_source"),
+    (("cli_first", "grok_cli_live"), ("api_first", "xai_api_live")),
+)
+async def test_auto_exact_pin_uses_live_plane_membership_and_policy(
+    monkeypatch, policy, expected_source
+):
+    from src import utils
+
+    shared_model = "grok-shared-exact"
+    monkeypatch.setenv("UNIGROK_PLANE_POLICY", policy)
+    monkeypatch.setattr(
+        utils,
+        "grok_cli_plane_status",
+        lambda **_: {
+            **READY_CLI,
+            "models": [shared_model],
+            "default_model": shared_model,
+        },
+    )
+    monkeypatch.setattr(
+        utils._MODEL_RESOLVER,
+        "catalog_snapshot",
+        AsyncMock(return_value=([shared_model], "xai_api_live", True)),
+    )
+
+    selected, _, receipt, _ = await utils._select_routing_model(
+        prompt="Use the exact shared model",
+        mode="auto",
+        thinking_mode=False,
+        requested_model=shared_model,
+        requested_plane="auto",
+        active_store=None,
+        input_messages=None,
+        enable_agentic=False,
+    )
+
+    assert selected == shared_model
+    assert receipt["catalog"]["source"] == expected_source
+
+
+@pytest.mark.asyncio
+async def test_auto_exact_pin_routes_cli_only_live_slug_to_cli(monkeypatch):
+    from src import utils
+
+    cli_model = "grok-cli-only-exact"
+    monkeypatch.setenv("UNIGROK_PLANE_POLICY", "api_first")
+    monkeypatch.setattr(
+        utils,
+        "grok_cli_plane_status",
+        lambda **_: {
+            **READY_CLI,
+            "models": [cli_model],
+            "default_model": cli_model,
+        },
+    )
+    monkeypatch.setattr(
+        utils._MODEL_RESOLVER,
+        "catalog_snapshot",
+        AsyncMock(return_value=(["grok-api-only"], "xai_api_live", True)),
+    )
+
+    _, _, receipt, _ = await utils._select_routing_model(
+        prompt="Use the exact CLI model",
+        mode="auto",
+        thinking_mode=False,
+        requested_model=cli_model,
+        requested_plane="auto",
+        active_store=None,
+        input_messages=None,
+        enable_agentic=False,
+    )
+
+    assert receipt["catalog"]["source"] == "grok_cli_live"
+
+
+@pytest.mark.asyncio
 async def test_strict_cli_rejects_api_only_model(monkeypatch):
     from src import utils
 

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -255,6 +255,15 @@ async def test_cli_first_keeps_api_only_and_explicit_paths(monkeypatch):
     monkeypatch.setenv("XAI_API_KEY", "configured")
     monkeypatch.setattr(utils, "XAI_API_KEY", "configured")
     monkeypatch.setattr(utils, "cli_plane_ready_for_local_runtime", lambda: True)
+    monkeypatch.setattr(
+        utils,
+        "grok_cli_plane_status",
+        lambda **_: {
+            **READY_CLI,
+            "models": ["grok-4.5", "grok-composer-2.5-fast"],
+            "default_model": "grok-4.5",
+        },
+    )
 
     pinned, _, pinned_receipt, _ = await utils._select_routing_model(
         prompt="Use 4.5", mode="auto", thinking_mode=False,

--- a/tests/test_github_review_integration.py
+++ b/tests/test_github_review_integration.py
@@ -81,6 +81,47 @@ def test_github_review_evidence_digest_is_commit_and_content_bound():
     assert first["evidence_sha256"] != changed["evidence_sha256"]
 
 
+def test_gateway_auth_prefers_short_lived_mint_over_static_fallback(monkeypatch):
+    module = _load_script()
+    captured = {}
+    monkeypatch.setenv("UNIGROK_MCP_TOKEN_SECRET", "s" * 40)
+    monkeypatch.setenv("UNIGROK_CLIENT_TOKEN", "stale-static-token")
+    monkeypatch.setenv("UNIGROK_TOKEN_TTL_SECONDS", "540")
+
+    def fake_mint(**kwargs):
+        captured.update(kwargs)
+        return "fresh-service-token"
+
+    monkeypatch.setattr("scripts.mint_mcp_service_token.mint_service_access_token", fake_mint)
+
+    assert module._gateway_bearer_token() == "fresh-service-token"
+    assert captured["ttl_seconds"] == 540
+    assert captured["service"] == "github-review-broker"
+
+
+def test_gateway_auth_uses_static_token_only_without_signing_secret(monkeypatch):
+    module = _load_script()
+    monkeypatch.delenv("UNIGROK_MCP_TOKEN_SECRET", raising=False)
+    monkeypatch.setenv("UNIGROK_CLIENT_TOKEN", "static-fallback")
+
+    assert module._gateway_bearer_token() == "static-fallback"
+
+
+def test_nested_error_formatter_honors_suppressed_context():
+    module = _load_script()
+
+    try:
+        try:
+            raise ValueError("private implementation detail")
+        except ValueError:
+            raise RuntimeError("public failure") from None
+    except RuntimeError as exc:
+        rendered = module._format_exc(exc)
+
+    assert "RuntimeError: public failure" in rendered
+    assert "private implementation detail" not in rendered
+
+
 def test_github_review_rejects_head_change_before_comment(tmp_path, monkeypatch):
     module = _load_script()
     head = "a" * 40

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -197,6 +197,16 @@ async def test_cloudrun_orchestrate_does_not_cli_fallback(monkeypatch):
     monkeypatch.setenv("UNIGROK_RUNTIME", "cloudrun")
     mock_call_plane = AsyncMock(side_effect=RuntimeError("api failed"))
     monkeypatch.setattr("src.utils._call_plane", mock_call_plane)
+    monkeypatch.setattr(
+        utils,
+        "grok_cli_plane_status",
+        lambda **_: {"ready": False, "models": []},
+    )
+    monkeypatch.setattr(
+        utils._MODEL_RESOLVER,
+        "catalog_snapshot",
+        AsyncMock(return_value=(["grok-4.3"], "xai_api_live", True)),
+    )
 
     with patch("asyncio.create_subprocess_exec") as mock_exec:
         layer = await utils.orchestrate(

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -132,10 +132,14 @@ def test_public_discovery_is_sanitized_in_cloudrun(monkeypatch):
         assert internal_field not in response.text
 
 
-def test_oauth_protected_resource_metadata_is_active(monkeypatch):
+@pytest.mark.parametrize(
+    "public_mcp_url",
+    ("https://mcp.grokmcp.org/mcp/", "https://mcp.grokmcp.org"),
+)
+def test_oauth_protected_resource_metadata_is_active(monkeypatch, public_mcp_url):
     monkeypatch.setenv("UNIGROK_RUNTIME", "cloudrun")
     monkeypatch.setenv("UNIGROK_API_KEYS", "client-secret")
-    monkeypatch.setenv("UNIGROK_PUBLIC_MCP_URL", "https://mcp.grokmcp.org/mcp/")
+    monkeypatch.setenv("UNIGROK_PUBLIC_MCP_URL", public_mcp_url)
     monkeypatch.setenv(
         "UNIGROK_OAUTH_AUTHORIZATION_SERVERS",
         "https://auth.grokmcp.org/, https://identity.example.com/tenant",

--- a/tests/test_mcp_session_guard.py
+++ b/tests/test_mcp_session_guard.py
@@ -1281,6 +1281,64 @@ async def test_sdk_private_registry_removes_orphaned_session_owner():
 
 
 @pytest.mark.asyncio
+async def test_sdk_private_registry_hides_transport_while_termination_is_pending():
+    from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    class BlockingTransport:
+        async def terminate(self) -> None:
+            started.set()
+            await release.wait()
+
+    manager = StreamableHTTPSessionManager(app=object())
+    manager._server_instances["session-a"] = BlockingTransport()
+    manager._session_owners["session-a"] = object()
+    registry = MCP128SessionTransportRegistry(manager)
+
+    cleanup = asyncio.create_task(registry.remove_and_terminate("session-a"))
+    await asyncio.wait_for(started.wait(), timeout=1)
+    assert await registry.contains("session-a") is False
+    assert "session-a" not in manager._session_owners
+    release.set()
+    assert await asyncio.wait_for(cleanup, timeout=1) is True
+
+
+@pytest.mark.asyncio
+async def test_sdk_private_registry_restores_failed_transport_without_overwriting_replacement():
+    from mcp.server.streamable_http_manager import StreamableHTTPSessionManager
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    class FailingTransport:
+        async def terminate(self) -> None:
+            started.set()
+            await release.wait()
+            raise RuntimeError("termination failed")
+
+    manager = StreamableHTTPSessionManager(app=object())
+    original = FailingTransport()
+    replacement = FakeTransport("replacement", [])
+    replacement_owner = object()
+    manager._server_instances["session-a"] = original
+    manager._session_owners["session-a"] = object()
+    registry = MCP128SessionTransportRegistry(manager)
+
+    cleanup = asyncio.create_task(registry.remove_and_terminate("session-a"))
+    await asyncio.wait_for(started.wait(), timeout=1)
+    async with manager._session_creation_lock:
+        manager._server_instances["session-a"] = replacement
+        manager._session_owners["session-a"] = replacement_owner
+    release.set()
+    with pytest.raises(RuntimeError, match="termination failed"):
+        await asyncio.wait_for(cleanup, timeout=1)
+    assert manager._server_instances["session-a"] is replacement
+    assert manager._session_owners["session-a"] is replacement_owner
+
+
+@pytest.mark.asyncio
 async def test_guard_interoperates_with_real_mcp_128_stateful_asgi():
     from mcp.server.fastmcp import FastMCP
 

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -93,6 +93,8 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert 'id="mcpEndpointDisplay"' in index.text
     assert 'id="copyMcpJsonBtn"' in index.text
     assert 'id="copyAgentPromptBtn"' in index.text
+    assert 'aria-label="Copy Cursor MCP JSON"' in index.text
+    assert 'aria-label="Copy agent setup prompt"' in index.text
     assert 'id="copyPrimaryActionBtn"' in index.text
     assert 'id="agentPromptSnippet"' in index.text
     assert 'id="discoverSelfDetails"' in index.text
@@ -102,6 +104,8 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert "genericMcpJson" in script.text
     assert "agentSetupPrompt" in script.text
     assert "syncPrimaryCta" in script.text
+    assert "resetConversation();" not in script.text
+    assert 'detailText ? "Gateway needs attention." : "Gateway offline."' in script.text
     assert "api_cost_usd ??" in script.text
     assert "details.open = true" in script.text
     assert 'textContent?.replace(/^tools:' in script.text or "textContent?.replace(/^tools:" in script.text
@@ -110,6 +114,7 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert ".plane-card" in styles.text
     assert ".connect-panel" in styles.text
     assert ".connect-snippet-block" in styles.text
+    assert "overflow-y: auto" in styles.text
     assert "startup ingestion is not automatic" in index.text
     assert "before hitting the API" not in script.text
     assert "safely route this call" not in script.text

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -592,6 +592,8 @@ class TestV17ProviderAttemptCertification:
         try:
             with pytest.raises(RuntimeError, match="unsupported.*18"):
                 await store._ensure_initialized()
+            assert store._conn is None
+            assert store._initialized is False
         finally:
             await store.close()
         conn = sqlite3.connect(db_path)

--- a/tests/test_mint_mcp_service_token.py
+++ b/tests/test_mint_mcp_service_token.py
@@ -140,16 +140,12 @@ def test_cli_print_claims_uses_independent_non_secret_metadata(
 
     import scripts.mint_mcp_service_token as mod
 
-    monkeypatch.setattr(
-        mod,
-        "mint_service_access_token",
-        lambda **_: f"{TOKEN_PREFIX}opaque-non-json-token",
-    )
+    monkeypatch.setattr(mod, "sign_cookie_payload", lambda *_: "opaque-non-json-token")
     assert mod.main(["--print-claims"]) == 0
     captured = capfd.readouterr()
     assert captured.out.startswith(TOKEN_PREFIX)
     assert json.loads(captured.err) == {
-        "exp": 1_700_000_120,
+        "exp": 1_700_000_600,
         "scope": ["unigrok:connect", "unigrok:review"],
         "sub": "service:github-review-broker",
     }

--- a/tests/test_provider_broker.py
+++ b/tests/test_provider_broker.py
@@ -1976,6 +1976,66 @@ async def test_subscription_failure_uses_one_same_provider_api_fallback_only():
 
 
 @pytest.mark.asyncio
+async def test_invalid_api_fallback_descriptor_cannot_block_subscription_success():
+    subscription = FakeAdapter(ProviderChannel.OPENAI_MCP_SAMPLING)
+    api = FakeAdapter(ProviderChannel.OPENAI_API)
+    plan = _plan()
+    broker = GrokWorkerBroker(
+        registry={
+            ProviderChannel.OPENAI_MCP_SAMPLING: subscription,
+            ProviderChannel.OPENAI_API: api,
+        },
+        store=FakeStore(),
+        clock=lambda: NOW,
+    )
+    api._descriptor = api.descriptor.model_copy(
+        update={"endpoint_host": "descriptor-drift.invalid"}
+    )
+
+    result = await broker.execute(plan)
+
+    assert result.status == "returned"
+    assert result.delegations[0].reason == "subscription_returned"
+    assert subscription.calls == 1
+    assert api.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_legacy_naive_ttl_projection_is_compared_as_utc():
+    subscription = FakeAdapter(ProviderChannel.OPENAI_MCP_SAMPLING)
+    store = FakeStore()
+    plan = _plan(fallback=False)
+    broker = GrokWorkerBroker(
+        registry={ProviderChannel.OPENAI_MCP_SAMPLING: subscription},
+        store=store,
+        clock=lambda: NOW,
+    )
+    await broker.execute(plan)
+    row = (await store.list_provider_attempts())[0]
+    row["ttl_expires_at"] = row["ttl_expires_at"].removesuffix("+00:00")
+
+    reconstructed = broker._reconstruct_stored_start(row)
+
+    assert reconstructed.request.supervision.ttl_expires_at == (
+        plan.supervision.ttl_expires_at
+    )
+
+
+def test_sampling_claim_inspector_does_not_swallow_process_control_exceptions():
+    adapter = FakeAdapter(ProviderChannel.OPENAI_MCP_SAMPLING)
+
+    def stop_process():
+        raise SystemExit(7)
+
+    adapter.effect_claimed = stop_process
+    with pytest.raises(SystemExit, match="7"):
+        GrokWorkerBroker._sampling_effect_requires_indeterminate(
+            channel=ProviderChannel.OPENAI_MCP_SAMPLING,
+            adapter=adapter,
+        )
+
+
+@pytest.mark.asyncio
 async def test_internal_subscription_failure_does_not_fallback_or_cross_provider():
     subscription = FakeAdapter(
         ProviderChannel.GOOGLE_MCP_SAMPLING,

--- a/tests/test_provider_harvest.py
+++ b/tests/test_provider_harvest.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import sqlite3
 import threading
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -214,6 +215,16 @@ def _effect_authority() -> _ProviderHarvestEffectAuthority:
     return _ProviderHarvestEffectAuthority.for_seconds(30)
 
 
+def test_expired_effect_authority_uses_timeout_error():
+    with pytest.raises(TimeoutError, match="expired"):
+        _ProviderHarvestEffectAuthority.until(time.monotonic() - 1)
+
+
+def test_provider_episode_canonical_json_rejects_nonfinite_numbers():
+    with pytest.raises(ValueError, match="JSON compliant"):
+        provider_utils._canonical_json_text({"value": float("nan")})
+
+
 def _downgrade_current_db_to_v16(path) -> None:
     connection = sqlite3.connect(path)
     try:
@@ -402,7 +413,16 @@ async def test_missing_credentials_or_client_leave_rows_pending_without_cloud_ca
     assert row["harvest_status"] == "pending"
     assert row["harvest_attempts"] == 0
 
+    monkeypatch.setenv("XAI_MANAGEMENT_API_KEY", "canonical-management")
+    monkeypatch.setenv("XAI_MANAGEMENT_KEY", "different-management")
+    conflicting_management = XAIWorkerEpisodeUploader(client_factory=forbidden_factory)
+    result = await ProviderAttemptHarvester(uploader=conflicting_management).run_once(store)
+    assert result.status == "unavailable"
+    assert result.reason == "management_key_conflict"
+    assert factory_calls == 0
+
     monkeypatch.setenv("XAI_MANAGEMENT_API_KEY", "management-test-value")
+    monkeypatch.delenv("XAI_MANAGEMENT_KEY", raising=False)
     monkeypatch.setattr(provider_utils, "XAI_API_KEY", "")
     missing_inference = XAIWorkerEpisodeUploader(client_factory=forbidden_factory)
     result = await ProviderAttemptHarvester(uploader=missing_inference).run_once(store)
@@ -709,6 +729,45 @@ async def test_upload_failure_is_secret_safe_and_retries_with_bounded_backoff(
     assert result.synced == 1
     assert (await store.list_provider_attempts())[0]["harvest_status"] == "synced"
     await store.close()
+
+
+@pytest.mark.asyncio
+async def test_null_legacy_harvest_attempt_count_uses_initial_retry_delay(tmp_path):
+    source_store = GrokSessionStore(tmp_path / "legacy-null-attempt.db")
+    row = await _completed(source_store)
+    await source_store.close()
+    row["harvest_attempts"] = None
+
+    class LegacyRowStore:
+        retry_delay = None
+        leased = False
+
+        async def lease_provider_attempts_for_harvest(self, *_args):
+            if self.leased:
+                return []
+            self.leased = True
+            return [row]
+
+        async def provider_attempt_harvest_lease_is_fresh(self, *_args):
+            return True
+
+        async def mark_provider_attempt_harvest_retry(
+            self, _attempt_id, _lease_id, _error, retry_delay
+        ):
+            self.retry_delay = retry_delay
+            return True
+
+    store = LegacyRowStore()
+    service = FakeCollections(fail_mode="secret_before_write")
+    result = await ProviderAttemptHarvester(
+        uploader=_uploader(service),
+        batch_size=1,
+        backoff_base_seconds=7,
+        lease_id_factory=lambda: "legacy-null-attempt",
+    ).run_once(store)
+
+    assert result.retry_wait == 1
+    assert store.retry_delay == 7
 
 
 @pytest.mark.asyncio

--- a/tests/test_release_hygiene.py
+++ b/tests/test_release_hygiene.py
@@ -1,4 +1,5 @@
 import json
+import re
 import tomllib
 from pathlib import Path
 
@@ -26,12 +27,28 @@ def test_release_version_is_aligned_across_package_runtime_and_ui():
 
 def test_dependabot_covers_every_shipped_dependency_surface():
     config = (ROOT / ".github" / "dependabot.yml").read_text(encoding="utf-8")
+    blocks = re.split(r"(?m)^\s{2}-\s+", config)[1:]
+    configured: set[tuple[str, str]] = set()
+    for block in blocks:
+        ecosystem_match = re.search(
+            r"(?m)^package-ecosystem:\s*['\"]?([^'\"\s]+)['\"]?\s*$",
+            block,
+        )
+        directory_match = re.search(
+            r"(?m)^\s*directory:\s*['\"]?([^'\"\s]+)['\"]?\s*$",
+            block,
+        )
+        assert ecosystem_match is not None
+        assert directory_match is not None
+        configured.add((ecosystem_match.group(1), directory_match.group(1)))
 
-    assert 'package-ecosystem: "uv"' in config
-    assert 'package-ecosystem: "npm"' in config
-    assert 'package-ecosystem: "github-actions"' in config
-    assert config.count('package-ecosystem: "docker"') == 2
-    assert 'directory: "/sites/unigrok-control-center"' in config
+    assert configured == {
+        ("uv", "/"),
+        ("npm", "/sites/unigrok-control-center"),
+        ("github-actions", "/"),
+        ("docker", "/"),
+        ("docker", "/sites/unigrok-control-center"),
+    }
 
 
 def test_public_runtime_files_do_not_embed_a_developer_home_path():

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -1,3 +1,7 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
 from src.routing import (
     _messages_have_image,
     choose_model_candidate,
@@ -5,7 +9,6 @@ from src.routing import (
     extract_routing_features,
     make_routing_receipt,
 )
-import pytest
 
 
 def test_features_are_bounded_prompt_free_and_deterministic():
@@ -231,10 +234,16 @@ async def test_research_route_selects_multi_agent_capability(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_explicit_model_short_circuits_catalog(monkeypatch):
+async def test_explicit_model_uses_live_catalog_to_resolve_auto_plane(monkeypatch):
     from src import utils
 
-    monkeypatch.setattr(utils._MODEL_RESOLVER, "catalog_snapshot", pytest.fail)
+    monkeypatch.setattr(
+        utils,
+        "grok_cli_plane_status",
+        lambda **_: {"ready": False, "models": []},
+    )
+    catalog = AsyncMock(return_value=(["grok-4.3"], "xai_api_live", True))
+    monkeypatch.setattr(utils._MODEL_RESOLVER, "catalog_snapshot", catalog)
     model, why, receipt, _ = await utils._select_routing_model(
         prompt="Anything",
         mode="auto",
@@ -247,6 +256,8 @@ async def test_explicit_model_short_circuits_catalog(monkeypatch):
     assert model == "grok-4.3"
     assert why == "pin"
     assert receipt["pin_source"] == "model"
+    assert receipt["catalog"]["source"] == "xai_api_live"
+    catalog.assert_awaited_once_with()
 
 
 @pytest.mark.asyncio

--- a/tests/test_service_workspace_boundary.py
+++ b/tests/test_service_workspace_boundary.py
@@ -362,6 +362,37 @@ def test_discover_bootstrap_surfaces_follow_connected_port(monkeypatch):
     )
 
 
+def test_discover_bootstrap_uses_validated_public_surface_in_cloudrun(monkeypatch):
+    from src.tools.system import _build_discover_bootstrap
+
+    monkeypatch.setenv("UNIGROK_RUNTIME", "cloudrun")
+    monkeypatch.setenv("UNIGROK_PUBLIC_MCP_URL", "https://mcp.grokmcp.org/mcp")
+    bootstrap = _build_discover_bootstrap(
+        contributor=False,
+        workspace_attached=False,
+        credential_planes={
+            "service_usable": True,
+            "degraded": False,
+            "api": {"available": True},
+            "cli": {"available": False},
+            "notices": [],
+        },
+        request_context={"client_id_present": True, "host_port": None},
+    )
+
+    assert bootstrap["surfaces"] == {
+        "canonical_mcp": "https://mcp.grokmcp.org/mcp",
+        "healthz": "https://mcp.grokmcp.org/healthz",
+        "readyz": "https://mcp.grokmcp.org/readyz",
+        "runtimez": "https://mcp.grokmcp.org/runtimez",
+        "ui": "https://mcp.grokmcp.org/ui/",
+    }
+    assert any(
+        "https://mcp.grokmcp.org/mcp" in step
+        for step in bootstrap["first_connect_checklist"]
+    )
+
+
 def test_discover_bootstrap_swarm_policy_matches_runtime_parser(monkeypatch):
     from src.tools.system import _build_discover_bootstrap
 

--- a/tests/test_service_workspace_boundary.py
+++ b/tests/test_service_workspace_boundary.py
@@ -393,6 +393,33 @@ def test_discover_bootstrap_uses_validated_public_surface_in_cloudrun(monkeypatc
     )
 
 
+def test_discover_bootstrap_expands_validated_public_origin_in_cloudrun(monkeypatch):
+    from src.tools.system import _build_discover_bootstrap
+
+    monkeypatch.setenv("UNIGROK_RUNTIME", "cloudrun")
+    monkeypatch.setenv("UNIGROK_PUBLIC_MCP_URL", "https://mcp.grokmcp.org")
+    bootstrap = _build_discover_bootstrap(
+        contributor=False,
+        workspace_attached=False,
+        credential_planes={
+            "service_usable": True,
+            "degraded": False,
+            "api": {"available": True},
+            "cli": {"available": False},
+            "notices": [],
+        },
+        request_context={"client_id_present": True, "host_port": None},
+    )
+
+    assert bootstrap["surfaces"] == {
+        "canonical_mcp": "https://mcp.grokmcp.org/mcp",
+        "healthz": "https://mcp.grokmcp.org/healthz",
+        "readyz": "https://mcp.grokmcp.org/readyz",
+        "runtimez": "https://mcp.grokmcp.org/runtimez",
+        "ui": "https://mcp.grokmcp.org/ui/",
+    }
+
+
 def test_discover_bootstrap_swarm_policy_matches_runtime_parser(monkeypatch):
     from src.tools.system import _build_discover_bootstrap
 

--- a/tests/test_subscription_transports.py
+++ b/tests/test_subscription_transports.py
@@ -47,7 +47,9 @@ from src.providers.subscription import (
     _create_sealed_mcp_sampling_adapter,
     _create_sealed_sampling_client_binding,
     _claude_subscription_environment,
+    _kill_and_reap,
     _run_bounded_process,
+    _snapshot_sampling_capability_descriptor,
 )
 
 
@@ -408,6 +410,20 @@ async def test_claude_cli_is_stdin_only_safe_mode_no_tools_and_subscription_hone
 
 
 @pytest.mark.asyncio
+async def test_claude_cli_sanitizes_unsafe_provider_response_id():
+    result = CLIProcessResult(
+        returncode=0,
+        stdout=_claude_result(extra={"uuid": "../../unsafe response id"}),
+        stderr=b"",
+        duration_ms=1,
+    )
+    response = await ClaudeCLIAdapter(
+        environ={}, runner=CapturingRunner(result)
+    ).complete(_request(model="claude-fable-5"))
+    assert response.receipt.response_id is None
+
+
+@pytest.mark.asyncio
 async def test_claude_timeout_and_ttl_are_bounded_before_any_process_effect():
     now = datetime(2030, 1, 1, tzinfo=UTC)
     runner = CapturingRunner()
@@ -566,6 +582,32 @@ async def test_process_runner_kills_child_when_timeout_fires(monkeypatch, tmp_pa
             stdout_limit_bytes=128,
             stderr_limit_bytes=128,
         )
+    assert process.killed is True
+
+
+@pytest.mark.asyncio
+async def test_kill_and_reap_falls_back_when_process_group_kill_is_unavailable(
+    monkeypatch,
+):
+    class FakeProcess:
+        pid = 123
+
+        def __init__(self):
+            self.killed = False
+
+        def kill(self):
+            self.killed = True
+
+        async def wait(self):
+            return -9
+
+    process = FakeProcess()
+
+    def missing_killpg(*_args):
+        raise AttributeError("killpg unavailable")
+
+    monkeypatch.setattr(os, "killpg", missing_killpg, raising=False)
+    await _kill_and_reap(process)
     assert process.killed is True
 
 
@@ -757,6 +799,29 @@ def test_sampling_binding_rejects_bare_callbacks_and_cross_provider_reuse():
             channel=ProviderChannel.ANTHROPIC_MCP_SAMPLING,
             binding=binding,
         )
+
+
+def test_sampling_descriptor_requires_exact_display_and_transport_identity():
+    async def callback(_request):
+        raise AssertionError("validation must remain inert")
+
+    request = _request(model="gpt-5.1")
+    binding = _sampling_binding(callback, request=request)
+    for descriptor in (
+        binding.descriptor.model_copy(update={"display_name": "renamed lane"}),
+        binding.descriptor.model_copy(
+            update={"transport_resource_identity": "sha256:" + "0" * 64}
+        ),
+    ):
+        with pytest.raises(ValueError, match="descriptor is invalid"):
+            _snapshot_sampling_capability_descriptor(
+                descriptor,
+                provider=binding.provider,
+                channel=binding.channel,
+                capability=binding.capability,
+                models=binding.models,
+                route=binding.route,
+            )
     with pytest.raises(TypeError, match="stateful MCP sampling lease"):
         MCPClientSamplingAdapter(
             provider=ProviderId.OPENAI,

--- a/tests/test_task_rag.py
+++ b/tests/test_task_rag.py
@@ -1182,3 +1182,20 @@ class TestKeylessOperation:
         assert "cloud mirror: disabled" in text
         assert "XAI_MANAGEMENT_API_KEY" in text
         assert "unsynced: 1" in text
+
+    def test_status_reports_management_alias_conflict_distinctly(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("UNIGROK_TASK_RAG", "shadow")
+        monkeypatch.setenv("XAI_MANAGEMENT_API_KEY", "canonical-management")
+        monkeypatch.setenv("XAI_MANAGEMENT_KEY", "different-management")
+        out = io.StringIO()
+        with patch("src.rag.get_xai_management_client") as mock_client:
+            code = rag.rag_cli(
+                ["status"],
+                stream=out,
+                store=GrokSessionStore(db_path=tmp_path / "conflict.db"),
+            )
+        mock_client.assert_not_called()
+        assert code == 0
+        assert "aliases conflict" in out.getvalue()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5360,10 +5360,15 @@ class TestUtilsQuickWins:
         proc._unigrok_process_group = True
         child_pid = None
         try:
+            for _ in range(100):
+                if child_pid_file.exists():
+                    break
+                await asyncio.sleep(0.01)
+            else:
+                pytest.fail("child PID was not published before timeout test")
             with pytest.raises(asyncio.TimeoutError):
                 await communicate_with_timeout(proc, 0.3)
             assert proc.returncode is not None
-            assert child_pid_file.exists()
             child_pid = int(child_pid_file.read_text())
             for _ in range(100):
                 try:

--- a/tests/test_xai_client_authority.py
+++ b/tests/test_xai_client_authority.py
@@ -12,6 +12,7 @@ from xai_sdk import Client as SDKClient
 
 from src import utils
 from src.provider_harvest import XAIWorkerEpisodeUploader
+from src.xai_credentials import _xai_management_key_state
 
 
 def test_inference_factory_constructs_with_only_inference_authority(monkeypatch):
@@ -177,6 +178,37 @@ def test_management_factory_rejects_conflicting_aliases_before_construction(
         utils.get_xai_management_client()
 
     constructor.assert_not_called()
+
+
+def test_management_key_state_treats_none_as_missing_and_reports_conflict():
+    assert _xai_management_key_state(
+        {"XAI_MANAGEMENT_API_KEY": None, "XAI_MANAGEMENT_KEY": None}
+    ) == "missing"
+    assert _xai_management_key_state(
+        {"XAI_MANAGEMENT_API_KEY": "one", "XAI_MANAGEMENT_KEY": "two"}
+    ) == "conflict"
+
+
+def test_management_facade_is_read_only_and_names_required_interface(monkeypatch):
+    class FakeClient:
+        def __init__(self, **_kwargs):
+            self.collections = object()
+            self.close = MagicMock()
+
+    monkeypatch.setattr("xai_sdk.Client", FakeClient)
+    monkeypatch.setattr(utils, "XAI_API_KEY", "inference-test-key")
+    monkeypatch.setenv("XAI_MANAGEMENT_API_KEY", "management-test-key")
+    monkeypatch.delenv("XAI_MANAGEMENT_KEY", raising=False)
+    monkeypatch.setattr(utils, "_management_client", None)
+    management = utils.get_xai_management_client()
+
+    with pytest.raises(AttributeError, match="read-only"):
+        management._collections = object()
+    with pytest.raises(AttributeError, match="read-only"):
+        del management._close_callback
+
+    with pytest.raises(RuntimeError, match="collections and callable close"):
+        utils._CollectionsOnlyXAIManagementClient(SimpleNamespace(collections=object()))
 
 
 def test_eval_recording_wraps_inference_but_never_management(monkeypatch):


### PR DESCRIPTION
## Exact head

07e487e499a1acc9bc84b021de2162b4681f21cd

## Scope

Repairs actionable post-merge review findings across exact-plane routing, MCP session cleanup, provider persistence and subscription adapters, hosted review authentication, Cloud Run bootstrap metadata, dependency automation, management-key diagnostics, and Core/Control UI state.

Changed paths:
- architecture.md
- docs/okf/api-reference.md
- mcp_ui/app.js, mcp_ui/index.html, mcp_ui/styles.css
- scripts/github-grok-review.py, scripts/mint_mcp_service_token.py
- sites/unigrok-control-center/Dockerfile.cloudrun
- sites/unigrok-control-center/app/lib/grok-review-surface.ts
- sites/unigrok-control-center/public/docs/okf/api-reference.md
- sites/unigrok-control-center/tests/grok-review-surface.test.ts
- src/completion_envelope.py, src/mcp_session_guard.py, src/provider_harvest.py
- src/providers/broker.py, src/providers/contracts.py, src/providers/subscription.py
- src/rag.py, src/tools/system.py, src/utils.py, src/xai_credentials.py
- tests/test_completion_envelope.py, tests/test_credentials.py
- tests/test_github_review_integration.py, tests/test_harness.py
- tests/test_mcp_session_guard.py, tests/test_mcp_ui.py, tests/test_migrations.py
- tests/test_mint_mcp_service_token.py, tests/test_provider_broker.py
- tests/test_provider_harvest.py, tests/test_release_hygiene.py, tests/test_routing.py
- tests/test_service_workspace_boundary.py, tests/test_subscription_transports.py
- tests/test_task_rag.py, tests/test_utils.py, tests/test_xai_client_authority.py

## Verification

- uv run pytest -q: 2,014 passed
- npm test: deployment safety, typecheck, verified Vinext build, 67 unit tests
- npm audit --json: 0 vulnerabilities
- uv run python scripts/generate_okf.py --check: passed
- Ruff on all directly changed Python modules/scripts/tests: passed
- Control Center Cloud Run Docker image: built successfully and served the UniGrok root as non-root
- git diff --check: passed
- attribution check: passed

## Risks

- Explicit auto model pins now fail closed when neither live xAI catalog can prove exact membership; this is intentional and prevents implicit credential-plane inference.
- Hosted GitHub review service tokens are bounded to 600 seconds so the authorized 540-second stream cannot outlive authentication.
- Cloud Run bootstrap URLs use the validated public MCP resource; local bootstrap continues to use the connected localhost port.

## Accountability and provenance

Human sponsor: djtelicloud

Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=integration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential-plane routing, OAuth/token lifetimes, MCP session lifecycle, and provider delegation fallbacks—important runtime paths, but changes are bounded and heavily tested.
> 
> **Overview**
> This PR tightens **integration and runtime edges** that were failing or misleading after merge: explicit **auto** model pins now require **live catalog proof** on CLI/API (fail closed instead of guessing a plane), **MCP session cleanup** pops transports before terminate and restores on failure, and the **provider broker** defers metered-API selection so a bad API descriptor cannot block a successful subscription attempt.
> 
> **xAI management keys** gain `xai_management_key_state()` (`configured` / `missing` / `conflict`); harvest, task RAG, and related paths surface **alias conflict** distinctly. **Hosted GitHub review** prefers **minted** service tokens (default **600s** TTL, optional `UNIGROK_TOKEN_TTL_SECONDS`) over static fallbacks when a signing secret exists; exception chaining respects **suppressed context**.
> 
> **Cloud Run** `discover_self` / OAuth metadata normalize `UNIGROK_PUBLIC_MCP_URL` to a **`/mcp`** resource when the path is omitted. **Completion envelope** and evidence validation map **RecursionError** to contract errors; subscription adapters tighten descriptor identity, CLI response IDs, and process-group kill fallback.
> 
> **Control Center** Grok-review UI **prioritizes failures** over successes without claiming “latest” check. **MCP UI** adjusts readiness copy, primary CTA behavior, copy-button **aria-labels**, snippet scrolling, and drops startup `resetConversation`. Docs/Dockerfile tweaks are minor (grammar, inlined Node image ARG).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07e487e499a1acc9bc84b021de2162b4681f21cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->