### PR TITLE
fix(routing): preserve thinking on API pins

### DIFF
--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -3999,7 +3999,7 @@ Return whether one unambiguous xAI management credential is configured.
 ### Function: `xai_management_key_state` {#utils-xai_management_key_state}
 
 ```python
-def xai_management_key_state() -> str
+def xai_management_key_state() -> XAIManagementKeyState
 ```
 
 **Keywords:** xai, management, key, state

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -3999,7 +3999,7 @@ Return whether one unambiguous xAI management credential is configured.
 ### Function: `xai_management_key_state` {#utils-xai_management_key_state}
 
 ```python
-def xai_management_key_state() -> str
+def xai_management_key_state() -> XAIManagementKeyState
 ```
 
 **Keywords:** xai, management, key, state

--- a/src/utils.py
+++ b/src/utils.py
@@ -43,6 +43,7 @@ from .credentials import (
     credential_plane_policy,
 )
 from .xai_credentials import (
+    XAIManagementKeyState,
     _require_xai_management_key,
     _xai_management_key_state,
 )
@@ -1972,7 +1973,7 @@ def xai_management_key_configured() -> bool:
     return xai_management_key_state() == "configured"
 
 
-def xai_management_key_state() -> str:
+def xai_management_key_state() -> XAIManagementKeyState:
     """Return configured, missing, or conflict without exposing either secret."""
 
     return _xai_management_key_state()
@@ -11107,6 +11108,9 @@ async def _select_routing_model(
         input_messages=input_messages,
         enable_agentic=enable_agentic,
     )
+    api_only_exact_pin = bool(
+        thinking_mode or mode == "research" or features.get("has_image")
+    )
 
     if requested_model:
         model = await resolve_model(requested_model)
@@ -11117,6 +11121,11 @@ async def _select_routing_model(
             )
         catalog_source = "not_consulted"
         if requested_plane == "cli":
+            if api_only_exact_pin:
+                raise ValueError(
+                    "Thinking, vision, and research capabilities are API-only "
+                    "and cannot start on the CLI plane."
+                )
             cli_status = grok_cli_plane_status()
             cli_models = {str(item) for item in cli_status.get("models", []) if str(item)}
             if not cli_status.get("ready") or model not in cli_models:
@@ -11143,7 +11152,14 @@ async def _select_routing_model(
             )
             api_contains = api_available and model in set(api_models)
             policy = credential_plane_policy(cloudrun=is_cloudrun_runtime())
-            if policy == "cli_first" and cli_contains:
+            if api_only_exact_pin and api_contains:
+                catalog_source = api_source
+            elif api_only_exact_pin and api_available:
+                raise ValueError(
+                    f"Model '{model}' is unavailable on the xAI developer API "
+                    "plane required by this capability."
+                )
+            elif policy == "cli_first" and cli_contains:
                 catalog_source = "grok_cli_live"
             elif api_contains:
                 catalog_source = api_source

--- a/src/utils.py
+++ b/src/utils.py
@@ -11089,6 +11089,14 @@ def _routing_failure_evidence(exc: Exception) -> Dict[str, Any]:
     return evidence
 
 
