### PR TITLE
docs(okf): add VS Code Copilot guidance

### DIFF
--- a/docs/okf/agent-tool.md
+++ b/docs/okf/agent-tool.md
@@ -134,3 +134,90 @@ live catalog returned by the `grok models` readiness probe. Coding prefers
 composer; reasoning prefers the CLI's reported default. Explicit API model
 pins remain on API even when the same slug is also exposed by the CLI
 subscription.
+
+## VS Code + GitHub Copilot integration patterns
+
+For VS Code Copilot and similar MCP clients, the stable HTTP `agent` is the
+default entrypoint. Keep the caller identity stable with
+`X-Client-ID: vscode`, call `grok_mcp_discover_self` early in a session, and
+use live `tools/list` as the contract before assuming a tool exists.
+
+### Mode and plane habits
+
+- Use `mode="fast"` for quick explanations, narrow refactors, and low-stakes
+  second opinions.
+- Use `mode="reasoning"` for design review, repo-wide tradeoffs, or when the
+  model should spend effort before answering.
+- Use `mode="thinking"` only when you explicitly want the slower reflection
+  loop; use `mode="research"` only when grounded fan-out is worth the extra
+  cost and latency.
+- Leave `plane="auto"` for normal CLI-first behavior. Use
+  `fallback_policy="same_plane"` when you must not cross the billing boundary,
+  especially for pinned API models or explicit CLI-only review flows.
+- Qualify `session` by task or repository so repeated Copilot follow-ups stay
+  attached to the same logical thread.
+
+### Supplying local evidence
+
+The stable HTTP surface is workspace-neutral. When Copilot needs local repo
+evidence, pass only the selected text through `workspace_context` and label it
+with `workspace_label`. Do not assume MCP registration grants filesystem
+authority over the open folder.
+
+```json
+{
+  "prompt": "Review this refactor plan for risk.",
+  "mode": "reasoning",
+  "session": "djtelicloud/grok-mcp-server:refactor-plan",
+  "workspace_label": "djtelicloud/grok-mcp-server",
+  "workspace_context": "Diff excerpt or error text chosen by Copilot"
+}
+```
+
+### Reading the response metadata
+
+Treat the structured response as the authoritative execution receipt:
+
+- `route`, `plane`, `model`, `why`, and `degraded` explain what ran and why.
+- `cost_usd`, `tokens`, and `latency_sec` support cost-aware IDE behavior.
+- `routing` carries the bounded routing explanation object safe for display and
+  logging.
+- `credentials.notices` is the action list for missing auth or repair steps.
+  Prompt once per notice id and do not ask the user to paste `XAI_API_KEY`
+  into chat or MCP config.
+
+```json
+{
+  "response": "No blocking findings.",
+  "model": "grok-4.5",
+  "route": "agentic",
+  "plane": "CLI",
+  "why": "cost",
+  "degraded": false,
+  "cost_usd": 0.0
+}
+```
+
+### Copilot-friendly request patterns
+
+Use these as bounded templates for common IDE flows:
+
+```json
+{
+  "prompt": "Summarize this stack trace and propose the first fix.",
+  "mode": "fast",
+  "session": "repo:bug-123",
+  "workspace_context": "Selected traceback"
+}
+```
+
+```json
+{
+  "prompt": "Give a second-opinion review of this patch.",
+  "mode": "reasoning",
+  "plane": "cli",
+  "fallback_policy": "same_plane",
+  "session": "repo:review-branch",
+  "workspace_context": "Selected diff hunk"
+}
+```

--- a/docs/okf/chat-modes.md
+++ b/docs/okf/chat-modes.md
@@ -17,6 +17,13 @@ critique.
 > public `agent` entrypoint instead. Confirm every deployment with MCP
 > `tools/list`.
 
+> **VS Code / Copilot note:** Copilot MCP clients on the public HTTP surface
+> should use the unified `agent` entrypoint with `mode="fast"`,
+> `mode="reasoning"`, `mode="thinking"`, or `mode="research"` rather than
+> expecting the trusted-stdio `chat*` tools below. See
+> [Agent Entrypoint](agent-tool.md) for the stable HTTP request patterns,
+> `workspace_context` rules, and model/plane metadata guidance.
+
 ## Schema contracts
 
 All chat and context tools return `ChatResult` (inheriting from `BaseResult`) with the exception of `grok_reflect` which returns `ReflectionResult`.

