### PR TITLE
feat: add bounded runtime hydration

### DIFF
--- a/architecture.md
+++ b/architecture.md
@@ -422,3 +422,22 @@ The server runs on macOS via a lightweight helper script (`grok-mcp-helper.sh`) 
 
 ### 8.2 Production Container Setup
 The system can be deployed in a lightweight `python:3.11-slim` container, mounting the local workspace to process files over standard input/output (`stdio`) streams.
+
+---
+
+## 9. Data Hydration vs Intelligence Rehydrate
+
+UniGrok explicitly separates two fundamentally different concepts of "rehydration":
+
+### 9.1 Runtime Telemetry Process Hydration (`src/hydration.py`)
+Responsible for recovering in-process accumulators, daily budgets, cost gates, and calibration caches after a process restart without re-arming exhausted budgets or losing metrics. 
+- **Owner**: MCP server process (`HydrationService` over `SessionStoreProtocol`).
+- **Source of Truth**: The public consumer SQLite (`grok_sessions.db`).
+- **Mechanism**: Formalized `HydrationHook` classes scoped by `process_day`, `process_lifetime`, or `session`. These hooks are strictly observational, non-mutating, and fail-open.
+- **Pattern**: Lazy, first-need (e.g. caller cost hydrates only on the first request for that caller; semantic budget hydrates on the first sampled evaluation).
+
+### 9.2 Intelligence Session Rehydrate
+Responsible for recovering agent product context across chat sessions (e.g., brand guidelines, land gates, task continuity, next steps).
+- **Owner**: `session-rehydrate` skill / public rehydrate packs.
+- **Source of Truth**: Git + disk (`.agents/`, private continuity files).
+- **Mechanism**: Never folded into the public SQLite telemetry store; remains a prompt-driven skill behavior.

--- a/architecture.md
+++ b/architecture.md
@@ -430,10 +430,10 @@ The system can be deployed in a lightweight `python:3.11-slim` container, mounti
 UniGrok explicitly separates two fundamentally different concepts of "rehydration":
 
 ### 9.1 Runtime Telemetry Process Hydration (`src/hydration.py`)
-Responsible for recovering in-process accumulators, daily budgets, cost gates, and calibration caches after a process restart without re-arming exhausted budgets or losing metrics. 
+Responsible for recovering bounded in-process accumulators, daily budgets, and cost gates after a process restart without re-arming exhausted budgets or losing metrics.
 - **Owner**: MCP server process (`HydrationService` over `SessionStoreProtocol`).
-- **Source of Truth**: The public consumer SQLite (`grok_sessions.db`).
-- **Mechanism**: Formalized `HydrationHook` classes scoped by `process_day`, `process_lifetime`, or `session`. These hooks are strictly observational, non-mutating, and fail-open.
+- **Source of Truth**: The configured `SessionStoreProtocol`; the reference implementation currently persists it in SQLite (`grok_sessions.db`).
+- **Mechanism**: Formalized `HydrationHook` classes scoped by `process_day`, `process_lifetime`, or `session`. Hooks read durable state and update only bounded in-memory process state; failed reads remain fail-open and retryable.
 - **Pattern**: Lazy, first-need (e.g. caller cost hydrates only on the first request for that caller; semantic budget hydrates on the first sampled evaluation).
 
 ### 9.2 Intelligence Session Rehydrate

--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -511,6 +511,62 @@ host. Production Cloud Run serves ``mcp.grokmcp.org`` (and similar), so
 authenticated /mcp traffic must allow the public hostname from
 ``UNIGROK_PUBLIC_MCP_URL`` or the optional override.
 
+## hydration.py {#hydration}
+
+### Class: `HydrationService` {#hydration-hydrationservice}
+
+```python
+class HydrationService
+```
+
+**Keywords:** hydration, service
+
+Coordinate idempotent hooks for one concrete store instance.
+
+Hook execution happens outside locks. A shared in-flight future prevents
+concurrent first-use requests from running the same hook twice. Failed or
+cancelled hydration is never marked complete, so a later request retries.
+
+### Method: `HydrationService.hydrate_hook` {#hydration-hydrationservice-hydrate_hook}
+
+```python
+async def HydrationService.hydrate_hook(self, hook_name: str, ctx: Optional[HydrationContext]=None) -> bool
+```
+
+**Keywords:** hydration, service, hydrate, hook
+
+Hydrate one hook, returning whether its scope is hydrated.
+
+### Function: `get_hydration_service` {#hydration-get_hydration_service}
+
+```python
+def get_hydration_service(store: SessionStoreProtocol) -> HydrationService
+```
+
+**Keywords:** get, hydration, service
+
+Return the service bound to exactly this store instance.
+
+### Function: `reset_hydration_services` {#hydration-reset_hydration_services}
+
+```python
+def reset_hydration_services() -> None
+```
+
+**Keywords:** reset, hydration, services
+
+Reset the process registry (tests and controlled service teardown).
+
+### Function: `reset_hydration_service` {#hydration-reset_hydration_service}
+
+```python
+def reset_hydration_service() -> None
+```
+
+**Keywords:** reset, hydration, service
+
+Backward-compatible singular alias.
+
 ## identity.py {#identity}
 
 ### Function: `scoped_session` {#identity-scoped_session}

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -511,6 +511,62 @@ host. Production Cloud Run serves ``mcp.grokmcp.org`` (and similar), so
 authenticated /mcp traffic must allow the public hostname from
 ``UNIGROK_PUBLIC_MCP_URL`` or the optional override.
 
+## hydration.py {#hydration}
+
+### Class: `HydrationService` {#hydration-hydrationservice}
+
+```python
+class HydrationService
+```
+
+**Keywords:** hydration, service
+
+Coordinate idempotent hooks for one concrete store instance.
+
+Hook execution happens outside locks. A shared in-flight future prevents
+concurrent first-use requests from running the same hook twice. Failed or
+cancelled hydration is never marked complete, so a later request retries.
+
+### Method: `HydrationService.hydrate_hook` {#hydration-hydrationservice-hydrate_hook}
+
+```python
+async def HydrationService.hydrate_hook(self, hook_name: str, ctx: Optional[HydrationContext]=None) -> bool
+```
+
+**Keywords:** hydration, service, hydrate, hook
+
+Hydrate one hook, returning whether its scope is hydrated.
+
+### Function: `get_hydration_service` {#hydration-get_hydration_service}
+
+```python
+def get_hydration_service(store: SessionStoreProtocol) -> HydrationService
+```
+
+**Keywords:** get, hydration, service
+
+Return the service bound to exactly this store instance.
+
+### Function: `reset_hydration_services` {#hydration-reset_hydration_services}
+
+```python
+def reset_hydration_services() -> None
+```
+
+**Keywords:** reset, hydration, services
+
+Reset the process registry (tests and controlled service teardown).
+
+### Function: `reset_hydration_service` {#hydration-reset_hydration_service}
+
+```python
+def reset_hydration_service() -> None
+```
+
+**Keywords:** reset, hydration, service
+
+Backward-compatible singular alias.
+
 ## identity.py {#identity}
 
 ### Function: `scoped_session` {#identity-scoped_session}

