### PR TITLE
docs(agents): lead status with task titles

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -64,9 +64,9 @@ pack v0”), not only `feat(docs): …` jargon when speaking to the sponsor.
 ### Forbidden in user-facing answers (unless user says “git” or “technical”)
 
 Do **not** lecture about: branch, worktree, rebase, fast-forward, origin, land,
-merge, force-push, SHA, trailers, remotes, cherry-pick, or lead with PR numbers.
-Internally use them; externally use **Ready / Not ready / Live / Not live /
-Blocked / Who (brand)** plus the **task title**.
+merge, force-push, SHA, trailers, remotes, or cherry-pick. Do **not** lead with
+PR numbers. Internally use them; externally use **Ready / Not ready / Live /
+Not live / Blocked / Who (brand)** plus the **task title**.
 
 ### Brand identity
 

--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -38,11 +38,35 @@ Dyslexia-hostile jargon in answers is a product failure.
 | Clean up / too many folders | Remove finished scratchpads | Own worktree remove; supervisor may prune orphans | **Cleaned** / **Left X (why)** |
 | Fix CI / make it green | Repair your PR checks | Fix and re-verify | **Green** / **Still red** (+ one plain cause) |
 
+### Task titles, not ticket numbers
+
+A draft request to the coordinator **is** a finished (or ready) **task packet**.
+The **task title** is what humans hear. Internal ticket numbers are optional
+footnotes for links — never the lead.
+
+**Template (every agent):**
+
+```text
+[Brand]: [Live | Ready for supervisor | Not ready | Blocked] — [plain English task title].
+[Optional one outcome line.]
+[Optional link; number only as (#N) at the end if needed.]
+```
+
+**Bad:** “Promoting PR #164. Yours is #165.”
+
+**Good:** “Codex: Live — refreshed maintainer handoff.”
+
+**Good:** “Grok: Ready for supervisor — public intelligence pack v0.”
+
+Write machine titles so the **human half is readable** (e.g. “public intelligence
+pack v0”), not only `feat(docs): …` jargon when speaking to the sponsor.
+
 ### Forbidden in user-facing answers (unless user says “git” or “technical”)
 
 Do **not** lecture about: branch, worktree, rebase, fast-forward, origin, land,
-merge, force-push, SHA, trailers, remotes, cherry-pick. Internally use them;
-externally use **Ready / Not ready / Live / Not live / Blocked / Who (brand)**.
+merge, force-push, SHA, trailers, remotes, cherry-pick, or lead with PR numbers.
+Internally use them; externally use **Ready / Not ready / Live / Not live /
+Blocked / Who (brand)** plus the **task title**.
 
 ### Brand identity
 

--- a/.agents/skills/session-rehydrate/SKILL.md
+++ b/.agents/skills/session-rehydrate/SKILL.md
@@ -23,9 +23,10 @@ Do this for the whole session after rehydrate:
 3. **No fake progress essays.** “I’m checking X… now Y…” is noise. Use tools;
    then speak.
 4. **Human language only to the user:** Ready / Not ready / Live / Not live /
-   Blocked / Who (**brand first**). Do not dump git jargon unless they asked
-   for git. “Done / pushed?” means **Ready for supervisor**, not a git lecture.
-   Full map: `.agents/AGENTS.md` → Human language.
+   Blocked / Who (**brand first**) + **plain task title**. Never lead with PR
+   numbers. Do not dump git jargon unless they asked for git. “Done / pushed?”
+   means **Ready for supervisor**, not a git lecture. Full map:
+   `.agents/AGENTS.md` → Human language.
 5. **UniGrok second opinions:** when calling MCP `agent` for hard product
    claims, prefer **CLI** + `mode=fast` for index-diff hive polls; keep
    **visible emit tiny**. Insider silent-think doctrine lives in private

--- a/.claude/skills/session-rehydrate/SKILL.md
+++ b/.claude/skills/session-rehydrate/SKILL.md
@@ -23,9 +23,10 @@ Do this for the whole session after rehydrate:
 3. **No fake progress essays.** “I’m checking X… now Y…” is noise. Use tools;
    then speak.
 4. **Human language only to the user:** Ready / Not ready / Live / Not live /
