### PR TITLE
docs(continuity): retire completed hydration lanes

### DIFF
--- a/.codex/memory/active-work.md
+++ b/.codex/memory/active-work.md
@@ -60,19 +60,22 @@ credentials, OAuth codes, tokens, or private keys here.
   `b6d58b44a27bb75bdac1e0e7ea003d057cefba11` after 2,037 tests. Protected
   merge commit `d277bf3b6948be1421943258e49a6554d36d9de5` is synchronized
   locally and remotely.
-- Exact-main CI and all three CodeQL analyzers passed. The checked GitHub state
-  has zero open PRs, code-scanning alerts, Dependabot alerts, secret-scanning
-  alerts, or draft advisories.
-- Codex pruned five finished or superseded Grok scratchpads and their stale
-  branches after proving no agent process used them and their outcomes were
-  merged or covered by passing release-hygiene tests.
+- Continuity refresh PR #174 is Live at
+  `88cb5c03819e405b038a705bbb7a1b3eb376bf11`; exact-main CI and all three
+  CodeQL analyzers passed. The checked GitHub state has zero open PRs,
+  code-scanning alerts, Dependabot alerts, secret-scanning alerts, or draft
+  advisories.
+- Five finished or superseded Grok scratchpads, one empty Antigravity
+  scratchpad, and the completed data-function scratchpad are removed. Each was
+  clean and process-free before supervisor cleanup; the data-function tree was
+  removed concurrently by its owning lane before Codex pruned its merged local
+  branch.
 - Preserve the active detached Codex thread worktree, the active
-  `agents/hydrate-data-function` worktree, the active
   `claude/hydrate-c23d9f` worktree, and the primary `main` checkout.
 - Stable `:4765` and contributor `:4766` are ready. The contributor runtime
-  marker is `b6d58b44a27bb75bdac1e0e7ea003d057cefba11` and matches the
-  current main tree. The final commit changed only a test assertion, so no
-  additional runtime restart was needed.
+  marker is `df7f6a811a15b2ae10e39e1aa0a1ce358930884a` and matches the
+  current main tree. The continuity-only landing changed no runtime source, so
+  no additional restart was needed.
 - Remote MCP is live at 100% on ready `us-central1` revision
   `unigrok-remote-mcp-7c7c30e`, image digest
   `sha256:a377d3c89cea616360cabe5cf162f5ba187fffd25a8541004cd13d32f5b03f81`.


### PR DESCRIPTION
## Summary

Keep the project-scoped handoff honest after the Antigravity and data-function hydration lanes completed.

## Exact head

`e05b265ddf5ffaf0e56f9c95dec2b15755fc123b`

## Changed path

- `.codex/memory/active-work.md`

## Verified state recorded

- Five finished Grok scratchpads, one empty Antigravity scratchpad, and the completed data-function scratchpad are removed
- The data-function owner removed its tree concurrently; Codex pruned only its merged local branch
- Active Claude, detached Codex, and primary main lanes remain protected
- Continuity refresh PR #174 is Live with exact-main CI and CodeQL green
- Runtime marker and current main remain tree-equivalent

## Tests

- `./scripts/land` on exact head — 2,037 passed; runtime unchanged
- `uv run pytest tests/test_release_hygiene.py -q` — 20 passed
- `git diff --check` — clean

## Risks

Documentation-only continuity correction. No runtime, dependency, product, or cloud source changes.

## Human sponsor

David Johnston / djtelicloud

## Provenance

- `Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=user-reported | surface=Codex Desktop | role=implementation`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only continuity update in `.codex/memory/active-work.md`; no runtime, dependency, or product code changes.
> 
> **Overview**
> Refreshes the **Latest maintainer sweep** in `.codex/memory/active-work.md` so the handoff matches post-#173 reality.
> 
> It records **continuity refresh PR #174** as Live (with CI/CodeQL green and a clean GitHub security surface), documents removal of **five finished Grok scratchpads**, an **empty Antigravity scratchpad**, and the **completed data-function scratchpad** (including concurrent owner cleanup and merged-branch pruning), and narrows the **lanes to preserve** to the detached Codex worktree, `claude/hydrate-c23d9f`, and primary `main`—dropping the retired `agents/hydrate-data-function` worktree from the list.
> 
> The **contributor runtime marker** is bumped to `df7f6a811a15b2ae10e39e1aa0a1ce358930884a` with a note that the continuity-only landing did not require another restart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e05b265ddf5ffaf0e56f9c95dec2b15755fc123b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
