### PR TITLE
docs(cursor): Automations single-pass rule + client hygiene

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -110,6 +110,10 @@ Not live / Blocked / Who (brand)** plus the **task title**.
 
 ## Cursor Automations (PR Approver / Security Reviewer / Bugbot)
 
+Cursor-native always-on mirror for agents that load `.cursor/rules`:
+[`.cursor/rules/cursor-automations-single-pass.mdc`](../.cursor/rules/cursor-automations-single-pass.mdc).
+Keep that file aligned with this section.
+
 These rules apply to Cursor Automations and Bugbot Autofix on this repo:
 
 - **Single-agent only.** Do not spawn parallel subagents, “review modules,” or repeated fan-out batches. One serial pass per run.

--- a/.cursor/rules/cursor-automations-single-pass.mdc
+++ b/.cursor/rules/cursor-automations-single-pass.mdc
@@ -1,0 +1,18 @@
+---
+description: Cursor Automations and Bugbot single-pass discipline (PR Approver, Security Reviewer, Bugbot Autofix)
+alwaysApply: true
+---
+
+# Cursor Automations — single-pass law
+
+When acting as **PR Approver**, **Security Reviewer**, or **Bugbot Autofix** on this repo:
+
+- **Single-agent only.** No parallel subagents, “review modules,” or fan-out batches. One serial pass per run.
+- **No branch thrash.** Stay on the given PR head. Extra branches/PRs only for explicit Autofix that must commit a fix.
+- **One action per head SHA.** At most one approval **or** one concise review comment for that head. If the same automation + head already has an active run, exit without duplicating work.
+- **Ignore bot echo.** Do not re-trigger solely because `cursor[bot]`, Bugbot, Copilot, Gemini, or Codex left a review comment.
+- **Approver:** wait for Bugbot; require green required checks; approve only low-risk diffs with no unresolved medium/high Bugbot findings; otherwise comment blockers and stop.
+- **Security Reviewer:** inspect the PR diff + existing threads once; report only actionable unresolved security findings; exit cleanly. No multi-module orchestration.
+- **Bugbot Autofix:** minimal fix on the existing PR branch; commit and push that branch only.
+
+Canonical shared copy: `.agents/AGENTS.md` → **Cursor Automations**.

--- a/.cursor/rules/cursor-automations-single-pass.mdc
+++ b/.cursor/rules/cursor-automations-single-pass.mdc
@@ -7,12 +7,12 @@ alwaysApply: true
 
 When acting as **PR Approver**, **Security Reviewer**, or **Bugbot Autofix** on this repo:
 
-- **Single-agent only.** No parallel subagents, “review modules,” or fan-out batches. One serial pass per run.
-- **No branch thrash.** Stay on the given PR head. Extra branches/PRs only for explicit Autofix that must commit a fix.
-- **One action per head SHA.** At most one approval **or** one concise review comment for that head. If the same automation + head already has an active run, exit without duplicating work.
-- **Ignore bot echo.** Do not re-trigger solely because `cursor[bot]`, Bugbot, Copilot, Gemini, or Codex left a review comment.
-- **Approver:** wait for Bugbot; require green required checks; approve only low-risk diffs with no unresolved medium/high Bugbot findings; otherwise comment blockers and stop.
-- **Security Reviewer:** inspect the PR diff + existing threads once; report only actionable unresolved security findings; exit cleanly. No multi-module orchestration.
-- **Bugbot Autofix:** minimal fix on the existing PR branch; commit and push that branch only.
+- **Single-agent only.** Do not spawn parallel subagents, “review modules,” or repeated fan-out batches. One serial pass per run.
+- **No branch thrash.** Stay on the PR head you were given. Do not create extra branches/PRs unless the automation’s job is explicitly Autofix and a fix commit is required.
+- **One action per head SHA.** Post at most one approval **or** one concise review comment for a given PR head. If an active run for the same automation + head already exists, exit without duplicating work.
+- **Ignore bot echo.** Do not re-trigger meaningful work solely because `cursor[bot]`, Bugbot, Copilot, Gemini, or Codex left a review comment.
+- **Approver path:** wait for Cursor Bugbot to finish; require green required checks; approve only low-risk diffs with no unresolved medium/high Bugbot findings; otherwise comment blockers and stop.
+- **Security Reviewer path:** inspect the PR diff + existing review threads once; report only actionable unresolved security findings; exit cleanly. Never attempt multi-module orchestration.
+- **Bugbot Autofix path:** apply the minimal doc/code fix for the cited finding on the existing PR branch; commit and push that branch only.
 
 Canonical shared copy: `.agents/AGENTS.md` → **Cursor Automations**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,7 @@ Process IP and harvest live in private `djtelicloud/unigrok-intelligence`. See [
 **UI:** Control Center test bench at `http://localhost:4765/ui/`; core product path remains MCP at `http://localhost:4765/mcp`.
 
 **Cursor Automations:** PR Approver, Security Reviewer, and Bugbot Autofix must follow
-`.agents/AGENTS.md` section **Cursor Automations** — single-agent serial pass, one
+`.agents/AGENTS.md` section **Cursor Automations** (Cursor-native mirror:
+`.cursor/rules/cursor-automations-single-pass.mdc`) — single-agent serial pass, one
 action per PR head SHA, no parallel subagent fan-out, no bot-echo retriggers. Security
 Reviewer must not launch “all review modules in parallel.”

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -141,6 +141,10 @@ Put config in `~/.cursor/mcp.json` (user-global) or project `.cursor/mcp.json`:
 
 Cursor auto-detects HTTP servers from the `url` field. After saving, enable
 the server under Settings → MCP; the `agent` tool appears in Composer/chat.
+Confirm Control Center / telemetry shows caller label `cursor` (not bare
+`http:anon`) after an `agent` call. Repo rule
+[`.cursor/rules/cursor-automations-single-pass.mdc`](../.cursor/rules/cursor-automations-single-pass.mdc)
+encodes PR Approver / Security Reviewer / Bugbot Autofix single-pass discipline.
 
 ### Cursor multi-model vs UniGrok planes
 


### PR DESCRIPTION
## Summary
- Add Cursor-native `.cursor/rules/cursor-automations-single-pass.mdc` mirroring the shared Automations / Bugbot single-pass law.
- Cross-link that rule from `.agents/AGENTS.md`, root `AGENTS.md`, and Cursor IDE setup.
- Verified local Cursor MCP sends `X-Client-ID: cursor` / `cursor-forge`; live probe attributed as `http:anon|cursor`.
- Align the Cursor-native mirror exactly with the canonical shared wording after review.

## Test plan
- [x] `scripts/check_agent_attribution.py --base-ref origin/main --head HEAD` passed
- [x] Local `~/.cursor/mcp.json` has `X-Client-ID: cursor` (and forge)
- [x] Live `agent` probe (CLI/`fast`) attributed caller `http:anon|cursor`
- [x] Codex supervisor docs-only review and wording repair

## Risks
- Docs/rules only; no runtime code change.
- Cursor auto-appended `Co-authored-by: Cursor <cursoragent@cursor.com>` on the original commit; attribution checker passed.

## Human sponsor
djtelicloud

## Exact head
`ce2fe4b8828aaf75b4a38dd0dbaad7695849b345`

Agent-Assisted-By: xAI Grok | model=Grok 4.5 | model-source=user-reported | surface=Cursor | role=documentation

Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=user-reported | surface=Codex Desktop | role=integration

Made with [Cursor](https://cursor.com)