### PR TITLE
docs: warn about unrelated PyPI package

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ how UniGrok runs on your machine — not as “you are a Docker developer.”
 
 ## 3. Run the gateway
 
+> [!WARNING]
+> UniGrok is not published on PyPI.
+> `pip install mcp-grok` installs an unrelated project; use this GitHub checkout.
+
 ```bash
 git clone https://github.com/djtelicloud/grok-mcp-server.git
 cd grok-mcp-server

--- a/tests/test_release_hygiene.py
+++ b/tests/test_release_hygiene.py
@@ -25,6 +25,13 @@ def test_release_version_is_aligned_across_package_runtime_and_ui():
     assert plugin["version"] == __version__
 
 
+def test_public_install_warns_about_unrelated_pypi_distribution():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+
+    assert "UniGrok is not published on PyPI." in readme
+    assert "`pip install mcp-grok` installs an unrelated" in readme
+
+
 def test_dependabot_covers_every_shipped_dependency_surface():
     config = (ROOT / ".github" / "dependabot.yml").read_text(encoding="utf-8")
     blocks = re.split(r"(?m)^\s{2}-\s+", config)[1:]

--- a/tests/test_release_hygiene.py
+++ b/tests/test_release_hygiene.py
@@ -27,9 +27,18 @@ def test_release_version_is_aligned_across_package_runtime_and_ui():
 
 def test_public_install_warns_about_unrelated_pypi_distribution():
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    blocks = re.findall(r"(?m)^> \[!WARNING\]\n((?:^>.*(?:\n|$))+)", readme)
+    warnings = [
+        " ".join(line.removeprefix("> ").strip() for line in block.splitlines()).lower()
+        for block in blocks
+    ]
 
-    assert "UniGrok is not published on PyPI." in readme
-    assert "`pip install mcp-grok` installs an unrelated" in readme
+    assert any(
+        "not published on pypi" in warning
+        and "pip install mcp-grok" in warning
+        and "unrelated project" in warning
+        for warning in warnings
+    )
 
 
 def test_dependabot_covers_every_shipped_dependency_surface():


### PR DESCRIPTION
## Summary

- warn users that UniGrok is not currently published on PyPI
- make clear that `pip install mcp-grok` resolves to an unrelated AceDataCloud package
- preserve GitHub checkout installation as the canonical public path
- add a semantic release-hygiene assertion that parses warning blocks and protects the three required facts without coupling to line wrapping

## Evidence

PyPI's live project metadata for `mcp-grok` identifies an unrelated package: “MCP Server for Grok Imagine AI Video Generation via AceDataCloud API,” with AceDataCloud project URLs and calendar-version releases. UniGrok's public docs already use the GitHub checkout and make no PyPI installation claim.

## Exact head

`95c334827e12d1b656e2fcbc290dd851373fdead`

## Changed paths

- `README.md`
- `tests/test_release_hygiene.py`

## Verification

- `uv run pytest -q tests/test_release_hygiene.py` — 16 passed
- `npx --yes markdown-link-check -q README.md` — passed
- `uv run pytest -q` — 2,017 passed on the exact current head
- `git diff --check` — passed

## Review follow-up

Gemini correctly noted that the first assertion was copy-sensitive. The current head parses GitHub warning blocks and requires the semantic facts `not published on PyPI`, `pip install mcp-grok`, and `unrelated project`, avoiding line-wrap coupling without weakening the safeguard to unrelated keyword matches.

## Risk

Low. Documentation and regression-test only; no package identity, runtime code, credentials, deployment configuration, or release publication changes.

## Sponsorship and provenance

- Human sponsor: `djtelicloud`
- Implementation/integration: OpenAI Codex, GPT-5 provider session, Codex Desktop
- Advisory review: Gemini Code Assist