### PR TITLE
feat(docs): finalize public onboarding and OKF mirror

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,9 +101,12 @@ mutate. Pasteable terminal prompts for agents beat multi-step browser forms.
   - **Agents / machine-readable knowledge:** `docs/okf/` (generated pieces via
     `scripts/generate_okf.py`, mirrored to the public site and gateway)
   - **Insiders:** this file + `docs/design/*`
-  - **GitHub Wiki is not a product surface.** Do not hand-edit it as source of
-    truth, do not auto-publish full OKF into `.wiki.git`, and do not send
-    public users there. Prefer disabling the Wiki tab or leaving it empty.
+  - **GitHub Wiki is a mirror only (optional).** Source of truth is `docs/okf/`
+    and https://grokmcp.org/docs/okf/. Do **not** hand-edit wiki pages. To
+    refresh the tab for humans, run
+    `uv run python scripts/publish_okf_wiki_mirror.py --out-dir /tmp/unigrok-wiki`
+    and push the generated markdown to the repo wiki. See
+    [docs/wiki-okf-mirror.md](docs/wiki-okf-mirror.md).
 - Run `uv run pytest` before opening a PR.
 
 Human contributors and coding agents use the same evidence contract: intent,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,9 @@ mutate. Pasteable terminal prompts for agents beat multi-step browser forms.
     and https://grokmcp.org/docs/okf/. Do **not** hand-edit wiki pages. To
     refresh the tab for humans, run
     `uv run python scripts/publish_okf_wiki_mirror.py --out-dir /tmp/unigrok-wiki`
-    and push the generated markdown to the repo wiki. See
+    and publish the generated pages with a deletion-aware sync. The generator
+    removes stale pages and renders manifest-listed JSON schemas/data as linked
+    wiki pages. See
     [docs/wiki-okf-mirror.md](docs/wiki-okf-mirror.md).
 - Run `uv run pytest` before opening a PR.
 

--- a/README.md
+++ b/README.md
@@ -67,23 +67,32 @@ how UniGrok runs on your machine — not as “you are a Docker developer.”
 ```bash
 git clone https://github.com/djtelicloud/grok-mcp-server.git && cd grok-mcp-server
 uv run python main.py init
-# Edit .env: set the xAI developer key (server only) — or use CLI auth after compose
 docker compose up --build -d
-curl --fail -s http://localhost:4765/readyz
 ```
 
 `init` creates `.env` if missing and prints IDE MCP snippets for
 `http://localhost:4765/mcp`. After the service is healthy, you can **close this
 repo** and work in any project with `@grok`.
 
-**CLI subscription path** (optional, after the image is up):
+Before checking readiness, complete **one** credential path:
+
+- **xAI API:** set the developer key in server `.env` before starting Compose
+  (or rerun `docker compose up -d` after editing it).
+- **CLI subscription:** after the image is up, run:
 
 ```bash
 docker compose run --rm grok-cli-auth
 ```
 
+Then verify the usable plane:
+
+```bash
+curl --fail -s http://localhost:4765/readyz
+```
+
 You are ready when `/readyz` reports `"status":"ready"`. `/healthz` only proves
-the process is up.
+the process is up; CLI-only installs must authenticate before this readiness
+check.
 
 ## 4. Connect your IDE (paste this to your agent)
 

--- a/README.md
+++ b/README.md
@@ -55,40 +55,31 @@ special mounts.
 Docker Desktop is the current packaging path for the shared service. Treat it as
 how UniGrok runs on your machine — not as “you are a Docker developer.”
 
-## 3. Run the gateway
+## 3. Run the gateway (one path)
 
 > [!WARNING]
 > UniGrok is not published on PyPI.
 > `pip install mcp-grok` installs an unrelated project; use this GitHub checkout.
+> There is no real `npx unigrok` server yet — Docker (or `uv` + compose) **is** the install.
+
+**Fast path (copy/paste):**
 
 ```bash
-git clone https://github.com/djtelicloud/grok-mcp-server.git
-cd grok-mcp-server
+git clone https://github.com/djtelicloud/grok-mcp-server.git && cd grok-mcp-server
 uv run python main.py init
-```
-
-`init` creates `.env` from the template (if missing) and prints IDE MCP snippets
-pointed at `http://localhost:4765/mcp`.
-
-**API path:** set in `.env` (server only):
-
-```bash
-XAI_API_KEY=your_real_xai_api_key
-```
-
-**CLI subscription path** (after the service image is available):
-
-```bash
+# Edit .env: set the xAI developer key (server only) — or use CLI auth after compose
 docker compose up --build -d
-docker compose run --rm grok-cli-auth
-```
-
-**Start (or refresh) the service:**
-
-```bash
-docker compose up --build -d
-curl --fail -s http://localhost:4765/healthz
 curl --fail -s http://localhost:4765/readyz
+```
+
+`init` creates `.env` if missing and prints IDE MCP snippets for
+`http://localhost:4765/mcp`. After the service is healthy, you can **close this
+repo** and work in any project with `@grok`.
+
+**CLI subscription path** (optional, after the image is up):
+
+```bash
+docker compose run --rm grok-cli-auth
 ```
 
 You are ready when `/readyz` reports `"status":"ready"`. `/healthz` only proves
