### PR TITLE
docs: make regional failover atomic

### DIFF
--- a/.codex/memory/active-work.md
+++ b/.codex/memory/active-work.md
@@ -2,8 +2,8 @@
 
 Last updated: 2026-07-15
 Owner: Codex
-Status: GitHub and security are clean. The remote MCP is live after regional
-failover. The Control rollout awaits Cloud Run recovery; Stage 1 live generation
+Status: GitHub and security are clean. The remote MCP and Control Center are
+live in `us-central1` with east-region rollback assets. Stage 1 live generation
 and training remain blocked.
 
 This is the project-scoped handoff for new Codex chats. Verify drift-prone Git,
@@ -52,18 +52,19 @@ credentials, OAuth codes, tokens, or private keys here.
 
 ## Latest maintainer sweep
 
-- Protected PRs #148-#153 are merged. They hardened maintainer integration,
+- Protected PRs #148-#154 are merged. They hardened maintainer integration,
   made runtime markers tree-aware and portable, warned about the unrelated
   public `mcp-grok` package, corrected RFC 9728 challenge metadata, and made a
-  missing OAuth bearer fail before remote introspection. The final repair passed
+  missing OAuth bearer fail before remote introspection. They also recorded the
+  regional recovery contract and refreshed this handoff. The final repair passed
   2,019 tests and `scripts/land` certified exact content head
-  `9d90342bbfb4c7b701c460bb9278e575a8c7dd5b` before protected merge.
+  `615c70404390e2ec3c624f2b8ea5215f8a94cac7` before protected merge.
 - Local `main` and protected `origin/main` agree at merge commit
-  `0d64a49ccf593780bbc80c00f4a419d1e413e0ef`. Exact-main CI and all three
-  CodeQL analyzers passed. At the sweep snapshot before this handoff PR, there
-  were no other open PRs, issues, discussions, review threads, code-scanning
-  alerts, Dependabot alerts, secret-scanning alerts, or draft private
-  advisories.
+  `2bf6647384922aa1b9e6162e645bd37560936133`. Exact-main CI and all three
+  CodeQL analyzers passed. At the sweep snapshot before the current handoff
+  repair, there were no open PRs, issues, discussions, review threads,
+  code-scanning alerts, Dependabot alerts, secret-scanning alerts, or draft
+  private advisories.
 - Merged task worktrees, local task branches, remote `codex/*` branches, and
   stale local remote-tracking refs are removed. The shared checkout is clean;
   its runtime source marker is tree-equivalent to `main`; stable and contributor
@@ -81,11 +82,21 @@ credentials, OAuth codes, tokens, or private keys here.
   secret bindings. East is detached from the load balancer and restored to its
   prior healthy revision as a rollback asset. Personalized Service Health is
   now enabled; it reports no active Cloud Run incident.
-- The Control Center remains healthy on revision
-  `unigrok-control-center-ab8d77b`. Its newer east candidate has the same
-  provider-managed activation failure and remains at zero traffic. Production
-  `https://control.grokmcp.org/`, OAuth metadata, and the protected control flow
-  remain healthy.
+- The Control Center image digest
+  `sha256:0a38494d0ebc01475ba168da4e8ed921b55d7f0d2d8de50646d5b407ccb2ca15`
+  is live on ready revision `unigrok-control-center-eb454cd` in `us-central1`.
+  Its site source tree is unchanged through current `main`. The URL map points
+  the control hostname to central-only backend
+  `unigrok-control-center-backend-central`; repeated project API, homepage,
+  discovery, `llms.txt`, and OAuth contract probes pass, and central request
+  logs confirm service of the public hostname.
+- Removing the east NEG from the active backend produced a transient provider
+  propagation gap and was rolled back automatically. The successful cutover
+  instead staged an independent central backend and atomically changed the URL
+  map. The prior `unigrok-control-center-backend` is now east-only and preserved
+  with healthy revision `unigrok-control-center-ab8d77b` as the immediate
+  rollback target. The newer east candidate remains at zero traffic because of
+  the provider-managed activation failure.
 - Release, source, and plugin versions agree at 0.6.0. Publishing a new release,
   accepting the `google-genai` 2.x migration, or changing the enabled empty
   GitHub Wiki remains a maintainer decision. Stage 2 generation, dataset writes,

--- a/docs/remote-mcp-deployment.md
+++ b/docs/remote-mcp-deployment.md
@@ -60,11 +60,13 @@ digests.
 For a bounded manual failover, prefer an atomic URL-map change over removing a
 NEG from the active backend. Stage and verify the replacement region first,
 then create a separate backend with its own verified NEG and the same protocol,
