### PR TITLE
feat(rehydrate): brand-specific next smartest steps

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -10,6 +10,10 @@
 - Continuity lives in git/disk: private
   `../unigrok-intelligence/codex/continuity/active-work-latest.md` (if present),
   open PR notes, and `./scripts/land-status` — not chat memory.
+- **Brand next steps are mandatory after the status table.** Every brand must
+  know its own strengths and offer **1–2 plain-title next smartest tasks** it
+  can actually do (problem or benefit), not a table-only “ready.” Details and
+  the brand map live in the session-rehydrate skill §6b.
 
 ## Communication discipline
 

--- a/.agents/skills/session-rehydrate/SKILL.md
+++ b/.agents/skills/session-rehydrate/SKILL.md
@@ -110,15 +110,58 @@ Do not reuse a bare generic session key across unrelated repos.
 
 ### 6. Emit to user (only this)
 
-A short **Rehydrated** block:
+A short **Rehydrated** block, then **required brand next steps**. Table alone
+is incomplete — stopping after the summary is a product failure (observed when
+Gemini/Antigravity and some Copilot hosts only printed the table).
+
+#### 6a. Status table
 
 | Field | Value |
 |-------|--------|
+| brand (you) | Grok / Codex / Claude / Gemini / Cursor / Copilot / … |
 | cwd / branch | … |
 | main / land-status | … |
 | continuity | loaded / missing |
-| open PRs you care about | … |
-| next action | … |
+| open PRs / ready tasks | plain titles first (numbers only as footnotes) |
+
+#### 6b. Next smartest steps (mandatory — your brand)
+
+Immediately after the table, emit **1–2 concrete offers** you are uniquely
+suited to do *now*, grounded in live gates (land-status, continuity, open
+drafts, leftover **your** scratchpads, product gaps). Not generic “wait for
+instructions.” Not someone else’s job.
+
+**Format:**
+
+```text
+### Next smartest steps ([Your brand])
+1. [plain English task title] — [why this brand / what benefit]
+2. [optional second] — …
+```
+
+**How to pick (silent scan, then offer):**
+
+1. Name **your brand** and its strengths from the map below.
+2. Scan live product state for a **real problem or benefit** that map fits.
+3. Prefer work that is ready, safe for a contributor, and human-readable.
+4. If nothing fits, say so once and offer the single best hygiene or doc fix
+   for **your** surface — never an empty next-action cell.
+
+**Brand strengths map (use your row; do not invent peer authority):**
+
+| Brand | Unique strengths | Typical smart offers after hydrate |
+| --- | --- | --- |
+| **Grok CLI** | UniGrok dual-plane, silent radio, MCP gateway, hive/index-diff habits, headless CLI sessions | Plane/routing truth, rehydrate/human-radio law, Control Center readiness, contributor product docs |
+| **Codex** | Supervisor / `scripts/land` only when authorized; protected main; multi-agent coordination | Land Ready packets; prune safe orphans as supervisor; integration review; continuity ownership |
+| **Claude Code** | Deep multi-file review, CLAUDE.md fidelity, finding real defects in code/docs | Code audit of recent Live work; fix issues it spots; skill/AGENTS consistency |
+| **Gemini / Antigravity** | Large context, Google/Antigravity worktree homes, GEMINI.md surface, broad codebase read | Antigravity IDE setup fidelity; large-context architecture/docs consistency; `gemini/*` task worktrees under provider home |
+| **Cursor** (local) | Multi-agent IDE, Bugbot/automations rules, hybrid local MCP | Cursor automation thrash rules; local UniGrok client id; PR approver single-pass discipline |
+| **Cursor Cloud** | GitHub-only remote coding | **No** laptop secrets/tunnels; GitHub-only tasks; optional hosted twin only if connected |
+| **Copilot / Kimi** (VS Code) | VS Code + Copilot instructions, fast in-editor edits | `.github/copilot-instructions.md` fidelity; VS Code MCP setup; plain-title human radio in VS Code |
+
+**Forbidden:** table with only “next action: wait”; peer-brand work presented as
+yours; supervisor land/merge as a non-Codex contributor; empty “I am ready”
+with no opportunity.
 
 Then wait for the user task — or continue if they already gave one.
 

--- a/.claude/skills/session-rehydrate/SKILL.md
+++ b/.claude/skills/session-rehydrate/SKILL.md
@@ -111,15 +111,58 @@ Do not reuse a bare generic session key across unrelated repos.
 
 ### 6. Emit to user (only this)
 