--- a/src/hydration.py
+++ b/src/hydration.py
@@ -1,0 +1,142 @@
+"""Hydration Service for broader application telemetry recovery.
+
+This module provides an orchestration seam to manage hydration hooks over
+the SessionStoreProtocol. It separates runtime telemetry process hydration
+(floors for in-process budgets, gates, caches) from intelligence session
+rehydration (a git/disk skill).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, Optional, Protocol, Set
+
+from .storage import SessionStoreProtocol
+
+_LOGGER = logging.getLogger("GrokMCP.Hydration")
+
+@dataclass
+class HydrationContext:
+    session_id: Optional[str] = None
+
+class HydrationResult:
+    pass
+
+class HydrationHook(Protocol):
+    name: str
+    scope: str  # "process_day" | "process_lifetime" | "session"
+
+    async def hydrate(self, store: SessionStoreProtocol, ctx: HydrationContext) -> HydrationResult:
+        ...
+
+class HydrationService:
+    def __init__(self, store: SessionStoreProtocol):
+        self.store = store
+        self._hooks: Dict[str, HydrationHook] = {}
+        self._lock = threading.Lock()
+        
+        # State tracking for idempotency
+        self._process_day_hydrated: Dict[str, str] = {}  # hook_name -> iso_date
+        self._process_lifetime_hydrated: Set[str] = set()  # hook_name
+        self._session_hydrated: Dict[str, Set[str]] = {}  # session_id -> set of hook_names
+
+    def register(self, hook: HydrationHook) -> None:
+        with self._lock:
+            self._hooks[hook.name] = hook
+
+    async def hydrate_hook(self, hook_name: str, ctx: Optional[HydrationContext] = None) -> None:
+        """Hydrate a specific hook by name, subject to its scope idempotency."""
+        hook = self._hooks.get(hook_name)
+        if not hook:
+            return
+
+        ctx = ctx or HydrationContext()
+        today = datetime.now().date().isoformat()
+        
+        with self._lock:
+            if hook.scope == "process_day":
+                if self._process_day_hydrated.get(hook.name) == today:
+                    return
+            elif hook.scope == "process_lifetime":
+                if hook.name in self._process_lifetime_hydrated:
+                    return
+            elif hook.scope == "session":
+                if not ctx.session_id:
+                    _LOGGER.warning(f"Hook {hook.name} requires session_id but none provided.")
+                    return
+                if hook.name in self._session_hydrated.get(ctx.session_id, set()):
+                    return
+
+        # Execute hydrate outside lock to avoid blocking other operations
+        try:
+            await hook.hydrate(self.store, ctx)
+        except Exception as exc:
+            _LOGGER.warning(f"Hydration failed for hook {hook.name}: {exc}")
+            return  # Fail open, do not mark as hydrated so it can retry
+
+        # Mark as hydrated upon success
+        with self._lock:
+            if hook.scope == "process_day":
+                self._process_day_hydrated[hook.name] = today
+            elif hook.scope == "process_lifetime":
+                self._process_lifetime_hydrated.add(hook.name)
+            elif hook.scope == "session":
+                if ctx.session_id:
+                    if ctx.session_id not in self._session_hydrated:
+                        self._session_hydrated[ctx.session_id] = set()
+                    self._session_hydrated[ctx.session_id].add(hook.name)
+
+    async def hydrate_process_day(self) -> None:
+        """Hydrate all process_day scoped hooks."""
+        hooks_to_run = []
+        with self._lock:
+            for hook in self._hooks.values():
+                if hook.scope == "process_day":
+                    hooks_to_run.append(hook.name)
+                    
+        # Parallelize independent hooks
+        if hooks_to_run:
+            tasks = [self.hydrate_hook(name) for name in hooks_to_run]
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def hydrate_process_lifetime(self) -> None:
+        """Hydrate all process_lifetime scoped hooks."""
+        hooks_to_run = []
+        with self._lock:
+            for hook in self._hooks.values():
+                if hook.scope == "process_lifetime":
+                    hooks_to_run.append(hook.name)
+                    
+        if hooks_to_run:
+            tasks = [self.hydrate_hook(name) for name in hooks_to_run]
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def hydrate_session(self, session_id: str) -> None:
+        """Hydrate all session scoped hooks for a given session_id."""
+        hooks_to_run = []
+        ctx = HydrationContext(session_id=session_id)
+        with self._lock:
+            for hook in self._hooks.values():
+                if hook.scope == "session":
+                    hooks_to_run.append(hook.name)
+                    
+        if hooks_to_run:
+            tasks = [self.hydrate_hook(name, ctx) for name in hooks_to_run]
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+_SERVICE: Optional[HydrationService] = None
+
+def get_hydration_service(store: SessionStoreProtocol) -> HydrationService:
+    global _SERVICE
+    if _SERVICE is None:
+        _SERVICE = HydrationService(store)
+    return _SERVICE
+
+def reset_hydration_service() -> None:
+    """Reset the global hydration service (for tests)."""
+    global _SERVICE
+    _SERVICE = None

--- a/src/hydration.py
+++ b/src/hydration.py
@@ -1,9 +1,8 @@
-"""Hydration Service for broader application telemetry recovery.
+"""Read-only process hydration for bounded in-memory runtime state.
 
-This module provides an orchestration seam to manage hydration hooks over
-the SessionStoreProtocol. It separates runtime telemetry process hydration
-(floors for in-process budgets, gates, caches) from intelligence session
-rehydration (a git/disk skill).
+Hydration hooks recover in-process counters and caches from the configured
+``SessionStoreProtocol``. This is intentionally separate from agent session
+rehydration, whose continuity remains in Git and disk-backed skills.
 """
 
 from __future__ import annotations
