### PR TITLE
feat(docs): finalize public intelligence pack v0

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -19,6 +19,9 @@
   a live play-by-play.
 - Prefer UniGrok MCP CLI/`fast` for cheap index-diff hive emits; keep visible
   output tiny. Insider silent-think doctrine is private (not public default).
+- **Public intelligence packs:** distilled gym wins for clones live under
+  `docs/public-intelligence/`. After Live work, ask once: promote a scrubbed
+  pack/skill? Never auto-sync private intelligence or raw memory to public.
 
 ## Human language (user-facing — mandatory)
 

--- a/.agents/skills/using-unigrok/SKILL.md
+++ b/.agents/skills/using-unigrok/SKILL.md
@@ -50,6 +50,14 @@ skill). Public product installs never require it.
 Do **not** invent multi-provider public chat tools. UniGrok's public `agent`
 remains Grok-routed; other providers stay behind Grok-supervised adapters.
 
+## Public intelligence packs
+
+New clones start smarter via **reviewed recipes** under
+`docs/public-intelligence/` (not private memory dumps). Read the latest pack
+in `docs/public-intelligence/packs/` when onboarding agents. Contributors:
+after work is Live, ask once whether to promote a scrubbed pack/skill update.
+Never continuous-sync private intelligence into public.
+
 
 ## Plan critique habit (opt-in)
 

--- a/docs/public-intelligence/README.md
+++ b/docs/public-intelligence/README.md
@@ -37,9 +37,8 @@ manifest, and open a product PR. Never force-push private history public.
 | Path | Role |
 | --- | --- |
 | `public-intelligence-pack.schema.json` | Pack shape + scrub rules fields |
-| `packs/manifest.json` | List of published packs |
+| `packs/manifest.json` | List of published packs and their machine metadata |
 | `packs/v0-*.md` | Human-readable pack bodies |
-| `packs/v0-*.json` | Machine metadata for the same pack |
 
 ## Related
 

--- a/docs/public-intelligence/README.md
+++ b/docs/public-intelligence/README.md
@@ -1,0 +1,48 @@
+# Public intelligence packs
+
+## What this is
+
+Contributor agents are the **real model gym**. Private intelligence
+(`unigrok-intelligence`) holds process IP and raw harvest. Public users who
+clone this repo get **only distilled, reviewed recipes** — never private memory
+dumps.
+
+```text
+private gym → scrub + review → versioned public pack → clone ships smarter defaults
+```
+
+Stable MCP (`:4765`) stays **workspace-neutral**. Packs are **product files**,
+not live SQLite or contributor workspace memory.
+
+## What never ships public
+
+- API keys, OAuth secrets, customer data
+- Raw task-RAG / session databases
+- Contributor workspace memory rows
+- Unreviewed chat logs or gym traces
+- Competitive silent-think / hive playbooks (private intelligence only)
+- Continuous auto-sync of the private repo into public history
+
+## Promote habit
+
+After a contributor outcome is **Live**, ask once (human or coordinator):
+
+> Promote a public pack / skill update from this win? yes / no
+
+If yes: add or bump a pack under `docs/public-intelligence/packs/`, update the
+manifest, and open a product PR. Never force-push private history public.
+
+## Layout
+
+| Path | Role |
+| --- | --- |
+| `public-intelligence-pack.schema.json` | Pack shape + scrub rules fields |
+| `packs/manifest.json` | List of published packs |
+| `packs/v0-*.md` | Human-readable pack bodies |
+| `packs/v0-*.json` | Machine metadata for the same pack |
+
+## Related
+
+- Public vs private git: [docs/design/public-private-git-split.md](../design/public-private-git-split.md)
+- Human language for agents: [.agents/AGENTS.md](../../.agents/AGENTS.md)
+- Insider capsules (not public consumer DB): [docs/okf/intelligence-capsule-v1.md](../okf/intelligence-capsule-v1.md)

--- a/docs/public-intelligence/packs/manifest.json
+++ b/docs/public-intelligence/packs/manifest.json
@@ -1,0 +1,32 @@
+{
+  "schema": "../public-intelligence-pack.schema.json",
+  "packs": [
+    {
+      "pack_id": "human-radio-and-cloud-boundary",
+      "version": "v0",
+      "title": "Human radio and cloud boundary",
+      "summary": "Speak Ready/Live/Blocked/Who; Cursor Cloud needs no laptop UniGrok secrets; disposable scratchpads.",
+      "audience": "public_and_contributor",
+      "body_path": "docs/public-intelligence/packs/v0-human-radio-and-cloud-boundary.md",
+      "source_gym": "Multi-agent UniGrok contributor sessions (Cursor cloud, dual crons, worktree clutter, human-language failures).",
+      "promoted_from": [
+        ".agents/AGENTS.md",
+        "PR #161",
+        "PR #162",
+        "PR #132"
+      ],
+      "scrub": {
+        "secrets": true,
+        "private_paths": true,
+        "raw_memory": true,
+        "unreviewed_logs": true
+      },
+      "never_includes": [
+        "API keys or OAuth secrets",
+        "Private unigrok-intelligence playbooks",
+        "Session or task-RAG database dumps",
+        "Contributor workspace memory rows"
+      ]
+    }
+  ]
+}