-A short **Rehydrated** block:
+A short **Rehydrated** block, then **required brand next steps**. Table alone
+is incomplete — stopping after the summary is a product failure (observed when
+Gemini/Antigravity and some Copilot hosts only printed the table).
+
+#### 6a. Status table
 
 | Field | Value |
 |-------|--------|
+| brand (you) | Grok / Codex / Claude / Gemini / Cursor / Copilot / … |
 | cwd / branch | … |
 | main / land-status | … |
 | continuity | loaded / missing |
-| open PRs you care about | … |
-| next action | … |
+| open PRs / ready tasks | plain titles first (numbers only as footnotes) |
+
+#### 6b. Next smartest steps (mandatory — your brand)
+
+Immediately after the table, emit **1–2 concrete offers** you are uniquely
+suited to do *now*, grounded in live gates (land-status, continuity, open
+drafts, leftover **your** scratchpads, product gaps). Not generic “wait for
+instructions.” Not someone else’s job.
+
+**Format:**
+
+```text
+### Next smartest steps ([Your brand])
+1. [plain English task title] — [why this brand / what benefit]
+2. [optional second] — …
+```
+
+**How to pick (silent scan, then offer):**
+
+1. Name **your brand** and its strengths from the map below.
+2. Scan live product state for a **real problem or benefit** that map fits.
+3. Prefer work that is ready, safe for a contributor, and human-readable.
+4. If nothing fits, say so once and offer the single best hygiene or doc fix
+   for **your** surface — never an empty next-action cell.
+
+**Brand strengths map (use your row; do not invent peer authority):**
+
+| Brand | Unique strengths | Typical smart offers after hydrate |
+| --- | --- | --- |
+| **Grok CLI** | UniGrok dual-plane, silent radio, MCP gateway, hive/index-diff habits, headless CLI sessions | Plane/routing truth, rehydrate/human-radio law, Control Center readiness, contributor product docs |
+| **Codex** | Supervisor / `scripts/land` only when authorized; protected main; multi-agent coordination | Land Ready packets; prune safe orphans as supervisor; integration review; continuity ownership |
+| **Claude Code** | Deep multi-file review, CLAUDE.md fidelity, finding real defects in code/docs | Code audit of recent Live work; fix issues it spots; skill/AGENTS consistency |
+| **Gemini / Antigravity** | Large context, Google/Antigravity worktree homes, GEMINI.md surface, broad codebase read | Antigravity IDE setup fidelity; large-context architecture/docs consistency; `gemini/*` task worktrees under provider home |
+| **Cursor** (local) | Multi-agent IDE, Bugbot/automations rules, hybrid local MCP | Cursor automation thrash rules; local UniGrok client id; PR approver single-pass discipline |
+| **Cursor Cloud** | GitHub-only remote coding | **No** laptop secrets/tunnels; GitHub-only tasks; optional hosted twin only if connected |
+| **Copilot / Kimi** (VS Code) | VS Code + Copilot instructions, fast in-editor edits | `.github/copilot-instructions.md` fidelity; VS Code MCP setup; plain-title human radio in VS Code |
+
+**Forbidden:** table with only “next action: wait”; peer-brand work presented as
+yours; supervisor land/merge as a non-Codex contributor; empty “I am ready”
+with no opportunity.
 
 Then wait for the user task — or continue if they already gave one.
 

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -34,6 +34,30 @@ Select modular tools based on the nature of the request:
 * **Scratchpad cleanup**: After Live, abandonment, or a new task, remove **your own** finished worktree. Never delete peers' live trees or dirty main.
 * **Sponsor status**: Use Ready / Not ready / Live / Not live / Blocked and lead with the agent brand plus a plain task title. Never lead with PR numbers. Keep diffs, tool dumps, progress essays, and Git terminology internal unless the sponsor asks for technical detail.
 
