### PR TITLE
test(control): lock introspection response fields

### DIFF
--- a/sites/unigrok-control-center/tests/oauth-control.test.ts
+++ b/sites/unigrok-control-center/tests/oauth-control.test.ts
@@ -142,15 +142,29 @@ test("introspection exposes claims only for a valid bearer with the required sco
     ));
     const wrongScope = await introspect("unigrok:invoke");
     assert.equal(wrongScope.status, 200);
+    assert.equal(wrongScope.headers.get("cache-control"), "no-store");
     assert.deepEqual(await wrongScope.json(), { active: false });
 
     const allowed = await introspect("unigrok:review");
     assert.equal(allowed.status, 200);
     assert.equal(allowed.headers.get("cache-control"), "no-store");
     const claims = await allowed.json() as Record<string, unknown>;
+    assert.deepEqual(Object.keys(claims).sort(), [
+      "active",
+      "aud",
+      "client_id",
+      "exp",
+      "iat",
+      "iss",
+      "scope",
+      "sub",
+      "token_type",
+    ]);
     assert.equal(claims.active, true);
     assert.equal(claims.aud, oauth.resource);
     assert.equal(claims.client_id, "service:github-review-broker");
+    assert.ok(typeof claims.exp === "number" && Number.isInteger(claims.exp));
+    assert.ok(typeof claims.iat === "number" && Number.isInteger(claims.iat));
     assert.equal(claims.iss, oauth.issuer);
     assert.equal(claims.scope, "unigrok:connect unigrok:review");
     assert.equal(claims.sub, "service:github-review-broker");


### PR DESCRIPTION
## Summary
- assert `Cache-Control: no-store` on the insufficient-scope introspection path
- lock active introspection responses to the exact nine-field allowlist
- require integer `exp` and `iat` claims

Addresses late review feedback on merged PR #156.

## Exact head
`18937f2bea9d83b8525537affbc919087965d6f6`

## Changed path
- `sites/unigrok-control-center/tests/oauth-control.test.ts`

## Verification
- `npm audit --audit-level=moderate` — 0 vulnerabilities
- focused OAuth suite — 8 passed
- `npm run lint`
- `npm run typecheck`
- `npm run test:deployment` — deployment safety, production build, 69 tests
- `uv run pytest -q` — 2,019 passed

## Risk
Very low. Test-only contract hardening; production behavior is unchanged.

Human sponsor: `djtelicloud`

Canonical provenance: `OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=implementation`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only test assertions were added; no production code paths were modified.
> 
> **Overview**
> **Test-only hardening** for the OAuth introspection endpoint in `oauth-control.test.ts`; runtime behavior is unchanged.
> 
> The insufficient-scope path (`required_scope` mismatch) now asserts **`Cache-Control: no-store`**, matching inactive introspection cases. For a successful service-token introspection, tests **pin the JSON shape** to exactly nine keys (`active`, `aud`, `client_id`, `exp`, `iat`, `iss`, `scope`, `sub`, `token_type`) and require **`exp` and `iat` to be integers**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18937f2bea9d83b8525537affbc919087965d6f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->