### PR TITLE
docs: record retired Codex scratchpads

### DIFF
--- a/.codex/memory/active-work.md
+++ b/.codex/memory/active-work.md
@@ -69,6 +69,12 @@ credentials, OAuth codes, tokens, or private keys here.
   scratchpad, the first and rehydrated `agents/hydrate-data-function`
   scratchpads, and `claude/hydrate-c23d9f` plus `claude/hydrate-0597fe` were
   removed only after clean, process-free, and integrated-state checks.
+- Six residual unregistered Codex task directories were retired after the app
+  reported every owning task completed and unloaded, no process referenced any
+  directory, no directory remained in the Git worktree registry, and no unique
+  remote commit or open PR existed: `503b`, `8cf2`, `8de4`, `cd53`, `e9a9`, and
+  `fbfd`. The active `b161` Codex task and the primary `main` checkout were
+  explicitly excluded and reverified clean after removal.
 - Provider IDEs may automatically rehydrate a clean scratchpad after cleanup.
   A clean zero-ahead worktree is not an orphan while any live process uses it.
   Before supervisor removal, re-check process ownership, dirty state, unique


### PR DESCRIPTION
## Supervisor receipt

Codex retired six residual unregistered task directories only after verifying each owning Codex task was completed and unloaded, no process referenced the directory, no directory remained registered as a Git worktree, and no unique remote commit or open PR existed.

Preserved:
- primary `main` checkout
- active detached Codex task `b161`

Exact head: `771e25787110746d21876043a51d4e85a035a8d2`

Changed paths:
- `.codex/memory/active-work.md`

Verification:
- agent attribution check passed
- `uv run pytest -q`: 2,037 passed
- primary `main` and active `b161` reverified clean after removal

Risk:
- continuity-only documentation change; no runtime source or deployment change

Human sponsor: djtelicloud
Provider/model provenance: OpenAI Codex | model=GPT-5 | model-source=user-reported | surface=Codex Desktop | role=integration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Continuity-only documentation in `.codex/memory/active-work.md`; no application, deployment, or runtime code changes.
> 
> **Overview**
> Updates the Codex handoff in **`.codex/memory/active-work.md`** so the latest maintainer sweep documents retirement of **six residual unregistered Codex task directories** (`503b`, `8cf2`, `8de4`, `cd53`, `e9a9`, `fbfd`).
> 
> The new bullet states removal happened only after the app reported each owning task completed and unloaded, no process held the directory, nothing remained in the Git worktree registry, and there was no unique remote commit or open PR. It also records that active task **`b161`** and the primary **`main`** checkout were left in place and reverified clean afterward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 771e25787110746d21876043a51d4e85a035a8d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->