-timeout, CDN, and Cloud Armor contract. Repoint only the relevant URL-map
-default service or path matcher to that backend. During propagation, each edge
-then sees either the complete old backend or the complete replacement backend;
-it never sees an in-place backend with a membership update still propagating.
-Do not alter unrelated host rules that share the URL map.
+timeout, disabled Cloud CDN setting, and Cloud Armor policy. In one validated
+URL-map configuration update, repoint every route that selects the old backend:
+the relevant default service, path-matcher default service, and any associated
+path rules. During propagation, each edge then sees either the complete old
+backend or the complete replacement backend; it never sees an in-place backend
+with a membership update still propagating. Do not alter unrelated host rules
+that share the URL map.
 
 After the URL-map update reports success, require repeated public health,
 readiness, metadata, and unauthenticated challenge probes, plus request-log

--- a/docs/remote-mcp-deployment.md
+++ b/docs/remote-mcp-deployment.md
@@ -55,13 +55,26 @@ an equivalent Cloud Run service in each region. Give each service its own
 regional serverless NEG and attach only verified, functionally equivalent
 regions to the global backend. A load balancer with multiple serverless NEGs
 routes by proximity, so never attach regions running different reviewed
-digests. A bounded manual failover is: stage and verify the replacement region,
-attach its NEG, wait for the backend update to report the new NEG and for public
-probes to remain healthy, remove the impaired region's NEG, and re-run the
-public health, readiness, metadata, and unauthenticated challenge probes.
-Reattach the prior NEG immediately if any contract fails. Keep the detached
-service intact until the replacement has remained healthy; deleting it is not
-part of a failover.
+digests.
+
+For a bounded manual failover, prefer an atomic URL-map change over removing a
+NEG from the active backend. Stage and verify the replacement region first,
+then create a separate backend with its own verified NEG and the same protocol,
+timeout, CDN, and Cloud Armor contract. Repoint only the relevant URL-map
+default service or path matcher to that backend. During propagation, each edge
+then sees either the complete old backend or the complete replacement backend;
+it never sees an in-place backend with a membership update still propagating.
+Do not alter unrelated host rules that share the URL map.
+
+After the URL-map update reports success, require repeated public health,
+readiness, metadata, and unauthenticated challenge probes, plus request-log
+evidence that the replacement region served the public hostname. Restore the
+previous URL-map backend immediately if any contract fails. Keep the old
+backend, NEG, service, and known revision intact until the replacement has
+remained healthy. Removing them is cleanup after the observation window, not
+part of the cutover. In-place removal of the old NEG is only acceptable after
+the active URL map no longer references that backend; a successful backend API
+update alone is not proof that every edge has finished propagating it.
 
 Keep the previous revision at zero traffic. Roll back by moving 100% traffic to
 that known digest; do not rebuild old source. Disabling the service or removing


### PR DESCRIPTION
## Summary
- require independently staged backends and atomic URL-map swaps for regional failover
- keep Cloud CDN disabled and update every default/path rule that targets the old backend
- preserve the old backend as immediate rollback and require public request-log proof
- refresh the tracked maintainer handoff with the live central Control Center topology

## Exact head
`990fa2103986cb704e1adcd2e21199f101c84f03`

## Verification
- `uv run python scripts/generate_okf.py --check`
- `git diff --check`
- `uv run pytest -q` — 2,019 passed after review repairs
- live Control Center topology: URL map -> central-only backend; east-only backend retained for rollback
- 20 consecutive public contract probes passed after atomic cutover

## Review repairs
- Gemini: update every path rule/default that still targets the old backend
- Copilot: explicitly preserve the disabled Cloud CDN setting

## Risk
Documentation and tracked handoff only. No runtime source changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and tracked handoff only; no application or infrastructure code changes.
> 
> **Overview**
> **Regional failover guidance** now favors **atomic URL-map backend swaps** instead of removing NEGs from the active backend, so edges never serve a backend whose membership is still propagating.
> 
> The deployment doc spells out staging a separate verified backend/NEG, repointing all URL-map routes in one update, requiring repeated public probes plus **request-log proof** the new region served the hostname, and keeping the old backend intact for immediate rollback. In-place NEG removal is only allowed after the URL map no longer references that backend.
> 
> The **Codex maintainer handoff** (`.codex/memory/active-work.md`) is refreshed: merged PR range through **#154**, new certified content head, live **us-central1** remote MCP and Control Center topology (central-only active backend, east preserved for rollback), and notes that an east NEG removal caused a transient gap—motivating the atomic cutover approach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 990fa2103986cb704e1adcd2e21199f101c84f03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->