### PR TITLE
fix(agents): human-language ops and disposable worktrees

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -20,6 +20,35 @@
 - Prefer UniGrok MCP CLI/`fast` for cheap index-diff hive emits; keep visible
   output tiny. Insider silent-think doctrine is private (not public default).
 
+## Human language (user-facing — mandatory)
+
+The sponsor is **not** a git operator. Match **intent**, not literal VCS vocabulary.
+Dyslexia-hostile jargon in answers is a product failure.
+
+### Intent map (user words → agent duty)
+
+| User says (examples) | Means | Agent does silently | Tell the user |
+| --- | --- | --- | --- |
+| Done? / finished? / is it pushed? / submitted? | Is my task complete and with the supervisor? | Open/update **draft PR** for your lane; hand exact head to supervisor when ready | **Ready for supervisor** / **Not ready** (+ one plain blocker) |
+| Live? / shipped? / on main? / in production? | Is it the real product now? | Check protected main / deploy only if you are supervisor | **Live** / **Not live** (+ one plain reason) |
+| Who did this? | Which **brand/agent** | Trailers / evidence | Lead with **Grok / Codex / Claude / …** — never “you wrote it” when an agent did |
+| Clean up / too many folders | Remove finished scratchpads | Own worktree remove; supervisor may prune orphans | **Cleaned** / **Left X (why)** |
+| Fix CI / make it green | Repair your PR checks | Fix and re-verify | **Green** / **Still red** (+ one plain cause) |
+
+### Forbidden in user-facing answers (unless user says “git” or “technical”)
+
+Do **not** lecture about: branch, worktree, rebase, fast-forward, origin, land,
+merge, force-push, SHA, trailers, remotes, cherry-pick. Internally use them;
+externally use **Ready / Not ready / Live / Not live / Blocked / Who (brand)**.
+
+### Brand identity
+
+- Lead with **your provider brand** (Grok CLI, Codex, Claude, Gemini, Copilot,
+  Cursor, …) for work you did.
+- Human sponsor is **accountable owner**, not the default “author of the idea.”
+- Cursor Cloud / remote GitHub workers: **no laptop secrets, no tunnel, no
+  loopback UniGrok** unless the user asked for local gateway help.
+
 ## Grok MCP Integration Rules
 - **Shared MCP Endpoint**: The host-facing shared service endpoint is `http://localhost:4765/mcp` (Streamable HTTP). Port `8080` is container-internal only. Start it with `docker compose up --build -d` from the primary checkout unless the user explicitly asks for stdio mode.
 - **Per-Agent Identity**: Every IDE/agent config should send `X-Client-ID` with a stable value such as `codex`, `claude-code`, `vscode`, or `antigravity`. This attributes telemetry and keeps sessions separate.
@@ -33,13 +62,14 @@
 - **PR-First Contribution Record**: Every change to `origin/main` goes through a pull request. After local verification, an authorized IDE agent may push only its own agent-prefixed task branch and open or update a draft pull request. If that agent lacks GitHub credentials, it hands Codex the exact commit so an authorized Codex session can publish the same branch and draft PR. A commit-only handoff is pre-PR evidence, not a substitute for the PR.
 - **Humans Accountable, Agents Traceable**: The sponsoring GitHub user remains the accountable contributor. Record material IDE/model work with the canonical `Agent-Assisted-By:` trailer and advisory review with `Agent-Reviewed-By:` as defined in [docs/agent-attribution.md](../docs/agent-attribution.md). Never invent `Co-authored-by` identities: use that trailer only for a real person's linked GitHub email or an exact bot identity in `.github/agent-identities.json`.
 - **Codex Owns Final Integration**: The Codex/project-admin role is independent of interface: Codex Desktop, CLI, GitHub Copilot, or another authorized Codex session may perform it. Contributor agents may inspect, edit, test, commit, push their own agent-prefixed branch, and open or update its draft PR. They must not push shared `main`, run `scripts/land`, merge, rebase shared `main`, publish releases or deployments, or delete worktrees unless they are explicitly acting as the Codex/project-admin integration session.