@@ -152,10 +143,13 @@ binding path. That control plane does not replace local UniGrok MCP on
 |---|---|
 | Installing / connecting an IDE | This README |
 | An agent needing schemas and operations | [OKF knowledge bundle](https://grokmcp.org/docs/okf/index.md) (also via `discover_self` and local `/docs/okf/`) |
+| Public “smarter defaults” recipes | [docs/public-intelligence/](docs/public-intelligence/) |
 | Changing UniGrok itself | [CONTRIBUTING.md](CONTRIBUTING.md) |
 
-There is **no** separate GitHub Wiki product surface. Prefer these three paths
-over any Wiki tab so public install and agent knowledge stay one source of truth.
+**Source of truth:** this repo’s `docs/okf/` + the site OKF.  
+**GitHub Wiki (optional):** human-friendly **mirror only**, generated from OKF
+(see [docs/wiki-okf-mirror.md](docs/wiki-okf-mirror.md)). Do not hand-edit the
+wiki as product docs. Empty or stale wiki is not an outage — use OKF.
 
 ## 9. Next steps
 

--- a/docs/design/public-vs-insider-surfaces.md
+++ b/docs/design/public-vs-insider-surfaces.md
@@ -138,7 +138,7 @@ public Quick Start.
 | GitHub write+ for all cloud Console entry | **LIVE** |
 | Unified single Insider UI (swarm+control+core) | **Deferred** |
 | Silent skill compiler into user repos | **Forbidden** |
-| GitHub Wiki as second docs tree / auto-synced `.wiki.git` from OKF | **Forbidden** — public knowledge is README + OKF only |
+| Hand-edited GitHub Wiki as second source of truth | **Forbidden** — source is README + OKF; wiki may be a **generated mirror only** (see docs/wiki-okf-mirror.md) |
 
 ## 8. Related docs
 

--- a/docs/public-intelligence/packs/manifest.json
+++ b/docs/public-intelligence/packs/manifest.json
@@ -27,6 +27,31 @@
         "Session or task-RAG database dumps",
         "Contributor workspace memory rows"
       ]
+    },
+    {
+      "pack_id": "install-and-any-project",
+      "version": "v0",
+      "title": "Install one-liner and any-project agents",
+      "summary": "Docker/uv install path, close-the-clone, discover_self first load, optional using-unigrok habit without full .agents tree.",
+      "audience": "public",
+      "body_path": "docs/public-intelligence/packs/v0-install-and-any-project.md",
+      "source_gym": "Public onboarding UX review (first MCP load, wiki, npx, foreign projects).",
+      "promoted_from": [
+        "README.md",
+        "docs/wiki-okf-mirror.md"
+      ],
+      "scrub": {
+        "secrets": true,
+        "private_paths": true,
+        "raw_memory": true,
+        "unreviewed_logs": true
+      },
+      "never_includes": [
+        "API keys or OAuth secrets",
+        "Private unigrok-intelligence playbooks",
+        "Session or task-RAG database dumps",
+        "Contributor workspace memory rows"
+      ]
     }
   ]
 }

--- a/docs/public-intelligence/packs/v0-install-and-any-project.md
+++ b/docs/public-intelligence/packs/v0-install-and-any-project.md
@@ -11,10 +11,20 @@ UniGrok is a **small always-on service** on your machine, not a one-file IDE plu
 git clone https://github.com/djtelicloud/grok-mcp-server.git
 cd grok-mcp-server
 uv run python main.py init          # .env + IDE paste blocks
-# Put your xAI developer key in server .env only (or use CLI auth after compose)
 docker compose up --build -d
+```
+
+Before the readiness check, choose one credential path: put the xAI developer
+key in server `.env` (then restart Compose), or authenticate the CLI subscription
+after the image is up:
+
+```bash
+docker compose run --rm grok-cli-auth
 curl -sf http://localhost:4765/readyz
 ```
+
+API users skip the CLI-auth command and run the same readiness check. CLI-only
+installs must authenticate before `/readyz` can report a usable model plane.
 
 Then paste the MCP block from `init` into your IDE (URL `http://localhost:4765/mcp`,
 stable `X-Client-ID`, **never** put the xAI key in IDE JSON).
@@ -49,6 +59,11 @@ When the user says `@grok` or wants a second opinion:
 3. Hive / deep-think / parallel voting = **opt-in** for hard problems, not every
    turn in foreign apps.
 4. Speak **Ready / Live / Blocked / Who (brand)** + plain task titles.
+
+## Task titles, not numbers
+
+Lead status updates with the provider brand, status, and a plain task title.
+Ticket or PR numbers are optional link footnotes, never the story.
 
 ### Do not copy into foreign apps
 

--- a/docs/public-intelligence/packs/v0-install-and-any-project.md
+++ b/docs/public-intelligence/packs/v0-install-and-any-project.md
@@ -1,0 +1,62 @@
+# Public pack — Install one-liner and any-project agents
+
+**Audience:** public installers  
+**Pack id:** `install-and-any-project` · **version:** `v0`
+
+## Fastest install (LIVE target path)
+
+UniGrok is a **small always-on service** on your machine, not a one-file IDE plugin.
+
+```bash
+git clone https://github.com/djtelicloud/grok-mcp-server.git
+cd grok-mcp-server
+uv run python main.py init          # .env + IDE paste blocks
+# Put your xAI developer key in server .env only (or use CLI auth after compose)
+docker compose up --build -d
+curl -sf http://localhost:4765/readyz
+```
+
+Then paste the MCP block from `init` into your IDE (URL `http://localhost:4765/mcp`,
+stable `X-Client-ID`, **never** put the xAI key in IDE JSON).
+
+You can **close the clone** after the service is running. Daily work is in
+**your** projects with `@grok` / the UniGrok `agent` tool.
+
+`npx` is **not** the server today. A thin launcher may wrap Docker later; do not
+`pip install mcp-grok` from PyPI (unrelated package).
+
+## First agent connect (what actually loads)
+
+1. IDE gets **tool list** only.
+2. Good agents call **`grok_mcp_discover_self`** → bootstrap + OKF pointers.
+3. OKF: https://grokmcp.org/docs/okf/index.md (also on the server under `/docs/okf/`).
+4. **No** automatic full-wiki dump. Optional GitHub Wiki is an OKF **mirror** only.
+
+## Any project (not the UniGrok clone)
+
+You do **not** need the UniGrok `.agents/` tree in your app.
+
+**Recommended:** install the small **using-unigrok** skill (or paste the habit
+below) so agents use UniGrok without becoming UniGrok contributors.
+
+### Optional habit (opt-in, not forced)
+
+When the user says `@grok` or wants a second opinion:
+
+1. Call UniGrok `agent` (start with `mode=fast` or `reasoning`).
+2. For multi-step plans, get a UniGrok second opinion **if the user wants that
+   habit** — do not silently burn metered API credits.
+3. Hive / deep-think / parallel voting = **opt-in** for hard problems, not every
+   turn in foreign apps.
+4. Speak **Ready / Live / Blocked / Who (brand)** + plain task titles.
+
+### Do not copy into foreign apps
+
+- Full contributor `.agents/`, Forge, Swarm, land workflows
+- Private intelligence playbooks
+- Laptop secrets into Cursor Cloud
+
+## Wiki
+
+If the GitHub Wiki has pages, they are a **mirror** of OKF + public packs.
+Source of truth remains the repo and the site.