@@ -13,130 +12,179 @@ import logging
 import threading
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, Optional, Protocol, Set
+from typing import Any, Dict, Literal, Optional, Protocol, Set, Tuple
+from weakref import WeakKeyDictionary
 
 from .storage import SessionStoreProtocol
 
 _LOGGER = logging.getLogger("GrokMCP.Hydration")
 
-@dataclass
+HydrationScope = Literal["process_day", "process_lifetime", "session"]
+_VALID_SCOPES = frozenset(("process_day", "process_lifetime", "session"))
+
+
+@dataclass(frozen=True)
 class HydrationContext:
     session_id: Optional[str] = None
 
+
+@dataclass(frozen=True)
 class HydrationResult:
-    pass
+    detail: str = ""
+
 
 class HydrationHook(Protocol):
     name: str
-    scope: str  # "process_day" | "process_lifetime" | "session"
+    scope: HydrationScope
 
-    async def hydrate(self, store: SessionStoreProtocol, ctx: HydrationContext) -> HydrationResult:
-        ...
+    async def hydrate(
+        self, store: SessionStoreProtocol, ctx: HydrationContext
+    ) -> HydrationResult: ...
+
 
 class HydrationService:
+    """Coordinate idempotent hooks for one concrete store instance.
+
+    Hook execution happens outside locks. A shared in-flight future prevents
+    concurrent first-use requests from running the same hook twice. Failed or
+    cancelled hydration is never marked complete, so a later request retries.
+    """
+
     def __init__(self, store: SessionStoreProtocol):
         self.store = store
         self._hooks: Dict[str, HydrationHook] = {}
-        self._lock = threading.Lock()
-        
-        # State tracking for idempotency
-        self._process_day_hydrated: Dict[str, str] = {}  # hook_name -> iso_date
-        self._process_lifetime_hydrated: Set[str] = set()  # hook_name
-        self._session_hydrated: Dict[str, Set[str]] = {}  # session_id -> set of hook_names
+        self._hooks_lock = threading.Lock()
+        self._state_lock = asyncio.Lock()
+        self._completed: Set[Tuple[str, str]] = set()
+        self._in_flight: Dict[Tuple[str, str], asyncio.Future[bool]] = {}
 
     def register(self, hook: HydrationHook) -> None:
-        with self._lock:
+        if not hook.name:
+            raise ValueError("hydration hook name must be non-empty")
+        if hook.scope not in _VALID_SCOPES:
+            raise ValueError(f"unsupported hydration scope: {hook.scope!r}")
+        with self._hooks_lock:
             self._hooks[hook.name] = hook
 
-    async def hydrate_hook(self, hook_name: str, ctx: Optional[HydrationContext] = None) -> None:
-        """Hydrate a specific hook by name, subject to its scope idempotency."""
-        hook = self._hooks.get(hook_name)
-        if not hook:
-            return
+    @staticmethod
+    def _scope_token(
+        hook: HydrationHook, ctx: HydrationContext
+    ) -> Optional[str]:
+        if hook.scope == "process_day":
+            return datetime.now().date().isoformat()
+        if hook.scope == "process_lifetime":
+            return "process"
+        return ctx.session_id
 
-        ctx = ctx or HydrationContext()
-        today = datetime.now().date().isoformat()
-        
-        with self._lock:
-            if hook.scope == "process_day":
-                if self._process_day_hydrated.get(hook.name) == today:
-                    return
-            elif hook.scope == "process_lifetime":
-                if hook.name in self._process_lifetime_hydrated:
-                    return
-            elif hook.scope == "session":
-                if not ctx.session_id:
-                    _LOGGER.warning(f"Hook {hook.name} requires session_id but none provided.")
-                    return
-                if hook.name in self._session_hydrated.get(ctx.session_id, set()):
-                    return
+    async def hydrate_hook(
+        self, hook_name: str, ctx: Optional[HydrationContext] = None
+    ) -> bool:
+        """Hydrate one hook, returning whether its scope is hydrated."""
+        with self._hooks_lock:
+            hook = self._hooks.get(hook_name)
+        if hook is None:
+            return False
 
-        # Execute hydrate outside lock to avoid blocking other operations
+        active_ctx = ctx or HydrationContext()
+        scope_token = self._scope_token(hook, active_ctx)
+        if scope_token is None:
+            _LOGGER.warning("Hydration hook %s requires a session id", hook.name)
+            return False
+
+        key = (hook.name, scope_token)
+        owner = False
+        async with self._state_lock:
+            if key in self._completed:
+                return True
+            future = self._in_flight.get(key)
+            if future is None:
+                future = asyncio.get_running_loop().create_future()
+                self._in_flight[key] = future
+                owner = True
+
+        if not owner:
+            return await asyncio.shield(future)
+
+        succeeded = False
         try:
-            await hook.hydrate(self.store, ctx)
+            await hook.hydrate(self.store, active_ctx)
+            succeeded = True
+            return True
+        except asyncio.CancelledError:
+            raise
         except Exception as exc:
-            _LOGGER.warning(f"Hydration failed for hook {hook.name}: {exc}")
-            return  # Fail open, do not mark as hydrated so it can retry
+            _LOGGER.warning("Hydration failed for hook %s: %s", hook.name, exc)
+            return False
+        finally:
+            async with self._state_lock:
+                if succeeded:
+                    self._completed.add(key)
+                completed_future = self._in_flight.pop(key, None)
+                if completed_future is not None and not completed_future.done():
+                    completed_future.set_result(succeeded)
 
-        # Mark as hydrated upon success
-        with self._lock:
-            if hook.scope == "process_day":
-                self._process_day_hydrated[hook.name] = today
-            elif hook.scope == "process_lifetime":
-                self._process_lifetime_hydrated.add(hook.name)
-            elif hook.scope == "session":
-                if ctx.session_id:
-                    if ctx.session_id not in self._session_hydrated:
-                        self._session_hydrated[ctx.session_id] = set()
-                    self._session_hydrated[ctx.session_id].add(hook.name)
+    def _hook_names_for_scope(self, scope: HydrationScope) -> list[str]:
+        with self._hooks_lock:
+            return [
+                hook.name for hook in self._hooks.values() if hook.scope == scope
+            ]
 
     async def hydrate_process_day(self) -> None:
-        """Hydrate all process_day scoped hooks."""
-        hooks_to_run = []
-        with self._lock:
-            for hook in self._hooks.values():
-                if hook.scope == "process_day":
-                    hooks_to_run.append(hook.name)
-                    
-        # Parallelize independent hooks
-        if hooks_to_run:
-            tasks = [self.hydrate_hook(name) for name in hooks_to_run]
-            await asyncio.gather(*tasks, return_exceptions=True)
+        names = self._hook_names_for_scope("process_day")
+        if names:
+            await asyncio.gather(
+                *(self.hydrate_hook(name) for name in names),
+                return_exceptions=True,
+            )
 
     async def hydrate_process_lifetime(self) -> None:
-        """Hydrate all process_lifetime scoped hooks."""
-        hooks_to_run = []
-        with self._lock:
-            for hook in self._hooks.values():
-                if hook.scope == "process_lifetime":
-                    hooks_to_run.append(hook.name)
-                    
-        if hooks_to_run:
-            tasks = [self.hydrate_hook(name) for name in hooks_to_run]
-            await asyncio.gather(*tasks, return_exceptions=True)
+        names = self._hook_names_for_scope("process_lifetime")
+        if names:
+            await asyncio.gather(
+                *(self.hydrate_hook(name) for name in names),
+                return_exceptions=True,
+            )
 
     async def hydrate_session(self, session_id: str) -> None:
-        """Hydrate all session scoped hooks for a given session_id."""
-        hooks_to_run = []
-        ctx = HydrationContext(session_id=session_id)
-        with self._lock:
-            for hook in self._hooks.values():
-                if hook.scope == "session":
-                    hooks_to_run.append(hook.name)
-                    
-        if hooks_to_run:
-            tasks = [self.hydrate_hook(name, ctx) for name in hooks_to_run]
-            await asyncio.gather(*tasks, return_exceptions=True)
+        names = self._hook_names_for_scope("session")
+        if names:
+            ctx = HydrationContext(session_id=session_id)
+            await asyncio.gather(
+                *(self.hydrate_hook(name, ctx) for name in names),
+                return_exceptions=True,
+            )
 
-_SERVICE: Optional[HydrationService] = None
+
+_SERVICES_LOCK = threading.Lock()
+_SERVICES: WeakKeyDictionary[Any, HydrationService] = WeakKeyDictionary()
+_FALLBACK_SERVICES: Dict[int, Tuple[Any, HydrationService]] = {}
+
 
 def get_hydration_service(store: SessionStoreProtocol) -> HydrationService:
-    global _SERVICE
-    if _SERVICE is None:
-        _SERVICE = HydrationService(store)
-    return _SERVICE
+    """Return the service bound to exactly this store instance."""
+    with _SERVICES_LOCK:
+        try:
+            service = _SERVICES.get(store)
+        except TypeError:
+            entry = _FALLBACK_SERVICES.get(id(store))
+            if entry is not None and entry[0] is store:
+                return entry[1]
+            service = HydrationService(store)
+            _FALLBACK_SERVICES[id(store)] = (store, service)
+            return service
+        if service is None:
+            service = HydrationService(store)
+            _SERVICES[store] = service
+        return service
+
+
+def reset_hydration_services() -> None:
+    """Reset the process registry (tests and controlled service teardown)."""
+    with _SERVICES_LOCK:
+        _SERVICES.clear()
+        _FALLBACK_SERVICES.clear()
+
 
 def reset_hydration_service() -> None:
-    """Reset the global hydration service (for tests)."""
-    global _SERVICE
-    _SERVICE = None
+    """Backward-compatible singular alias."""
+    reset_hydration_services()

--- a/src/hydration.py
+++ b/src/hydration.py
@@ -63,8 +63,14 @@ class HydrationService:
             raise ValueError("hydration hook name must be non-empty")
         if hook.scope not in _VALID_SCOPES:
             raise ValueError(f"unsupported hydration scope: {hook.scope!r}")
+        if hook.name in self._hooks:
+            return
         with self._hooks_lock:
-            self._hooks[hook.name] = hook
+            if hook.name in self._hooks:
+                return
+            hooks = dict(self._hooks)
+            hooks[hook.name] = hook
+            self._hooks = hooks
 
     @staticmethod
     def _scope_token(
@@ -80,8 +86,7 @@ class HydrationService:
         self, hook_name: str, ctx: Optional[HydrationContext] = None
     ) -> bool:
         """Hydrate one hook, returning whether its scope is hydrated."""
-        with self._hooks_lock:
-            hook = self._hooks.get(hook_name)
+        hook = self._hooks.get(hook_name)
         if hook is None:
             return False
 
@@ -124,10 +129,9 @@ class HydrationService:
                     completed_future.set_result(succeeded)
 
     def _hook_names_for_scope(self, scope: HydrationScope) -> list[str]:
-        with self._hooks_lock:
-            return [
-                hook.name for hook in self._hooks.values() if hook.scope == scope
-            ]
+        return [
+            hook.name for hook in self._hooks.values() if hook.scope == scope
+        ]
 
     async def hydrate_process_day(self) -> None:
         names = self._hook_names_for_scope("process_day")

--- a/src/semantic_evals.py
+++ b/src/semantic_evals.py
@@ -32,6 +32,12 @@ from typing import Any, Dict, List, Optional, Set
 
 from pydantic import BaseModel, Field as PydanticField
 