-- **Shared Main Checkout**: This repository may be opened by several local IDE agents at once. The primary checkout should stay on `main` and represent the latest integrated local development state.
-- **Do Not Branch-Switch the Shared Folder**: Agents must not switch branches or perform experimental edits in the shared `main` checkout when other IDEs may be using it. Branch switching changes the files visible to every agent using this folder.
-- **Use Per-Agent Worktrees**: Every implementation runs in an agent-prefixed task worktree such as `codex/task-name`, `claude/task-name`, `gemini/task-name`, or `grok/task-name`. Never edit implementation files directly in the shared `main` checkout.
-- **One Completion Gate**: The contributor publishes the draft PR when credentials permit. A Codex/project-admin session verifies its exact current head and required checks, then runs `./scripts/land` only from a `codex/*` integration branch. The command refuses contributor-prefixed branches, checks generated artifacts without amending commits, runs the full suite, serializes the local fast-forward, and reconciles the contributor runtime. That session then completes the protected GitHub merge and synchronizes local `main` to the resulting `origin/main`.
-- **Definition of Done**: Passing tests, committing, or pushing a task branch is not completion. Do not tell the user an implementation is complete until the command prints `LANDED TO MAIN: <sha>`. If it cannot land, report `NOT LANDED: <specific blocker>` and keep working when the blocker is agent-resolvable.
-- **Concurrent Landings**: Do not bypass the landing command with a manual merge. If the reviewed branch is behind `main`, or another agent advances `main` while tests run, `scripts/land` fails closed. Rebase the task branch, publish the new head, rerun verification, and obtain exact-head review before landing it.
-- **Protect Open IDEs**: Never stash, reset, clean, delete, or remove another worktree. A dirty tracked `main` is a blocker to report, not something to overwrite. Leave the task worktree and branch present after landing because an open IDE may still be using them.
-- **Protected Remote Is Canonical**: `origin/main` is the public contribution system of record. Local `main` must be synchronized after the protected PR merge and remains the user-facing local checkout. Contributor agents may fetch and publish only their own task branch and draft PR. The Codex/project-admin role exclusively owns protected-main mutation, final PR disposition, tags, releases, deployments, and remote-mirror decisions under the user's standing authorization.
-- **Status Check**: Run `./scripts/land-status` when starting an implementation or diagnosing drift. It shows the visible main commit, open worktrees, branches ahead of main, and shared runtime readiness.
+- **Shared Main Checkout**: Primary product folder stays on integrated `main`. Agents do not thrash it for experiments.
+- **Do Not Branch-Switch the Shared Folder**: Parallel work uses separate scratchpads so other IDEs keep a stable main folder.
+- **Worktrees Are Disposable Scratchpads**: One task, one contained tree only — under `<repo>/.worktrees/<agent>/<task>/` or `/tmp/unigrok-<agent>-<task>/`. Never sibling clutter like `Documents/…/grok-<feature>/` next to the real repo.
+- **Worktree lifecycle**: Start task → contained tree → draft PR for supervisor → when **Live**, abandoned, or **new task** → **same agent removes its own finished tree**, then create a fresh one. Never delete another agent’s live tree or primary main. Supervisor may prune safe orphans.
+- **Contributor done (user language)**: **Ready for supervisor** = your draft PR is open with exact head + verification. Not “I ran push/merge myself.”
+- **Supervisor done (user language)**: **Live** only after protected integration succeeds (`LANDED TO MAIN` internally). Else **Not live** / **Blocked** with one plain reason.
+- **Protect main and peers**: Never overwrite dirty main. Never remove peers’ live scratchpads. Your own finished scratchpad **must** go when the task ends.
+- **Cursor Cloud**: GitHub coding needs no laptop UniGrok env/tunnel. Optional Grok = hosted twin only when connected.
+- **Status Check**: Prefer `./scripts/land-status` silently. Many leftover trees = hygiene debt; clean yours before starting more.
+- **`.worktrees/` is local only** (gitignored scratch).
 - **Workspace Memory**: For implementation, debugging, architecture, and review work, use `.agents/skills/unigrok-workspace-memory/SKILL.md` when available. Recall with the agent worktree's own full HEAD. After `scripts/land` succeeds, record one concise landed outcome; never write Git Notes directly. Memory mirror failure is reportable but does not undo a verified landing.

--- a/.agents/skills/session-rehydrate/SKILL.md
+++ b/.agents/skills/session-rehydrate/SKILL.md
@@ -22,11 +22,15 @@ Do this for the whole session after rehydrate:
    unless the user asked for a live play-by-play.
 3. **No fake progress essays.** “I’m checking X… now Y…” is noise. Use tools;
    then speak.
-4. **UniGrok second opinions:** when calling MCP `agent` for hard product
+4. **Human language only to the user:** Ready / Not ready / Live / Not live /
+   Blocked / Who (**brand first**). Do not dump git jargon unless they asked
+   for git. “Done / pushed?” means **Ready for supervisor**, not a git lecture.
+   Full map: `.agents/AGENTS.md` → Human language.
+5. **UniGrok second opinions:** when calling MCP `agent` for hard product
    claims, prefer **CLI** + `mode=fast` for index-diff hive polls; keep
    **visible emit tiny**. Insider silent-think doctrine lives in private
    `../unigrok-intelligence/playbooks/silent-think-harness.md` (not public default).
-5. **Exceptions:** user asks “explain as you go”, safety/permission prompts,
+6. **Exceptions:** user asks “explain as you go”, safety/permission prompts,
    or a blocking question that needs a human.
 
 This is **session law** when this skill or `.agents/AGENTS.md` is loaded — not