--- a/docs/wiki-okf-mirror.md
+++ b/docs/wiki-okf-mirror.md
@@ -1,0 +1,29 @@
+# GitHub Wiki as OKF mirror (only)
+
+## Decision
+
+The GitHub Wiki tab may be a **human-friendly mirror** of the public OKF bundle
+and public intelligence packs. It is **never** source of truth.
+
+| Role | Surface |
+| --- | --- |
+| **Source of truth** | `docs/okf/` in this repo + https://grokmcp.org/docs/okf/ |
+| **Optional mirror** | GitHub Wiki (auto or script-generated) |
+| **Agents** | Prefer OKF via `discover_self` / site / local `/docs/okf/` |
+
+## Rules
+
+1. **Do not hand-edit** wiki pages as product docs.
+2. **Regenerate** from OKF on release (or via `scripts/publish_okf_wiki_mirror.py`).
+3. Wiki pages must say they are a **mirror** and link to OKF index.
+4. If the mirror is stale or missing, that is not a product outage — use OKF.
+
+## Why this is better than an empty wiki
+
+Humans open the Wiki tab. An empty tab feels broken. A **generated** mirror
+matches OKF without a second brain to maintain by hand.
+
+## Why this is safer than a free-form wiki
+
+Hand-edited wikis drift. Agents might trust them. Mirror-only + regen keeps
+one knowledge pipeline: **repo OKF → site → optional wiki**.

--- a/docs/wiki-okf-mirror.md
+++ b/docs/wiki-okf-mirror.md
@@ -14,9 +14,13 @@ and public intelligence packs. It is **never** source of truth.
 ## Rules
 
 1. **Do not hand-edit** wiki pages as product docs.
-2. **Regenerate** from OKF on release (or via `scripts/publish_okf_wiki_mirror.py`).
+2. **Regenerate** from OKF on release via
+   `scripts/publish_okf_wiki_mirror.py`; it prunes stale pages and includes the
+   manifest-listed JSON schema/data artifacts as rendered pages.
 3. Wiki pages must say they are a **mirror** and link to OKF index.
 4. If the mirror is stale or missing, that is not a product outage — use OKF.
+5. Publish with a deletion-aware copy such as the script's printed
+   `rsync --delete` recipe so removed sources cannot survive in the wiki.
 
 ## Why this is better than an empty wiki
 

--- a/scripts/publish_okf_wiki_mirror.py
+++ b/scripts/publish_okf_wiki_mirror.py
@@ -17,10 +17,16 @@ import re
 import shlex
 from pathlib import Path
 
+from jsonschema import Draft202012Validator
+
 ROOT = Path(__file__).resolve().parents[1]
 OKF = ROOT / "docs" / "okf"
 PACKS = ROOT / "docs" / "public-intelligence" / "packs"
 OKF_MANIFEST = OKF / "okf-manifest.json"
