### PR TITLE
fix: advertise OAuth resource metadata URL

### DIFF
--- a/src/http_server.py
+++ b/src/http_server.py
@@ -583,7 +583,10 @@ class GatewayAuthMiddleware:
         response = _json_error("Unauthorized", status_code=401, code="unauthorized")
         # RFC 9728: point clients at the protected-resource metadata document.
         if _oauth_introspection_url():
-            metadata_url = _oauth_protected_resource_metadata_url()
+            metadata_url = _oauth_protected_resource_metadata_url(
+                path=path,
+                query_string=scope.get("query_string", b""),
+            )
             if metadata_url:
                 response.headers["WWW-Authenticate"] = (
                     f'Bearer resource_metadata="{metadata_url}", '
@@ -968,16 +971,22 @@ def _validated_https_url(value: str) -> Optional[str]:
 def _public_mcp_resource() -> Optional[str]:
     resource = _validated_https_url(os.environ.get("UNIGROK_PUBLIC_MCP_URL", ""))
     if resource and not urlsplit(resource).path:
-        return f"{resource}/mcp"
-    return resource
+        resource = f"{resource}/mcp"
+    if resource and urlsplit(resource).path == "/mcp":
+        return resource
+    return None
 
 
-def _oauth_protected_resource_metadata_url() -> Optional[str]:
-    """Return the RFC 9728 metadata URL for the configured MCP resource."""
+def _oauth_protected_resource_metadata_url(
+    *, path: str, query_string: bytes
+) -> Optional[str]:
+    """Return metadata only when the request exactly matches the MCP resource."""
     resource = _public_mcp_resource()
     if resource is None:
         return None
     parsed = urlsplit(resource)
+    if path != parsed.path or query_string:
+        return None
     return (
         f"{parsed.scheme}://{parsed.netloc}"
         f"/.well-known/oauth-protected-resource{parsed.path}"

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -581,10 +581,10 @@ class GatewayAuthMiddleware:
             return
         _oauth_audit("access_denied", scope, required_scope=required_scope)
         response = _json_error("Unauthorized", status_code=401, code="unauthorized")
-        # RFC 6750: advertise the expected auth scheme on every 401.
+        # RFC 9728: point clients at the protected-resource metadata document.
         if _oauth_introspection_url():
             response.headers["WWW-Authenticate"] = (
-                f'Bearer resource_metadata="{_public_mcp_resource() or "/.well-known/oauth-protected-resource/mcp"}", '
+                f'Bearer resource_metadata="{_oauth_protected_resource_metadata_url()}", '
                 f'scope="{required_scope}"'
             )
         else:
@@ -966,6 +966,18 @@ def _public_mcp_resource() -> Optional[str]:
     if resource and not urlsplit(resource).path:
         return f"{resource}/mcp"
     return resource
+
+
+def _oauth_protected_resource_metadata_url() -> str:
+    """Return the RFC 9728 metadata URL for the configured MCP resource."""
+    resource = _public_mcp_resource()
+    if resource is None:
+        return "/.well-known/oauth-protected-resource/mcp"
+    parsed = urlsplit(resource)
+    return (
+        f"{parsed.scheme}://{parsed.netloc}"
+        f"/.well-known/oauth-protected-resource{parsed.path}"
+    )
 
 
 def _oauth_authorization_servers() -> List[str]:

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -583,10 +583,14 @@ class GatewayAuthMiddleware:
         response = _json_error("Unauthorized", status_code=401, code="unauthorized")
         # RFC 9728: point clients at the protected-resource metadata document.
         if _oauth_introspection_url():
-            response.headers["WWW-Authenticate"] = (
-                f'Bearer resource_metadata="{_oauth_protected_resource_metadata_url()}", '
-                f'scope="{required_scope}"'
-            )
+            metadata_url = _oauth_protected_resource_metadata_url()
+            if metadata_url:
+                response.headers["WWW-Authenticate"] = (
+                    f'Bearer resource_metadata="{metadata_url}", '
+                    f'scope="{required_scope}"'
+                )
+            else:
+                response.headers["WWW-Authenticate"] = f'Bearer scope="{required_scope}"'
         else:
             response.headers["WWW-Authenticate"] = "Bearer"
         await response(scope, receive, send)
@@ -968,11 +972,11 @@ def _public_mcp_resource() -> Optional[str]:
     return resource
 
 
-def _oauth_protected_resource_metadata_url() -> str:
+def _oauth_protected_resource_metadata_url() -> Optional[str]:
     """Return the RFC 9728 metadata URL for the configured MCP resource."""
     resource = _public_mcp_resource()
     if resource is None:
-        return "/.well-known/oauth-protected-resource/mcp"
+        return None
     parsed = urlsplit(resource)
     return (
         f"{parsed.scheme}://{parsed.netloc}"

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -261,12 +261,17 @@ def test_cloudrun_requires_api_keys(monkeypatch):
 def test_cloudrun_accepts_oauth_introspection_without_static_keys(monkeypatch):
     monkeypatch.setenv("UNIGROK_RUNTIME", "cloudrun")
     monkeypatch.delenv("UNIGROK_API_KEYS", raising=False)
+    monkeypatch.delenv("UNIGROK_PUBLIC_MCP_URL", raising=False)
     monkeypatch.setenv(
         "UNIGROK_OAUTH_INTROSPECTION_URL",
         "https://control.grokmcp.org/oauth/introspect",
     )
 
-    create_app()
+    with TestClient(create_app()) as client:
+        response = client.get("/metrics")
+
+    assert response.status_code == 401
+    assert response.headers["WWW-Authenticate"] == 'Bearer scope="unigrok:status"'
 
 
 def test_oauth_introspection_enforces_surface_and_tool_scopes(monkeypatch):

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -174,6 +174,7 @@ def test_oauth_protected_resource_metadata_is_active(monkeypatch, public_mcp_url
     [
         ("", "https://auth.grokmcp.org"),
         ("http://mcp.grokmcp.org/mcp", "https://auth.grokmcp.org"),
+        ("https://mcp.grokmcp.org/tenant/mcp", "https://auth.grokmcp.org"),
         ("https://127.0.0.1/mcp", "https://auth.grokmcp.org"),
         ("https://10.0.0.1/mcp", "https://auth.grokmcp.org"),
         ("https://[::1]/mcp", "https://auth.grokmcp.org"),
@@ -337,11 +338,35 @@ def test_oauth_introspection_enforces_surface_and_tool_scopes(monkeypatch):
         "unigrok:connect unigrok:invoke",
         "unigrok:connect unigrok:invoke unigrok:review",
     ]
+    assert metrics.headers["WWW-Authenticate"] == 'Bearer scope="unigrok:status"'
     assert review.headers["WWW-Authenticate"] == (
         'Bearer resource_metadata="https://mcp.grokmcp.org/'
         '.well-known/oauth-protected-resource/mcp", '
         'scope="unigrok:connect unigrok:review"'
     )
+
+
+def test_oauth_metadata_challenge_omits_mcp_document_for_query_variant(monkeypatch):
+    monkeypatch.setenv("UNIGROK_RUNTIME", "cloudrun")
+    monkeypatch.delenv("UNIGROK_API_KEYS", raising=False)
+    monkeypatch.setenv("UNIGROK_PUBLIC_MCP_URL", "https://mcp.grokmcp.org/mcp")
+    monkeypatch.setenv(
+        "UNIGROK_OAUTH_INTROSPECTION_URL",
+        "https://control.grokmcp.org/oauth/introspect",
+    )
+
+    async def deny(_token, _required_scope):
+        return None
+
+    monkeypatch.setattr("src.http_server._introspect_oauth_token", deny)
+    with TestClient(create_app(), base_url="https://mcp.grokmcp.org") as client:
+        response = client.get(
+            "/mcp?session=unexpected",
+            headers={"Authorization": "Bearer token-value"},
+        )
+
+    assert response.status_code == 401
+    assert response.headers["WWW-Authenticate"] == 'Bearer scope="unigrok:connect"'
 
 
 def test_oauth_introspection_allows_valid_status_token(monkeypatch):

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -332,7 +332,11 @@ def test_oauth_introspection_enforces_surface_and_tool_scopes(monkeypatch):
         "unigrok:connect unigrok:invoke",
         "unigrok:connect unigrok:invoke unigrok:review",
     ]
-    assert 'scope="unigrok:connect unigrok:review"' in review.headers["WWW-Authenticate"]
+    assert review.headers["WWW-Authenticate"] == (
+        'Bearer resource_metadata="https://mcp.grokmcp.org/'
+        '.well-known/oauth-protected-resource/mcp", '
+        'scope="unigrok:connect unigrok:review"'
+    )
 
 
 def test_oauth_introspection_allows_valid_status_token(monkeypatch):


### PR DESCRIPTION
## Summary
- advertise the RFC 9728 protected-resource metadata document URL only for an exact query-free `/mcp` challenge
- derive the URL only from the validated configured public MCP resource
- omit `resource_metadata` for non-MCP resources, query variants, or invalid/missing public configuration
- reject unsupported path-prefixed public MCP URLs because the app does not serve their derived well-known routes
- lock hosted, non-MCP, query-variant, and invalid-configuration behavior with regression assertions

## Exact head
`1fc9409dedf40b942e03c05b73d2579a30554f35`

## Changed paths
- `src/http_server.py`
- `tests/test_http_server.py`

## Verification
- `uv run pytest -q tests/test_http_server.py` — 116 passed
- `uv run ruff check src/http_server.py tests/test_http_server.py`
- `git diff --check`
- `uv run pytest -q` — 2,019 passed
- `uv run python scripts/check_agent_attribution.py --base-ref origin/main --head HEAD`

## Review follow-up
- Gemini's absolute-URL edge case is addressed.
- GitHub Codex's resource-match and unsupported-path findings are addressed.
- The prior threads are superseded by the current head and are intentionally left for GitHub to mark outdated.

## Risk
Low. The change narrows OAuth discovery advertising to requests whose URL can validate against the published metadata. All other protected surfaces retain their required scope challenge without a misleading metadata pointer.

## Accountability and provenance
- Human sponsor: `djtelicloud`
- Accountable GitHub contributor: `djtelicloud`
- OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=implementation
- Google Gemini | model=unverified | model-source=unverified | surface=GitHub | role=advisory
- OpenAI Codex | model=unverified | model-source=unverified | surface=GitHub | role=advisory

Standards: [RFC 9728 §3.3](https://www.rfc-editor.org/rfc/rfc9728.html#section-3.3), [RFC 9728 §5.1](https://www.rfc-editor.org/rfc/rfc9728.html#section-5.1), [MCP authorization discovery](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#protected-resource-metadata-discovery-requirements)