--- a/.agents/skills/session-rehydrate/SKILL.md
+++ b/.agents/skills/session-rehydrate/SKILL.md
@@ -51,6 +51,7 @@ Read (skim) when available:
 
 - `.agents/AGENTS.md` — multi-agent git, MCP endpoint, credentials boundary
 - Root `AGENTS.md` if present
+- Root `CLAUDE.md` if present
 
 ### 2. Continuity (private brain)
 
@@ -81,7 +82,10 @@ From product root:
 
 Note: visible main, worktrees, stable/forge readiness.
 Primary shared checkout should stay on **clean `main`**. Implementation uses
-**agent-prefixed worktrees** only.
+**agent-prefixed worktrees** only — under `<repo>/.worktrees/…` or
+`/tmp/unigrok-…` (or provider homes like `~/.gemini/…/worktrees`,
+`~/.codex/worktrees`). Never Documents sibling clutter. Many leftover trees =
+hygiene debt; remove **yours** before starting more.
 
 ### 4. Runtime (optional quick)
 
@@ -129,6 +133,8 @@ Then wait for the user task — or continue if they already gave one.
 Before leaving a session that produced decisions:
 
 1. Update private `active-work-latest.md` when continuity changed
-2. Put exact head + “ready for Codex land?” on the PR
+2. Put exact head + “ready for supervisor?” on the PR
 3. Leave primary checkout on clean `main`
 4. Hive receipts (if any) under private `harvest/index-diff-hive/`
+5. If this task is done (Live, abandoned, or new task assigned): remove **your
+   own** finished worktree and prune. Do not leave disposable scratchpads.

--- a/.agents/skills/uni-grok-mcp/SKILL.md
+++ b/.agents/skills/uni-grok-mcp/SKILL.md
@@ -92,6 +92,13 @@ Capability names are surface-specific. Treat the connected server's live
 
 ---
 
+## 3b. Human language to the sponsor
+
+- User-facing: **Ready for supervisor** / **Not ready** / **Live** / **Not live** / **Blocked** / **Who (brand)**.
+- Do not lecture git (push/branch/worktree/land/merge) unless the user asks for git.
+- “Done / pushed?” → readiness for supervisor, not a git tutorial.
+- See `.agents/AGENTS.md` section **Human language**.
+
 ## 4. Multi-Agent Git Coordination Rules
 
 Multiple IDE agents can collaborate on this project concurrently. Follow these rules to prevent merge conflicts and branch switching issues:

--- a/.claude/skills/session-rehydrate/SKILL.md
+++ b/.claude/skills/session-rehydrate/SKILL.md
@@ -51,6 +51,7 @@ Read (skim) when available:
 
 - `.agents/AGENTS.md` — multi-agent git, MCP endpoint, credentials boundary
 - Root `AGENTS.md` if present
+- Root `CLAUDE.md` if present
 
 ### 2. Continuity (private brain)
 
@@ -81,7 +82,10 @@ From product root:
 
 Note: visible main, worktrees, stable/forge readiness.
 Primary shared checkout should stay on **clean `main`**. Implementation uses
-**agent-prefixed worktrees** only.
+**agent-prefixed worktrees** only — under `<repo>/.worktrees/…` or
+`/tmp/unigrok-…` (or provider homes like `~/.gemini/…/worktrees`,
+`~/.codex/worktrees`). Never Documents sibling clutter. Many leftover trees =
+hygiene debt; remove **yours** before starting more.
 
 ### 4. Runtime (optional quick)
 
@@ -129,6 +133,8 @@ Then wait for the user task — or continue if they already gave one.
 Before leaving a session that produced decisions:
 
 1. Update private `active-work-latest.md` when continuity changed
-2. Put exact head + “ready for Codex land?” on the PR
+2. Put exact head + “ready for supervisor?” on the PR
 3. Leave primary checkout on clean `main`
 4. Hive receipts (if any) under private `harvest/index-diff-hive/`
+5. If this task is done (Live, abandoned, or new task assigned): remove **your
+   own** finished worktree and prune. Do not leave disposable scratchpads.

--- a/.claude/skills/session-rehydrate/SKILL.md
+++ b/.claude/skills/session-rehydrate/SKILL.md
@@ -22,11 +22,15 @@ Do this for the whole session after rehydrate:
    unless the user asked for a live play-by-play.
 3. **No fake progress essays.** “I’m checking X… now Y…” is noise. Use tools;
    then speak.
