### PR TITLE
feat(docs): OKF wiki mirror, one-line install, any-project pack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,9 +101,12 @@ mutate. Pasteable terminal prompts for agents beat multi-step browser forms.
   - **Agents / machine-readable knowledge:** `docs/okf/` (generated pieces via
     `scripts/generate_okf.py`, mirrored to the public site and gateway)
   - **Insiders:** this file + `docs/design/*`
-  - **GitHub Wiki is not a product surface.** Do not hand-edit it as source of
-    truth, do not auto-publish full OKF into `.wiki.git`, and do not send
-    public users there. Prefer disabling the Wiki tab or leaving it empty.
+  - **GitHub Wiki is a mirror only (optional).** Source of truth is `docs/okf/`
+    and https://grokmcp.org/docs/okf/. Do **not** hand-edit wiki pages. To
+    refresh the tab for humans, run
+    `uv run python scripts/publish_okf_wiki_mirror.py --out-dir /tmp/unigrok-wiki`
+    and push the generated markdown to the repo wiki. See
+    [docs/wiki-okf-mirror.md](docs/wiki-okf-mirror.md).
 - Run `uv run pytest` before opening a PR.
 
 Human contributors and coding agents use the same evidence contract: intent,

--- a/README.md
+++ b/README.md
@@ -55,40 +55,31 @@ special mounts.
 Docker Desktop is the current packaging path for the shared service. Treat it as
 how UniGrok runs on your machine — not as “you are a Docker developer.”
 
-## 3. Run the gateway
+## 3. Run the gateway (one path)
 
 > [!WARNING]
 > UniGrok is not published on PyPI.
 > `pip install mcp-grok` installs an unrelated project; use this GitHub checkout.
+> There is no real `npx unigrok` server yet — Docker (or `uv` + compose) **is** the install.
+
+**Fast path (copy/paste):**
 
 ```bash
-git clone https://github.com/djtelicloud/grok-mcp-server.git
-cd grok-mcp-server
+git clone https://github.com/djtelicloud/grok-mcp-server.git && cd grok-mcp-server
 uv run python main.py init
-```
-
-`init` creates `.env` from the template (if missing) and prints IDE MCP snippets
-pointed at `http://localhost:4765/mcp`.
-
-**API path:** set in `.env` (server only):
-
-```bash
-XAI_API_KEY=your_real_xai_api_key
-```
-
-**CLI subscription path** (after the service image is available):
-
-```bash
+# Edit .env: set the xAI developer key (server only) — or use CLI auth after compose
 docker compose up --build -d
-docker compose run --rm grok-cli-auth
-```
-
-**Start (or refresh) the service:**
-
-```bash
-docker compose up --build -d
-curl --fail -s http://localhost:4765/healthz
 curl --fail -s http://localhost:4765/readyz
+```
+
+`init` creates `.env` if missing and prints IDE MCP snippets for
+`http://localhost:4765/mcp`. After the service is healthy, you can **close this
+repo** and work in any project with `@grok`.
+
+**CLI subscription path** (optional, after the image is up):
+
+```bash
+docker compose run --rm grok-cli-auth
 ```
 
 You are ready when `/readyz` reports `"status":"ready"`. `/healthz` only proves
@@ -152,10 +143,13 @@ binding path. That control plane does not replace local UniGrok MCP on
 |---|---|
 | Installing / connecting an IDE | This README |
 | An agent needing schemas and operations | [OKF knowledge bundle](https://grokmcp.org/docs/okf/index.md) (also via `discover_self` and local `/docs/okf/`) |
+| Public “smarter defaults” recipes | [docs/public-intelligence/](docs/public-intelligence/) |
 | Changing UniGrok itself | [CONTRIBUTING.md](CONTRIBUTING.md) |
 
-There is **no** separate GitHub Wiki product surface. Prefer these three paths
-over any Wiki tab so public install and agent knowledge stay one source of truth.
+**Source of truth:** this repo’s `docs/okf/` + the site OKF.  
+**GitHub Wiki (optional):** human-friendly **mirror only**, generated from OKF
+(see [docs/wiki-okf-mirror.md](docs/wiki-okf-mirror.md)). Do not hand-edit the
+wiki as product docs. Empty or stale wiki is not an outage — use OKF.
 
 ## 9. Next steps
 

--- a/docs/design/public-vs-insider-surfaces.md
+++ b/docs/design/public-vs-insider-surfaces.md
@@ -138,7 +138,7 @@ public Quick Start.
 | GitHub write+ for all cloud Console entry | **LIVE** |
 | Unified single Insider UI (swarm+control+core) | **Deferred** |
 | Silent skill compiler into user repos | **Forbidden** |
-| GitHub Wiki as second docs tree / auto-synced `.wiki.git` from OKF | **Forbidden** — public knowledge is README + OKF only |
+| Hand-edited GitHub Wiki as second source of truth | **Forbidden** — source is README + OKF; wiki may be a **generated mirror only** (see docs/wiki-okf-mirror.md) |
 
 ## 8. Related docs
 

--- a/docs/public-intelligence/packs/manifest.json
+++ b/docs/public-intelligence/packs/manifest.json
@@ -27,6 +27,31 @@
         "Session or task-RAG database dumps",
         "Contributor workspace memory rows"
       ]