--- a/docs/public-intelligence/packs/v0-human-radio-and-cloud-boundary.md
+++ b/docs/public-intelligence/packs/v0-human-radio-and-cloud-boundary.md
@@ -1,0 +1,53 @@
+# Public pack v0 — Human radio and cloud boundary
+
+**Audience:** public installers and contributor agents  
+**Pack id:** `human-radio-and-cloud-boundary` · **version:** `v0`
+
+Distilled from real multi-agent gym work. Safe to ship: no secrets, no private
+memory, no competitive process IP.
+
+## 1. Talk to humans this way
+
+| Human says | You mean | Say back |
+| --- | --- | --- |
+| Done? / pushed? / finished? | Is it with the coordinator? | **Ready for supervisor** / **Not ready** (+ one plain blocker) |
+| Live? / shipped? | Is it the real product? | **Live** / **Not live** (+ one plain reason) |
+| Who did this? | Which brand? | **Grok / Codex / Claude / Cursor / …** first — not “you wrote it” when an agent did |
+| Clean up? | Too many folders | **Cleaned** / **Left X (why)** |
+
+Do **not** lecture about branches, worktrees, rebases, remotes, or land unless
+the human asked for technical detail.
+
+**Example finish line**
+
+> I finished building X. Tests passed. Sent to coordinator under PR #N — Title.  
+> If the goal is A, next is B. If the goal is C, next is D.
+
+## 2. Cursor Cloud vs laptop UniGrok
+
+| Mode | UniGrok |
+| --- | --- |
+| Local Cursor / laptop agents | Shared gateway on the machine (default loopback MCP) |
+| Cursor Cloud agents on GitHub | GitHub is enough to code. **No** laptop secrets, **no** tunnel, **no** `localhost` UniGrok |
+| Hosted twin (optional later) | `https://mcp.grokmcp.org/mcp` — server holds the xAI key; agent only needs a proper connect path |
+
+Never paste a full developer `.env` into Cursor Cloud secrets.
+
+## 3. Scratchpads, not second homes
+
+- One task → one temporary workspace under the product’s hidden scratch layout
+  (or the provider’s own worktree home).
+- When the task is Live, abandoned, or a new task starts → remove **your own**
+  finished scratchpad.
+- Never delete another agent’s live workspace or the primary product folder.
+
+## 4. Always UniGrok ≠ auto public intelligence
+
+Using UniGrok for planning helps **your** gym and routing. Public stable MCP
+stays **workspace-neutral**. Only **reviewed packs and skills** in this repo
+reach new public clones—not private SQLite or chat logs.
+
+## 5. Promote habit (contributors)
+
+After something is **Live**, ask once: promote a public pack/skill update?
+If yes, scrub and open a product PR under `docs/public-intelligence/`.

--- a/docs/public-intelligence/public-intelligence-pack.schema.json
+++ b/docs/public-intelligence/public-intelligence-pack.schema.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://grokmcp.org/docs/public-intelligence/public-intelligence-pack.schema.json",
+  "title": "UniGrokPublicIntelligencePack",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "pack_id",
+    "version",
+    "title",
+    "summary",
+    "audience",
+    "body_path",
+    "scrub",
+    "never_includes"
+  ],
+  "properties": {
+    "pack_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9]+(?:-[a-z0-9]+)*$",
+      "description": "Stable id without version (e.g. human-radio-and-cloud-boundary)."
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^v[0-9]+(?:\\.[0-9]+)*$",
+      "description": "Pack version label, e.g. v0 or v0.1."
+    },
+    "title": { "type": "string", "minLength": 1, "maxLength": 120 },
+    "summary": { "type": "string", "minLength": 1, "maxLength": 500 },
+    "audience": {
+      "type": "string",
+      "enum": ["public", "public_and_contributor"]
+    },
+    "body_path": {
+      "type": "string",
+      "description": "Repo-relative path to the markdown body."
+    },
+    "source_gym": {
+      "type": "string",
+      "description": "Non-secret description of which gym wins this distills."
+    },
+    "promoted_from": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Optional product paths or PR numbers (public only)."
+    },
+    "scrub": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["secrets", "private_paths", "raw_memory", "unreviewed_logs"],
+      "properties": {
+        "secrets": { "type": "boolean" },
+        "private_paths": { "type": "boolean" },
+        "raw_memory": { "type": "boolean" },
+        "unreviewed_logs": { "type": "boolean" }
+      }
+    },
+    "never_includes": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/skills/using-unigrok/SKILL.md
+++ b/skills/using-unigrok/SKILL.md
@@ -50,6 +50,14 @@ skill). Public product installs never require it.
 Do **not** invent multi-provider public chat tools. UniGrok's public `agent`
 remains Grok-routed; other providers stay behind Grok-supervised adapters.
 
