### PR TITLE
feat(codex): discover model and plane routing live

### DIFF
--- a/.codex/mcp/grok-routing.json
+++ b/.codex/mcp/grok-routing.json
@@ -1,17 +1,45 @@
 {
   "$schema": "../schemas/grok-routing.schema.json",
-  "schema_version": 1,
+  "schema_version": 2,
   "purpose": "Codex-to-UniGrok MCP routing for this project",
   "server": "grok",
+  "logical_tools": {
+    "agent": "agent",
+    "discovery": "grok_mcp_discover_self",
+    "status": "grok_mcp_status"
+  },
+  "model_plane_contract": {
+    "catalog_source": "grok_mcp_discover_self(include_models=true)",
+    "catalog_policy": "Treat each plane's live catalog as authoritative. Never infer plane membership from a product name or persist a model snapshot as routing truth.",
+    "default_request": {
+      "mode": "auto",
+      "plane": "auto",
+      "model": null
+    },
+    "pin_policy": "Pin only an exact model id present in the selected live plane catalog. A model pin selects a model, not a new credential plane.",
+    "fallback_policy": {
+      "same_plane": "Use when crossing the caller's selected credential or billing plane is forbidden.",
+      "cross_plane": "Use only when the user or caller explicitly permits bounded recovery on the other credential plane."
+    },
+    "required_receipt_fields": [
+      "model",
+      "resolved_plane",
+      "billing_class",
+      "cost_usd",
+      "fallback_policy",
+      "finish_reason"
+    ]
+  },
   "routes": [
     {
       "id": "status",
       "when": "Codex needs UniGrok MCP availability, adapter status, or server health.",
       "preferred_tools": [
-        "agent"
+        "grok_mcp_discover_self",
+        "grok_mcp_status"
       ],
       "external_content_risk": "low",
-      "note": "Use mode fast with a short health-check prompt. The public HTTP MCP surface exposes the unified agent tool."
+      "note": "Use discovery with include_models=true when model routing matters; use status for current plane health. Neither check needs an inference call."
     },
     {
       "id": "project-file-context",
@@ -90,6 +118,6 @@
     "do_not_send_secrets": true,
     "warn_before_external_model_review_of_nonpublic_content": true,
     "discover_tools_before_using_provider_specific_deferred_routes": true,
-    "public_http_mcp_entrypoint": "mcp__grok.agent"
+    "public_http_mcp_entrypoint": "agent"
   }
 }

--- a/.codex/mcp/grok-routing.json
+++ b/.codex/mcp/grok-routing.json
@@ -14,7 +14,8 @@
     "default_request": {
       "mode": "auto",
       "plane": "auto",
-      "model": null
+      "model": null,
+      "fallback_policy": "same_plane"
     },
     "pin_policy": "Pin only an exact model id present in the selected live plane catalog. A model pin selects a model, not a new credential plane.",
     "fallback_policy": {

--- a/.codex/schemas/grok-routing.schema.json
+++ b/.codex/schemas/grok-routing.schema.json
@@ -13,8 +13,14 @@
     "safety"
   ],
   "properties": {
+    "$schema": {
+      "const": "../schemas/grok-routing.schema.json"
+    },
     "schema_version": {
       "const": 2
+    },
+    "purpose": {
+      "const": "Codex-to-UniGrok MCP routing for this project"
     },
     "server": {
       "const": "grok"
@@ -62,7 +68,8 @@
           "required": [
             "mode",
             "plane",
-            "model"
+            "model",
+            "fallback_policy"
           ],
           "properties": {
             "mode": {
@@ -73,6 +80,9 @@
             },
             "model": {
               "type": "null"
+            },
+            "fallback_policy": {
+              "const": "same_plane"
             }
           },
           "additionalProperties": false
@@ -115,6 +125,43 @@
     "routes": {
       "type": "array",
       "minItems": 1
+    },
+    "do_not_answer_directly_when": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "safety": {
+      "type": "object",
+      "required": [
+        "prefer_local_read_tools_first",
+        "do_not_send_secrets",
+        "warn_before_external_model_review_of_nonpublic_content",
+        "discover_tools_before_using_provider_specific_deferred_routes",
+        "public_http_mcp_entrypoint"
+      ],
+      "properties": {
+        "prefer_local_read_tools_first": {
+          "const": true
+        },
+        "do_not_send_secrets": {
+          "const": true
+        },
+        "warn_before_external_model_review_of_nonpublic_content": {
+          "const": true
+        },
+        "discover_tools_before_using_provider_specific_deferred_routes": {
+          "const": true
+        },
+        "public_http_mcp_entrypoint": {
+          "const": "agent"
+        }
+      },
+      "additionalProperties": false
     }
-  }
+  },
+  "additionalProperties": false
 }

--- a/.codex/schemas/grok-routing.schema.json
+++ b/.codex/schemas/grok-routing.schema.json
@@ -7,15 +7,110 @@
     "schema_version",
     "purpose",
     "server",