+PACK_MANIFEST = PACKS / "manifest.json"
+PACK_SCHEMA = (
+    ROOT / "docs" / "public-intelligence" / "public-intelligence-pack.schema.json"
+)
 RESERVED_WIKI_SLUGS = {"home", "_sidebar"}
 HOME_BANNER = """\
 > **Mirror only.** Source of truth: [OKF on the site](https://grokmcp.org/docs/okf/index.md)
@@ -82,15 +88,50 @@ def _manifest_files() -> tuple[Path, list[Path]]:
         if not isinstance(name, str) or Path(name).name != name:
             raise ValueError(f"invalid OKF manifest path: {name!r}")
         path = OKF / name
-        if path.suffix not in {".md", ".json"} or not path.is_file():
+        if path.suffix.lower() not in {".md", ".json"} or not path.is_file():
             raise ValueError(f"missing or unsupported OKF artifact: {name!r}")
         files.append(path)
     return OKF / root_name, files
 
 
+def _pack_files() -> list[Path]:
+    schema = json.loads(PACK_SCHEMA.read_text(encoding="utf-8"))
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+    manifest = json.loads(PACK_MANIFEST.read_text(encoding="utf-8"))
+    if set(manifest) != {"schema", "packs"}:
+        raise ValueError("public pack manifest must contain only schema and packs")
+
+    files: list[Path] = []
+    seen: set[Path] = set()
+    packs_root = PACKS.resolve()
+    for pack in manifest["packs"]:
+        validator.validate(pack)
+        if not all(pack["scrub"].values()):
+            raise ValueError(f"public pack {pack['pack_id']!r} is not fully scrubbed")
+        expected = (
+            f"docs/public-intelligence/packs/{pack['version']}-{pack['pack_id']}.md"
+        )
+        if pack["body_path"] != expected:
+            raise ValueError(f"public pack body path must be {expected!r}")
+        path = (ROOT / pack["body_path"]).resolve()
+        if not path.is_relative_to(packs_root) or not path.is_file():
+            raise ValueError(
+                f"missing or escaped public pack body: {pack['body_path']!r}"
+            )
+        if path in seen:
+            raise ValueError(f"duplicate public pack body: {pack['body_path']!r}")
+        seen.add(path)
+        files.append(path)
+    return files
+
+
 def _json_page(path: Path) -> str:
     raw = path.read_text(encoding="utf-8")
-    json.loads(raw)
+    try:
+        json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON in OKF artifact {path.name}: {exc}") from exc
     return f"# {path.name}\n\n```json\n{raw.rstrip()}\n```\n"
 
 
@@ -105,7 +146,7 @@ def build_mirror(out: Path) -> list[Path]:
         old.unlink()
 
     index_path, okf_files = _manifest_files()
-    pack_files = sorted(PACKS.glob("v*.md")) if PACKS.is_dir() else []
+    pack_files = _pack_files()
     seen = {slug: f"generated {slug}" for slug in RESERVED_WIKI_SLUGS}
 
     index = _strip_front_matter(index_path.read_text(encoding="utf-8"))
@@ -115,8 +156,8 @@ def build_mirror(out: Path) -> list[Path]:
         home += f"- [[{_slug(pack.name)}|{pack.stem}]]\n"
     (out / "Home.md").write_text(HOME_BANNER + home, encoding="utf-8")
 
-    markdown_files = [path for path in okf_files if path.suffix == ".md"]
-    json_files = [path for path in okf_files if path.suffix == ".json"]
+    markdown_files = [path for path in okf_files if path.suffix.lower() == ".md"]
+    json_files = [path for path in okf_files if path.suffix.lower() == ".json"]
     for path in markdown_files:
         if path == index_path:
             continue

--- a/scripts/publish_okf_wiki_mirror.py
+++ b/scripts/publish_okf_wiki_mirror.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
-"""Build a GitHub Wiki mirror from docs/okf + public intelligence packs.
+"""Build a deterministic GitHub Wiki mirror from public UniGrok knowledge.
 
-Mirror only — never the source of truth. Writes markdown into --out-dir.
-Push to the repo wiki is a separate operator step (or CI with wiki write token).
+Mirror only — never the source of truth. The output directory is replaced on
+each run so deleted OKF pages cannot survive as stale wiki content. Publishing
+to the repository wiki remains a separate operator step.
 
 Example:
   uv run python scripts/publish_okf_wiki_mirror.py --out-dir /tmp/unigrok-wiki
@@ -11,13 +12,16 @@ Example:
 from __future__ import annotations
 
 import argparse
+import json
 import re
-import shutil
+import shlex
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 OKF = ROOT / "docs" / "okf"
 PACKS = ROOT / "docs" / "public-intelligence" / "packs"
+OKF_MANIFEST = OKF / "okf-manifest.json"
+RESERVED_WIKI_SLUGS = {"home", "_sidebar"}
 HOME_BANNER = """\
 > **Mirror only.** Source of truth: [OKF on the site](https://grokmcp.org/docs/okf/index.md)
 > and `docs/okf/` in the repository. Do not hand-edit this wiki.
@@ -25,9 +29,135 @@ HOME_BANNER = """\
 """
 
 
+def _strip_front_matter(text: str) -> str:
+    if not text.startswith("---"):
+        return text
+    parts = text.split("---", 2)
+    return parts[2].lstrip("\r\n") if len(parts) == 3 else text
+
+
 def _slug(name: str) -> str:
-    base = Path(name).stem
-    return re.sub(r"[^A-Za-z0-9._-]+", "-", base).strip("-") or "page"
+    base = Path(name).name
+    if base.lower().endswith(".md"):
+        base = base[:-3]
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "-", base).strip("-") or "page"
+    if slug.casefold() in RESERVED_WIKI_SLUGS:
+        raise ValueError(f"{name!r} produces reserved wiki slug {slug!r}")
+    return slug
+
+
+def _reserve_slug(seen: dict[str, str], slug: str, source: str) -> None:
+    key = slug.casefold()
+    previous = seen.get(key)
+    if previous is not None:
+        raise ValueError(
+            f"wiki slug collision for {slug!r}: {previous!r} and {source!r}"
+        )
+    seen[key] = source
+
+
+def _write_page(
+    out: Path,
+    *,
+    slug: str,
+    body: str,
+    source: str,
+    seen: dict[str, str],
+) -> None:
+    _reserve_slug(seen, slug, source)
+    (out / f"{slug}.md").write_text(HOME_BANNER + body, encoding="utf-8")
+
+
+def _manifest_files() -> tuple[Path, list[Path]]:
+    manifest = json.loads(OKF_MANIFEST.read_text(encoding="utf-8"))
+    names = manifest.get("files")
+    root_name = manifest.get("root")
+    if not isinstance(names, list) or not names:
+        raise ValueError("OKF manifest files must be a non-empty list")
+    if not isinstance(root_name, str) or root_name not in names:
+        raise ValueError("OKF manifest root must name one listed file")
+
+    files: list[Path] = []
+    for name in names:
+        if not isinstance(name, str) or Path(name).name != name:
+            raise ValueError(f"invalid OKF manifest path: {name!r}")
+        path = OKF / name
+        if path.suffix not in {".md", ".json"} or not path.is_file():
+            raise ValueError(f"missing or unsupported OKF artifact: {name!r}")
+        files.append(path)
+    return OKF / root_name, files
+
+
+def _json_page(path: Path) -> str:
+    raw = path.read_text(encoding="utf-8")
+    json.loads(raw)
+    return f"# {path.name}\n\n```json\n{raw.rstrip()}\n```\n"
+
+
+def build_mirror(out: Path) -> list[Path]:
+    out = out.resolve()
+    root = ROOT.resolve()
+    if out == root or out.is_relative_to(root):
+        raise ValueError("--out-dir must be outside the repository")
+
+    out.mkdir(parents=True, exist_ok=True)
+    for old in out.glob("*.md"):
+        old.unlink()
+
+    index_path, okf_files = _manifest_files()
+    pack_files = sorted(PACKS.glob("v*.md")) if PACKS.is_dir() else []
+    seen = {slug: f"generated {slug}" for slug in RESERVED_WIKI_SLUGS}
+
+    index = _strip_front_matter(index_path.read_text(encoding="utf-8"))
+    home = "# UniGrok knowledge (OKF mirror)\n\n" + index
+    home += "\n\n## Public intelligence packs\n\n"
+    for pack in pack_files:
+        home += f"- [[{_slug(pack.name)}|{pack.stem}]]\n"
+    (out / "Home.md").write_text(HOME_BANNER + home, encoding="utf-8")
+
+    markdown_files = [path for path in okf_files if path.suffix == ".md"]
+    json_files = [path for path in okf_files if path.suffix == ".json"]
+    for path in markdown_files:
+        if path == index_path:
+            continue
+        _write_page(
+            out,
+            slug=_slug(path.name),
+            body=_strip_front_matter(path.read_text(encoding="utf-8")),
+            source=str(path.relative_to(ROOT)),
+            seen=seen,
+        )
+    for path in json_files:
+        _write_page(
+            out,
+            slug=_slug(path.name),
+            body=_json_page(path),
+            source=str(path.relative_to(ROOT)),
+            seen=seen,
+        )
+    for path in pack_files:
+        _write_page(
+            out,
+            slug=_slug(path.name),
+            body=_strip_front_matter(path.read_text(encoding="utf-8")),
+            source=str(path.relative_to(ROOT)),
+            seen=seen,
+        )
+
+    sidebar_lines = [HOME_BANNER.strip(), "", "**OKF**", "[[Home]]"]
+    for path in markdown_files:
+        if path != index_path:
+            sidebar_lines.append(f"[[{_slug(path.name)}|{path.stem}]]")
+    if json_files:
+        sidebar_lines.extend(["", "**Schemas and data**"])
+        for path in json_files:
+            sidebar_lines.append(f"[[{_slug(path.name)}|{path.name}]]")
+    if pack_files:
+        sidebar_lines.extend(["", "**Public packs**"])
+        for path in pack_files:
+            sidebar_lines.append(f"[[{_slug(path.name)}|{path.stem}]]")
+    (out / "_Sidebar.md").write_text("\n".join(sidebar_lines) + "\n", encoding="utf-8")
+    return sorted(out.glob("*.md"))
 
 
 def main() -> int:
@@ -36,77 +166,20 @@ def main() -> int:
         "--out-dir",
         type=Path,
         required=True,
-        help="Directory to write wiki markdown (created if missing).",
-    )
-    parser.add_argument(
-        "--clean",
-        action="store_true",
-        help="Remove existing .md files in out-dir before writing.",
+        help="External directory replaced with generated wiki markdown.",
     )
     args = parser.parse_args()
-    out: Path = args.out_dir
-    out.mkdir(parents=True, exist_ok=True)
-    if args.clean:
-        for old in out.glob("*.md"):
-            old.unlink()
+    written = build_mirror(args.out_dir)
+    out = args.out_dir.resolve()
 
-    # Home
-    index = (OKF / "index.md").read_text(encoding="utf-8")
-    # Strip YAML front matter if present
-    if index.startswith("---"):
-        parts = index.split("---", 2)
-        if len(parts) >= 3:
-            index = parts[2].lstrip("\n")
-    home = HOME_BANNER + "# UniGrok knowledge (OKF mirror)\n\n" + index
-    home += "\n\n## Public intelligence packs\n\n"
-    if PACKS.is_dir():
-        for pack in sorted(PACKS.glob("v*.md")):
-            home += f"- [[{_slug(pack.name)}|{pack.stem}]]\n"
-    (out / "Home.md").write_text(home, encoding="utf-8")
-
-    # OKF pages
-    for path in sorted(OKF.glob("*.md")):
-        if path.name == "index.md":
-            continue
-        body = path.read_text(encoding="utf-8")
-        if body.startswith("---"):
-            parts = body.split("---", 2)
-            if len(parts) >= 3:
-                body = parts[2].lstrip("\n")
-        (out / f"{_slug(path.name)}.md").write_text(
-            HOME_BANNER + body, encoding="utf-8"
-        )
-
-    # Public packs
-    if PACKS.is_dir():
-        for path in sorted(PACKS.glob("v*.md")):
-            body = path.read_text(encoding="utf-8")
-            (out / f"{_slug(path.name)}.md").write_text(
-                HOME_BANNER + body, encoding="utf-8"
-            )
-
-    # Sidebar for GitHub wiki
-    sidebar_lines = [
-        HOME_BANNER.strip(),
-        "",
-        "**OKF**",
-        "[[Home]]",
-    ]
-    for path in sorted(OKF.glob("*.md")):
-        if path.name == "index.md":
-            continue
-        sidebar_lines.append(f"[[{_slug(path.name)}|{path.stem}]]")
-    if PACKS.is_dir() and any(PACKS.glob("v*.md")):
-        sidebar_lines.append("")
-        sidebar_lines.append("**Public packs**")
-        for path in sorted(PACKS.glob("v*.md")):
-            sidebar_lines.append(f"[[{_slug(path.name)}|{path.stem}]]")
-    (out / "_Sidebar.md").write_text("\n".join(sidebar_lines) + "\n", encoding="utf-8")
-
-    print(f"Wrote wiki mirror to {out}")
-    print("Push separately, e.g.:")
-    print("  git clone https://github.com/djtelicloud/grok-mcp-server.wiki.git")
-    print("  cp -R out-dir/* wiki-clone/ && cd wiki-clone && git add -A && git commit && git push")
+    print(f"Wrote {len(written)} wiki pages to {out}")
+    print("Publish separately, e.g.:")
+    print(
+        "  git clone https://github.com/djtelicloud/grok-mcp-server.wiki.git "
+        "grok-mcp-server.wiki"
+    )
+    print(f"  rsync -a --delete {shlex.quote(f'{out}/')} grok-mcp-server.wiki/")
+    print("  cd grok-mcp-server.wiki && git add -A && git commit && git push")
     return 0
 
 

--- a/scripts/publish_okf_wiki_mirror.py
+++ b/scripts/publish_okf_wiki_mirror.py
@@ -15,6 +15,7 @@ import argparse
 import json
 import re
 import shlex
+import shutil
 from pathlib import Path
 
 from jsonschema import Draft202012Validator