-   Blocked / Who (**brand first**). Do not dump git jargon unless they asked
-   for git. “Done / pushed?” means **Ready for supervisor**, not a git lecture.
-   Full map: `.agents/AGENTS.md` → Human language.
+   Blocked / Who (**brand first**) + **plain task title**. Never lead with PR
+   numbers. Do not dump git jargon unless they asked for git. “Done / pushed?”
+   means **Ready for supervisor**, not a git lecture. Full map:
+   `.agents/AGENTS.md` → Human language.
 5. **UniGrok second opinions:** when calling MCP `agent` for hard product
    claims, prefer **CLI** + `mode=fast` for index-diff hive polls; keep
    **visible emit tiny**. Insider silent-think doctrine lives in private

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -32,7 +32,7 @@ Select modular tools based on the nature of the request:
 * **Codex Integration Owner**: The Codex/project-admin role is interface-independent; Codex Desktop, CLI, GitHub Copilot, or another authorized Codex session may perform final landing, protected-main mutation, approval, merge, tag, release, deployment, and synchronization.
 * **Submit, Then Hand Off**: Commit the intended work, run relevant tests, publish the task branch and draft PR when possible, and provide the full commit SHA, changed paths, test results, known risks, human sponsor, and the canonical Google Gemini provider/model trailer from [docs/agent-attribution.md](../docs/agent-attribution.md). Do not run `scripts/land`, push shared `main`, merge/rebase shared `main`, or publish releases/deployments unless explicitly acting as the Codex/project-admin integration session. Exception: remove only your own finished disposable scratchpad; never delete peers' live trees or the primary main checkout.
 * **Scratchpad cleanup**: After Live, abandonment, or a new task, remove **your own** finished worktree. Never delete peers' live trees or dirty main.
-* **Sponsor status**: Use Ready / Not ready / Live / Not live / Blocked and lead with the agent brand. Keep Git terminology internal unless the sponsor asks for it.
+* **Sponsor status**: Use Ready / Not ready / Live / Not live / Blocked and lead with the agent brand plus a plain task title. Never lead with PR numbers. Keep Git terminology internal unless the sponsor asks for it.
 
 ## 5. Verification Requirements
 * A Codex/project-admin session reviews the draft PR's exact current head and alone runs `scripts/land` from a `codex/*` integration branch before protected merge and local synchronization.

--- a/docs/public-intelligence/packs/v0-human-radio-and-cloud-boundary.md
+++ b/docs/public-intelligence/packs/v0-human-radio-and-cloud-boundary.md
@@ -20,8 +20,17 @@ the human asked for technical detail.
 
 **Example finish line**
 
