### PR TITLE
test: make land status checks portable

### DIFF
--- a/tests/test_land_workflow.py
+++ b/tests/test_land_workflow.py
@@ -1,5 +1,6 @@
 import importlib.util
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -128,12 +129,12 @@ def test_land_status_accepts_tree_equivalent_protected_merge(repo_with_agent):
     main, agent = repo_with_agent
     landed = commit(agent, "agent change\n")
     marker = main / ".git" / "unigrok-land" / "runtime-head"
-    marker.parent.mkdir(parents=True)
+    marker.parent.mkdir(parents=True, exist_ok=True)
     marker.write_text(f"{landed}\n", encoding="utf-8")
     git(main, "merge", "--no-ff", "codex/task", "-m", "protected merge")
 
     result = subprocess.run(
-        ["python3", str(ROOT / "scripts" / "land-status.py")],
+        [sys.executable, str(ROOT / "scripts" / "land-status.py")],
         cwd=main,
         check=True,
         text=True,
@@ -151,7 +152,7 @@ def test_land_status_missing_marker_cannot_resolve_unknown_ref(repo_with_agent):
     git(main, "branch", "unknown", "main")
 
     result = subprocess.run(
-        ["python3", str(ROOT / "scripts" / "land-status.py")],
+        [sys.executable, str(ROOT / "scripts" / "land-status.py")],
         cwd=main,
         check=True,
         text=True,


### PR DESCRIPTION
## Summary

- make the runtime-marker test setup idempotent with `exist_ok=True`
- run `land-status.py` with `sys.executable` so subprocess checks use the same interpreter as pytest
- addresses the three actionable post-merge Copilot comments on PR #149

## Exact head

`79c20cf6ec1b479e0ebde191aa17cafad0a26726`

## Changed paths

- `tests/test_land_workflow.py`

## Verification

- `uv run pytest -q tests/test_land_workflow.py` — 15 passed
- `uv run pytest -q` — 2,016 passed
- `git diff --check` — passed

## Risk

Low. Test-only portability and fixture-hardening changes; no runtime code or configuration changes.

## Sponsorship and provenance

- Human sponsor: `djtelicloud`
- Implementation/integration: OpenAI Codex, GPT-5 provider session, Codex Desktop
- Advisory review source: GitHub Copilot post-merge review on PR #149

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in tests/test_land_workflow.py; no production or land script behavior is modified.
> 
> **Overview**
> Hardens **land workflow** tests so they behave consistently under `uv run pytest` and when marker directories already exist.
> 
> `land-status.py` is now invoked via **`sys.executable`** instead of a hardcoded `python3`, so subprocess checks use the same interpreter as the test run. Runtime-marker setup uses **`mkdir(..., exist_ok=True)`** so repeated or overlapping fixture setup does not fail if the parent path is already present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79c20cf6ec1b479e0ebde191aa17cafad0a26726. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->