+def _api_only_capability_requested(
+    *, mode: str, thinking_mode: bool, features: Dict[str, Any]
+) -> bool:
+    """Return whether the request needs an API-native execution capability."""
+
+    return bool(thinking_mode or mode == "research" or features.get("has_image"))
+
+
 async def _select_routing_model(
     *,
     prompt: str,
@@ -11108,8 +11116,10 @@ async def _select_routing_model(
         input_messages=input_messages,
         enable_agentic=enable_agentic,
     )
-    api_only_exact_pin = bool(
-        thinking_mode or mode == "research" or features.get("has_image")
+    api_only_exact_pin = _api_only_capability_requested(
+        mode=mode,
+        thinking_mode=thinking_mode,
+        features=features,
     )
 
     if requested_model:
@@ -11428,10 +11438,10 @@ async def orchestrate(
         input_messages=input_messages,
         enable_agentic=enable_agentic,
     )
-    cli_selection_compatible = not (
-        thinking_mode
-        or mode == "research"
-        or bool(selection_features.get("has_image"))
+    cli_selection_compatible = not _api_only_capability_requested(
+        mode=mode,
+        thinking_mode=thinking_mode,
+        features=selection_features,
     )
 
     async def _select_for_plane(

--- a/src/utils.py
+++ b/src/utils.py
@@ -11116,13 +11116,12 @@ async def _select_routing_model(
         input_messages=input_messages,
         enable_agentic=enable_agentic,
     )
-    api_only_exact_pin = _api_only_capability_requested(
-        mode=mode,
-        thinking_mode=thinking_mode,
-        features=features,
-    )
-
     if requested_model:
+        api_only_exact_pin = _api_only_capability_requested(
+            mode=mode,
+            thinking_mode=thinking_mode,
+            features=features,
+        )
         model = await resolve_model(requested_model)
         if mode == "research" and not model.startswith("grok-4.20-multi-agent"):
             raise ValueError(

--- a/src/utils.py
+++ b/src/utils.py
@@ -11159,6 +11159,12 @@ async def _select_routing_model(
                     f"Model '{model}' is unavailable on the xAI developer API "
                     "plane required by this capability."
                 )
+            elif api_only_exact_pin and xai_api_key_configured():
+                # An exact pin is still executable when live catalog discovery
+                # is temporarily unavailable. Keep API-only capabilities on
+                # the credentialed API plane instead of silently downgrading
+                # them to a shared CLI slug under cli_first.
+                catalog_source = api_source
             elif policy == "cli_first" and cli_contains:
                 catalog_source = "grok_cli_live"
             elif api_contains:

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -396,6 +396,43 @@ async def test_auto_exact_pin_keeps_thinking_on_api_under_cli_first(monkeypatch)
 
 
 @pytest.mark.asyncio
+async def test_auto_exact_pin_keeps_thinking_on_api_when_discovery_fails(monkeypatch):
+    from src import utils
+
+    shared_model = "grok-shared-exact"
+    monkeypatch.setenv("UNIGROK_PLANE_POLICY", "cli_first")
+    monkeypatch.setenv("XAI_API_KEY", "configured")
+    monkeypatch.setattr(utils, "XAI_API_KEY", "configured")
+    monkeypatch.setattr(
+        utils,
+        "grok_cli_plane_status",
+        lambda **_: {
+            **READY_CLI,
+            "models": [shared_model],
+            "default_model": shared_model,
+        },
+    )
+    monkeypatch.setattr(
+        utils._MODEL_RESOLVER,
+        "catalog_snapshot",
+        AsyncMock(return_value=([shared_model], "static_fallback", False)),
+    )
+
+    _, _, receipt, _ = await utils._select_routing_model(
+        prompt="Think deeply while discovery is unavailable",
+        mode="auto",
+        thinking_mode=True,
+        requested_model=shared_model,
+        requested_plane="auto",
+        active_store=None,
+        input_messages=None,
+        enable_agentic=True,
+    )
+
+    assert receipt["catalog"]["source"] == "static_fallback"
+
+
+@pytest.mark.asyncio
 async def test_auto_exact_pin_routes_cli_only_live_slug_to_cli(monkeypatch):
     from src import utils
 

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -360,6 +360,42 @@ async def test_auto_exact_pin_uses_live_plane_membership_and_policy(
 
 
 @pytest.mark.asyncio
+async def test_auto_exact_pin_keeps_thinking_on_api_under_cli_first(monkeypatch):
+    from src import utils
+
+    shared_model = "grok-shared-exact"
+    monkeypatch.setenv("UNIGROK_PLANE_POLICY", "cli_first")
+    monkeypatch.setattr(
+        utils,
+        "grok_cli_plane_status",
+        lambda **_: {
+            **READY_CLI,
+            "models": [shared_model],
+            "default_model": shared_model,
+        },
+    )
+    monkeypatch.setattr(
+        utils._MODEL_RESOLVER,
+        "catalog_snapshot",
+        AsyncMock(return_value=([shared_model], "xai_api_live", True)),
+    )
+
+    selected, _, receipt, _ = await utils._select_routing_model(
+        prompt="Think deeply with the exact shared model",
+        mode="auto",
+        thinking_mode=True,
+        requested_model=shared_model,
+        requested_plane="auto",
+        active_store=None,
+        input_messages=None,
+        enable_agentic=True,
+    )
+
+    assert selected == shared_model
+    assert receipt["catalog"]["source"] == "xai_api_live"
+
+
+@pytest.mark.asyncio
 async def test_auto_exact_pin_routes_cli_only_live_slug_to_cli(monkeypatch):
     from src import utils
 
@@ -412,6 +448,23 @@ async def test_strict_cli_rejects_api_only_model(monkeypatch):
             prompt="Pin API coding model", mode="auto", thinking_mode=False,
             requested_model="grok-build-0.1", requested_plane="cli", active_store=None,
             input_messages=None, enable_agentic=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_strict_cli_rejects_exact_pin_for_thinking(monkeypatch):
+    from src import utils
+
+    with pytest.raises(ValueError, match="API-only"):
+        await utils._select_routing_model(
+            prompt="Think deeply",
+            mode="auto",
+            thinking_mode=True,
+            requested_model="grok-4.5",
+            requested_plane="cli",
+            active_store=None,
+            input_messages=None,
+            enable_agentic=True,
         )
 
 


### PR DESCRIPTION
## Summary

- keep API-only thinking, vision, and research capabilities on the API plane for exact model pins
- keep credentialed API-only pins on API when live catalog discovery is temporarily unavailable
- reject strict CLI exact pins for API-only capabilities instead of silently downgrading them
- centralize and correctly scope the API-only exact-pin predicate
- expose the precise management-key state return type and refresh generated API mirrors

## Exact head

`7064323b8bc3ac7d4cf72a5cb14c472539bf4265`

## Changed paths

- `src/utils.py`
- `tests/test_credentials.py`
- `docs/okf/api-reference.md`
- `sites/unigrok-control-center/public/docs/okf/api-reference.md`

## Verification

- routing/server regression group — 519 passed after final review follow-up
- generated API reference check passed
- `uv run pytest -q` — 2,022 passed
- attribution check passed
- `git diff --check` passed

## Risk

Low and bounded to exact-pin plane selection. Keyless CLI graceful fallback remains unchanged.

Human-Sponsor: djtelicloud

Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=implementation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to exact-pin plane selection in routing; default CLI fallback behavior for non-API-only requests is unchanged.
> 
> **Overview**
> **Exact model pins** for thinking, vision, or research no longer get routed to the CLI plane under `cli_first` when the same slug exists on both catalogs. Auto routing now prefers the **xAI API** catalog for those API-only capabilities, including when live catalog discovery fails but an API key is configured, instead of silently using the shared CLI slug.
> 
> **Strict `requested_plane="cli"`** now raises a clear error for API-only exact pins rather than downgrading.
> 
> A shared **`_api_only_capability_requested`** helper centralizes that predicate for both `_select_routing_model` and orchestration CLI compatibility checks. **`xai_management_key_state`** is typed to return **`XAIManagementKeyState`**, with generated API reference docs updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7064323b8bc3ac7d4cf72a5cb14c472539bf4265. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->