--- a/docs/okf/metrics-tool.md
+++ b/docs/okf/metrics-tool.md
@@ -80,6 +80,19 @@ coverage, and bounded repair actions. Agents must ask the user before running
 installation, device-auth, or secret-configuration actions and suppress repeat
 prompts until the notice id changes.
 
+## IDE session checks
+
+For VS Code Copilot and other IDE clients, use the metadata returned by the
+public `agent` tool and `grok_mcp_status(view="json")` to confirm the session
+is behaving as expected:
+
+- Verify `model`, `route`, `plane`, `why`, `degraded`, `cost_usd`, and
+  `latency_sec` after a request instead of inferring behavior from prose.
+- Use `credentials.notices` and the shared `credential_planes` object to decide
+  whether to prompt for CLI auth, API configuration, or no action at all.
+- Treat `X-Client-ID` as a reporting/session label for dashboards and budgets,
+  not as a credential or permission grant.
+
 ## Circuit Breakers & Failover
 
 The gateway maintains per-model circuit breakers to prevent repeated xAI API

--- a/sites/unigrok-control-center/public/docs/okf/agent-tool.md
+++ b/sites/unigrok-control-center/public/docs/okf/agent-tool.md
@@ -134,3 +134,90 @@ live catalog returned by the `grok models` readiness probe. Coding prefers
 composer; reasoning prefers the CLI's reported default. Explicit API model
 pins remain on API even when the same slug is also exposed by the CLI
 subscription.
+
+## VS Code + GitHub Copilot integration patterns
+
+For VS Code Copilot and similar MCP clients, the stable HTTP `agent` is the
+default entrypoint. Keep the caller identity stable with
+`X-Client-ID: vscode`, call `grok_mcp_discover_self` early in a session, and
+use live `tools/list` as the contract before assuming a tool exists.
+
+### Mode and plane habits
+
+- Use `mode="fast"` for quick explanations, narrow refactors, and low-stakes
+  second opinions.
+- Use `mode="reasoning"` for design review, repo-wide tradeoffs, or when the
+  model should spend effort before answering.
+- Use `mode="thinking"` only when you explicitly want the slower reflection
+  loop; use `mode="research"` only when grounded fan-out is worth the extra
+  cost and latency.
+- Leave `plane="auto"` for normal CLI-first behavior. Use
+  `fallback_policy="same_plane"` when you must not cross the billing boundary,
+  especially for pinned API models or explicit CLI-only review flows.
+- Qualify `session` by task or repository so repeated Copilot follow-ups stay
+  attached to the same logical thread.
+
+### Supplying local evidence
+
+The stable HTTP surface is workspace-neutral. When Copilot needs local repo
+evidence, pass only the selected text through `workspace_context` and label it
+with `workspace_label`. Do not assume MCP registration grants filesystem
+authority over the open folder.
+
+```json
+{
+  "prompt": "Review this refactor plan for risk.",
+  "mode": "reasoning",
+  "session": "djtelicloud/grok-mcp-server:refactor-plan",
+  "workspace_label": "djtelicloud/grok-mcp-server",
+  "workspace_context": "Diff excerpt or error text chosen by Copilot"
+}
+```
+
+### Reading the response metadata
+
+Treat the structured response as the authoritative execution receipt:
+
+- `route`, `plane`, `model`, `why`, and `degraded` explain what ran and why.
+- `cost_usd`, `tokens`, and `latency_sec` support cost-aware IDE behavior.
+- `routing` carries the bounded routing explanation object safe for display and
+  logging.
+- `credentials.notices` is the action list for missing auth or repair steps.
+  Prompt once per notice id and do not ask the user to paste `XAI_API_KEY`
+  into chat or MCP config.
+
+```json
+{
+  "response": "No blocking findings.",
+  "model": "grok-4.5",
+  "route": "agentic",
+  "plane": "CLI",
+  "why": "cost",
+  "degraded": false,
+  "cost_usd": 0.0
+}
+```
+
+### Copilot-friendly request patterns
+
+Use these as bounded templates for common IDE flows:
+
+```json
+{
+  "prompt": "Summarize this stack trace and propose the first fix.",
+  "mode": "fast",
+  "session": "repo:bug-123",
+  "workspace_context": "Selected traceback"
+}
+```
+
+```json
+{
+  "prompt": "Give a second-opinion review of this patch.",
+  "mode": "reasoning",
+  "plane": "cli",
+  "fallback_policy": "same_plane",
+  "session": "repo:review-branch",
+  "workspace_context": "Selected diff hunk"
+}
+```

