### PR TITLE
docs(faq): add VS Code dual-lane Copilot entry

### DIFF
--- a/docs/okf/faq.md
+++ b/docs/okf/faq.md
@@ -36,6 +36,42 @@ Enable the server under Cursor **Settings → MCP**. Cursor and the gateway must
 run on the same machine: `localhost` inside a remote development container or
 SSH host refers to that remote environment, not your laptop.
 
+## How do I connect VS Code Copilot to both the stable and Forge lanes? {#vscode-copilot-connect}
+
+**Keywords:** vscode, copilot, forge, mcp.json, dual lane, vscode-forge
+
+Use `.vscode/mcp.json` for a repository-local setup or the user-level VS Code
+MCP config when you want the same lanes in every workspace:
+
+```json
+{
+  "servers": {
+    "unigrok": {
+      "type": "http",
+      "url": "http://localhost:4765/mcp",
+      "headers": { "X-Client-ID": "vscode" }
+    },
+    "unigrok-forge": {
+      "type": "http",
+      "url": "http://localhost:4766/mcp",
+      "headers": { "X-Client-ID": "vscode-forge" }
+    }
+  }
+}
+```
+
+Use `unigrok` on port `4765` for ordinary Copilot chat and other
+workspace-neutral requests. Add `unigrok-forge` on port `4766` only while
+developing UniGrok itself, where you need repository-mounted file/git/test
+tools, workspace memory, or Swarm. Keep `XAI_API_KEY` out of the IDE config:
+credentials belong to the server-side `.env` or the authenticated Grok CLI
+plane.
+
+For day-to-day use, start with `agent(mode="fast")` or the default `auto`
+route on the stable lane and escalate to `reasoning` only when the repo state,
+tool surface, or model routing needs a deeper pass. Reload the VS Code window
+after adding the Forge lane if the tool list still looks stale.
+
 ## Do I need an xAI API key in every IDE? {#shared-api-key}
 
 **Keywords:** api key, xai api key, credentials, ide, shared gateway

--- a/sites/unigrok-control-center/public/docs/okf/faq.md
+++ b/sites/unigrok-control-center/public/docs/okf/faq.md
@@ -36,6 +36,42 @@ Enable the server under Cursor **Settings → MCP**. Cursor and the gateway must
 run on the same machine: `localhost` inside a remote development container or
 SSH host refers to that remote environment, not your laptop.
 
+## How do I connect VS Code Copilot to both the stable and Forge lanes? {#vscode-copilot-connect}
+
+**Keywords:** vscode, copilot, forge, mcp.json, dual lane, vscode-forge
+
+Use `.vscode/mcp.json` for a repository-local setup or the user-level VS Code
+MCP config when you want the same lanes in every workspace:
+
+```json
+{
+  "servers": {
+    "unigrok": {
+      "type": "http",
+      "url": "http://localhost:4765/mcp",
+      "headers": { "X-Client-ID": "vscode" }
+    },
+    "unigrok-forge": {
+      "type": "http",
+      "url": "http://localhost:4766/mcp",
+      "headers": { "X-Client-ID": "vscode-forge" }
+    }
+  }
+}
+```
+
+Use `unigrok` on port `4765` for ordinary Copilot chat and other
+workspace-neutral requests. Add `unigrok-forge` on port `4766` only while
+developing UniGrok itself, where you need repository-mounted file/git/test
+tools, workspace memory, or Swarm. Keep `XAI_API_KEY` out of the IDE config:
+credentials belong to the server-side `.env` or the authenticated Grok CLI
+plane.
+
+For day-to-day use, start with `agent(mode="fast")` or the default `auto`
+route on the stable lane and escalate to `reasoning` only when the repo state,
+tool surface, or model routing needs a deeper pass. Reload the VS Code window
+after adding the Forge lane if the tool list still looks stale.
+
 ## Do I need an xAI API key in every IDE? {#shared-api-key}
 
 **Keywords:** api key, xai api key, credentials, ide, shared gateway

--- a/tests/test_faq.py
+++ b/tests/test_faq.py
@@ -17,6 +17,7 @@ def test_faq_document_parses_release_versioned_entries():
     assert index.source_version == "0.6.0"
     assert index.get("cursor-connect") is not None
     assert index.get("CURSOR CONNECT") is not None
+    assert index.get("vscode-copilot-connect") is not None
 
 
 def test_faq_document_rejects_entries_without_keywords():
@@ -43,6 +44,19 @@ async def test_agent_faq_lookup_returns_verified_cursor_context():
     assert result["count"] >= 1
     assert result["matches"][0]["id"] == "cursor-connect"
     assert ".cursor/mcp.json" in result["matches"][0]["answer_excerpt"]
+
+
+@pytest.mark.asyncio
+async def test_agent_faq_lookup_returns_verified_vscode_dual_lane_context():
+    result = json.loads(
+        await lookup_unigrok_faq("How do I connect VS Code Copilot to stable and Forge lanes?")
+    )
+
+    assert result["source_uri"] == "grok://faq"
+    assert result["count"] >= 1
+    assert result["matches"][0]["id"] == "vscode-copilot-connect"
+    assert "vscode-forge" in result["matches"][0]["answer_excerpt"]
+    assert "agent(mode=\"fast\")" in result["matches"][0]["answer_excerpt"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a release-versioned FAQ entry for VS Code Copilot dual-lane UniGrok setup using stable `unigrok` (`:4765`) and repo-specific `unigrok-forge` (`:4766`)
- document the low-risk model habit for VS Code users: start on stable `fast` / `auto`, escalate to `reasoning` only when repo state or routing needs a deeper pass
- add FAQ tests so the new answer is parsed and retrieved through the private FAQ lookup path

## Why this avoids collisions
- exact changed paths are limited to `docs/okf/faq.md`, `sites/unigrok-control-center/public/docs/okf/faq.md`, and `tests/test_faq.py`
- this intentionally avoids `.github/copilot-instructions.md` (owned by #187) and `docs/ide-setup.md` (currently touched by open drafts #188, #190, #191, #192, and #193)

## Landing contract
- Exact head:
  - `e8663659ebc68544aaf9d11f1b1da5926e18a7e3`
- Changed paths:
  - `docs/okf/faq.md`
  - `sites/unigrok-control-center/public/docs/okf/faq.md`
  - `tests/test_faq.py`
- Verification:
  - `uv run pytest -q tests/test_faq.py tests/test_release_hygiene.py`
  - `uv run python scripts/check_agent_attribution.py --base-ref origin/main --head HEAD`
  - `uv run python scripts/generate_okf.py --write`
- Known risks:
  - low risk, docs + generated docs + tests only
  - no runtime, transport, model-routing, or credential behavior changed
- Generated files:
  - `sites/unigrok-control-center/public/docs/okf/faq.md`
- Accountable GitHub contributor:
  - David Johnston

## Agent provenance
- Agent-Assisted-By: GitHub Copilot | model=GPT-5.6 Sol | model-source=user-reported | surface=VS Code | role=implementation
- Co-authored-by: Copilot <198982749+Copilot@users.noreply.github.com>