### PR TITLE
feat(docs): public intelligence pack v0 promote path

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -19,6 +19,9 @@
   a live play-by-play.
 - Prefer UniGrok MCP CLI/`fast` for cheap index-diff hive emits; keep visible
   output tiny. Insider silent-think doctrine is private (not public default).
+- **Public intelligence packs:** distilled gym wins for clones live under
+  `docs/public-intelligence/`. After Live work, ask once: promote a scrubbed
+  pack/skill? Never auto-sync private intelligence or raw memory to public.
 
 ## Human language (user-facing — mandatory)
 

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -38,11 +38,33 @@ Dyslexia-hostile jargon in answers is a product failure.
 | Clean up / too many folders | Remove finished scratchpads | Own worktree remove; supervisor may prune orphans | **Cleaned** / **Left X (why)** |
 | Fix CI / make it green | Repair your PR checks | Fix and re-verify | **Green** / **Still red** (+ one plain cause) |
 
+### Task titles, not ticket numbers
+
+A draft request to the coordinator **is** a finished (or ready) **task packet**.
+The **task title** is what humans hear. Internal ticket numbers are optional
+footnotes for links — never the lead.
+
+**Template (every agent):**
+
+```text
+[Brand]: [Live | Ready for supervisor | Not ready | Blocked] — [plain English task title].
+[Optional one outcome line.]
+[Optional link; number only as (#N) at the end if needed.]
+```
+
+**Bad:** “Promoting PR #164. Yours is #165.”  
+**Good:** “Codex: Live — refreshed maintainer handoff.”  
+**Good:** “Grok: Ready for supervisor — public intelligence pack v0.”
+
+Write machine titles so the **human half is readable** (e.g. “public intelligence
+pack v0”), not only `feat(docs): …` jargon when speaking to the sponsor.
+
 ### Forbidden in user-facing answers (unless user says “git” or “technical”)
 
 Do **not** lecture about: branch, worktree, rebase, fast-forward, origin, land,
-merge, force-push, SHA, trailers, remotes, cherry-pick. Internally use them;
-externally use **Ready / Not ready / Live / Not live / Blocked / Who (brand)**.
+merge, force-push, SHA, trailers, remotes, cherry-pick, or lead with PR numbers.
+Internally use them; externally use **Ready / Not ready / Live / Not live /
+Blocked / Who (brand)** plus the **task title**.
 
 ### Brand identity
 

--- a/.agents/skills/session-rehydrate/SKILL.md
+++ b/.agents/skills/session-rehydrate/SKILL.md
@@ -23,9 +23,10 @@ Do this for the whole session after rehydrate:
 3. **No fake progress essays.** “I’m checking X… now Y…” is noise. Use tools;
    then speak.
 4. **Human language only to the user:** Ready / Not ready / Live / Not live /
-   Blocked / Who (**brand first**). Do not dump git jargon unless they asked
-   for git. “Done / pushed?” means **Ready for supervisor**, not a git lecture.
-   Full map: `.agents/AGENTS.md` → Human language.
+   Blocked / Who (**brand first**) + **plain task title**. Never lead with PR
+   numbers. Do not dump git jargon unless they asked for git. “Done / pushed?”
+   means **Ready for supervisor**, not a git lecture. Full map:
+   `.agents/AGENTS.md` → Human language.
 5. **UniGrok second opinions:** when calling MCP `agent` for hard product
    claims, prefer **CLI** + `mode=fast` for index-diff hive polls; keep
    **visible emit tiny**. Insider silent-think doctrine lives in private

--- a/.agents/skills/using-unigrok/SKILL.md
+++ b/.agents/skills/using-unigrok/SKILL.md
@@ -50,6 +50,14 @@ skill). Public product installs never require it.
 Do **not** invent multi-provider public chat tools. UniGrok's public `agent`
 remains Grok-routed; other providers stay behind Grok-supervised adapters.
 
+## Public intelligence packs
+
+New clones start smarter via **reviewed recipes** under
+`docs/public-intelligence/` (not private memory dumps). Read the latest pack
+in `docs/public-intelligence/packs/` when onboarding agents. Contributors:
+after work is Live, ask once whether to promote a scrubbed pack/skill update.
+Never continuous-sync private intelligence into public.
+
 
 ## Plan critique habit (opt-in)
 

--- a/.claude/skills/session-rehydrate/SKILL.md
+++ b/.claude/skills/session-rehydrate/SKILL.md
@@ -23,9 +23,10 @@ Do this for the whole session after rehydrate:
 3. **No fake progress essays.** “I’m checking X… now Y…” is noise. Use tools;
    then speak.
 4. **Human language only to the user:** Ready / Not ready / Live / Not live /