--- a/sites/unigrok-control-center/public/docs/okf/chat-modes.md
+++ b/sites/unigrok-control-center/public/docs/okf/chat-modes.md
@@ -17,6 +17,13 @@ critique.
 > public `agent` entrypoint instead. Confirm every deployment with MCP
 > `tools/list`.
 
+> **VS Code / Copilot note:** Copilot MCP clients on the public HTTP surface
+> should use the unified `agent` entrypoint with `mode="fast"`,
+> `mode="reasoning"`, `mode="thinking"`, or `mode="research"` rather than
+> expecting the trusted-stdio `chat*` tools below. See
+> [Agent Entrypoint](agent-tool.md) for the stable HTTP request patterns,
+> `workspace_context` rules, and model/plane metadata guidance.
+
 ## Schema contracts
 
 All chat and context tools return `ChatResult` (inheriting from `BaseResult`) with the exception of `grok_reflect` which returns `ReflectionResult`.

--- a/sites/unigrok-control-center/public/docs/okf/metrics-tool.md
+++ b/sites/unigrok-control-center/public/docs/okf/metrics-tool.md
@@ -80,6 +80,19 @@ coverage, and bounded repair actions. Agents must ask the user before running
 installation, device-auth, or secret-configuration actions and suppress repeat
 prompts until the notice id changes.
 
+## IDE session checks
+
+For VS Code Copilot and other IDE clients, use the metadata returned by the
+public `agent` tool and `grok_mcp_status(view="json")` to confirm the session
+is behaving as expected:
+
+- Verify `model`, `route`, `plane`, `why`, `degraded`, `cost_usd`, and
+  `latency_sec` after a request instead of inferring behavior from prose.
+- Use `credentials.notices` and the shared `credential_planes` object to decide
+  whether to prompt for CLI auth, API configuration, or no action at all.
+- Treat `X-Client-ID` as a reporting/session label for dashboards and budgets,
+  not as a credential or permission grant.
+
 ## Circuit Breakers & Failover
 
 The gateway maintains per-model circuit breakers to prevent repeated xAI API

--- a/tests/test_okf_vscode_guidance.py
+++ b/tests/test_okf_vscode_guidance.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_agent_tool_documents_vscode_copilot_patterns() -> None:
+    text = (ROOT / "docs" / "okf" / "agent-tool.md").read_text(encoding="utf-8")
+
+    assert "VS Code + GitHub Copilot integration patterns" in text
+    assert 'X-Client-ID: vscode' in text
+    assert 'fallback_policy="same_plane"' in text
+    assert "workspace_context" in text
+    assert "credentials.notices" in text
+    assert '"mode": "reasoning"' in text
+
+
+def test_chat_modes_points_http_clients_to_agent_entrypoint() -> None:
+    text = (ROOT / "docs" / "okf" / "chat-modes.md").read_text(encoding="utf-8")
+
+    assert "VS Code / Copilot note" in text
+    assert 'mode="fast"' in text
+    assert "Agent Entrypoint" in text
+
+
+def test_metrics_tool_documents_ide_session_checks() -> None:
+    text = (ROOT / "docs" / "okf" / "metrics-tool.md").read_text(encoding="utf-8")
+
+    assert "IDE session checks" in text
+    assert "grok_mcp_status(view=\"json\")" in text
+    assert "X-Client-ID" in text
+    assert "cost_usd" in text