+## 4b. Session rehydrate — brand next steps (Gemini / Antigravity)
+
+On **rehydrate** / **boot** / first message after IDE reset, follow
+`.agents/skills/session-rehydrate/SKILL.md`. After the short status table you
+**must** add **Next smartest steps (Gemini)** with 1–2 concrete offers.
+
+- **Your brand strengths:** large-context read of architecture and docs;
+  Antigravity / Google worktree homes; `gemini/*` task branches; GEMINI.md
+  fidelity; broad consistency sweeps humans and narrower agents miss.
+- **Do not stop at the summary table.** A table-only rehydrate is incomplete.
+- **Pick live opportunities** from land-status leftovers, open Ready packets,
+  missing Antigravity/IDE setup fidelity, or product gaps you can fix in a
+  contained worktree — plain English task titles, not PR-number leads.
+- **Not your job:** run `scripts/land`, push shared `main`, or act as Codex
+  supervisor unless the human explicitly puts you in that role.
+
+Example shape (fill with real live state, not this template text):
+
+```text
+### Next smartest steps (Gemini)
+1. Audit Antigravity MCP + worktree placement against ide-setup — catch Google-path drift.
+2. Large-context pass on architecture vs dual-plane docs — report 1–2 fixable gaps.
+```
+
 ## 5. Verification Requirements
 * A Codex/project-admin session reviews the draft PR's exact current head and alone runs `scripts/land` from a `codex/*` integration branch before protected merge and local synchronization.
 * Use `.agents/skills/unigrok-workspace-memory/SKILL.md` for commit-anchored recall. Pass the Gemini worktree's own full HEAD; Codex records the verified outcome after landing.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,6 +7,20 @@ Use the shared workspace skill at `.github/skills/using-unigrok/SKILL.md` when
 the user asks for Grok usage, "@grok" queries, second-model review, or
 cross-repo UniGrok guidance in VS Code.
 
+## Session rehydrate — brand next steps (Copilot / Kimi)
+
+On **rehydrate** / **boot** / first message after IDE reset, follow
+`.agents/skills/session-rehydrate/SKILL.md`. After the short status table you
+**must** emit **Next smartest steps (Copilot)** (or Kimi if that is the host
+model brand) with **1–2 concrete offers**. A table-only rehydrate is incomplete.
+
+- **Your strengths:** VS Code in-editor speed; this file’s fidelity; VS Code MCP
+  client setup; plain-title human radio for sponsor status.
+- **Pick live work** from land-status, open Ready packets, or VS Code / Copilot
+  setup gaps — never invent supervisor land authority.
+- Lead with brand + Ready/Live/Blocked + plain task title. Never lead with PR
+  numbers.
+
 For normal feature work:
 
 1. Keep the shared checkout on `main`; work in an isolated agent-prefixed

--- a/src/tools/resources.py
+++ b/src/tools/resources.py
@@ -36,7 +36,9 @@ def _to_json(payload: Any) -> str:
 # The workspace document is read by every connected agent, so every section
 # is clamped: agent-instruction files per-file, the git log block, the
 # session listing, and the assembled document as a whole.
-_WORKSPACE_DOC_LIMIT = 6000
+# Keep enough headroom for the shared rules' coordination sections while the
+# total resource clamp still bounds the payload sent to every connected agent.
+_WORKSPACE_DOC_LIMIT = 8000
 _WORKSPACE_TOTAL_LIMIT = 24000
 _WORKSPACE_SESSION_LIMIT = 20
 _WORKSPACE_GIT_TTL_SEC = 30.0

--- a/tests/test_release_hygiene.py
+++ b/tests/test_release_hygiene.py
@@ -275,7 +275,7 @@ def test_rehydrate_requires_brand_specific_next_steps() -> None:
         assert "Brand strengths map" in skill
         assert "Gemini / Antigravity" in skill
         assert "Copilot / Kimi" in skill
-        assert "Table alone" in skill or "table alone" in skill.lower()
+        assert "table alone" in skill.lower()
     assert "Next smartest steps (Gemini)" in gemini_rules
     assert "table-only rehydrate is incomplete" in gemini_rules
     assert "Next smartest steps (Copilot)" in copilot

--- a/tests/test_release_hygiene.py
+++ b/tests/test_release_hygiene.py
@@ -255,6 +255,33 @@ def test_agent_human_radio_stays_silent_and_consistent() -> None:
     assert "Root `CLAUDE.md` if present" in claude_skill
 
 