+    },
+    {
+      "pack_id": "install-and-any-project",
+      "version": "v0",
+      "title": "Install one-liner and any-project agents",
+      "summary": "Docker/uv install path, close-the-clone, discover_self first load, optional using-unigrok habit without full .agents tree.",
+      "audience": "public",
+      "body_path": "docs/public-intelligence/packs/v0-install-and-any-project.md",
+      "source_gym": "Public onboarding UX review (first MCP load, wiki, npx, foreign projects).",
+      "promoted_from": [
+        "README.md",
+        "docs/wiki-okf-mirror.md"
+      ],
+      "scrub": {
+        "secrets": true,
+        "private_paths": true,
+        "raw_memory": true,
+        "unreviewed_logs": true
+      },
+      "never_includes": [
+        "API keys or OAuth secrets",
+        "Private unigrok-intelligence playbooks",
+        "Session or task-RAG database dumps",
+        "Contributor workspace memory rows"
+      ]
     }
   ]
 }

--- a/docs/public-intelligence/packs/v0-install-and-any-project.md
+++ b/docs/public-intelligence/packs/v0-install-and-any-project.md
@@ -1,0 +1,62 @@
+# Public pack — Install one-liner and any-project agents
+
+**Audience:** public installers  
+**Pack id:** `install-and-any-project` · **version:** `v0`
+
+## Fastest install (LIVE target path)
+
+UniGrok is a **small always-on service** on your machine, not a one-file IDE plugin.
+
+```bash
+git clone https://github.com/djtelicloud/grok-mcp-server.git
+cd grok-mcp-server
+uv run python main.py init          # .env + IDE paste blocks
+# Put your xAI developer key in server .env only (or use CLI auth after compose)
+docker compose up --build -d
+curl -sf http://localhost:4765/readyz
+```
+
+Then paste the MCP block from `init` into your IDE (URL `http://localhost:4765/mcp`,
+stable `X-Client-ID`, **never** put the xAI key in IDE JSON).
+
+You can **close the clone** after the service is running. Daily work is in
+**your** projects with `@grok` / the UniGrok `agent` tool.
+
+`npx` is **not** the server today. A thin launcher may wrap Docker later; do not
+`pip install mcp-grok` from PyPI (unrelated package).
+
+## First agent connect (what actually loads)
+
+1. IDE gets **tool list** only.
+2. Good agents call **`grok_mcp_discover_self`** → bootstrap + OKF pointers.
+3. OKF: https://grokmcp.org/docs/okf/index.md (also on the server under `/docs/okf/`).
+4. **No** automatic full-wiki dump. Optional GitHub Wiki is an OKF **mirror** only.
+
+## Any project (not the UniGrok clone)
+
+You do **not** need the UniGrok `.agents/` tree in your app.
+
+**Recommended:** install the small **using-unigrok** skill (or paste the habit
+below) so agents use UniGrok without becoming UniGrok contributors.
+
+### Optional habit (opt-in, not forced)
+
+When the user says `@grok` or wants a second opinion:
+
+1. Call UniGrok `agent` (start with `mode=fast` or `reasoning`).
+2. For multi-step plans, get a UniGrok second opinion **if the user wants that
+   habit** — do not silently burn metered API credits.
+3. Hive / deep-think / parallel voting = **opt-in** for hard problems, not every
+   turn in foreign apps.
+4. Speak **Ready / Live / Blocked / Who (brand)** + plain task titles.
+
+### Do not copy into foreign apps
+
+- Full contributor `.agents/`, Forge, Swarm, land workflows
+- Private intelligence playbooks
+- Laptop secrets into Cursor Cloud
+
+## Wiki
+
+If the GitHub Wiki has pages, they are a **mirror** of OKF + public packs.
+Source of truth remains the repo and the site.