+## Public intelligence packs
+
+New clones start smarter via **reviewed recipes** under
+`docs/public-intelligence/` (not private memory dumps). Read the latest pack
+in `docs/public-intelligence/packs/` when onboarding agents. Contributors:
+after work is Live, ask once whether to promote a scrubbed pack/skill update.
+Never continuous-sync private intelligence into public.
+
 
 ## Plan critique habit (opt-in)
 

--- a/tests/test_public_intelligence_packs.py
+++ b/tests/test_public_intelligence_packs.py
@@ -24,6 +24,10 @@ def test_manifest_and_bodies_exist_and_match_schema_shape() -> None:
     assert manifest["schema"] == "../public-intelligence-pack.schema.json"
     packs = manifest["packs"]
     assert packs, "at least one public pack required"
+    banned_markers = ("XAI_API_KEY", "unigrok-intelligence/codex")
+    public_metadata = json.dumps(manifest, sort_keys=True)
+    for marker in banned_markers:
+        assert marker not in public_metadata
     for pack in packs:
         validator.validate(pack)
         assert pack["scrub"]["secrets"] is True
@@ -39,8 +43,8 @@ def test_manifest_and_bodies_exist_and_match_schema_shape() -> None:
         assert body.is_file(), pack["body_path"]
         text = body.read_text(encoding="utf-8")
         # Hard ban on private repo name dumps and secret placeholders.
-        assert "XAI_API_KEY" not in text
-        assert "unigrok-intelligence/codex" not in text
+        for marker in banned_markers:
+            assert marker not in text
         assert "Ready for supervisor" in text or "Live" in text
 
 