-4. **UniGrok second opinions:** when calling MCP `agent` for hard product
+4. **Human language only to the user:** Ready / Not ready / Live / Not live /
+   Blocked / Who (**brand first**). Do not dump git jargon unless they asked
+   for git. “Done / pushed?” means **Ready for supervisor**, not a git lecture.
+   Full map: `.agents/AGENTS.md` → Human language.
+5. **UniGrok second opinions:** when calling MCP `agent` for hard product
    claims, prefer **CLI** + `mode=fast` for index-diff hive polls; keep
    **visible emit tiny**. Insider silent-think doctrine lives in private
    `../unigrok-intelligence/playbooks/silent-think-harness.md` (not public default).
-5. **Exceptions:** user asks “explain as you go”, safety/permission prompts,
+6. **Exceptions:** user asks “explain as you go”, safety/permission prompts,
    or a blocking question that needs a human.
 
 This is **session law** when this skill or `.agents/AGENTS.md` is loaded — not
@@ -46,7 +50,6 @@ so these rules load.
 Read (skim) when available:
 
 - `.agents/AGENTS.md` — multi-agent git, MCP endpoint, credentials boundary
-- Root `CLAUDE.md` if present — Claude MCP names, branch rules, and attribution
 - Root `AGENTS.md` if present
 
 ### 2. Continuity (private brain)

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -27,11 +27,11 @@ Select modular tools based on the nature of the request:
 
 ## 4. Multi-Agent Git Protocol
 * **No Main Branch Switch**: Do not switch the shared main folder branch. 
-* **Isolated Worktrees**: Work on task-specific sibling worktrees (`gemini/task-name`).
+* **Isolated Worktrees**: Prefer Antigravity/provider home worktrees or `<repo>/.worktrees/gemini/<task>/` — never clutter Documents. Branch prefix `gemini/task-name`.
 * **Pull Requests Are Canonical**: Every contribution reaches `origin/main` through a pull request. After local verification, push only your own `gemini/*` task branch and open or update a draft pull request when GitHub credentials are available. Otherwise give an authorized Codex session the exact commit for publication.
 * **Codex Integration Owner**: The Codex/project-admin role is interface-independent; Codex Desktop, CLI, GitHub Copilot, or another authorized Codex session may perform final landing, protected-main mutation, approval, merge, tag, release, deployment, and synchronization.
 * **Submit, Then Hand Off**: Commit the intended work, run relevant tests, publish the task branch and draft PR when possible, and provide the full commit SHA, changed paths, test results, known risks, human sponsor, and the canonical Google Gemini provider/model trailer from [docs/agent-attribution.md](../docs/agent-attribution.md). Do not run `scripts/land`, push shared `main`, merge/rebase shared `main`, publish releases/deployments, or delete worktrees unless explicitly acting as the Codex/project-admin integration session.
-* **Open IDE Safety**: Never remove a worktree after landing or overwrite a dirty tracked `main`; another IDE may still be using it.
+* **Scratchpad cleanup**: After Ready for supervisor and task end (or new task), remove **your own** finished worktree. Never delete peers' live trees or dirty main.
 
 ## 5. Verification Requirements
 * A Codex/project-admin session reviews the draft PR's exact current head and alone runs `scripts/land` from a `codex/*` integration branch before protected merge and local synchronization.

--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,6 @@ evals/cassettes/recorded.jsonl
 !sites/unigrok-control-center/build/
 !sites/unigrok-control-center/build/sites-vite-plugin.ts
 sites/unigrok-control-center/public/swarm/
+
+# Agent task scratchpads (never commit)
+.worktrees/


### PR DESCRIPTION
## Summary
- User-facing language: Ready / Live / Blocked / Who (brand) — no git dumps unless asked.
- Intent map: done/pushed → Ready for supervisor; live → product live.
- Disposable contained worktrees; Cursor Cloud no laptop secrets.
- Supersedes/overlaps #158 worktree hygiene.

## Ready for supervisor?
Yes after CI green.

Human-Sponsor: djtelicloud

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown and `.gitignore` only; no runtime, auth, or integration behavior changes.
> 
> **Overview**
> Agents are now required to talk to the sponsor in **plain status language** (Ready / Not ready, Live / Not live, Blocked, brand-first **Who**) instead of git vocabulary, with an intent map in `.agents/AGENTS.md` for phrases like “done?” or “pushed?”.
> 
> **Multi-agent git guidance** is rewritten around **disposable scratchpads**: work only in `<repo>/.worktrees/…` or `/tmp/unigrok-…`, agents remove their own finished trees, and `.worktrees/` is **gitignored**. Cursor Cloud is called out as not needing laptop UniGrok/tunnels.
> 
> The same rules are mirrored in **session-rehydrate** (`.agents` + `.claude`), **uni-grok-mcp** skill §3b, and **`.gemini/GEMINI.md`** (paths + scratchpad cleanup). PR handoff wording shifts to **“ready for supervisor?”** instead of Codex-land jargon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96837bcc93e8f77db4d940a327f9cb5ab2198b71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->