--- a/docs/wiki-okf-mirror.md
+++ b/docs/wiki-okf-mirror.md
@@ -1,0 +1,29 @@
+# GitHub Wiki as OKF mirror (only)
+
+## Decision
+
+The GitHub Wiki tab may be a **human-friendly mirror** of the public OKF bundle
+and public intelligence packs. It is **never** source of truth.
+
+| Role | Surface |
+| --- | --- |
+| **Source of truth** | `docs/okf/` in this repo + https://grokmcp.org/docs/okf/ |
+| **Optional mirror** | GitHub Wiki (auto or script-generated) |
+| **Agents** | Prefer OKF via `discover_self` / site / local `/docs/okf/` |
+
+## Rules
+
+1. **Do not hand-edit** wiki pages as product docs.
+2. **Regenerate** from OKF on release (or via `scripts/publish_okf_wiki_mirror.py`).
+3. Wiki pages must say they are a **mirror** and link to OKF index.
+4. If the mirror is stale or missing, that is not a product outage — use OKF.
+
+## Why this is better than an empty wiki
+
+Humans open the Wiki tab. An empty tab feels broken. A **generated** mirror
+matches OKF without a second brain to maintain by hand.
+
+## Why this is safer than a free-form wiki
+
+Hand-edited wikis drift. Agents might trust them. Mirror-only + regen keeps
+one knowledge pipeline: **repo OKF → site → optional wiki**.

--- a/scripts/publish_okf_wiki_mirror.py
+++ b/scripts/publish_okf_wiki_mirror.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Build a GitHub Wiki mirror from docs/okf + public intelligence packs.
+
+Mirror only — never the source of truth. Writes markdown into --out-dir.
+Push to the repo wiki is a separate operator step (or CI with wiki write token).
+
+Example:
+  uv run python scripts/publish_okf_wiki_mirror.py --out-dir /tmp/unigrok-wiki
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+OKF = ROOT / "docs" / "okf"
+PACKS = ROOT / "docs" / "public-intelligence" / "packs"
+HOME_BANNER = """\
+> **Mirror only.** Source of truth: [OKF on the site](https://grokmcp.org/docs/okf/index.md)
+> and `docs/okf/` in the repository. Do not hand-edit this wiki.
+
+"""
+
+
+def _slug(name: str) -> str:
+    base = Path(name).stem
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", base).strip("-") or "page"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        required=True,
+        help="Directory to write wiki markdown (created if missing).",
+    )
+    parser.add_argument(
+        "--clean",
+        action="store_true",
+        help="Remove existing .md files in out-dir before writing.",
+    )
+    args = parser.parse_args()
+    out: Path = args.out_dir
+    out.mkdir(parents=True, exist_ok=True)
+    if args.clean:
+        for old in out.glob("*.md"):
+            old.unlink()
+
+    # Home
+    index = (OKF / "index.md").read_text(encoding="utf-8")
+    # Strip YAML front matter if present
+    if index.startswith("---"):
+        parts = index.split("---", 2)
+        if len(parts) >= 3:
+            index = parts[2].lstrip("\n")
+    home = HOME_BANNER + "# UniGrok knowledge (OKF mirror)\n\n" + index
+    home += "\n\n## Public intelligence packs\n\n"
+    if PACKS.is_dir():
+        for pack in sorted(PACKS.glob("v*.md")):
+            home += f"- [[{_slug(pack.name)}|{pack.stem}]]\n"
+    (out / "Home.md").write_text(home, encoding="utf-8")
+
+    # OKF pages
+    for path in sorted(OKF.glob("*.md")):
+        if path.name == "index.md":
+            continue
+        body = path.read_text(encoding="utf-8")
+        if body.startswith("---"):
+            parts = body.split("---", 2)
+            if len(parts) >= 3:
+                body = parts[2].lstrip("\n")
+        (out / f"{_slug(path.name)}.md").write_text(
+            HOME_BANNER + body, encoding="utf-8"
+        )
+
+    # Public packs
+    if PACKS.is_dir():
+        for path in sorted(PACKS.glob("v*.md")):
+            body = path.read_text(encoding="utf-8")
+            (out / f"{_slug(path.name)}.md").write_text(
+                HOME_BANNER + body, encoding="utf-8"
+            )
+
+    # Sidebar for GitHub wiki
+    sidebar_lines = [
+        HOME_BANNER.strip(),
+        "",
+        "**OKF**",
+        "[[Home]]",
+    ]
+    for path in sorted(OKF.glob("*.md")):
+        if path.name == "index.md":
+            continue
+        sidebar_lines.append(f"[[{_slug(path.name)}|{path.stem}]]")
+    if PACKS.is_dir() and any(PACKS.glob("v*.md")):
+        sidebar_lines.append("")
+        sidebar_lines.append("**Public packs**")
+        for path in sorted(PACKS.glob("v*.md")):
+            sidebar_lines.append(f"[[{_slug(path.name)}|{path.stem}]]")
+    (out / "_Sidebar.md").write_text("\n".join(sidebar_lines) + "\n", encoding="utf-8")
+
+    print(f"Wrote wiki mirror to {out}")
+    print("Push separately, e.g.:")
+    print("  git clone https://github.com/djtelicloud/grok-mcp-server.wiki.git")
+    print("  cp -R out-dir/* wiki-clone/ && cd wiki-clone && git add -A && git commit && git push")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_hygiene.py
+++ b/tests/test_release_hygiene.py
@@ -249,22 +249,20 @@ def test_disposable_scratchpad_cleanup_is_consistent():
     assert "Never remove task worktrees after landing" not in skill
 
 