-   Blocked / Who (**brand first**). Do not dump git jargon unless they asked
-   for git. “Done / pushed?” means **Ready for supervisor**, not a git lecture.
-   Full map: `.agents/AGENTS.md` → Human language.
+   Blocked / Who (**brand first**) + **plain task title**. Never lead with PR
+   numbers. Do not dump git jargon unless they asked for git. “Done / pushed?”
+   means **Ready for supervisor**, not a git lecture. Full map:
+   `.agents/AGENTS.md` → Human language.
 5. **UniGrok second opinions:** when calling MCP `agent` for hard product
    claims, prefer **CLI** + `mode=fast` for index-diff hive polls; keep
    **visible emit tiny**. Insider silent-think doctrine lives in private
@@ -51,7 +52,6 @@ Read (skim) when available:
 
 - `.agents/AGENTS.md` — multi-agent git, MCP endpoint, credentials boundary
 - Root `AGENTS.md` if present
-- Root `CLAUDE.md` if present
 
 ### 2. Continuity (private brain)
 

--- a/docs/public-intelligence/README.md
+++ b/docs/public-intelligence/README.md
@@ -1,0 +1,48 @@
+# Public intelligence packs
+
+## What this is
+
+Contributor agents are the **real model gym**. Private intelligence
+(`unigrok-intelligence`) holds process IP and raw harvest. Public users who
+clone this repo get **only distilled, reviewed recipes** — never private memory
+dumps.
+
+```text
+private gym → scrub + review → versioned public pack → clone ships smarter defaults
+```
+
+Stable MCP (`:4765`) stays **workspace-neutral**. Packs are **product files**,
+not live SQLite or contributor workspace memory.
+
+## What never ships public
+
+- API keys, OAuth secrets, customer data
+- Raw task-RAG / session databases
+- Contributor workspace memory rows
+- Unreviewed chat logs or gym traces
+- Competitive silent-think / hive playbooks (private intelligence only)
+- Continuous auto-sync of the private repo into public history
+
+## Promote habit
+
+After a contributor outcome is **Live**, ask once (human or coordinator):
+
+> Promote a public pack / skill update from this win? yes / no
+
+If yes: add or bump a pack under `docs/public-intelligence/packs/`, update the
+manifest, and open a product PR. Never force-push private history public.
+
+## Layout
+
+| Path | Role |
+| --- | --- |
+| `public-intelligence-pack.schema.json` | Pack shape + scrub rules fields |
+| `packs/manifest.json` | List of published packs |
+| `packs/v0-*.md` | Human-readable pack bodies |
+| `packs/v0-*.json` | Machine metadata for the same pack |
+
+## Related
+
+- Public vs private git: [docs/design/public-private-git-split.md](../design/public-private-git-split.md)
+- Human language for agents: [.agents/AGENTS.md](../../.agents/AGENTS.md)
+- Insider capsules (not public consumer DB): [docs/okf/intelligence-capsule-v1.md](../okf/intelligence-capsule-v1.md)

--- a/docs/public-intelligence/packs/manifest.json
+++ b/docs/public-intelligence/packs/manifest.json
@@ -1,0 +1,32 @@
+{
+  "schema": "../public-intelligence-pack.schema.json",
+  "packs": [
+    {
+      "pack_id": "human-radio-and-cloud-boundary",
+      "version": "v0",
+      "title": "Human radio and cloud boundary",
+      "summary": "Speak Ready/Live/Blocked/Who; Cursor Cloud needs no laptop UniGrok secrets; disposable scratchpads.",
+      "audience": "public_and_contributor",
+      "body_path": "docs/public-intelligence/packs/v0-human-radio-and-cloud-boundary.md",
+      "source_gym": "Multi-agent UniGrok contributor sessions (Cursor cloud, dual crons, worktree clutter, human-language failures).",
+      "promoted_from": [
+        ".agents/AGENTS.md",
+        "PR #161",
+        "PR #162",
+        "PR #132"
+      ],
+      "scrub": {
+        "secrets": true,
+        "private_paths": true,
+        "raw_memory": true,
+        "unreviewed_logs": true
+      },
+      "never_includes": [
+        "API keys or OAuth secrets",
+        "Private unigrok-intelligence playbooks",
+        "Session or task-RAG database dumps",
+        "Contributor workspace memory rows"
+      ]
+    }
+  ]
+}

--- a/docs/public-intelligence/packs/v0-human-radio-and-cloud-boundary.md
+++ b/docs/public-intelligence/packs/v0-human-radio-and-cloud-boundary.md
@@ -20,8 +20,15 @@ the human asked for technical detail.
 
 **Example finish line**
 