-> I finished building X. Tests passed. Sent to coordinator under PR #N — Title.  
+> **Grok:** Ready for supervisor — built X. Tests passed.
+>
+> Sent to coordinator as “X task title” (#N only if a link helps).
+>
 > If the goal is A, next is B. If the goal is C, next is D.
+
+**Task titles, not numbers**
+
+- A coordinator packet **is** a task. **Title = task name** in human speech.
+- Never lead with “PR #164 / #165.” Lead with brand + status + plain title.
+- Numbers are machine footnotes, not the story.
 
 ## 2. Cursor Cloud vs laptop UniGrok
 

--- a/tests/test_public_intelligence_packs.py
+++ b/tests/test_public_intelligence_packs.py
@@ -46,6 +46,7 @@ def test_manifest_and_bodies_exist_and_match_schema_shape() -> None:
         for marker in banned_markers:
             assert marker not in text
         assert "Ready for supervisor" in text or "Live" in text
+        assert "Task titles, not numbers" in text
 
 
 def test_readme_states_promote_not_auto_sync() -> None:

--- a/tests/test_release_hygiene.py
+++ b/tests/test_release_hygiene.py
@@ -213,12 +213,13 @@ def test_agent_statuses_lead_with_plain_task_titles() -> None:
     claude_skill = (
         ROOT / ".claude" / "skills" / "session-rehydrate" / "SKILL.md"
     ).read_text(encoding="utf-8")
+    gemini_rules = (ROOT / ".gemini" / "GEMINI.md").read_text(encoding="utf-8")
 
     assert "Task titles, not ticket numbers" in shared_rules
     assert "never the lead" in shared_rules
-    for skill in (agent_skill, claude_skill):
-        assert "plain task title" in skill
-        assert "Never lead with PR" in skill
+    for guidance in (agent_skill, claude_skill, gemini_rules):
+        assert "plain task title" in guidance
+        assert "Never lead with PR" in guidance
 
 
 def test_disposable_scratchpad_cleanup_is_consistent():

--- a/tests/test_release_hygiene.py
+++ b/tests/test_release_hygiene.py
@@ -205,6 +205,22 @@ def test_session_rehydrate_skills_use_project_qualified_continuity():
     assert "Root `CLAUDE.md` if present" in claude_skill
 
 
+def test_agent_statuses_lead_with_plain_task_titles() -> None:
+    shared_rules = (ROOT / ".agents" / "AGENTS.md").read_text(encoding="utf-8")
+    agent_skill = (
+        ROOT / ".agents" / "skills" / "session-rehydrate" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    claude_skill = (
+        ROOT / ".claude" / "skills" / "session-rehydrate" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+
+    assert "Task titles, not ticket numbers" in shared_rules
+    assert "never the lead" in shared_rules
+    for skill in (agent_skill, claude_skill):
+        assert "plain task title" in skill
+        assert "Never lead with PR" in skill
+
+
 def test_disposable_scratchpad_cleanup_is_consistent():
     """Own finished scratchpads may be removed; peer/main deletion stays forbidden."""
     shared = (ROOT / ".agents" / "AGENTS.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Promote the useful plain-task-title guidance from the superseded Grok lane.
- Preserve the hardened public-pack schema and scrub tests already Live.
- Preserve Claude-specific root CLAUDE.md rehydrate behavior.
- Align Gemini with the same plain-title rule and add cross-surface coverage.

## Exact head
445453ade7a26b9f0ace3155aece98d3bcd008e6

## Changed paths
- .agents/AGENTS.md
- .agents/skills/session-rehydrate/SKILL.md
- .claude/skills/session-rehydrate/SKILL.md
- .gemini/GEMINI.md
- docs/public-intelligence/packs/v0-human-radio-and-cloud-boundary.md
- tests/test_public_intelligence_packs.py
- tests/test_release_hygiene.py

## Verification
- uv run pytest -q tests/test_release_hygiene.py tests/test_public_intelligence_packs.py — 21 passed
- git diff --check — clean

## Risk
Low: documentation and test-only human-radio clarification. No runtime, auth, packaging, or deployment changes.

Human-Sponsor: djtelicloud

Agent-Assisted-By: xAI Grok | model=grok-4.5 | model-source=provider-session | surface=Grok Build CLI | role=implementation
Agent-Assisted-By: Google Gemini | model=gemini-code-assist | model-source=github-review | surface=GitHub | role=review
Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=integration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and regression tests only; no runtime, auth, or deployment behavior changes.
> 
> **Overview**
> Agents are told to report **brand + status + plain English task title** to sponsors, and to treat PR/ticket numbers as optional footnotes—not the lead line.
> 
> **`.agents/AGENTS.md`** adds a **Task titles, not ticket numbers** section with a status template and good/bad examples, and extends the “forbidden jargon” list to include **not leading with PR numbers**. **`session-rehydrate`** (`.agents` and `.claude`) and **`.gemini/GEMINI.md`** sponsor-status bullets now require a **plain task title** and **never lead with PR numbers**.
> 
> The public intelligence pack **`v0-human-radio-and-cloud-boundary.md`** replaces a PR-number-first finish-line example with brand-first wording and adds a **Task titles, not numbers** subsection.
> 
> **Tests** lock this in: pack bodies must include `Task titles, not numbers`, and **`test_agent_statuses_lead_with_plain_task_titles`** asserts the shared rules and per-surface guidance stay aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 445453ade7a26b9f0ace3155aece98d3bcd008e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->