+from .hydration import (
+    HydrationContext,
+    HydrationResult,
+    get_hydration_service,
+    reset_hydration_services,
+)
 from .utils import (
     _bounded_redacted,
     _env_timeout,
@@ -183,18 +189,15 @@ def _settle_budget(reservation: float, actual_cost: float) -> None:
         _STATS["judge_cost_usd_today"] += max(0.0, float(actual_cost or 0.0))
 
 
-from .hydration import HydrationContext, HydrationResult, get_hydration_service
-
 class SemanticJudgeBudgetHook:
     name = "semantic_judge_budget"
     scope = "process_day"
 
     async def hydrate(self, store: Any, ctx: HydrationContext) -> HydrationResult:
-        try:
-            durable = max(0.0, float(await store.get_semantic_judge_cost_today() or 0.0))
-        except Exception as exc:
-            logging.getLogger(_LOGGER).warning(f"Semantic eval budget hydration failed: {exc}")
-            raise  # Raise so HydrationService knows it failed and doesn't mark as hydrated
+        durable = max(
+            0.0,
+            float(await store.get_semantic_judge_cost_today() or 0.0),
+        )
 
         with _STATS_LOCK:
             _roll_budget_day_locked()
@@ -202,6 +205,7 @@ class SemanticJudgeBudgetHook:
             if durable > _STATS["judge_cost_usd_today"]:
                 _STATS["judge_cost_usd_today"] = durable
         return HydrationResult()
+
 
 async def _hydrate_budget_from_store(store: Any) -> None:
     """Once per process-day, floor the in-process spend accumulator at the
@@ -255,9 +259,7 @@ def reset_semantic_evals_state() -> None:
     _TESTING_OVERRIDE = False
     _JUDGE_SEMAPHORE = None
     _PENDING.clear()
-    
-    from .hydration import reset_hydration_service
-    reset_hydration_service()
+    reset_hydration_services()
 
 
 # ─── Judge schema + prompts ──────────────────────────────────────────────────

--- a/src/semantic_evals.py
+++ b/src/semantic_evals.py
@@ -183,26 +183,35 @@ def _settle_budget(reservation: float, actual_cost: float) -> None:
         _STATS["judge_cost_usd_today"] += max(0.0, float(actual_cost or 0.0))
 
 
+from .hydration import HydrationContext, HydrationResult, get_hydration_service
+
+class SemanticJudgeBudgetHook:
+    name = "semantic_judge_budget"
+    scope = "process_day"
+
+    async def hydrate(self, store: Any, ctx: HydrationContext) -> HydrationResult:
+        try:
+            durable = max(0.0, float(await store.get_semantic_judge_cost_today() or 0.0))
+        except Exception as exc:
+            logging.getLogger(_LOGGER).warning(f"Semantic eval budget hydration failed: {exc}")
+            raise  # Raise so HydrationService knows it failed and doesn't mark as hydrated
+
+        with _STATS_LOCK:
+            _roll_budget_day_locked()
+            _STATS["budget_hydrated_day"] = datetime.now().date().isoformat()
+            if durable > _STATS["judge_cost_usd_today"]:
+                _STATS["judge_cost_usd_today"] = durable
+        return HydrationResult()
+
 async def _hydrate_budget_from_store(store: Any) -> None:
     """Once per process-day, floor the in-process spend accumulator at the
     durable telemetry record (summed semantic.judge_cost_usd) so a restart
     cannot silently re-arm an exhausted budget. A failed store read fails
     open — un-hydrated, the in-process accounting still bounds spend within
     this process — and retries on the next sampled call."""
-    today = datetime.now().date().isoformat()
-    with _STATS_LOCK:
-        if _STATS["budget_hydrated_day"] == today:
-            return
-    try:
-        durable = max(0.0, float(await store.get_semantic_judge_cost_today() or 0.0))
-    except Exception as exc:
-        logging.getLogger(_LOGGER).warning(f"Semantic eval budget hydration failed: {exc}")
-        return
-    with _STATS_LOCK:
-        _roll_budget_day_locked()
-        _STATS["budget_hydrated_day"] = today
-        if durable > _STATS["judge_cost_usd_today"]:
-            _STATS["judge_cost_usd_today"] = durable
+    service = get_hydration_service(store)
+    service.register(SemanticJudgeBudgetHook())
+    await service.hydrate_hook("semantic_judge_budget")
 
 
 def _record_scores(scores: Dict[str, int], overall: float) -> None:
@@ -246,6 +255,9 @@ def reset_semantic_evals_state() -> None:
     _TESTING_OVERRIDE = False
     _JUDGE_SEMAPHORE = None
     _PENDING.clear()
+    
+    from .hydration import reset_hydration_service
+    reset_hydration_service()
 
 
 # ─── Judge schema + prompts ──────────────────────────────────────────────────

--- a/src/utils.py
+++ b/src/utils.py
@@ -747,9 +747,12 @@ class CallerCostHook:
 
     async def hydrate(self, store: Any, ctx: HydrationContext) -> HydrationResult:
         now = time.time()
+        costs = await asyncio.gather(
+            *(store.get_caller_cost_today(principal) for principal in self.principals)
+        )
         hydrated = {
-            principal: (float(await store.get_caller_cost_today(principal)), now)
-            for principal in self.principals
+            principal: (float(cost), now)
+            for principal, cost in zip(self.principals, costs)
         }
         _CALLER_SPEND_CACHE.update(hydrated)
         return HydrationResult()

--- a/src/utils.py
+++ b/src/utils.py
@@ -736,17 +736,30 @@ def _match_caller_budget(caller: str, budgets: Dict[str, float]) -> Optional[tup
     )
 
 
-async def enforce_caller_budget(store_param: Any, caller: Optional[str]) -> None:
-    """Pre-execution per-caller daily budget gate.
+from .hydration import HydrationContext, HydrationResult, get_hydration_service
 
-    No-op unless UNIGROK_CALLER_BUDGETS is set AND the caller matches an
-    entry (unset env returns before any parsing — zero hot-path cost by
-    default). Spend is today's telemetry cost across every caller matching
-    the entry's substring (the entry IS the shared pot), read via one
-    created_at-indexed query and cached ~60s per entry. At/over budget raises
-    CallerBudgetExceeded; a failing store read degrades OPEN — a broken
-    telemetry table must not block traffic.
-    """
+class CallerCostHook:
+    name = "caller_cost"
+    scope = "process_day"
+
+    async def hydrate(self, store: Any, ctx: HydrationContext) -> HydrationResult:
+        now = time.time()
+        for principal in _caller_budgets():
+            try:
+                spent = float(await store.get_caller_cost_today(principal))
+                _CALLER_SPEND_CACHE[principal] = (spent, now)
+            except Exception as exc:
+                logging.getLogger("GrokMCP").warning(f"Caller budget hydration failed for {principal}: {exc}")
+                raise  # Fail open
+        return HydrationResult()
+
+async def enforce_caller_budget(store_param: Any, caller: Optional[str]) -> None:
+    """Check the caller against UNIGROK_CALLER_BUDGETS; raise if exceeded.
+    
+    Tolerates store unavailability (fails open so traffic isn't blocked by
+    temporary read failures). Uses a short local TTL cache to avoid hitting
+    SQLite on every single chat turn when limits are enabled. Returns safely
+    if no budget is configured or the caller has no limits."""
     if not caller or not os.environ.get("UNIGROK_CALLER_BUDGETS", "").strip():
         return
     match = _match_caller_budget(caller, _caller_budgets())
@@ -756,6 +769,11 @@ async def enforce_caller_budget(store_param: Any, caller: Optional[str]) -> None
     active_store = store_param if store_param is not None else store
     if active_store is None:
         return
+        
+    service = get_hydration_service(active_store)
+    service.register(CallerCostHook())
+    await service.hydrate_hook("caller_cost")
+    
     now = time.time()
     cached = _CALLER_SPEND_CACHE.get(entry)
     if cached is not None and (now - cached[1]) < _CALLER_SPEND_TTL_SEC:
@@ -9413,6 +9431,28 @@ class RoutingDecision:
     coding_signal: float = 0.0
     confidence: float = 0.0
     at: float = field(default_factory=time.time)
+class RoutingCalibrationHook:
+    name = "routing_calibration"
+    scope = "process_lifetime"
+    
+    def __init__(self, advisor: Any):
+        self.advisor = advisor
+
+    async def hydrate(self, store: Any, ctx: HydrationContext) -> HydrationResult:
+        try:
+            calib = await store.get_routing_calibration(
+                max_age_hours=_calibration_ttl_hours()
+            )
+            self.advisor._calibration = calib
+            self.advisor._calibration_fetched_at = time.time()
+        except Exception as exc:
+            logging.getLogger("GrokMCP").warning(
+                f"Routing calibration refresh failed: {exc}"
+            )
+            self.advisor._calibration = self.advisor._calibration or []
+            self.advisor._calibration_fetched_at = time.time()
+            raise  # Fail open
+        return HydrationResult()
 
 
 class RoutingAdvisor:
@@ -9518,7 +9558,6 @@ class RoutingAdvisor:
             # not re-probe on every borderline prompt.
             self._fetched_at = time.time()
         return self._stats
-
     async def _calibration_snapshot(self, store: Any) -> List[Dict[str, Any]]:
         """Fresh eval-calibration rows (updated_at within the TTL window).
         Mirrors _snapshot's caching/bypass rules; a store predating the v6
@@ -9532,19 +9571,12 @@ class RoutingAdvisor:
             return self._calibration or []
         if self._calibration is not None and (time.time() - self._calibration_fetched_at) < self._ttl:
             return self._calibration
-        async with self._lock:
-            if self._calibration is not None and (time.time() - self._calibration_fetched_at) < self._ttl:
-                return self._calibration
-            try:
-                self._calibration = await store.get_routing_calibration(
-                    max_age_hours=_calibration_ttl_hours()
-                )
-            except Exception as exc:
-                logging.getLogger("GrokMCP").warning(
-                    f"Routing calibration refresh failed: {exc}"
-                )
-                self._calibration = self._calibration or []
-            self._calibration_fetched_at = time.time()
+        
+        service = get_hydration_service(store)
+        service.register(RoutingCalibrationHook(self))
+        await service.hydrate_hook("routing_calibration")
+        
+        return self._calibration or []
         return self._calibration
 
     @classmethod

--- a/src/utils.py
+++ b/src/utils.py
@@ -29,6 +29,7 @@ from datetime import UTC, datetime, timedelta
 from typing import Optional, List, Dict, Any, Literal, Callable, Awaitable
 from dotenv import load_dotenv
 from pydantic import BaseModel, Field as PydanticField
+from .hydration import HydrationContext, HydrationResult, get_hydration_service
 from .routing import (
     ROUTE_CANDIDATES,
     choose_model_candidate,
@@ -736,44 +737,52 @@ def _match_caller_budget(caller: str, budgets: Dict[str, float]) -> Optional[tup
     )
 
 
-from .hydration import HydrationContext, HydrationResult, get_hydration_service
-
 class CallerCostHook:
-    name = "caller_cost"
     scope = "process_day"
+
+    def __init__(self, principals: tuple[str, ...]):
+        self.principals = principals
+        fingerprint = hashlib.sha256("\0".join(principals).encode()).hexdigest()[:12]
+        self.name = f"caller_cost:{fingerprint}"
 
     async def hydrate(self, store: Any, ctx: HydrationContext) -> HydrationResult:
         now = time.time()
-        for principal in _caller_budgets():
-            try:
-                spent = float(await store.get_caller_cost_today(principal))
-                _CALLER_SPEND_CACHE[principal] = (spent, now)
-            except Exception as exc:
-                logging.getLogger("GrokMCP").warning(f"Caller budget hydration failed for {principal}: {exc}")
-                raise  # Fail open
+        hydrated = {
+            principal: (float(await store.get_caller_cost_today(principal)), now)
+            for principal in self.principals
+        }
+        _CALLER_SPEND_CACHE.update(hydrated)
         return HydrationResult()
 
+
 async def enforce_caller_budget(store_param: Any, caller: Optional[str]) -> None:
-    """Check the caller against UNIGROK_CALLER_BUDGETS; raise if exceeded.
-    
-    Tolerates store unavailability (fails open so traffic isn't blocked by
-    temporary read failures). Uses a short local TTL cache to avoid hitting
-    SQLite on every single chat turn when limits are enabled. Returns safely
-    if no budget is configured or the caller has no limits."""
+    """Pre-execution per-caller daily budget gate.
+
+    No-op unless UNIGROK_CALLER_BUDGETS is set AND the caller matches an
+    entry (unset env returns before any parsing — zero hot-path cost by
+    default). Spend is today's telemetry cost across every caller matching
+    the entry's substring (the entry IS the shared pot), read via one
+    created_at-indexed query and cached ~60s per entry. At/over budget raises
+    CallerBudgetExceeded; a failing store read degrades OPEN — a broken
+    telemetry table must not block traffic.
+    """
     if not caller or not os.environ.get("UNIGROK_CALLER_BUDGETS", "").strip():
         return
-    match = _match_caller_budget(caller, _caller_budgets())
+    budgets = _caller_budgets()
+    match = _match_caller_budget(caller, budgets)
     if match is None:
         return
     entry, limit_usd = match
     active_store = store_param if store_param is not None else store
     if active_store is None:
         return
-        
+
+    principals = tuple(sorted(budgets))
+    hook = CallerCostHook(principals)
     service = get_hydration_service(active_store)
-    service.register(CallerCostHook())
-    await service.hydrate_hook("caller_cost")
-    
+    service.register(hook)
+    await service.hydrate_hook(hook.name)
+
     now = time.time()
     cached = _CALLER_SPEND_CACHE.get(entry)
     if cached is not None and (now - cached[1]) < _CALLER_SPEND_TTL_SEC:
@@ -9431,28 +9440,6 @@ class RoutingDecision:
     coding_signal: float = 0.0
     confidence: float = 0.0
     at: float = field(default_factory=time.time)
-class RoutingCalibrationHook:
-    name = "routing_calibration"
-    scope = "process_lifetime"
-    
-    def __init__(self, advisor: Any):
-        self.advisor = advisor
-
-    async def hydrate(self, store: Any, ctx: HydrationContext) -> HydrationResult:
-        try:
-            calib = await store.get_routing_calibration(
-                max_age_hours=_calibration_ttl_hours()
-            )
-            self.advisor._calibration = calib
-            self.advisor._calibration_fetched_at = time.time()
-        except Exception as exc:
-            logging.getLogger("GrokMCP").warning(
-                f"Routing calibration refresh failed: {exc}"
-            )
-            self.advisor._calibration = self.advisor._calibration or []
-            self.advisor._calibration_fetched_at = time.time()
-            raise  # Fail open
-        return HydrationResult()
 
 
 class RoutingAdvisor:
@@ -9571,12 +9558,19 @@ class RoutingAdvisor:
             return self._calibration or []
         if self._calibration is not None and (time.time() - self._calibration_fetched_at) < self._ttl:
             return self._calibration
-        
-        service = get_hydration_service(store)
-        service.register(RoutingCalibrationHook(self))
-        await service.hydrate_hook("routing_calibration")
-        
-        return self._calibration or []
+        async with self._lock:
+            if self._calibration is not None and (time.time() - self._calibration_fetched_at) < self._ttl:
+                return self._calibration
+            try:
+                self._calibration = await store.get_routing_calibration(
+                    max_age_hours=_calibration_ttl_hours()
+                )
+            except Exception as exc:
+                logging.getLogger("GrokMCP").warning(
+                    f"Routing calibration refresh failed: {exc}"
+                )
+                self._calibration = self._calibration or []
+            self._calibration_fetched_at = time.time()
         return self._calibration
 
     @classmethod

--- a/tests/test_hydration.py
+++ b/tests/test_hydration.py
@@ -1,0 +1,107 @@
+"""Unit tests for hydration service."""
+
+import asyncio
+import pytest
+from datetime import datetime
+
+from src.hydration import (
+    HydrationService,
+    HydrationContext,
+    HydrationResult,
+    get_hydration_service,
+    reset_hydration_service,
+)
+from src.storage import SessionStoreProtocol
+
+class FakeStore:
+    def __init__(self, cost_to_return=1.5, should_fail=False):
+        self.cost_to_return = cost_to_return
+        self.should_fail = should_fail
+        self.get_caller_cost_today_calls = 0
+
+    async def get_caller_cost_today(self, caller_principal: str) -> float:
+        self.get_caller_cost_today_calls += 1
+        if self.should_fail:
+            raise Exception("Store offline")
+        return self.cost_to_return
+
+class FakeHook:
+    def __init__(self, name, scope):
+        self.name = name
+        self.scope = scope
+        self.calls = 0
+        self.last_ctx = None
+
+    async def hydrate(self, store, ctx):
+        self.calls += 1
+        self.last_ctx = ctx
+        # Let's interact with store to prove it works
+        if hasattr(store, "get_caller_cost_today"):
+            await store.get_caller_cost_today("test")
+        return HydrationResult()
+
+@pytest.fixture
+def service():
+    reset_hydration_service()
+    store = FakeStore()
+    return get_hydration_service(store)
+
+@pytest.mark.asyncio
+async def test_hydration_service_singleton(service):
+    store2 = FakeStore()
+    service2 = get_hydration_service(store2)
+    assert service is service2
+
+@pytest.mark.asyncio
+async def test_process_day_idempotency(service):
+    hook = FakeHook("day_hook", "process_day")
+    service.register(hook)
+    
+    await service.hydrate_process_day()
+    assert hook.calls == 1
+    
+    # Second call on same day should be idempotent
+    await service.hydrate_process_day()
+    assert hook.calls == 1
+
+@pytest.mark.asyncio
+async def test_process_lifetime_idempotency(service):
+    hook = FakeHook("lifetime_hook", "process_lifetime")
+    service.register(hook)
+    
+    await service.hydrate_process_lifetime()
+    assert hook.calls == 1
+    
+    await service.hydrate_process_lifetime()
+    assert hook.calls == 1
+
+@pytest.mark.asyncio
+async def test_session_idempotency(service):
+    hook = FakeHook("session_hook", "session")
+    service.register(hook)
+    
+    await service.hydrate_session("sess-1")
+    assert hook.calls == 1
+    
+    # Same session should not trigger again
+    await service.hydrate_session("sess-1")
+    assert hook.calls == 1
+    
+    # New session should trigger
+    await service.hydrate_session("sess-2")
+    assert hook.calls == 2
+
+@pytest.mark.asyncio
+async def test_fail_open(service):
+    service.store.should_fail = True
+    hook = FakeHook("fail_hook", "process_day")
+    service.register(hook)
+    
+    await service.hydrate_process_day()
+    # Hook was called, store raised exception, HydrationService caught it (fail open)
+    assert hook.calls == 1
+    
+    # Because it failed open, it wasn't marked hydrated. The next call SHOULD try again!
+    service.store.should_fail = False
+    await service.hydrate_process_day()
+    assert hook.calls == 2

--- a/tests/test_hydration.py
+++ b/tests/test_hydration.py
@@ -123,3 +123,15 @@ async def test_failed_hydration_retries(service):
 def test_invalid_scope_is_rejected(service):
     with pytest.raises(ValueError, match="unsupported hydration scope"):
         service.register(FakeHook("invalid", "request"))
+
+
+@pytest.mark.asyncio
+async def test_first_registration_wins(service):
+    first = FakeHook("stable_hook", "process_lifetime")
+    duplicate = FakeHook("stable_hook", "process_lifetime")
+    service.register(first)
+    service.register(duplicate)
+
+    assert await service.hydrate_hook(first.name) is True
+    assert first.calls == 1
+    assert duplicate.calls == 0

--- a/tests/test_hydration.py
+++ b/tests/test_hydration.py
@@ -1,17 +1,15 @@
-"""Unit tests for hydration service."""
+"""Unit tests for bounded runtime hydration."""
 
 import asyncio
+
 import pytest
-from datetime import datetime
 
 from src.hydration import (
-    HydrationService,
-    HydrationContext,
     HydrationResult,
     get_hydration_service,
-    reset_hydration_service,
+    reset_hydration_services,
 )
-from src.storage import SessionStoreProtocol
+
 
 class FakeStore:
     def __init__(self, cost_to_return=1.5, should_fail=False):
@@ -22,86 +20,106 @@ class FakeStore:
     async def get_caller_cost_today(self, caller_principal: str) -> float:
         self.get_caller_cost_today_calls += 1
         if self.should_fail:
-            raise Exception("Store offline")
+            raise RuntimeError("store offline")
         return self.cost_to_return
 
+
 class FakeHook:
-    def __init__(self, name, scope):
+    def __init__(self, name, scope, gate=None):
         self.name = name
         self.scope = scope
+        self.gate = gate
         self.calls = 0
         self.last_ctx = None
 
     async def hydrate(self, store, ctx):
         self.calls += 1
         self.last_ctx = ctx
-        # Let's interact with store to prove it works
-        if hasattr(store, "get_caller_cost_today"):
-            await store.get_caller_cost_today("test")
+        if self.gate is not None:
+            await self.gate.wait()
+        await store.get_caller_cost_today("test")
         return HydrationResult()
+
 
 @pytest.fixture
 def service():
-    reset_hydration_service()
-    store = FakeStore()
-    return get_hydration_service(store)
+    reset_hydration_services()
+    return get_hydration_service(FakeStore())
 
-@pytest.mark.asyncio
-async def test_hydration_service_singleton(service):
-    store2 = FakeStore()
-    service2 = get_hydration_service(store2)
-    assert service is service2
+
+def test_service_is_bound_to_store_instance():
+    reset_hydration_services()
+    first_store = FakeStore()
+    second_store = FakeStore()
+
+    first = get_hydration_service(first_store)
+
+    assert get_hydration_service(first_store) is first
+    assert get_hydration_service(second_store) is not first
+
 
 @pytest.mark.asyncio
 async def test_process_day_idempotency(service):
     hook = FakeHook("day_hook", "process_day")
     service.register(hook)
-    
+
     await service.hydrate_process_day()
-    assert hook.calls == 1
-    
-    # Second call on same day should be idempotent
     await service.hydrate_process_day()
+
     assert hook.calls == 1
+
 
 @pytest.mark.asyncio
 async def test_process_lifetime_idempotency(service):
     hook = FakeHook("lifetime_hook", "process_lifetime")
     service.register(hook)
-    
+
     await service.hydrate_process_lifetime()
-    assert hook.calls == 1
-    
     await service.hydrate_process_lifetime()
+
     assert hook.calls == 1
+
 
 @pytest.mark.asyncio
 async def test_session_idempotency(service):
     hook = FakeHook("session_hook", "session")
     service.register(hook)
-    
+
     await service.hydrate_session("sess-1")
-    assert hook.calls == 1
-    
-    # Same session should not trigger again
     await service.hydrate_session("sess-1")
-    assert hook.calls == 1
-    
-    # New session should trigger
     await service.hydrate_session("sess-2")
+
     assert hook.calls == 2
 
+
 @pytest.mark.asyncio
-async def test_fail_open(service):
+async def test_concurrent_first_use_runs_hook_once(service):
+    gate = asyncio.Event()
+    hook = FakeHook("concurrent_hook", "process_lifetime", gate=gate)
+    service.register(hook)
+
+    first = asyncio.create_task(service.hydrate_hook(hook.name))
+    second = asyncio.create_task(service.hydrate_hook(hook.name))
+    await asyncio.sleep(0)
+    gate.set()
+
+    assert await asyncio.gather(first, second) == [True, True]
+    assert hook.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_hydration_retries(service):
     service.store.should_fail = True
     hook = FakeHook("fail_hook", "process_day")
     service.register(hook)
-    
-    await service.hydrate_process_day()
-    # Hook was called, store raised exception, HydrationService caught it (fail open)
-    assert hook.calls == 1
-    
-    # Because it failed open, it wasn't marked hydrated. The next call SHOULD try again!
+
+    assert await service.hydrate_hook(hook.name) is False
+
     service.store.should_fail = False
-    await service.hydrate_process_day()
+    assert await service.hydrate_hook(hook.name) is True
     assert hook.calls == 2
+
+
+def test_invalid_scope_is_rejected(service):
+    with pytest.raises(ValueError, match="unsupported hydration scope"):
+        service.register(FakeHook("invalid", "request"))


### PR DESCRIPTION
## Summary
- add store-bound, scope-aware runtime hydration for restart-safe in-memory gates
- hydrate caller and semantic-eval daily spend without changing routing calibration TTL semantics
- serialize concurrent first-use, retry failures, and refresh generated OKF mirrors
- use copy-on-write hook registration and concurrent caller-cost reads after exact-head review

## Landing contract
- Exact head: `31f63939a4a44d2c1210c7e35a9bc2fb4c797a82`
- Changed paths: `architecture.md`, `docs/okf/api-reference.md`, `sites/unigrok-control-center/public/docs/okf/api-reference.md`, `src/hydration.py`, `src/semantic_evals.py`, `src/utils.py`, `tests/test_hydration.py`
- Verification: `uv run pytest -q` — 2045 passed; focused hydration/semantic/caller/routing/OKF suite — 155 passed; compileall passed; attribution check passed
- Risk: process-local concurrency and restart accounting; bounded by per-store services, fail-open retry, unchanged calibration TTL behavior, and full regression coverage
- Human sponsor: David Johnston

## Agent provenance
- Implementation origin: Google Gemini | model=Gemini 3.1 Pro | model-source=provider-session | surface=Antigravity | role=implementation
- Integration and repair: OpenAI Codex | model=GPT-5 | model-source=user-reported | surface=Codex Desktop | role=implementation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pre-execution caller budgets and semantic-eval spend caps with new concurrency on first-use hydration; behavior stays fail-open on store errors with full test coverage.
> 
> **Overview**
> Introduces **`HydrationService`** (`src/hydration.py`) as a shared, **store-bound** coordinator for **idempotent** runtime hydration: hooks are scoped by **`process_day`**, **`process_lifetime`**, or **`session`**, run lazily on first need, dedupe concurrent first-use via in-flight futures, and **retry** after failures instead of marking complete.
> 
> **Semantic judge daily spend** and **per-caller budget** paths now register hooks instead of ad hoc “once per day” logic: `SemanticJudgeBudgetHook` floors in-process judge spend from durable telemetry after restart; `CallerCostHook` bulk-loads today’s spend for all budget principals (parallel store reads) into `_CALLER_SPEND_CACHE` before the existing ~60s per-entry cache path.
> 
> **`architecture.md`** adds §9 separating **runtime telemetry process hydration** (SQLite-backed MCP process state) from **intelligence session rehydrate** (Git/skills). Generated **OKF API reference** documents the new module; **`tests/test_hydration.py`** covers idempotency, concurrency, retries, and store binding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4532dfd34874c0fd07bf90c276d101bbfef56238. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->