-> I finished building X. Tests passed. Sent to coordinator under PR #N — Title.  
+> **Grok:** Ready for supervisor — built X. Tests passed.  
+> Sent to coordinator as “X task title” (#N only if a link helps).  
 > If the goal is A, next is B. If the goal is C, next is D.
+
+**Task titles, not numbers**
+
+- A coordinator packet **is** a task. **Title = task name** in human speech.
+- Never lead with “PR #164 / #165.” Lead with brand + status + plain title.
+- Numbers are machine footnotes, not the story.
 
 ## 2. Cursor Cloud vs laptop UniGrok
 

--- a/docs/public-intelligence/packs/v0-human-radio-and-cloud-boundary.md
+++ b/docs/public-intelligence/packs/v0-human-radio-and-cloud-boundary.md
@@ -1,0 +1,53 @@
+# Public pack v0 — Human radio and cloud boundary
+
+**Audience:** public installers and contributor agents  
+**Pack id:** `human-radio-and-cloud-boundary` · **version:** `v0`
+
+Distilled from real multi-agent gym work. Safe to ship: no secrets, no private
+memory, no competitive process IP.
+
+## 1. Talk to humans this way
+
+| Human says | You mean | Say back |
+| --- | --- | --- |
+| Done? / pushed? / finished? | Is it with the coordinator? | **Ready for supervisor** / **Not ready** (+ one plain blocker) |
+| Live? / shipped? | Is it the real product? | **Live** / **Not live** (+ one plain reason) |
+| Who did this? | Which brand? | **Grok / Codex / Claude / Cursor / …** first — not “you wrote it” when an agent did |
+| Clean up? | Too many folders | **Cleaned** / **Left X (why)** |
+
+Do **not** lecture about branches, worktrees, rebases, remotes, or land unless
+the human asked for technical detail.
+
+**Example finish line**
+
+> I finished building X. Tests passed. Sent to coordinator under PR #N — Title.  
+> If the goal is A, next is B. If the goal is C, next is D.
+
+## 2. Cursor Cloud vs laptop UniGrok
+
+| Mode | UniGrok |
+| --- | --- |
+| Local Cursor / laptop agents | Shared gateway on the machine (default loopback MCP) |
+| Cursor Cloud agents on GitHub | GitHub is enough to code. **No** laptop secrets, **no** tunnel, **no** `localhost` UniGrok |
+| Hosted twin (optional later) | `https://mcp.grokmcp.org/mcp` — server holds the xAI key; agent only needs a proper connect path |
+
+Never paste a full developer `.env` into Cursor Cloud secrets.
+
+## 3. Scratchpads, not second homes
+
+- One task → one temporary workspace under the product’s hidden scratch layout
+  (or the provider’s own worktree home).
+- When the task is Live, abandoned, or a new task starts → remove **your own**
+  finished scratchpad.
+- Never delete another agent’s live workspace or the primary product folder.
+
+## 4. Always UniGrok ≠ auto public intelligence
+
+Using UniGrok for planning helps **your** gym and routing. Public stable MCP
+stays **workspace-neutral**. Only **reviewed packs and skills** in this repo
+reach new public clones—not private SQLite or chat logs.
+
+## 5. Promote habit (contributors)
+
+After something is **Live**, ask once: promote a public pack/skill update?
+If yes, scrub and open a product PR under `docs/public-intelligence/`.

--- a/docs/public-intelligence/public-intelligence-pack.schema.json
+++ b/docs/public-intelligence/public-intelligence-pack.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://grokmcp.org/docs/public-intelligence/public-intelligence-pack.schema.json",
+  "title": "UniGrokPublicIntelligencePack",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "pack_id",
+    "version",
+    "title",
+    "summary",
+    "audience",
+    "body_path",
+    "scrub",
+    "never_includes"
+  ],
+  "properties": {
+    "pack_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+      "description": "Stable id without version (e.g. human-radio-and-cloud-boundary)."
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^v[0-9]+(?:\\.[0-9]+)*$",
+      "description": "Pack version label, e.g. v0 or v0.1."
+    },
+    "title": { "type": "string", "minLength": 1, "maxLength": 120 },
+    "summary": { "type": "string", "minLength": 1, "maxLength": 500 },
+    "audience": {
+      "type": "string",
+      "enum": ["public", "public_and_contributor"]
+    },
+    "body_path": {
+      "type": "string",
+      "description": "Repo-relative path to the markdown body."
+    },
+    "source_gym": {
+      "type": "string",
+      "description": "Non-secret description of which gym wins this distills."
+    },
+    "promoted_from": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Optional product paths or PR numbers (public only)."
+    },
+    "scrub": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["secrets", "private_paths", "raw_memory", "unreviewed_logs"],
+      "properties": {
+        "secrets": { "type": "boolean" },
+        "private_paths": { "type": "boolean" },
+        "raw_memory": { "type": "boolean" },
+        "unreviewed_logs": { "type": "boolean" }
+      }
+    },
+    "never_includes": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/skills/using-unigrok/SKILL.md
+++ b/skills/using-unigrok/SKILL.md
@@ -50,6 +50,14 @@ skill). Public product installs never require it.
 Do **not** invent multi-provider public chat tools. UniGrok's public `agent`
 remains Grok-routed; other providers stay behind Grok-supervised adapters.
 
