### PR TITLE
feat(rehydrate): brand-specific next smartest steps

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -10,6 +10,10 @@
 - Continuity lives in git/disk: private
   `../unigrok-intelligence/codex/continuity/active-work-latest.md` (if present),
   open PR notes, and `./scripts/land-status` — not chat memory.
+- **Brand next steps are mandatory after the status table.** Every brand must
+  know its own strengths and offer **1–2 plain-title next smartest tasks** it
+  can actually do (problem or benefit), not a table-only “ready.” Details and
+  the brand map live in the session-rehydrate skill §6b.
 
 ## Communication discipline
 

--- a/.agents/skills/session-rehydrate/SKILL.md
+++ b/.agents/skills/session-rehydrate/SKILL.md
@@ -110,15 +110,58 @@ Do not reuse a bare generic session key across unrelated repos.
 
 ### 6. Emit to user (only this)
 
-A short **Rehydrated** block:
+A short **Rehydrated** block, then **required brand next steps**. Table alone
+is incomplete — stopping after the summary is a product failure (observed when
+Gemini/Antigravity and some Copilot hosts only printed the table).
+
+#### 6a. Status table
 
 | Field | Value |
 |-------|--------|
+| brand (you) | Grok / Codex / Claude / Gemini / Cursor / Copilot / … |
 | cwd / branch | … |
 | main / land-status | … |
 | continuity | loaded / missing |
-| open PRs you care about | … |
-| next action | … |
+| open PRs / ready tasks | plain titles first (numbers only as footnotes) |
+
+#### 6b. Next smartest steps (mandatory — your brand)
+
+Immediately after the table, emit **1–2 concrete offers** you are uniquely
+suited to do *now*, grounded in live gates (land-status, continuity, open
+drafts, leftover **your** scratchpads, product gaps). Not generic “wait for
+instructions.” Not someone else’s job.
+
+**Format:**
+
+```text
+### Next smartest steps ([Your brand])
+1. [plain English task title] — [why this brand / what benefit]
+2. [optional second] — …
+```
+
+**How to pick (silent scan, then offer):**
+
+1. Name **your brand** and its strengths from the map below.
+2. Scan live product state for a **real problem or benefit** that map fits.
+3. Prefer work that is ready, safe for a contributor, and human-readable.
+4. If nothing fits, say so once and offer the single best hygiene or doc fix
+   for **your** surface — never an empty next-action cell.
+
+**Brand strengths map (use your row; do not invent peer authority):**
+
+| Brand | Unique strengths | Typical smart offers after hydrate |
+| --- | --- | --- |
+| **Grok CLI** | UniGrok dual-plane, silent radio, MCP gateway, hive/index-diff habits, headless CLI sessions | Plane/routing truth, rehydrate/human-radio law, Control Center readiness, contributor product docs |
+| **Codex** | Supervisor / `scripts/land` only when authorized; protected main; multi-agent coordination | Land Ready packets; prune safe orphans as supervisor; integration review; continuity ownership |
+| **Claude Code** | Deep multi-file review, CLAUDE.md fidelity, finding real defects in code/docs | Code audit of recent Live work; fix issues it spots; skill/AGENTS consistency |
+| **Gemini / Antigravity** | Large context, Google/Antigravity worktree homes, GEMINI.md surface, broad codebase read | Antigravity IDE setup fidelity; large-context architecture/docs consistency; `gemini/*` task worktrees under provider home |
+| **Cursor** (local) | Multi-agent IDE, Bugbot/automations rules, hybrid local MCP | Cursor automation thrash rules; local UniGrok client id; PR approver single-pass discipline |
+| **Cursor Cloud** | GitHub-only remote coding | **No** laptop secrets/tunnels; GitHub-only tasks; optional hosted twin only if connected |
+| **Copilot / Kimi** (VS Code) | VS Code + Copilot instructions, fast in-editor edits | `.github/copilot-instructions.md` fidelity; VS Code MCP setup; plain-title human radio in VS Code |
+
+**Forbidden:** table with only “next action: wait”; peer-brand work presented as
+yours; supervisor land/merge as a non-Codex contributor; empty “I am ready”
+with no opportunity.
 
 Then wait for the user task — or continue if they already gave one.
 

--- a/.claude/skills/session-rehydrate/SKILL.md
+++ b/.claude/skills/session-rehydrate/SKILL.md
@@ -111,15 +111,58 @@ Do not reuse a bare generic session key across unrelated repos.
 
 ### 6. Emit to user (only this)
 
-A short **Rehydrated** block:
+A short **Rehydrated** block, then **required brand next steps**. Table alone
+is incomplete — stopping after the summary is a product failure (observed when
+Gemini/Antigravity and some Copilot hosts only printed the table).
+
+#### 6a. Status table
 
 | Field | Value |
 |-------|--------|
+| brand (you) | Grok / Codex / Claude / Gemini / Cursor / Copilot / … |
 | cwd / branch | … |
 | main / land-status | … |
 | continuity | loaded / missing |