-def test_public_docs_surfaces_exclude_github_wiki_as_product():
-    """Public knowledge is README + OKF; GitHub Wiki is not a second tree."""
+def test_public_docs_surfaces_wiki_is_okf_mirror_only():
+    """Public knowledge source is README + OKF; wiki may mirror, never hand-edit."""
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     contributing = (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
-    freeze = (ROOT / "docs" / "design" / "public-vs-insider-surfaces.md").read_text(
-        encoding="utf-8"
-    )
+    wiki_policy = (ROOT / "docs" / "wiki-okf-mirror.md").read_text(encoding="utf-8")
 
     assert "## 8. Where docs live" in readme
     assert "https://grokmcp.org/docs/okf/index.md" in readme
-    assert "There is **no** separate GitHub Wiki product surface" in readme
-    assert "GitHub Wiki is not a product surface" in contributing
-    assert "Do not hand-edit it as source of" in contributing
-    assert "auto-publish full OKF into `.wiki.git`" in contributing
-    assert "GitHub Wiki as second docs tree" in freeze
-    assert "Forbidden** — public knowledge is README + OKF only" in freeze
+    assert "mirror only" in readme.lower() or "Mirror only" in readme
+    assert "GitHub Wiki is a mirror only" in contributing or "mirror only" in contributing.lower()
+    assert "Do **not** hand-edit" in contributing or "Do not hand-edit" in contributing
+    assert "publish_okf_wiki_mirror" in contributing
+    assert "never** source of truth" in wiki_policy or "never source of truth" in wiki_policy.lower()
+    assert "Do not hand-edit" in wiki_policy
 
 
 def test_agent_guidance_preserves_workspace_and_credential_boundaries():


### PR DESCRIPTION
## Summary
- Wiki = OKF **mirror only** (docs + `scripts/publish_okf_wiki_mirror.py`)
- README one-path install; close-the-clone after service up
- Public pack: install + any-project agents (opt-in UniGrok habit, no full `.agents`)
- Hygiene tests updated for mirror policy

## Ready for supervisor?
Yes after CI green. Task title: public onboard UX (wiki mirror + easy install).

Human-Sponsor: djtelicloud

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a local markdown generator only; no runtime, auth, or credential-path changes.
> 
> **Overview**
> **Docs policy shift:** GitHub Wiki moves from “forbidden product surface” to an **optional, script-generated OKF mirror** (`docs/wiki-okf-mirror.md`, `scripts/publish_okf_wiki_mirror.py`). `README`, `CONTRIBUTING`, and the public-vs-insider freeze doc now say **README + OKF/site** stay source of truth; wiki pages must not be hand-edited.
> 
> **Onboarding:** `README` §3 is collapsed into a single copy/paste fast path (`init` → `.env` → `docker compose` → `/readyz`), clarifies Docker is the real install (no `npx` server), and tells users they can **close the clone** after the service is up. Adds a pointer to `docs/public-intelligence/` in “Where docs live.”
> 
> **Public intelligence:** New pack `install-and-any-project` in the manifest plus `v0-install-and-any-project.md` (install flow, `discover_self`, opt-in `@grok` habit, no full `.agents` in foreign repos).
> 
> **Tests:** `test_public_docs_surfaces_exclude_github_wiki_as_product` is renamed/rewritten to assert mirror-only wiki policy instead of “no wiki surface.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64fe536575d634677b0198542b6931dd27bd4e5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->