--- a/tests/test_public_intelligence_packs.py
+++ b/tests/test_public_intelligence_packs.py
@@ -1,0 +1,42 @@
+"""Public intelligence packs: schema + scrub invariants."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PACK_DIR = ROOT / "docs" / "public-intelligence"
+MANIFEST = PACK_DIR / "packs" / "manifest.json"
+SCHEMA = PACK_DIR / "public-intelligence-pack.schema.json"
+
+
+def test_manifest_and_bodies_exist_and_match_schema_shape() -> None:
+    assert SCHEMA.is_file()
+    assert MANIFEST.is_file()
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    required = set(schema["required"])
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    packs = manifest["packs"]
+    assert packs, "at least one public pack required"
+    for pack in packs:
+        missing = required - set(pack)
+        assert not missing, f"{pack.get('pack_id')}: missing {missing}"
+        assert pack["scrub"]["secrets"] is True
+        assert pack["scrub"]["raw_memory"] is True
+        assert pack["scrub"]["private_paths"] is True
+        assert pack["scrub"]["unreviewed_logs"] is True
+        body = ROOT / pack["body_path"]
+        assert body.is_file(), pack["body_path"]
+        text = body.read_text(encoding="utf-8")
+        # Hard ban on private repo name dumps and secret placeholders.
+        assert "XAI_API_KEY=" not in text
+        assert "unigrok-intelligence/codex" not in text
+        assert "Ready for supervisor" in text or "Live" in text
+
+
+def test_readme_states_promote_not_auto_sync() -> None:
+    readme = (PACK_DIR / "README.md").read_text(encoding="utf-8")
+    assert "distilled, reviewed recipes" in readme
+    assert "Continuous auto-sync" in readme or "never" in readme.lower()
+    assert "workspace-neutral" in readme

--- a/tests/test_public_intelligence_packs.py
+++ b/tests/test_public_intelligence_packs.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from jsonschema import Draft202012Validator
+
 ROOT = Path(__file__).resolve().parents[1]
 PACK_DIR = ROOT / "docs" / "public-intelligence"
 MANIFEST = PACK_DIR / "packs" / "manifest.json"
@@ -15,22 +17,29 @@ def test_manifest_and_bodies_exist_and_match_schema_shape() -> None:
     assert SCHEMA.is_file()
     assert MANIFEST.is_file()
     schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
-    required = set(schema["required"])
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
     manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    assert set(manifest) == {"schema", "packs"}
+    assert manifest["schema"] == "../public-intelligence-pack.schema.json"
     packs = manifest["packs"]
     assert packs, "at least one public pack required"
     for pack in packs:
-        missing = required - set(pack)
-        assert not missing, f"{pack.get('pack_id')}: missing {missing}"
+        validator.validate(pack)
         assert pack["scrub"]["secrets"] is True
         assert pack["scrub"]["raw_memory"] is True
         assert pack["scrub"]["private_paths"] is True
         assert pack["scrub"]["unreviewed_logs"] is True
-        body = ROOT / pack["body_path"]
+        expected_body = (
+            f"docs/public-intelligence/packs/{pack['version']}-{pack['pack_id']}.md"
+        )
+        assert pack["body_path"] == expected_body, pack["body_path"]
+        body = (ROOT / pack["body_path"]).resolve()
+        assert body.is_relative_to((PACK_DIR / "packs").resolve()), pack["body_path"]
         assert body.is_file(), pack["body_path"]
         text = body.read_text(encoding="utf-8")
         # Hard ban on private repo name dumps and secret placeholders.
-        assert "XAI_API_KEY=" not in text
+        assert "XAI_API_KEY" not in text
         assert "unigrok-intelligence/codex" not in text
         assert "Ready for supervisor" in text or "Live" in text
 
@@ -38,5 +47,13 @@ def test_manifest_and_bodies_exist_and_match_schema_shape() -> None:
 def test_readme_states_promote_not_auto_sync() -> None:
     readme = (PACK_DIR / "README.md").read_text(encoding="utf-8")
     assert "distilled, reviewed recipes" in readme
-    assert "Continuous auto-sync" in readme or "never" in readme.lower()
+    assert "Continuous auto-sync" in readme
     assert "workspace-neutral" in readme
+
+
+def test_using_unigrok_skills_are_identical() -> None:
+    public_skill = ROOT / "skills" / "using-unigrok" / "SKILL.md"
+    agent_skill = ROOT / ".agents" / "skills" / "using-unigrok" / "SKILL.md"
+    assert public_skill.read_text(encoding="utf-8") == agent_skill.read_text(
+        encoding="utf-8"
+    ), "public and agent using-unigrok skills have drifted"


### PR DESCRIPTION
## Summary

Supersedes PR #165 on current main with its public intelligence pack v0 plus Codex’s review repairs. Public packs remain scrubbed product files; no private memory or automatic private-to-public synchronization is introduced.

## Review repairs

- validate each pack with the declared Draft 2020-12 schema, including unknown-field rejection
- reject manifest wrapper drift and require the declared per-pack schema reference
- constrain body paths to the exact version/id filename under the pack directory
- require the explicit Continuous auto-sync prohibition
- scan for the full `XAI_API_KEY` marker, not only assignment syntax
- keep both using-unigrok skill copies byte-identical
- correct README layout to show manifest-embedded machine metadata

The manifest keeps the custom `schema` field because the referenced schema validates each pack entry, not the manifest wrapper; changing it to JSON Schema’s `$schema` keyword would incorrectly validate the wrapper as a pack.

## Integration evidence

- Exact head: `8142c20c0347404a7ab0e5ead0150b6852cf4c59`
- Source contribution: PR #165 head `87156b08d87aef88fa1b33bf3cce3f1b07dd0f7d`, preserved as a contributor commit
- Changed paths: `.agents/AGENTS.md`, both `using-unigrok` skills, `docs/public-intelligence/**`, `tests/test_public_intelligence_packs.py`
- Validation: focused public-pack and release-hygiene suites — 20 passed; both JSON documents parsed; attribution and diff checks passed
- Risk: low; docs, schema, manifest, and tests only
- Human sponsor: djtelicloud

## Provenance

- Original implementation: xAI Grok 4.5 through Grok Build CLI
- Final integration and review repairs: OpenAI Codex, GPT-5, Codex Desktop

Ready for exact-head protected checks and Codex landing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, JSON schema, manifest, and test-only changes with no runtime or secret-handling code paths.
> 
> **Overview**
> Introduces **`docs/public-intelligence/`** as the channel for **reviewed, scrubbed recipes** that new public clones can read—explicitly **not** private memory, SQLite, or continuous sync from `unigrok-intelligence`.
> 
> Adds a **Draft 2020-12 pack schema**, **`packs/manifest.json`**, and the first body **`v0-human-radio-and-cloud-boundary`** (human radio, Cursor Cloud vs laptop UniGrok, scratchpads, promote-once-after-Live). **`.agents/AGENTS.md`** and both **`using-unigrok`** skill copies get matching **public intelligence packs** guidance.
> 
> **`tests/test_public_intelligence_packs.py`** locks invariants: manifest shape, per-pack schema validation, scrub flags, body path/filename rules, banned markers (e.g. `XAI_API_KEY`), README promote-not-auto-sync wording, and byte-identical skills.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3d44359b45b47bcaa63abe47452953cb4cab731. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->