-| open PRs you care about | … |
-| next action | … |
+| open PRs / ready tasks | plain titles first (numbers only as footnotes) |
+
+#### 6b. Next smartest steps (mandatory — your brand)
+
+Immediately after the table, emit **1–2 concrete offers** you are uniquely
+suited to do *now*, grounded in live gates (land-status, continuity, open
+drafts, leftover **your** scratchpads, product gaps). Not generic “wait for
+instructions.” Not someone else’s job.
+
+**Format:**
+
+```text
+### Next smartest steps ([Your brand])
+1. [plain English task title] — [why this brand / what benefit]
+2. [optional second] — …
+```
+
+**How to pick (silent scan, then offer):**
+
+1. Name **your brand** and its strengths from the map below.
+2. Scan live product state for a **real problem or benefit** that map fits.
+3. Prefer work that is ready, safe for a contributor, and human-readable.
+4. If nothing fits, say so once and offer the single best hygiene or doc fix
+   for **your** surface — never an empty next-action cell.
+
+**Brand strengths map (use your row; do not invent peer authority):**
+
+| Brand | Unique strengths | Typical smart offers after hydrate |
+| --- | --- | --- |
+| **Grok CLI** | UniGrok dual-plane, silent radio, MCP gateway, hive/index-diff habits, headless CLI sessions | Plane/routing truth, rehydrate/human-radio law, Control Center readiness, contributor product docs |
+| **Codex** | Supervisor / `scripts/land` only when authorized; protected main; multi-agent coordination | Land Ready packets; prune safe orphans as supervisor; integration review; continuity ownership |
+| **Claude Code** | Deep multi-file review, CLAUDE.md fidelity, finding real defects in code/docs | Code audit of recent Live work; fix issues it spots; skill/AGENTS consistency |
+| **Gemini / Antigravity** | Large context, Google/Antigravity worktree homes, GEMINI.md surface, broad codebase read | Antigravity IDE setup fidelity; large-context architecture/docs consistency; `gemini/*` task worktrees under provider home |
+| **Cursor** (local) | Multi-agent IDE, Bugbot/automations rules, hybrid local MCP | Cursor automation thrash rules; local UniGrok client id; PR approver single-pass discipline |
+| **Cursor Cloud** | GitHub-only remote coding | **No** laptop secrets/tunnels; GitHub-only tasks; optional hosted twin only if connected |
+| **Copilot / Kimi** (VS Code) | VS Code + Copilot instructions, fast in-editor edits | `.github/copilot-instructions.md` fidelity; VS Code MCP setup; plain-title human radio in VS Code |
+
+**Forbidden:** table with only “next action: wait”; peer-brand work presented as
+yours; supervisor land/merge as a non-Codex contributor; empty “I am ready”
+with no opportunity.
 
 Then wait for the user task — or continue if they already gave one.
 

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -34,6 +34,30 @@ Select modular tools based on the nature of the request:
 * **Scratchpad cleanup**: After Live, abandonment, or a new task, remove **your own** finished worktree. Never delete peers' live trees or dirty main.
 * **Sponsor status**: Use Ready / Not ready / Live / Not live / Blocked and lead with the agent brand plus a plain task title. Never lead with PR numbers. Keep diffs, tool dumps, progress essays, and Git terminology internal unless the sponsor asks for technical detail.
 
+## 4b. Session rehydrate — brand next steps (Gemini / Antigravity)
+
+On **rehydrate** / **boot** / first message after IDE reset, follow
+`.agents/skills/session-rehydrate/SKILL.md`. After the short status table you
+**must** add **Next smartest steps (Gemini)** with 1–2 concrete offers.
+
+- **Your brand strengths:** large-context read of architecture and docs;
+  Antigravity / Google worktree homes; `gemini/*` task branches; GEMINI.md
+  fidelity; broad consistency sweeps humans and narrower agents miss.
+- **Do not stop at the summary table.** A table-only rehydrate is incomplete.
+- **Pick live opportunities** from land-status leftovers, open Ready packets,
+  missing Antigravity/IDE setup fidelity, or product gaps you can fix in a
+  contained worktree — plain English task titles, not PR-number leads.
+- **Not your job:** run `scripts/land`, push shared `main`, or act as Codex
+  supervisor unless the human explicitly puts you in that role.
+
+Example shape (fill with real live state, not this template text):
+
+```text
+### Next smartest steps (Gemini)
+1. Audit Antigravity MCP + worktree placement against ide-setup — catch Google-path drift.
+2. Large-context pass on architecture vs dual-plane docs — report 1–2 fixable gaps.
+```
+
 ## 5. Verification Requirements
 * A Codex/project-admin session reviews the draft PR's exact current head and alone runs `scripts/land` from a `codex/*` integration branch before protected merge and local synchronization.
 * Use `.agents/skills/unigrok-workspace-memory/SKILL.md` for commit-anchored recall. Pass the Gemini worktree's own full HEAD; Codex records the verified outcome after landing.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,6 +7,20 @@ Use the shared workspace skill at `.github/skills/using-unigrok/SKILL.md` when
 the user asks for Grok usage, "@grok" queries, second-model review, or
 cross-repo UniGrok guidance in VS Code.
 