### PR DESCRIPTION
## Summary
- add VS Code Copilot integration patterns to the canonical OKF agent docs, including `mode`, `plane`, `fallback_policy`, `workspace_context`, and metadata-reading habits
- clarify in `chat-modes.md` that public HTTP Copilot clients use the unified `agent` entrypoint rather than trusted-stdio `chat*` tools
- add an IDE session checks note in `metrics-tool.md` and a focused test file proving the new guidance exists

## Why this avoids collisions
- exact changed paths are limited to:
  - `docs/okf/agent-tool.md`
  - `docs/okf/chat-modes.md`
  - `docs/okf/metrics-tool.md`
  - `sites/unigrok-control-center/public/docs/okf/agent-tool.md`
  - `sites/unigrok-control-center/public/docs/okf/chat-modes.md`
  - `sites/unigrok-control-center/public/docs/okf/metrics-tool.md`
  - `tests/test_okf_vscode_guidance.py`
- this intentionally avoids all currently-owned open PR files, including:
  - `.github/copilot-instructions.md` (#187)
  - `docs/ide-setup.md` (#188, #190, #191, #192, #193)
  - `docs/okf/faq.md` and `tests/test_faq.py` (#196)
  - `docs/okf/grok-4.5-pinning.md`, the using-unigrok skills, and `tests/test_dual_plane_model_discipline.py` (#195)
  - `.cursor/rules/cursor-unigrok-routing.mdc` (#194)

## Landing contract
- Exact head:
  - `05d5047d25d8bda6c52671aa75b1c7405c92b154`
- Changed paths:
  - `docs/okf/agent-tool.md`
  - `docs/okf/chat-modes.md`
  - `docs/okf/metrics-tool.md`
  - `sites/unigrok-control-center/public/docs/okf/agent-tool.md`
  - `sites/unigrok-control-center/public/docs/okf/chat-modes.md`
  - `sites/unigrok-control-center/public/docs/okf/metrics-tool.md`
  - `tests/test_okf_vscode_guidance.py`
- Verification:
  - `uv run pytest -q tests/test_okf_vscode_guidance.py tests/test_release_hygiene.py`
  - `uv run python scripts/check_agent_attribution.py --base-ref origin/main --head HEAD`
  - `uv run python scripts/generate_okf.py --write`
- Known risks:
  - low risk, docs + generated docs + tests only
  - no runtime, routing logic, credential handling, or model selection code changed
- Generated files:
  - `sites/unigrok-control-center/public/docs/okf/agent-tool.md`
  - `sites/unigrok-control-center/public/docs/okf/chat-modes.md`
  - `sites/unigrok-control-center/public/docs/okf/metrics-tool.md`
- Accountable GitHub contributor:
  - David Johnston

## Agent provenance
- Agent-Assisted-By: GitHub Copilot | model=GPT-5.6 Sol | model-source=user-reported | surface=VS Code | role=implementation
- Co-authored-by: Copilot <198982749+Copilot@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and string-presence tests only; no runtime, routing, or credential code changes.
> 
> **Overview**
> Adds **VS Code + GitHub Copilot** guidance to the OKF docs so IDE clients know how to use the stable HTTP **`agent`** entrypoint instead of trusted-stdio **`chat*`** tools.
> 
> **`agent-tool.md`** gains a new section covering **`X-Client-ID: vscode`**, mode/plane/`fallback_policy` habits, **`workspace_context`** / **`workspace_label`** for selected local text (no implicit filesystem access), reading **`route`**, **`plane`**, **`credentials.notices`**, and JSON request templates for common flows. The same content is mirrored under **`sites/unigrok-control-center/public/docs/okf/`**.
> 
> **`chat-modes.md`** adds a Copilot callout that points HTTP clients at **`agent`** modes and links to the agent doc. **`metrics-tool.md`** adds **IDE session checks**—validate execution via structured fields from **`agent`** and **`grok_mcp_status(view="json")`**, and treat **`X-Client-ID`** as telemetry only.
> 
> **`tests/test_okf_vscode_guidance.py`** asserts the canonical **`docs/okf`** files contain the new headings and key strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a16064c21096cc8adc1068543c2705ee080d45f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->