### PR TITLE
fix: recognize tree-equivalent runtime markers

### DIFF
--- a/scripts/land-status.py
+++ b/scripts/land-status.py
@@ -13,6 +13,15 @@ from urllib.request import urlopen
 from land import LandError, common_git_dir, git, main_worktree, worktrees
 
 
+def tree_id(repo: Path, revision: str) -> str | None:
+    """Resolve a commit tree without letting a stale marker break status."""
+
+    try:
+        return git(repo, "rev-parse", "--verify", f"{revision}^{{tree}}")
+    except LandError:
+        return None
+
+
 def main() -> int:
     repo = Path(git(Path.cwd(), "rev-parse", "--show-toplevel"))
     primary = main_worktree(repo)
@@ -23,7 +32,12 @@ def main() -> int:
         runtime_head = marker.read_text(encoding="utf-8").strip()
     except OSError:
         runtime_head = "unknown"
-    relation = "matches main" if runtime_head == main_head else "differs or not yet recorded"
+    if runtime_head == main_head:
+        relation = "matches main"
+    elif tree_id(primary, runtime_head) == tree_id(primary, main_head):
+        relation = "matches main tree"
+    else:
+        relation = "differs or not yet recorded"
     print(f"Contributor runtime source marker: {runtime_head} ({relation})")
     print("Worktrees:")
     for item in worktrees(repo):

--- a/scripts/land-status.py
+++ b/scripts/land-status.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -16,6 +17,8 @@ from land import LandError, common_git_dir, git, main_worktree, worktrees
 def tree_id(repo: Path, revision: str) -> str | None:
     """Resolve a commit tree without letting a stale marker break status."""
 
+    if re.fullmatch(r"[0-9a-f]{40}", revision) is None:
+        return None
     try:
         return git(repo, "rev-parse", "--verify", f"{revision}^{{tree}}")
     except LandError:
@@ -34,10 +37,14 @@ def main() -> int:
         runtime_head = "unknown"
     if runtime_head == main_head:
         relation = "matches main"
-    elif tree_id(primary, runtime_head) == tree_id(primary, main_head):
-        relation = "matches main tree"
     else:
-        relation = "differs or not yet recorded"
+        runtime_tree = tree_id(primary, runtime_head)
+        main_tree = tree_id(primary, main_head)
+        relation = (
+            "matches main tree"
+            if runtime_tree is not None and runtime_tree == main_tree
+            else "differs or not yet recorded"
+        )
     print(f"Contributor runtime source marker: {runtime_head} ({relation})")
     print("Worktrees:")
     for item in worktrees(repo):

--- a/tests/test_land_workflow.py
+++ b/tests/test_land_workflow.py
@@ -124,6 +124,28 @@ def test_land_fast_forwards_visible_main(repo_with_agent, monkeypatch):
     assert receipt.read_bytes() == original_receipt
 
 
+def test_land_status_accepts_tree_equivalent_protected_merge(repo_with_agent):
+    main, agent = repo_with_agent
+    landed = commit(agent, "agent change\n")
+    marker = main / ".git" / "unigrok-land" / "runtime-head"
+    marker.parent.mkdir(parents=True)
+    marker.write_text(f"{landed}\n", encoding="utf-8")
+    git(main, "merge", "--no-ff", "codex/task", "-m", "protected merge")
+
+    result = subprocess.run(
+        ["python3", str(ROOT / "scripts" / "land-status.py")],
+        cwd=main,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    assert (
+        f"Contributor runtime source marker: {landed} (matches main tree)"
+        in result.stdout
+    )
+
+
 def test_land_refuses_behind_reviewed_head(repo_with_agent, monkeypatch):
     main, agent = repo_with_agent
     write(main / "main-only.txt", "other agent\n")

--- a/tests/test_land_workflow.py
+++ b/tests/test_land_workflow.py
@@ -146,6 +146,24 @@ def test_land_status_accepts_tree_equivalent_protected_merge(repo_with_agent):
     )
 
 
+def test_land_status_missing_marker_cannot_resolve_unknown_ref(repo_with_agent):
+    main, _ = repo_with_agent
+    git(main, "branch", "unknown", "main")
+
+    result = subprocess.run(
+        ["python3", str(ROOT / "scripts" / "land-status.py")],
+        cwd=main,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    assert (
+        "Contributor runtime source marker: unknown "
+        "(differs or not yet recorded)" in result.stdout
+    )
+
+
 def test_land_refuses_behind_reviewed_head(repo_with_agent, monkeypatch):
     main, agent = repo_with_agent
     write(main / "main-only.txt", "other agent\n")


### PR DESCRIPTION
## Exact head

4b0d6aebbd6471edde871321d83a69069db54945

## What changed

- Resolve the runtime marker and visible `main` to Git tree IDs when their commit SHAs differ.
- Report `matches main tree` when a protected GitHub merge commit has the exact content certified and restarted by `./scripts/land`.
- Accept only full 40-character lowercase commit SHAs for tree lookup, so a missing marker cannot resolve a coincidental Git ref such as `unknown`.
- Require a non-null runtime tree before declaring equivalence; failed lookups remain fail-closed.
- Add regression tests for both a tree-equivalent protected merge and a missing marker with an `unknown` branch.

## Why

The required local landing gate certifies and restarts the contributor runtime at the reviewed branch head. GitHub then creates a merge commit whose tree is identical but whose SHA is different, so the status command incorrectly reported runtime drift after every protected merge.

## Impact

Maintainers get accurate runtime/source status without rewriting the immutable landing marker or restarting a tree-identical runtime. Invalid or missing markers still report drift. The stable service remains untouched.

## Verification

- `uv run pytest -q`: 2,016 passed
- focused land-status and CodeQL contract tests: 3 passed
- `uv run ruff check scripts/land-status.py tests/test_land_workflow.py`: passed
- `git diff --check`: passed
- live `./scripts/land-status`: reports `matches main tree`; stable and contributor services ready

## Review feedback

Addressed both actionable threads on the prior head: failed tree lookups can no longer compare equal, and the literal missing-marker sentinel cannot resolve as a Git ref.

## Risk

Low. This changes status classification only; landing, receipts, runtime reconciliation, and Git refs are not mutated.

## Accountability and provenance

Human sponsor: djtelicloud

Agent-Reviewed-By: Cursor Bugbot and Gemini Code Assist | surface=GitHub | role=advisory

Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=integration