+## Session rehydrate — brand next steps (Copilot / Kimi)
+
+On **rehydrate** / **boot** / first message after IDE reset, follow
+`.agents/skills/session-rehydrate/SKILL.md`. After the short status table you
+**must** emit **Next smartest steps (Copilot)** (or Kimi if that is the host
+model brand) with **1–2 concrete offers**. A table-only rehydrate is incomplete.
+
+- **Your strengths:** VS Code in-editor speed; this file’s fidelity; VS Code MCP
+  client setup; plain-title human radio for sponsor status.
+- **Pick live work** from land-status, open Ready packets, or VS Code / Copilot
+  setup gaps — never invent supervisor land authority.
+- Lead with brand + Ready/Live/Blocked + plain task title. Never lead with PR
+  numbers.
+
 For normal feature work:
 
 1. Keep the shared checkout on `main`; work in an isolated agent-prefixed

--- a/tests/test_release_hygiene.py
+++ b/tests/test_release_hygiene.py
@@ -255,6 +255,33 @@ def test_agent_human_radio_stays_silent_and_consistent() -> None:
     assert "Root `CLAUDE.md` if present" in claude_skill
 
 
+def test_rehydrate_requires_brand_specific_next_steps() -> None:
+    """Table-only rehydrate is incomplete; each brand must offer smart next work."""
+    shared_rules = (ROOT / ".agents" / "AGENTS.md").read_text(encoding="utf-8")
+    agent_skill = (
+        ROOT / ".agents" / "skills" / "session-rehydrate" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    claude_skill = (
+        ROOT / ".claude" / "skills" / "session-rehydrate" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    gemini_rules = (ROOT / ".gemini" / "GEMINI.md").read_text(encoding="utf-8")
+    copilot = (ROOT / ".github" / "copilot-instructions.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "Brand next steps are mandatory after the status table" in shared_rules
+    for skill in (agent_skill, claude_skill):
+        assert "Next smartest steps (mandatory — your brand)" in skill
+        assert "Brand strengths map" in skill
+        assert "Gemini / Antigravity" in skill
+        assert "Copilot / Kimi" in skill
+        assert "Table alone" in skill or "table alone" in skill.lower()
+    assert "Next smartest steps (Gemini)" in gemini_rules
+    assert "table-only rehydrate is incomplete" in gemini_rules
+    assert "Next smartest steps (Copilot)" in copilot
+    assert "table-only rehydrate is incomplete" in copilot
+
+
 def test_disposable_scratchpad_cleanup_is_consistent():
     """Own finished scratchpads may be removed; peer/main deletion stays forbidden."""
     shared = (ROOT / ".agents" / "AGENTS.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Rehydrate was sometimes **table-only** (Gemini/Antigravity, some Copilot/Kimi hosts) while Claude and Cursor already offered real next work. This makes brand-strength **Next smartest steps** mandatory after the status table.

## Changes

- Session-rehydrate skill (§6a table + §6b brand map + required 1–2 offers) for `.agents` and `.claude`
- Shared `.agents/AGENTS.md` mandate
- Gemini/Antigravity: `.gemini/GEMINI.md` §4b
- Copilot/Kimi: `.github/copilot-instructions.md`
- Hygiene test: `test_rehydrate_requires_brand_specific_next_steps`

## Tests

- `uv run pytest tests/test_release_hygiene.py -q` → 20 passed

## Risks

- Doc/skill only; agents must load product checkout for rules to apply

## Human sponsor

David Johnston / djtelicloud

## Provenance

- Head: `ca6a8e7e0f5c3ea18b4e17a2e0a568d2dd0197e4`
- Agent-Assisted-By: xAI Grok | model=grok-4.5 | model-source=provider-session | surface=Grok CLI | role=implementation

Ready for supervisor?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent-guidance only; behavior depends on agents loading the product checkout rules.
> 
> **Overview**
> Session rehydrate is tightened so agents cannot stop after a status table alone. **`.agents/AGENTS.md`** now requires **1–2 brand-specific “next smartest” tasks** after hydrate, with detail in the session-rehydrate skill.
> 
> The shared **session-rehydrate** skill (`.agents` and `.claude`) splits §6 into **6a** (table adds `brand (you)`, plain-title ready tasks) and **6b** (mandatory **Next smartest steps**, selection rules, forbidden empty “wait”, and a **brand strengths map** for Grok, Codex, Claude, Gemini, Cursor, Copilot/Kimi).
> 
> **Gemini/Antigravity** (`.gemini/GEMINI.md` §4b) and **Copilot/Kimi** (`.github/copilot-instructions.md`) get host-specific sections that mirror the same requirement.
> 
> **`test_rehydrate_requires_brand_specific_next_steps`** in `tests/test_release_hygiene.py` asserts the new strings across those guidance surfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca6a8e7e0f5c3ea18b4e17a2e0a568d2dd0197e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->