### PR TITLE
fix: skip introspection without bearer token

### DIFF
--- a/src/http_server.py
+++ b/src/http_server.py
@@ -245,7 +245,7 @@ def _oauth_required_scope(path: str, body: bytes = b"") -> str:
 
 async def _introspect_oauth_token(token: str, required_scope: str) -> Optional[Dict[str, Any]]:
     url = _oauth_introspection_url()
-    if not url or len(token) > 8_192:
+    if not url or not token or len(token) > 8_192:
         return None
     try:
         async with httpx.AsyncClient(timeout=5.0, follow_redirects=False) as client:

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -268,6 +268,11 @@ def test_cloudrun_accepts_oauth_introspection_without_static_keys(monkeypatch):
         "https://control.grokmcp.org/oauth/introspect",
     )
 
+    def forbid_http_client(*_args, **_kwargs):
+        raise AssertionError("missing bearer tokens must not reach OAuth introspection")
+
+    monkeypatch.setattr("src.http_server.httpx.AsyncClient", forbid_http_client)
+
     with TestClient(create_app()) as client:
         response = client.get("/metrics")
 


### PR DESCRIPTION
## Summary
- short-circuit OAuth introspection when no bearer token is present
- prevent unauthenticated requests from generating needless control-origin HTTP traffic
- make the Cloud Run auth regression test fail if an HTTP client is constructed

## Exact head
`9d90342bbfb4c7b701c460bb9278e575a8c7dd5b`

## Changed paths
- `src/http_server.py`
- `tests/test_http_server.py`

## Verification
- `uv run pytest -q tests/test_http_server.py` — 116 passed
- `uv run ruff check src/http_server.py tests/test_http_server.py`
- `git diff --check`
- `uv run pytest -q` — 2,019 passed
- `uv run python scripts/check_agent_attribution.py --base-ref origin/main --head HEAD`

## Review follow-up
- addresses the late GitHub Codex review on merged PR #152

## Risk
Low. Non-empty tokens retain the same bounded remote-introspection path; missing tokens now fail locally before network I/O.

## Accountability and provenance
- Human sponsor: `djtelicloud`
- Accountable GitHub contributor: `djtelicloud`
- OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=implementation
- OpenAI Codex | model=unverified | model-source=unverified | surface=GitHub | role=advisory

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Auth behavior for requests with real bearer tokens is unchanged; the change only avoids outbound introspection calls when no token is present.
> 
> **Overview**
> **OAuth gateway auth** now rejects missing bearer tokens locally in `_introspect_oauth_token` instead of opening an HTTP client to the control-plane introspection URL. Valid non-empty tokens still follow the same remote introspection path (including the existing length cap).
> 
> The Cloud Run regression test for OAuth-only auth (`/metrics` without `Authorization`) now patches `httpx.AsyncClient` so any attempt to introspect without a token fails the test explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d90342bbfb4c7b701c460bb9278e575a8c7dd5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->