+    "logical_tools",
+    "model_plane_contract",
     "routes",
     "safety"
   ],
   "properties": {
     "schema_version": {
-      "const": 1
+      "const": 2
     },
     "server": {
       "const": "grok"
+    },
+    "logical_tools": {
+      "type": "object",
+      "required": [
+        "agent",
+        "discovery",
+        "status"
+      ],
+      "properties": {
+        "agent": {
+          "const": "agent"
+        },
+        "discovery": {
+          "const": "grok_mcp_discover_self"
+        },
+        "status": {
+          "const": "grok_mcp_status"
+        }
+      },
+      "additionalProperties": false
+    },
+    "model_plane_contract": {
+      "type": "object",
+      "required": [
+        "catalog_source",
+        "catalog_policy",
+        "default_request",
+        "pin_policy",
+        "fallback_policy",
+        "required_receipt_fields"
+      ],
+      "properties": {
+        "catalog_source": {
+          "const": "grok_mcp_discover_self(include_models=true)"
+        },
+        "catalog_policy": {
+          "type": "string",
+          "minLength": 1
+        },
+        "default_request": {
+          "type": "object",
+          "required": [
+            "mode",
+            "plane",
+            "model"
+          ],
+          "properties": {
+            "mode": {
+              "const": "auto"
+            },
+            "plane": {
+              "const": "auto"
+            },
+            "model": {
+              "type": "null"
+            }
+          },
+          "additionalProperties": false
+        },
+        "pin_policy": {
+          "type": "string",
+          "minLength": 1
+        },
+        "fallback_policy": {
+          "type": "object",
+          "required": [
+            "same_plane",
+            "cross_plane"
+          ],
+          "properties": {
+            "same_plane": {
+              "type": "string",
+              "minLength": 1
+            },
+            "cross_plane": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "additionalProperties": false
+        },
+        "required_receipt_fields": {
+          "const": [
+            "model",
+            "resolved_plane",
+            "billing_class",
+            "cost_usd",
+            "fallback_policy",
+            "finish_reason"
+          ]
+        }
+      },
+      "additionalProperties": false
     },
     "routes": {
       "type": "array",
@@ -23,4 +118,3 @@
     }
   }
 }
-

--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -2443,12 +2443,12 @@ Raised defensively if a swarm generation is non-CLI or charged.
 ### Function: `generate_mutation` {#swarm-generate-generate_mutation}
 
 ```python
-async def generate_mutation(prompt: str, system_prompt: str, *, remaining_budget_usd: float, session: Optional[str]=None) -> GenerationResult
+async def generate_mutation(prompt: str, system_prompt: str, *, remaining_budget_usd: float, session: Optional[str]=None, model_provider: Optional[str]=None) -> GenerationResult
 ```
 
 **Keywords:** generate, mutation
 
-One toolless completion, strictly on the CLI subscription plane.
+One toolless completion, supporting cross-model routing if model_provider is set.
 
 ## swarm/mutators.py {#swarm-mutators}
 

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -2443,12 +2443,12 @@ Raised defensively if a swarm generation is non-CLI or charged.
 ### Function: `generate_mutation` {#swarm-generate-generate_mutation}
 
 ```python
-async def generate_mutation(prompt: str, system_prompt: str, *, remaining_budget_usd: float, session: Optional[str]=None) -> GenerationResult
+async def generate_mutation(prompt: str, system_prompt: str, *, remaining_budget_usd: float, session: Optional[str]=None, model_provider: Optional[str]=None) -> GenerationResult
 ```
 
 **Keywords:** generate, mutation
 
-One toolless completion, strictly on the CLI subscription plane.
+One toolless completion, supporting cross-model routing if model_provider is set.
 
 ## swarm/mutators.py {#swarm-mutators}
 


### PR DESCRIPTION
## Summary
- Add live model/plane discovery names to the Codex routing contract
- Default unpinned requests to explicit same-plane fallback
- Schema-enforce logical tools, purpose, default routing, and safety invariants

## Handoff
- Exact head: `debb5253f9eae639d07d5d84a752f7e8032614d7`
- Changed paths: `.codex/mcp/grok-routing.json`, `.codex/schemas/grok-routing.schema.json`
- Verification: Codex namespace validator; Draft 2020-12 schema self-check and instance validation; JSON parse; diff hygiene; attribution check
- Risk: low, Codex-local configuration only; no runtime behavior change
- Cost: $0
- Ready for Codex land: yes
- Human sponsor: @djtelicloud

## Provenance
Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=user-reported | surface=Codex Desktop | role=implementation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Codex-local JSON config, its schema validator, and generated API reference text—no runtime server code in this diff.
> 
> **Overview**
> Bumps the Codex **Grok MCP routing** contract to **schema v2** and tightens the JSON Schema so routing behavior is explicit instead of implied.
> 
> Adds **`logical_tools`** (`agent`, `grok_mcp_discover_self`, `grok_mcp_status`) and a **`model_plane_contract`**: live catalog via discovery with `include_models=true`, default unpinned requests (`auto` / `same_plane`), pin and cross-plane fallback rules, and required inference **receipt** fields (`model`, `resolved_plane`, `billing_class`, etc.). The **status** route now points at discovery/status tools rather than **`agent`**, and **`public_http_mcp_entrypoint`** is documented as **`agent`** (not `mcp__grok.agent`).
> 
> OKF **API reference** (repo + control-center copy) documents optional **`model_provider`** on **`generate_mutation`** for cross-model swarm routing—docs-only relative to this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2462cd8d498b8a491cb4134586fb919e507bfa94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->