@@ -142,8 +143,13 @@ def build_mirror(out: Path) -> list[Path]:
         raise ValueError("--out-dir must be outside the repository")
 
     out.mkdir(parents=True, exist_ok=True)
-    for old in out.glob("*.md"):
-        old.unlink()
+    if (out / ".git").exists():
+        raise ValueError("--out-dir must be staging, not a Git checkout")
+    for old in out.iterdir():
+        if old.is_symlink() or old.is_file():
+            old.unlink()
+        elif old.is_dir():
+            shutil.rmtree(old)
 
     index_path, okf_files = _manifest_files()
     pack_files = _pack_files()

--- a/scripts/publish_okf_wiki_mirror.py
+++ b/scripts/publish_okf_wiki_mirror.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Build a GitHub Wiki mirror from docs/okf + public intelligence packs.
+
+Mirror only — never the source of truth. Writes markdown into --out-dir.
+Push to the repo wiki is a separate operator step (or CI with wiki write token).
+
+Example:
+  uv run python scripts/publish_okf_wiki_mirror.py --out-dir /tmp/unigrok-wiki
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+OKF = ROOT / "docs" / "okf"
+PACKS = ROOT / "docs" / "public-intelligence" / "packs"
+HOME_BANNER = """\
+> **Mirror only.** Source of truth: [OKF on the site](https://grokmcp.org/docs/okf/index.md)
+> and `docs/okf/` in the repository. Do not hand-edit this wiki.
+
+"""
+
+
+def _slug(name: str) -> str:
+    base = Path(name).stem
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", base).strip("-") or "page"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        required=True,
+        help="Directory to write wiki markdown (created if missing).",
+    )
+    parser.add_argument(
+        "--clean",
+        action="store_true",
+        help="Remove existing .md files in out-dir before writing.",
+    )
+    args = parser.parse_args()
+    out: Path = args.out_dir
+    out.mkdir(parents=True, exist_ok=True)
+    if args.clean:
+        for old in out.glob("*.md"):
+            old.unlink()
+
+    # Home
+    index = (OKF / "index.md").read_text(encoding="utf-8")
+    # Strip YAML front matter if present
+    if index.startswith("---"):
+        parts = index.split("---", 2)
+        if len(parts) >= 3:
+            index = parts[2].lstrip("\n")
+    home = HOME_BANNER + "# UniGrok knowledge (OKF mirror)\n\n" + index
+    home += "\n\n## Public intelligence packs\n\n"
+    if PACKS.is_dir():
+        for pack in sorted(PACKS.glob("v*.md")):
+            home += f"- [[{_slug(pack.name)}|{pack.stem}]]\n"
+    (out / "Home.md").write_text(home, encoding="utf-8")
+
+    # OKF pages
+    for path in sorted(OKF.glob("*.md")):
+        if path.name == "index.md":
+            continue
+        body = path.read_text(encoding="utf-8")
+        if body.startswith("---"):
+            parts = body.split("---", 2)
+            if len(parts) >= 3:
+                body = parts[2].lstrip("\n")
+        (out / f"{_slug(path.name)}.md").write_text(
+            HOME_BANNER + body, encoding="utf-8"
+        )
+
+    # Public packs
+    if PACKS.is_dir():
+        for path in sorted(PACKS.glob("v*.md")):
+            body = path.read_text(encoding="utf-8")
+            (out / f"{_slug(path.name)}.md").write_text(
+                HOME_BANNER + body, encoding="utf-8"
+            )
+
+    # Sidebar for GitHub wiki
+    sidebar_lines = [
+        HOME_BANNER.strip(),
+        "",
+        "**OKF**",
+        "[[Home]]",
+    ]
+    for path in sorted(OKF.glob("*.md")):
+        if path.name == "index.md":
+            continue
+        sidebar_lines.append(f"[[{_slug(path.name)}|{path.stem}]]")
+    if PACKS.is_dir() and any(PACKS.glob("v*.md")):
+        sidebar_lines.append("")
+        sidebar_lines.append("**Public packs**")
+        for path in sorted(PACKS.glob("v*.md")):
+            sidebar_lines.append(f"[[{_slug(path.name)}|{path.stem}]]")
+    (out / "_Sidebar.md").write_text("\n".join(sidebar_lines) + "\n", encoding="utf-8")
+
+    print(f"Wrote wiki mirror to {out}")
+    print("Push separately, e.g.:")
+    print("  git clone https://github.com/djtelicloud/grok-mcp-server.wiki.git")
+    print("  cp -R out-dir/* wiki-clone/ && cd wiki-clone && git add -A && git commit && git push")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_publish_okf_wiki_mirror.py
+++ b/tests/test_publish_okf_wiki_mirror.py
@@ -15,10 +15,17 @@ def test_build_mirror_prunes_stale_pages_and_covers_manifest(tmp_path: Path) -> 
     out.mkdir()
     stale = out / "removed-source.md"
     stale.write_text("stale", encoding="utf-8")
+    stale_data = out / "removed-source.json"
+    stale_data.write_text("{}", encoding="utf-8")
+    stale_dir = out / "removed-section"
+    stale_dir.mkdir()
+    (stale_dir / "page.md").write_text("stale", encoding="utf-8")
 
     written = mirror.build_mirror(out)
 
     assert not stale.exists()
+    assert not stale_data.exists()
+    assert not stale_dir.exists()
     assert out / "Home.md" in written
     assert out / "_Sidebar.md" in written
     manifest = json.loads(mirror.OKF_MANIFEST.read_text(encoding="utf-8"))
@@ -30,12 +37,13 @@ def test_build_mirror_prunes_stale_pages_and_covers_manifest(tmp_path: Path) -> 
     listed_packs = [mirror.ROOT / pack["body_path"] for pack in pack_manifest["packs"]]
     for pack in listed_packs:
         assert (out / f"{mirror._slug(pack.name)}.md").is_file(), pack.name
