### PR TITLE
fix(agents): silent final-answer law for all UniGrok agents

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -13,15 +13,34 @@
 
 ## Communication discipline
 
-- **Silent process, loud finish:** use tools and plan without narrating every
-  step. Deliver one concise end-state answer (tables, decisions, links, blockers).
-- Do not stream progress essays (“now I’ll check…”) unless the user asked for
-  a live play-by-play.
-- Prefer UniGrok MCP CLI/`fast` for cheap index-diff hive emits; keep visible
-  output tiny. Insider silent-think doctrine is private (not public default).
-- **Public intelligence packs:** distilled gym wins for clones live under
-  `docs/public-intelligence/`. After Live work, ask once: promote a scrubbed
-  pack/skill? Never auto-sync private intelligence or raw memory to public.
+### Silent final answer (mandatory for all UniGrok agents)
+
+**Chat pollution is a product bug.** Intermediate narration, diffs, tool dumps,
+and command theater bloat context, cost, and latency.
+
+| Allowed in the human chat | Forbidden in the human chat |
+| --- | --- |
+| One final status block when work is done | “I’m checking…”, “now I’ll…”, play-by-play |
+| **Brand + status + plain task title** | Diffs, patches, file hunks, full logs |
+| Optional one link or (#N) footnote | Raw tool payloads, schemas, stack traces |
+| Blocked + one plain choice if human needed | Git ceremony, PR-number soup |
+
+**Process:** tools and UniGrok thinking stay **off-chat** (product may show
+“Running tool…” chrome; agents must not add essays on top).  
+**Emit:** only the finish line, e.g.
+
+```text
+Grok: Ready for supervisor — silent final-answer law for all agents.
+```
+
+Expand only if the user asks “explain” or “technical”. Safety/permission prompts
+are the only exception.
+
+- Prefer UniGrok MCP CLI/`fast` for hard judgment (hive/plan); keep **visible**
+  emit tiny. Insider silent-think is private.
+- **Public intelligence packs:** distilled gym wins under
+  `docs/public-intelligence/`. After Live, ask once: promote a scrubbed pack?
+  Never auto-sync private intelligence or raw memory to public.
 
 ## Human language (user-facing — mandatory)
 

--- a/.agents/skills/session-rehydrate/SKILL.md
+++ b/.agents/skills/session-rehydrate/SKILL.md
@@ -16,12 +16,11 @@ Intelligence is rehydrated from **git + disk**, not model memory.
 Do this for the whole session after rehydrate:
 
 1. **Think and tool silently.** Prefer tool calls and internal planning over
-   step-by-step narration to the user.
-2. **One end-state answer.** Deliver a concise final report (status table,
-   decisions, links, next action). Do not stream a blog of intermediate work
-   unless the user asked for a live play-by-play.
+   step-by-step narration to the user. No diffs, patches, or tool dumps in chat.
+2. **One end-state answer only.** Brand + status + plain task title (e.g.
+   `Grok: Ready for supervisor — …`). Nothing before that except product chrome.
 3. **No fake progress essays.** “I’m checking X… now Y…” is noise. Use tools;
-   then speak.
+   then speak once.
 4. **Human language only to the user:** Ready / Not ready / Live / Not live /
    Blocked / Who (**brand first**). Do not dump git jargon unless they asked
    for git. “Done / pushed?” means **Ready for supervisor**, not a git lecture.

--- a/.claude/skills/session-rehydrate/SKILL.md
+++ b/.claude/skills/session-rehydrate/SKILL.md
@@ -16,12 +16,11 @@ Intelligence is rehydrated from **git + disk**, not model memory.
 Do this for the whole session after rehydrate:
 
 1. **Think and tool silently.** Prefer tool calls and internal planning over
-   step-by-step narration to the user.
-2. **One end-state answer.** Deliver a concise final report (status table,
-   decisions, links, next action). Do not stream a blog of intermediate work
-   unless the user asked for a live play-by-play.
+   step-by-step narration to the user. No diffs, patches, or tool dumps in chat.
+2. **One end-state answer only.** Brand + status + plain task title (e.g.
+   `Grok: Ready for supervisor — …`). Nothing before that except product chrome.
 3. **No fake progress essays.** “I’m checking X… now Y…” is noise. Use tools;
-   then speak.
+   then speak once.
 4. **Human language only to the user:** Ready / Not ready / Live / Not live /
    Blocked / Who (**brand first**). Do not dump git jargon unless they asked
    for git. “Done / pushed?” means **Ready for supervisor**, not a git lecture.
@@ -51,7 +50,6 @@ Read (skim) when available:
 
 - `.agents/AGENTS.md` — multi-agent git, MCP endpoint, credentials boundary
 - Root `AGENTS.md` if present
-- Root `CLAUDE.md` if present
 
 ### 2. Continuity (private brain)
 

--- a/docs/public-intelligence/packs/v0-human-radio-and-cloud-boundary.md
+++ b/docs/public-intelligence/packs/v0-human-radio-and-cloud-boundary.md
@@ -51,3 +51,11 @@ reach new public clones—not private SQLite or chat logs.
 
 After something is **Live**, ask once: promote a public pack/skill update?
 If yes, scrub and open a product PR under `docs/public-intelligence/`.
+
+## Silent final answer
+
+Do all work off-chat. When finished, emit **only**:
+
+`[Brand]: [Ready for supervisor | Live | Not ready | Blocked] — [plain task title].`
+
+No diffs, logs, or “I’m checking…” in human chat. Expand only if asked.


### PR DESCRIPTION
## Summary
Codify silent process + one human finish line for every UniGrok agent. No chat pollution (diffs, tool dumps, progress essays).

## Ready for supervisor?
Yes after CI green. Task: silent final-answer law.

Human-Sponsor: djtelicloud

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only policy changes with no runtime, auth, or data-path impact.
> 
> **Overview**
> **Codifies mandatory silent process + one human finish line** for every UniGrok agent, treating chat pollution (progress essays, diffs, tool dumps) as a product bug.
> 
> In **`.agents/AGENTS.md`**, the old brief communication bullets are replaced with a **Silent final answer** subsection: an allowed/forbidden table, off-chat tooling, and a single emit format (`Brand: Ready for supervisor — plain task title`). Public-intelligence promote wording is slightly tightened.
> 
> **Session rehydrate** (`.agents/skills/session-rehydrate/SKILL.md` and mirrored `.claude/skills/session-rehydrate/SKILL.md`) now explicitly bans diffs/patches in chat, requires brand + status + title only, and drops **`Root CLAUDE.md`** from the product-law skim list.
> 
> The public pack **`v0-human-radio-and-cloud-boundary`** gains a matching **Silent final answer** section so contributor-facing docs align with agent law.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 959b0cd25a923337e0c1af6a37c904fbed53c07d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->