### PR TITLE
docs: distinguish session rehydrate vs process hydration

### DIFF
--- a/.agents/skills/session-rehydrate/SKILL.md
+++ b/.agents/skills/session-rehydrate/SKILL.md
@@ -11,6 +11,13 @@ description: >-
 New Grok/Claude/Codex sessions do **not** inherit prior chat transcripts.
 Intelligence is rehydrated from **git + disk**, not model memory.
 
+> [!IMPORTANT]
+> **Glossary: Do not conflate "Hydrate" concepts**
+> - **Session Rehydrate**: Booting intelligence from git/disk across chats (this skill).
+> - **Process / Telemetry Hydration**: In-process runtime accumulators surviving server restarts (`src/hydration.py`).
+> - **Hydration Lanes / Scratchpads**: Disposable worktrees used for isolation/continuity (`.worktrees/`).
+> Never mix these up; they are three completely separate boundaries.
+
 ## Communication discipline (same experience every session)
 
 Do this for the whole session after rehydrate:

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -34,6 +34,13 @@ Select modular tools based on the nature of the request:
 * **Scratchpad cleanup**: After Live, abandonment, or a new task, remove **your own** finished worktree. Never delete peers' live trees or dirty main.
 * **Sponsor status**: Use Ready / Not ready / Live / Not live / Blocked and lead with the agent brand plus a plain task title. Never lead with PR numbers. Keep diffs, tool dumps, progress essays, and Git terminology internal unless the sponsor asks for technical detail.
 
+> [!IMPORTANT]
+> **Glossary: Do not conflate "Hydrate" concepts**
+> - **Session Rehydrate**: Booting intelligence from git/disk across chats.
+> - **Process / Telemetry Hydration**: In-process runtime accumulators surviving server restarts (`src/hydration.py`).
+> - **Hydration Lanes / Scratchpads**: Disposable worktrees used for isolation/continuity (`.worktrees/`).
+> Never mix these up; they are three completely separate boundaries.
+
 ## 4b. Session rehydrate — brand next steps (Gemini / Antigravity)
 
 On **rehydrate** / **boot** / first message after IDE reset, follow

--- a/architecture.md
+++ b/architecture.md
@@ -422,3 +422,27 @@ The server runs on macOS via a lightweight helper script (`grok-mcp-helper.sh`) 
 
 ### 8.2 Production Container Setup
 The system can be deployed in a lightweight `python:3.11-slim` container, mounting the local workspace to process files over standard input/output (`stdio`) streams.
+
+---
+
+## 9. Glossary: The Three "Hydrate" Concepts
+
+UniGrok explicitly separates three fundamentally different concepts of "hydration" which must never be conflated:
+
+### 9.1 Runtime Telemetry Process Hydration
+Responsible for recovering in-process accumulators, daily budgets, cost gates, and calibration caches after a process restart.
+- **Owner**: MCP server process (`src/hydration.py` over `SessionStoreProtocol`).
+- **Source of Truth**: The public consumer SQLite (`grok_sessions.db`).
+- **Mechanism**: Formalized `HydrationHook` classes (`process_day`, `process_lifetime`). Lazy, first-need (observational, non-mutating, fail-open).
+
+### 9.2 Intelligence Session Rehydrate
+Responsible for recovering agent product context across chat sessions (e.g., brand guidelines, land gates, task continuity, next steps).
+- **Owner**: `session-rehydrate` skill / public rehydrate packs.
+- **Source of Truth**: Git + disk (`.agents/`, private continuity files).
+- **Mechanism**: A prompt-driven skill behavior; never folded into the public SQLite telemetry store.
+
+### 9.3 Hydration Lanes / Scratchpads
+Disposable worktrees used exclusively for isolating parallel agents or persisting intermediate state across sessions without dirtying `main`.
+- **Owner**: Agent orchestration scripts (e.g., Codex continuity).
+- **Source of Truth**: `.worktrees/` directory on disk.
+- **Mechanism**: Git worktrees used purely for git isolation.

--- a/docs/okf/metrics-tool.md
+++ b/docs/okf/metrics-tool.md
@@ -16,6 +16,13 @@ UniGrok is built for zero-trust swarm environments, providing rich operational t
 
 ## Telemetry Observability
 
+> [!IMPORTANT]
+> **Glossary: Process Hydration vs Intelligence Rehydrate**
+> - **Process / Telemetry Hydration**: When the server restarts, metrics (like caller budgets and semantic evaluator spend) are "hydrated" (recovered) from the durable `grok_sessions.db` to ensure honest limits and observability.
+> - **Session Rehydrate**: The act of an agent reading git/disk to recover task intelligence.
+> - **Hydration Lanes**: Disposable `.worktrees/` used for isolation.
+> Only **Process Hydration** relates to UniGrok telemetry.
+
 ### 1. MCP Status Tool (`grok_mcp_status`)
 Query gateway metrics through the MCP tool on any surface where live
 `tools/list` exposes it:


### PR DESCRIPTION
## Summary
- distinguish runtime telemetry hydration, intelligence session rehydrate, and disposable worktree scratchpads
- keep runtime claims aligned with the landed store-bound hydration contract
- mirror the telemetry glossary into the public OKF bundle

## Landing contract
- Exact head: `8b568202564fd0cb341f65ebcad4a8be1f3f8bf3`
- Changed paths: `.agents/skills/session-rehydrate/SKILL.md`, `.gemini/GEMINI.md`, `architecture.md`, `docs/okf/metrics-tool.md`, `sites/unigrok-control-center/public/docs/okf/metrics-tool.md`
- Verification: `uv run pytest -q` — 2045 passed; release hygiene and generated OKF checks — 25 passed; attribution check passed
- Risk: documentation and agent-contract wording only; corrected stale SQLite-only and calibration-cache claims before publication
- Human sponsor: David Johnston

## Agent provenance
- Documentation origin: Google Gemini | model=Gemini 3.1 Pro | model-source=provider-session | surface=Antigravity | role=documentation
- Conflict resolution and integration: OpenAI Codex | model=GPT-5 | model-source=user-reported | surface=Codex Desktop | role=integration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent-contract wording only; no runtime or API behavior changes.
> 
> **Overview**
> This PR adds a shared **glossary** so agents and readers do not mix three similarly named “hydrate” ideas: **session rehydrate** (git/disk intelligence boot), **process / telemetry hydration** (`HydrationService` over the configured durable store after restart), and **hydration lanes / scratchpads** (disposable Git worktrees).
> 
> **Session rehydrate** and **Gemini** agent guidance now include an `[!IMPORTANT]` callout with the three definitions. **architecture.md** renames section 9 to a three-concept glossary, tightens runtime hydration wording to the store-bound contract (reference SQLite), and documents scratchpads as PR/commit truth—not the worktree folder. **OKF metrics** (`docs/okf/metrics-tool.md` and the Control Center public mirror) add the same telemetry-focused glossary, clarifying that only **process hydration** applies to gateway metrics and budgets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b585efbfe6c5107407750aeb6d5c6c52b26d47f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->