-    generated_pack_names = {
-        path.name for path in written if path.stem.startswith("v0-")
-    }
-    assert generated_pack_names == {
-        f"{mirror._slug(pack.name)}.md" for pack in listed_packs
-    }
+    written_names = {path.name for path in written}
+    expected_pack_names = {f"{mirror._slug(pack.name)}.md" for pack in listed_packs}
+    unlisted_pack_names = {
+        f"{mirror._slug(pack.name)}.md" for pack in mirror.PACKS.glob("v*.md")
+    } - expected_pack_names
+    assert expected_pack_names <= written_names
+    assert written_names.isdisjoint(unlisted_pack_names)
 
     schema_page = out / "gno-envelope-v1.schema.json.md"
     schema_text = schema_page.read_text(encoding="utf-8")
@@ -54,6 +62,13 @@ def test_reserved_wiki_slugs_are_rejected(name: str) -> None:
 def test_output_directory_must_stay_outside_repository() -> None:
     with pytest.raises(ValueError, match="outside the repository"):
         mirror.build_mirror(mirror.ROOT / "wiki-output")
+
+
+def test_git_checkout_is_never_used_as_replaceable_staging(tmp_path: Path) -> None:
+    out = tmp_path / "wiki-checkout"
+    (out / ".git").mkdir(parents=True)
+    with pytest.raises(ValueError, match="staging, not a Git checkout"):
+        mirror.build_mirror(out)
 
 
 def test_invalid_json_error_names_the_artifact(tmp_path: Path) -> None:

--- a/tests/test_publish_okf_wiki_mirror.py
+++ b/tests/test_publish_okf_wiki_mirror.py
@@ -26,8 +26,16 @@ def test_build_mirror_prunes_stale_pages_and_covers_manifest(tmp_path: Path) -> 
         if name == manifest["root"]:
             continue
         assert (out / f"{mirror._slug(name)}.md").is_file(), name
-    for pack in mirror.PACKS.glob("v*.md"):
+    pack_manifest = json.loads(mirror.PACK_MANIFEST.read_text(encoding="utf-8"))
+    listed_packs = [mirror.ROOT / pack["body_path"] for pack in pack_manifest["packs"]]
+    for pack in listed_packs:
         assert (out / f"{mirror._slug(pack.name)}.md").is_file(), pack.name
+    generated_pack_names = {
+        path.name for path in written if path.stem.startswith("v0-")
+    }
+    assert generated_pack_names == {
+        f"{mirror._slug(pack.name)}.md" for pack in listed_packs
+    }
 
     schema_page = out / "gno-envelope-v1.schema.json.md"
     schema_text = schema_page.read_text(encoding="utf-8")
@@ -46,6 +54,13 @@ def test_reserved_wiki_slugs_are_rejected(name: str) -> None:
 def test_output_directory_must_stay_outside_repository() -> None:
     with pytest.raises(ValueError, match="outside the repository"):
         mirror.build_mirror(mirror.ROOT / "wiki-output")
+
+
+def test_invalid_json_error_names_the_artifact(tmp_path: Path) -> None:
+    artifact = tmp_path / "broken.schema.json"
+    artifact.write_text("{", encoding="utf-8")
+    with pytest.raises(ValueError, match="broken.schema.json"):
+        mirror._json_page(artifact)
 
 
 def test_subscription_auth_precedes_readiness_check_in_public_docs() -> None:

