### PR TITLE
docs(cursor): add alwaysApply UniGrok hybrid routing rule

### DIFF
--- a/.cursor/rules/cursor-unigrok-routing.mdc
+++ b/.cursor/rules/cursor-unigrok-routing.mdc
@@ -1,0 +1,33 @@
+---
+description: Cursor hybrid UniGrok MCP routing — Composer Grok 4.5 vs UniGrok planes vs Build pin
+alwaysApply: true
+---
+
+# Cursor × UniGrok routing (IDE + models)
+
+Cursor-owned always-on rule. Do **not** rewrite `docs/ide-setup.md` or
+repo-root `.mcp.json` from this rule — those surfaces have other packets.
+
+- **Hybrid MCP identity.** Prefer local UniGrok with `X-Client-ID: cursor`
+  (stable `:4765`) or `cursor-forge` (contributor `:4766`). Healthy telemetry
+  looks like `http:anon|cursor` — never treat bare `http:anon` as a healthy
+  Cursor path.
+- **Composer Grok 4.5 (Cursor-native).** Use for ordinary IDE-local edits,
+  Automations loops, and Bugbot single-pass work inside Cursor. That spend is
+  Cursor-native billing — not a UniGrok credential plane / Control Center
+  **Planes** row.
+- **UniGrok `agent` / `@grok`.** Use for dual-plane cost/route honesty,
+  cross-IDE continuity, research, CLI-sub vs metered API truth, and peer
+  review other brands can also query at `http://localhost:4765/mcp`.
+- **Build pin ≠ credential plane.** Pinning `grok-build-0.1` on UniGrok
+  `agent` is a model choice for code-heavy implementation only. CLI vs API
+  still follows UniGrok plane policy.
+- **Automations stay single-pass.** Obey
+  `cursor-automations-single-pass.mdc` — one serial pass, one action per head,
+  no peer fan-out. Interactive Composer is not Autofix authorization.
+- **Ownership boundary.** Leave repo-root `.mcp.json` (`vscode` /
+  `vscode-forge`) and peer brand packets alone. Cursor owns
+  `~/.cursor/mcp.json` / `.cursor/mcp.json` plus this rule.
+- **Provable calls.** When you invoke UniGrok, prefer recording
+  `client_id` + `model` + `plane` + `cost_usd` / billing class when the tool
+  returns them (Ready packets and live smokes).


### PR DESCRIPTION
## Summary
- Add `.cursor/rules/cursor-unigrok-routing.mdc` (alwaysApply) for Composer Grok 4.5 vs UniGrok planes vs Build pin
- Non-colliding: does **not** touch `docs/ide-setup.md`, `.mcp.json`, or peer packets
- Executable Cursor IDE+models improvement agents load automatically

## Live proof (this session)
- `grok_mcp_discover_self`: `client_id_present=true`, `client_id_normalized=cursor`, bootstrap OK, surface stable_core
- `agent` mode=fast marker `YOLO_PROOF_MARKER cursor-routing-rule-20260715T2333Z` → `PROOF_OK cursor-routing-rule`
- Receipt: model=`grok-composer-2.5-fast`, plane=`CLI`, route=`fast`, billing=`subscription`, cost_usd=`0.0`

## Codex seam
- Reconcile as Cursor-rules-only; do not fold into ide-setup consolidation (#192) unless intentional
- Leave `#188/#190/#191` and Copilot/Gemini packets alone
- Leave repo-root `.mcp.json` vscode path alone

## Test plan
- [ ] Open rule file; confirm alwaysApply + routing bullets
- [ ] Confirm PR diff is single new file under `.cursor/rules/`
- [ ] Optional: reload Cursor rules and confirm rule appears for agents


Made with [Cursor](https://cursor.com)