+## Public intelligence packs
+
+New clones start smarter via **reviewed recipes** under
+`docs/public-intelligence/` (not private memory dumps). Read the latest pack
+in `docs/public-intelligence/packs/` when onboarding agents. Contributors:
+after work is Live, ask once whether to promote a scrubbed pack/skill update.
+Never continuous-sync private intelligence into public.
+
 
 ## Plan critique habit (opt-in)
 

--- a/tests/test_public_intelligence_packs.py
+++ b/tests/test_public_intelligence_packs.py
@@ -1,0 +1,42 @@
+"""Public intelligence packs: schema + scrub invariants."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PACK_DIR = ROOT / "docs" / "public-intelligence"
+MANIFEST = PACK_DIR / "packs" / "manifest.json"
+SCHEMA = PACK_DIR / "public-intelligence-pack.schema.json"
+
+
+def test_manifest_and_bodies_exist_and_match_schema_shape() -> None:
+    assert SCHEMA.is_file()
+    assert MANIFEST.is_file()
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    required = set(schema["required"])
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    packs = manifest["packs"]
+    assert packs, "at least one public pack required"
+    for pack in packs:
+        missing = required - set(pack)
+        assert not missing, f"{pack.get('pack_id')}: missing {missing}"
+        assert pack["scrub"]["secrets"] is True
+        assert pack["scrub"]["raw_memory"] is True
+        assert pack["scrub"]["private_paths"] is True
+        assert pack["scrub"]["unreviewed_logs"] is True
+        body = ROOT / pack["body_path"]
+        assert body.is_file(), pack["body_path"]
+        text = body.read_text(encoding="utf-8")
+        # Hard ban on private repo name dumps and secret placeholders.
+        assert "XAI_API_KEY=" not in text
+        assert "unigrok-intelligence/codex" not in text
+        assert "Ready for supervisor" in text or "Live" in text
+
+
+def test_readme_states_promote_not_auto_sync() -> None:
+    readme = (PACK_DIR / "README.md").read_text(encoding="utf-8")
+    assert "distilled, reviewed recipes" in readme
+    assert "Continuous auto-sync" in readme or "never" in readme.lower()
+    assert "workspace-neutral" in readme


### PR DESCRIPTION
## Summary
- Public intelligence packs: schema, manifest, README (promote not auto-sync).
- Pack **v0**: human radio (Ready/Live/Blocked/Who) + Cursor cloud boundary + scratchpad hygiene.
- using-unigrok + `.agents/AGENTS.md` promote habit.
- Tests lock scrub flags and body safety.

## Ready for supervisor?
Yes after CI green.

Human-Sponsor: djtelicloud
Agent-Assisted-By: xAI Grok | model=grok-4.5 | surface=Grok Build CLI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, agent guidance, and content-safety tests only; no auth, MCP runtime, or data-plane behavior changes.
> 
> **Overview**
> Introduces **`docs/public-intelligence/`** as the reviewed, scrubbed channel for gym wins on public clones: README (promote-once after Live, no auto-sync), JSON schema, manifest, and **pack v0** (*Human radio and cloud boundary*) covering Ready/Live/Blocked/Who, Cursor Cloud vs laptop UniGrok, scratchpad hygiene, and workspace-neutral MCP.
> 
> **Agent-facing rules** gain the same promote habit and stronger **human radio**: status + **plain task title**, not leading with PR numbers — in `.agents/AGENTS.md`, mirrored **session-rehydrate** skills (`.agents` and `.claude`), and **using-unigrok** (`.agents` + `skills/`). Claude rehydrate drops **Root `CLAUDE.md`** from the skim list.
> 
> **`tests/test_public_intelligence_packs.py`** enforces manifest/schema fields, scrub flags, body file presence, and bans obvious secret/private-path strings in pack bodies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13784a7ac6bbacf4472f9b19ddda38fd4b445415. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->