--- a/tests/test_publish_okf_wiki_mirror.py
+++ b/tests/test_publish_okf_wiki_mirror.py
@@ -1,0 +1,59 @@
+"""Deterministic public OKF wiki-mirror coverage."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import publish_okf_wiki_mirror as mirror
+
+
+def test_build_mirror_prunes_stale_pages_and_covers_manifest(tmp_path: Path) -> None:
+    out = tmp_path / "wiki"
+    out.mkdir()
+    stale = out / "removed-source.md"
+    stale.write_text("stale", encoding="utf-8")
+
+    written = mirror.build_mirror(out)
+
+    assert not stale.exists()
+    assert out / "Home.md" in written
+    assert out / "_Sidebar.md" in written
+    manifest = json.loads(mirror.OKF_MANIFEST.read_text(encoding="utf-8"))
+    for name in manifest["files"]:
+        if name == manifest["root"]:
+            continue
+        assert (out / f"{mirror._slug(name)}.md").is_file(), name
+    for pack in mirror.PACKS.glob("v*.md"):
+        assert (out / f"{mirror._slug(pack.name)}.md").is_file(), pack.name
+
+    schema_page = out / "gno-envelope-v1.schema.json.md"
+    schema_text = schema_page.read_text(encoding="utf-8")
+    assert "**Mirror only.**" in schema_text
+    assert "```json" in schema_text
+    assert '"$schema"' in schema_text
+    assert "Schemas and data" in (out / "_Sidebar.md").read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("name", ["Home.md", "home.MD", "_Sidebar.md"])
+def test_reserved_wiki_slugs_are_rejected(name: str) -> None:
+    with pytest.raises(ValueError, match="reserved wiki slug"):
+        mirror._slug(name)
+
+
+def test_output_directory_must_stay_outside_repository() -> None:
+    with pytest.raises(ValueError, match="outside the repository"):
+        mirror.build_mirror(mirror.ROOT / "wiki-output")
+
+
+def test_subscription_auth_precedes_readiness_check_in_public_docs() -> None:
+    readme = (mirror.ROOT / "README.md").read_text(encoding="utf-8")
+    run_section = readme.split("## 3. Run the gateway", maxsplit=1)[1].split(
+        "## 4. Connect your IDE", maxsplit=1
+    )[0]
+    assert run_section.index(
+        "docker compose run --rm grok-cli-auth"
+    ) < run_section.index("curl --fail -s http://localhost:4765/readyz")
+    assert "CLI-only installs must authenticate before" in run_section

--- a/tests/test_release_hygiene.py
+++ b/tests/test_release_hygiene.py
@@ -299,22 +299,20 @@ def test_disposable_scratchpad_cleanup_is_consistent():
     assert "Never remove task worktrees after landing" not in skill
 
 
-def test_public_docs_surfaces_exclude_github_wiki_as_product():
-    """Public knowledge is README + OKF; GitHub Wiki is not a second tree."""
+def test_public_docs_surfaces_wiki_is_okf_mirror_only():
+    """Public knowledge source is README + OKF; wiki may mirror, never hand-edit."""
     readme = (ROOT / "README.md").read_text(encoding="utf-8")
     contributing = (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
-    freeze = (ROOT / "docs" / "design" / "public-vs-insider-surfaces.md").read_text(
-        encoding="utf-8"
-    )
+    wiki_policy = (ROOT / "docs" / "wiki-okf-mirror.md").read_text(encoding="utf-8")
 
     assert "## 8. Where docs live" in readme
     assert "https://grokmcp.org/docs/okf/index.md" in readme
-    assert "There is **no** separate GitHub Wiki product surface" in readme
-    assert "GitHub Wiki is not a product surface" in contributing
-    assert "Do not hand-edit it as source of" in contributing
-    assert "auto-publish full OKF into `.wiki.git`" in contributing
-    assert "GitHub Wiki as second docs tree" in freeze
-    assert "Forbidden** — public knowledge is README + OKF only" in freeze
+    assert "mirror only" in readme.lower() or "Mirror only" in readme
+    assert "GitHub Wiki is a mirror only" in contributing or "mirror only" in contributing.lower()
+    assert "Do **not** hand-edit" in contributing or "Do not hand-edit" in contributing
+    assert "publish_okf_wiki_mirror" in contributing
+    assert "never** source of truth" in wiki_policy or "never source of truth" in wiki_policy.lower()
+    assert "Do not hand-edit" in wiki_policy
 
 
 def test_agent_guidance_preserves_workspace_and_credential_boundaries():

--- a/tests/test_release_hygiene.py
+++ b/tests/test_release_hygiene.py
@@ -307,12 +307,14 @@ def test_public_docs_surfaces_wiki_is_okf_mirror_only():
 
     assert "## 8. Where docs live" in readme
     assert "https://grokmcp.org/docs/okf/index.md" in readme
-    assert "mirror only" in readme.lower() or "Mirror only" in readme
-    assert "GitHub Wiki is a mirror only" in contributing or "mirror only" in contributing.lower()
-    assert "Do **not** hand-edit" in contributing or "Do not hand-edit" in contributing
+    assert "mirror only" in readme.lower()
+    assert "mirror only" in contributing.lower()
+    assert "do not hand-edit" in contributing.lower().replace("**", "")
     assert "publish_okf_wiki_mirror" in contributing
-    assert "never** source of truth" in wiki_policy or "never source of truth" in wiki_policy.lower()
-    assert "Do not hand-edit" in wiki_policy
+    normalized_policy = " ".join(wiki_policy.lower().replace("**", "").split())
+    assert "never source of truth" in normalized_policy
+    assert "do not hand-edit" in normalized_policy
+    assert "rsync --delete" in wiki_policy
 
 
 def test_agent_guidance_preserves_workspace_and_credential_boundaries():


### PR DESCRIPTION
## Summary
- Promote the Grok public onboarding task onto current main.
- Make API-vs-CLI credential ordering honest before readiness checks.
- Generate a deterministic, fully replaced Wiki staging mirror from trusted manifests.
- Render linked JSON schemas/data as wiki pages and reject reserved/colliding slugs.
- Publish only schema-valid, fully scrubbed public packs and add end-to-end coverage.

## Exact head
de17e8ce86fd0b1959ddf1510a311829deeb9d69

## Changed paths
- CONTRIBUTING.md
- README.md
- docs/design/public-vs-insider-surfaces.md
- docs/public-intelligence/packs/manifest.json
- docs/public-intelligence/packs/v0-install-and-any-project.md
- docs/wiki-okf-mirror.md
- scripts/publish_okf_wiki_mirror.py
- tests/test_publish_okf_wiki_mirror.py
- tests/test_release_hygiene.py

## Verification
- uv run pytest -q tests/test_publish_okf_wiki_mirror.py tests/test_public_intelligence_packs.py tests/test_release_hygiene.py — 30 passed
- uv run ruff check scripts/publish_okf_wiki_mirror.py tests/test_publish_okf_wiki_mirror.py — passed
- uv run ruff format --check scripts/publish_okf_wiki_mirror.py tests/test_publish_okf_wiki_mirror.py — passed
- Manual mirror generation produced 21 linked pages, including JSON schema pages
- git diff --check — clean

## Risk
Low-to-moderate documentation/operator tooling. No runtime, auth implementation, package, automatic Wiki write, or Cloud Run source changes. Publishing remains a separate operator step.

Human-Sponsor: djtelicloud

Agent-Assisted-By: xAI Grok | model=grok-4.5 | model-source=provider-session | surface=Grok Build CLI | role=implementation
Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=integration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and offline operator tooling only; no auth, runtime, or automatic wiki writes.
> 
> **Overview**
> **Public onboarding** is tightened in the README: a single copy/paste Docker path, explicit warnings that there is no `npx` server and PyPI `mcp-grok` is unrelated, and **honest credential ordering** (xAI key in `.env` or `grok-cli-auth` before `/readyz`). Docs now point at **public intelligence packs** and the “close the clone, work in any project” habit.
> 
> **GitHub Wiki policy flips** from “forbidden second tree” to **optional generated mirror only** (`docs/wiki-okf-mirror.md`, CONTRIBUTING, design freeze). Source of truth stays `docs/okf/` + the site.
> 
> **New operator tooling:** `scripts/publish_okf_wiki_mirror.py` rebuilds an external staging dir from `okf-manifest.json` and schema-valid public packs—prunes stale pages, renders JSON as wiki pages, rejects slug collisions/reserved names, and prints an `rsync --delete` publish recipe (no automatic wiki push).
> 
> **New public pack** `install-and-any-project` plus tests for mirror behavior and README auth-before-readiness ordering; release hygiene asserts mirror-only wiki wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de17e8ce86fd0b1959ddf1510a311829deeb9d69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->