### PR TITLE
docs(cursor): add Bugbot Autofix live fidelity smoke checklist

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -126,3 +126,6 @@ These rules apply to Cursor Automations and Bugbot Autofix on this repo:
 - **Security Reviewer path:** inspect the PR diff + existing review threads once; report only actionable unresolved security findings; exit cleanly. Never attempt multi-module orchestration.
 - **Bugbot Autofix path:** apply the minimal doc/code fix for the cited finding on the existing PR branch; commit and push that branch only.
 - **Autofix fidelity:** one cited finding → one minimal fix → one push on the given PR head. Do not reopen review modules, spawn peers, or “also fix” adjacent nits. If another Autofix / Approver / Security run is already active for this head, exit.
+
+Live operator checklist: `docs/ide-setup.md` → **Bugbot Autofix live fidelity smoke**.
+Keep that checklist aligned with the bullets above.

--- a/.cursor/rules/cursor-automations-single-pass.mdc
+++ b/.cursor/rules/cursor-automations-single-pass.mdc
@@ -21,4 +21,6 @@ When in one of those automation roles on this repo:
 - **Bugbot Autofix path:** apply the minimal doc/code fix for the cited finding on the existing PR branch; commit and push that branch only.
 - **Autofix fidelity:** one cited finding → one minimal fix → one push on the given PR head. Do not reopen review modules, spawn peers, or “also fix” adjacent nits. If another Autofix / Approver / Security run is already active for this head, exit.
 
+Live operator checklist (ide-setup): **Bugbot Autofix live fidelity smoke**.
+
 Canonical shared copy: `.agents/AGENTS.md` → **Cursor Automations**.

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -157,6 +157,27 @@ own `cursor` / `cursor-forge` labels in `~/.cursor/mcp.json` or
 [`.cursor/rules/cursor-automations-single-pass.mdc`](../.cursor/rules/cursor-automations-single-pass.mdc)
 encodes PR Approver / Security Reviewer / Bugbot Autofix single-pass discipline.
 
+### Bugbot Autofix live fidelity smoke
+
+After the Autofix fidelity contract is Live, verify Automations still obey it
+before trusting the next Autofix run:
+
+1. Confirm shared law and Cursor mirror still match: `.agents/AGENTS.md` →
+   **Cursor Automations** and
+   [`.cursor/rules/cursor-automations-single-pass.mdc`](../.cursor/rules/cursor-automations-single-pass.mdc)
+   both include **Autofix fidelity** (one cited finding → one minimal fix →
+   one push) plus the Composer role gate (interactive chat is not Autofix
+   authorization).
+2. On the next real Bugbot finding: Autofix must stay on the given PR head,
+   touch only the cited finding, push once, and exit if another
+   Autofix / Approver / Security run is already active for that head.
+3. Fail the smoke if Autofix spawns peers, reopens “review modules,” or
+   “also fixes” adjacent nits — that is thrash, not fidelity.
+
+Interactive Composer (including Cursor Grok 4.5 chat) remains outside these
+automation paths; use UniGrok `@grok` peer review when you want dual-plane
+cost/route honesty instead of an Autofix mutation.
+
 ### Cursor multi-model vs UniGrok planes
 
 Cursor may list **non-Grok** models for native chat (Claude, GPT, etc.). Those


### PR DESCRIPTION
## Summary
- Add Autofix live fidelity smoke checklist to ide-setup
- Point shared AGENTS + Cursor rule mirror at that checklist (parity)
- Dry-run on Live main: Autofix fidelity bullet present in both sources after #185 merge
- Seam: Codex reconcile with open attribution smoke (#188) if both touch ide-setup; leave Claude/Copilot/Gemini packets alone

## Test plan
- [ ] Skim Autofix fidelity smoke vs Autofix fidelity bullet
- [ ] Confirm Composer role gate still excludes interactive chat from Autofix auth

Made with [Cursor](https://cursor.com)