+def test_rehydrate_requires_brand_specific_next_steps() -> None:
+    """Table-only rehydrate is incomplete; each brand must offer smart next work."""
+    shared_rules = (ROOT / ".agents" / "AGENTS.md").read_text(encoding="utf-8")
+    agent_skill = (
+        ROOT / ".agents" / "skills" / "session-rehydrate" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    claude_skill = (
+        ROOT / ".claude" / "skills" / "session-rehydrate" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    gemini_rules = (ROOT / ".gemini" / "GEMINI.md").read_text(encoding="utf-8")
+    copilot = (ROOT / ".github" / "copilot-instructions.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "Brand next steps are mandatory after the status table" in shared_rules
+    for skill in (agent_skill, claude_skill):
+        assert "Next smartest steps (mandatory — your brand)" in skill
+        assert "Brand strengths map" in skill
+        assert "Gemini / Antigravity" in skill
+        assert "Copilot / Kimi" in skill
+        assert "Table alone" in skill or "table alone" in skill.lower()
+    assert "Next smartest steps (Gemini)" in gemini_rules
+    assert "table-only rehydrate is incomplete" in gemini_rules
+    assert "Next smartest steps (Copilot)" in copilot
+    assert "table-only rehydrate is incomplete" in copilot
+
+
 def test_disposable_scratchpad_cleanup_is_consistent():
     """Own finished scratchpads may be removed; peer/main deletion stays forbidden."""
     shared = (ROOT / ".agents" / "AGENTS.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Integrates Grok's ready rehydrate guidance and the smallest Codex repairs required by the full landing gate. Brand-specific next steps now follow the status table across shared, Claude, Gemini/Antigravity, and Copilot/Kimi surfaces. The workspace resource per-document bound rises from 6000 to 8000 characters so the expanded shared guidance still carries its coordination sections; the existing 24000-character total clamp remains unchanged.

Supersedes #172 without modifying the active Grok lane.

## Exact head

`b6d58b44a27bb75bdac1e0e7ea003d057cefba11`

## Changed paths

- `.agents/AGENTS.md`
- `.agents/skills/session-rehydrate/SKILL.md`
- `.claude/skills/session-rehydrate/SKILL.md`
- `.gemini/GEMINI.md`
- `.github/copilot-instructions.md`
- `src/tools/resources.py`
- `tests/test_release_hygiene.py`

## Tests

- `uv run pytest tests/test_release_hygiene.py -q` — 20 passed on the final head
- `uv run pytest tests/test_multiagent.py::TestWorkspaceResource tests/test_release_hygiene.py -q` — 24 passed after the resource repair
- `./scripts/land` on final exact head — 2037 passed; runtime reconciled

## Review findings

- The first full landing attempt exposed one deterministic failure: new shared guidance pushed `Multi-Agent Git Coordination` past the 6000-character per-file workspace bound. Codex increased only that per-file bound to 8000 while preserving the 24000-character total payload clamp.
- The Gemini false positive on #172 claimed `.gemini/GEMINI.md` was missing; the file is present and the targeted suite passes.
- The valid assertion-cleanup suggestion on this PR is included in the final head.

## Risks

Low. Guidance changes affect agent boot behavior; the runtime repair only increases one already bounded instruction slice by 2000 characters and retains the overall resource cap.

## Human sponsor

David Johnston / djtelicloud

## Provenance

- `Agent-Assisted-By: xAI Grok | model=grok-4.5 | model-source=provider-session | surface=Grok CLI | role=implementation`
- `Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=user-reported | surface=Codex Desktop | role=implementation`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are agent boot/guidance and a bounded workspace slice increase; no auth, data, or core runtime behavior beyond instruction payload size.
> 
> **Overview**
> Session **rehydrate** now treats a status table alone as incomplete: agents must follow with **1–2 brand-specific “next smartest steps”** grounded in live gates, with a strengths map and forbidden patterns (empty “wait”, peer authority, table-only boot).
> 
> The rule is wired through **shared** `.agents/AGENTS.md`, **Claude** and **shared** `session-rehydrate` skills, plus **Gemini/Antigravity** (`GEMINI.md` §4b) and **Copilot/Kimi** (`.github/copilot-instructions.md`). Status tables gain a **brand (you)** row and **open PRs / ready tasks** with plain titles first.
> 
> **Runtime:** `grok://workspace` per-file instruction clamp in `resources.py` rises **6000 → 8000** characters so expanded coordination text still fits; the **24000** total workspace cap is unchanged.
> 
> **Tests:** `test_rehydrate_requires_brand_specific_next_steps` asserts the new copy across those guidance surfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6d58b44a27bb75bdac1e0e7ea003d057cefba11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
