### PR TITLE
docs(cursor): gate Automations rule to automation roles only

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -112,7 +112,9 @@ Not live / Blocked / Who (brand)** plus the **task title**.
 
 Cursor-native always-on mirror for agents that load `.cursor/rules`:
 [`.cursor/rules/cursor-automations-single-pass.mdc`](../.cursor/rules/cursor-automations-single-pass.mdc).
-Keep that file aligned with this section.
+Keep that file’s automation-role bullets aligned with this section. Interactive
+Composer is not bound by the automation paths below; the mirror is for
+Automations / Bugbot roles only.
 
 These rules apply to Cursor Automations and Bugbot Autofix on this repo:
 

--- a/.cursor/rules/cursor-automations-single-pass.mdc
+++ b/.cursor/rules/cursor-automations-single-pass.mdc
@@ -5,7 +5,12 @@ alwaysApply: true
 
 # Cursor Automations — single-pass law
 
-When acting as **PR Approver**, **Security Reviewer**, or **Bugbot Autofix** on this repo:
+These bullets apply **only** when acting as **PR Approver**, **Security Reviewer**,
+or **Bugbot Autofix**. Interactive Composer / normal Cursor chat is not an
+automation role — do not treat this file as commit/push authorization outside
+Autofix.
+
+When in one of those automation roles on this repo:
 
 - **Single-agent only.** Do not spawn parallel subagents, “review modules,” or repeated fan-out batches. One serial pass per run.
 - **No branch thrash.** Stay on the PR head you were given. Do not create extra branches/PRs unless the automation’s job is explicitly Autofix and a fix commit is required.


### PR DESCRIPTION
## Summary
- Close Grok residual `alwaysApply` blast-radius note after Automations single-pass law went Live.
- Clarify interactive Composer is not Autofix commit/push authorization; keep bullet parity with shared Cursor Automations law.

## Test plan
- [ ] Skim `.cursor/rules/cursor-automations-single-pass.mdc` vs `.agents/AGENTS.md` Cursor Automations bullets for parity
- [ ] Confirm role gate language is clear for Composer vs PR Approver / Security Reviewer / Bugbot Autofix


Made with [Cursor](https://cursor.com)