### PR TITLE
docs(okf): add Copilot agent playbook

### DIFF
--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -3405,6 +3405,24 @@ status incl. staleness override, target, focus node, generations run,
 spend). The Playground's task picker consumes this — read-only, no gate:
 on a service that never ran a swarm it simply returns [].
 
+### Function: `plan_swarm_campaign` {#tools-swarm-plan_swarm_campaign}
+
+```python
+async def plan_swarm_campaign(target_paths: List[str], test_roots: List[str]=['tests'], max_targets: int=5) -> Dict[str, Any]
+```
+
+**Keywords:** plan, swarm, campaign
+
+Perform a wide-pass analysis to find swarmable hotspot functions.
+
+Deterministically maps files/functions to available tests and categorizes
+them into a campaign plan without executing any code.
+
+Args:
+    target_paths: Workspace-relative paths to files or directories to scan.
+    test_roots: Workspace-relative paths where tests live (default: ["tests"]).
+    max_targets: Maximum number of swarm-ready targets to rank and return.
+
 ## tools/system.py {#tools-system}
 
 ### Function: `grok_mcp_status` {#tools-system-grok_mcp_status}

--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -2974,6 +2974,26 @@ async def raw_get_session_history(session: str) -> str
 
 Get local chat history for a session — lets agent recall prior context.
 
+## tools/consistency.py {#tools-consistency}
+
+### Function: `architecture_consistency_sweep` {#tools-consistency-architecture_consistency_sweep}
+
+```python
+async def architecture_consistency_sweep(target_paths: List[str], rules_paths: List[str], ctx: Optional[Context]=None) -> Dict[str, Any]
+```
+
+**Keywords:** architecture, consistency, sweep
+
+Perform a wide-pass consistency sweep across target code and rule documents.
+
+This tool reads the provided files, runs a deep reasoning pass using Grok,
+and returns a scored consistency report indicating where the codebase has
+drifted from the authoritative claims in the rules_paths.
+
+Args:
+    target_paths: A list of paths to target source files to audit.
+    rules_paths: A list of paths to authoritative documents (e.g. docs/ide-setup.md).
+
 ## tools/faq.py {#tools-faq}
 
 ### Function: `lookup_unigrok_faq` {#tools-faq-lookup_unigrok_faq}

--- a/docs/okf/copilot-agent-playbook.md
+++ b/docs/okf/copilot-agent-playbook.md
@@ -1,0 +1,64 @@
+---
+okf_version: "0.1"
+title: "VS Code Copilot Agent Playbook"
+type: "topic"
+description: "How GitHub Copilot in VS Code should call UniGrok agent, package workspace_context, choose modes and planes, and self-verify."
+---
+
+# VS Code Copilot Agent Playbook
+
+This playbook turns UniGrok's stable HTTP contract into repeatable habits for
+GitHub Copilot in VS Code.
+
+## Superpowers to lean on
+
+- Multi-file Edit and Agent work paired with terminal verification.
+- MCP `agent` on stable `:4765` with `X-Client-ID: vscode` for ordinary work.
+- Forge `:4766` with `X-Client-ID: vscode-forge` only while developing UniGrok
+  itself and needing repository-mounted tools, workspace memory, or Swarm.
+- Explicit `workspace_context` plus `workspace_label`, because the stable lane
+  is workspace-neutral and cannot browse the open folder on its own.
+- Structured result metadata such as `cost_usd`, `plane`, `routing`,
+  `credentials.notices`, and `finish_reason`.
+
+## Mandatory caller contract
+
+1. Configure `.vscode/mcp.json` or the VS Code user MCP config with stable
+   `X-Client-ID` headers. Never place `XAI_API_KEY` in IDE config.
+2. On first connect, degraded results, or credential prompts, call discovery or
+   status and surface each `credentials.notices` id once. Ask before any
+   install or authentication action. Never request the key in chat.
+3. For non-trivial tasks, deliberately pass evidence such as diffs, errors, key
+   files, or test output through `workspace_context` and optionally
+   `workspace_label`. Do not assume the gateway can see the current workspace.
+4. Prefer the service defaults under `cli_first`. Use
+   `fallback_policy="same_plane"` unless the user explicitly authorizes
+   cross-plane recovery.
+5. After every `agent` call, inspect `plane`, `cost_usd`, `routing`, and
+   `credentials.notices` before escalating the mode or applying edits.
+
+## Mode map
+
+- Quick Ask or narrow follow-up: `mode="fast"` or default `auto`.
+- Multi-file Edit or local coding: `mode="auto"` or `mode="reasoning"` with
+  rich `workspace_context`.
+- Deep planning, architecture, or hard bugs: `mode="reasoning"` or
+  `mode="thinking"`.
+- Broad research or multi-source synthesis: `mode="research"`.
+- Explicit model pins stay on their declared plane; never assume CLI and API
+  catalogs are interchangeable.
+
+## Self-verification loop
+
+- Run targeted `pytest` or the repo's existing verification commands after
+  edits.
+- Use status and metrics tools for session checks, plane visibility, and
+  `cost_usd` review.
+- Prefer small, auditable changes and avoid other brands' owned surfaces when a
+  non-colliding lane exists.
+
+## When to use Forge
+
+Use Forge only for UniGrok repository work that needs mounted workspace tools,
+workspace memory, or Swarm. Day-to-day use across other projects should stay on
+stable `http://localhost:4765/mcp`.

--- a/docs/okf/index.md
+++ b/docs/okf/index.md
@@ -5,6 +5,7 @@ type: "index"
 description: "Zero-shot agent knowledge bundle for discoverability and usage of the UniGrok MCP server."
 topics:
   - "agent-tool"
+  - "copilot-agent-playbook"
   - "chat-modes"
   - "reasoning-guard"
   - "grok-4.5-pinning"
@@ -41,6 +42,7 @@ authoritative.
 
 ## Navigation Map
 - [Agent Entrypoint](agent-tool.md): Stable HTTP and trusted stdio agent contracts.
+- [VS Code Copilot Agent Playbook](copilot-agent-playbook.md): Stable-lane habits, mode selection, context packaging, and self-verification for Copilot.
 - [Chat & Context Modes](chat-modes.md): Trusted-stdio direct text, stateful threads, files, and vision tools.
 - [Reasoning Guard & Level Enforcement](reasoning-guard.md): Trusted-stdio minimum-profile enforcement and its HTTP boundary.
 - [Model Pinning & Profiles](grok-4.5-pinning.md): API vs CLI paths, fallback parameters, and Grok 4.5 capabilities.

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -3405,6 +3405,24 @@ status incl. staleness override, target, focus node, generations run,
 spend). The Playground's task picker consumes this — read-only, no gate:
 on a service that never ran a swarm it simply returns [].
 
+### Function: `plan_swarm_campaign` {#tools-swarm-plan_swarm_campaign}
+
+```python
+async def plan_swarm_campaign(target_paths: List[str], test_roots: List[str]=['tests'], max_targets: int=5) -> Dict[str, Any]
+```
+
+**Keywords:** plan, swarm, campaign
+
+Perform a wide-pass analysis to find swarmable hotspot functions.
+
+Deterministically maps files/functions to available tests and categorizes
+them into a campaign plan without executing any code.
+
+Args:
+    target_paths: Workspace-relative paths to files or directories to scan.
+    test_roots: Workspace-relative paths where tests live (default: ["tests"]).
+    max_targets: Maximum number of swarm-ready targets to rank and return.
+
 ## tools/system.py {#tools-system}
 
 ### Function: `grok_mcp_status` {#tools-system-grok_mcp_status}

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -2974,6 +2974,26 @@ async def raw_get_session_history(session: str) -> str
 
 Get local chat history for a session — lets agent recall prior context.
 
+## tools/consistency.py {#tools-consistency}
+
+### Function: `architecture_consistency_sweep` {#tools-consistency-architecture_consistency_sweep}
+
+```python
+async def architecture_consistency_sweep(target_paths: List[str], rules_paths: List[str], ctx: Optional[Context]=None) -> Dict[str, Any]
+```
+
+**Keywords:** architecture, consistency, sweep
+
+Perform a wide-pass consistency sweep across target code and rule documents.
+
+This tool reads the provided files, runs a deep reasoning pass using Grok,
+and returns a scored consistency report indicating where the codebase has
+drifted from the authoritative claims in the rules_paths.
+
+Args:
+    target_paths: A list of paths to target source files to audit.
+    rules_paths: A list of paths to authoritative documents (e.g. docs/ide-setup.md).
+
 ## tools/faq.py {#tools-faq}
 
 ### Function: `lookup_unigrok_faq` {#tools-faq-lookup_unigrok_faq}

--- a/sites/unigrok-control-center/public/docs/okf/copilot-agent-playbook.md
+++ b/sites/unigrok-control-center/public/docs/okf/copilot-agent-playbook.md
@@ -1,0 +1,64 @@
+---
+okf_version: "0.1"
+title: "VS Code Copilot Agent Playbook"
+type: "topic"
+description: "How GitHub Copilot in VS Code should call UniGrok agent, package workspace_context, choose modes and planes, and self-verify."
+---
+
+# VS Code Copilot Agent Playbook
+
+This playbook turns UniGrok's stable HTTP contract into repeatable habits for
+GitHub Copilot in VS Code.
+
+## Superpowers to lean on
+
+- Multi-file Edit and Agent work paired with terminal verification.
+- MCP `agent` on stable `:4765` with `X-Client-ID: vscode` for ordinary work.
+- Forge `:4766` with `X-Client-ID: vscode-forge` only while developing UniGrok
+  itself and needing repository-mounted tools, workspace memory, or Swarm.
+- Explicit `workspace_context` plus `workspace_label`, because the stable lane
+  is workspace-neutral and cannot browse the open folder on its own.
+- Structured result metadata such as `cost_usd`, `plane`, `routing`,
+  `credentials.notices`, and `finish_reason`.
+
+## Mandatory caller contract
+
+1. Configure `.vscode/mcp.json` or the VS Code user MCP config with stable
+   `X-Client-ID` headers. Never place `XAI_API_KEY` in IDE config.
+2. On first connect, degraded results, or credential prompts, call discovery or
+   status and surface each `credentials.notices` id once. Ask before any
+   install or authentication action. Never request the key in chat.
+3. For non-trivial tasks, deliberately pass evidence such as diffs, errors, key
+   files, or test output through `workspace_context` and optionally
+   `workspace_label`. Do not assume the gateway can see the current workspace.
+4. Prefer the service defaults under `cli_first`. Use
+   `fallback_policy="same_plane"` unless the user explicitly authorizes
+   cross-plane recovery.
+5. After every `agent` call, inspect `plane`, `cost_usd`, `routing`, and
+   `credentials.notices` before escalating the mode or applying edits.
+
+## Mode map
+
+- Quick Ask or narrow follow-up: `mode="fast"` or default `auto`.
+- Multi-file Edit or local coding: `mode="auto"` or `mode="reasoning"` with
+  rich `workspace_context`.
+- Deep planning, architecture, or hard bugs: `mode="reasoning"` or
+  `mode="thinking"`.
+- Broad research or multi-source synthesis: `mode="research"`.
+- Explicit model pins stay on their declared plane; never assume CLI and API
+  catalogs are interchangeable.
+
+## Self-verification loop
+
+- Run targeted `pytest` or the repo's existing verification commands after
+  edits.
+- Use status and metrics tools for session checks, plane visibility, and
+  `cost_usd` review.
+- Prefer small, auditable changes and avoid other brands' owned surfaces when a
+  non-colliding lane exists.
+
+## When to use Forge
+
+Use Forge only for UniGrok repository work that needs mounted workspace tools,
+workspace memory, or Swarm. Day-to-day use across other projects should stay on
+stable `http://localhost:4765/mcp`.

--- a/sites/unigrok-control-center/public/docs/okf/index.md
+++ b/sites/unigrok-control-center/public/docs/okf/index.md
@@ -5,6 +5,7 @@ type: "index"
 description: "Zero-shot agent knowledge bundle for discoverability and usage of the UniGrok MCP server."
 topics:
   - "agent-tool"
+  - "copilot-agent-playbook"
   - "chat-modes"
   - "reasoning-guard"
   - "grok-4.5-pinning"
@@ -41,6 +42,7 @@ authoritative.
 
 ## Navigation Map
 - [Agent Entrypoint](agent-tool.md): Stable HTTP and trusted stdio agent contracts.
+- [VS Code Copilot Agent Playbook](copilot-agent-playbook.md): Stable-lane habits, mode selection, context packaging, and self-verification for Copilot.
 - [Chat & Context Modes](chat-modes.md): Trusted-stdio direct text, stateful threads, files, and vision tools.
 - [Reasoning Guard & Level Enforcement](reasoning-guard.md): Trusted-stdio minimum-profile enforcement and its HTTP boundary.
 - [Model Pinning & Profiles](grok-4.5-pinning.md): API vs CLI paths, fallback parameters, and Grok 4.5 capabilities.

--- a/tests/test_okf_copilot_playbook.py
+++ b/tests/test_okf_copilot_playbook.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_copilot_playbook_exists_and_covers_contract() -> None:
+    text = (ROOT / "docs" / "okf" / "copilot-agent-playbook.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "VS Code Copilot Agent Playbook" in text
+    assert "workspace_context" in text
+    assert "workspace_label" in text
+    assert "X-Client-ID: vscode" in text
+    assert "credentials.notices" in text
+    assert 'fallback_policy="same_plane"' in text
+    assert "cli_first" in text
+    assert "XAI_API_KEY" in text
+    assert 'mode="fast"' in text
+    assert 'mode="reasoning"' in text
+    assert 'mode="thinking"' in text
+    assert 'mode="research"' in text
+
+
+def test_okf_index_lists_copilot_playbook() -> None:
+    text = (ROOT / "docs" / "okf" / "index.md").read_text(encoding="utf-8")
+
+    assert "copilot-agent-playbook" in text
+    assert "VS Code Copilot Agent Playbook" in text


### PR DESCRIPTION
## Summary
- add a standalone OKF playbook for GitHub Copilot in VS Code
- document Copilot-specific mode, plane, workspace_context, and self-verification habits
- refresh generated OKF outputs, including the API reference, after main moved under the branch

## Why now
A Grok deep-think review recommended a self-contained Copilot playbook as the best non-colliding next improvement for this repo's IDE guidance. It avoids all active PR-owned files while tightening repeatable Copilot behavior on the stable and Forge lanes.

## Exact head
- `1434758b18f64a238297e99e15952aefe1f4ab6e`

## Changed paths
- `docs/okf/copilot-agent-playbook.md`
- `docs/okf/index.md`
- `docs/okf/api-reference.md`
- `tests/test_okf_copilot_playbook.py`
- `sites/unigrok-control-center/public/docs/okf/copilot-agent-playbook.md`
- `sites/unigrok-control-center/public/docs/okf/index.md`
- `sites/unigrok-control-center/public/docs/okf/api-reference.md`

## Verification
- `uv run python scripts/generate_okf.py --write`
- `uv run pytest -q tests/test_okf_copilot_playbook.py tests/test_release_hygiene.py`
- `uv run python scripts/check_agent_attribution.py --base-ref origin/main --head HEAD`

## Generated files
- `docs/okf/api-reference.md`
- `sites/unigrok-control-center/public/docs/okf/copilot-agent-playbook.md`
- `sites/unigrok-control-center/public/docs/okf/index.md`
- `sites/unigrok-control-center/public/docs/okf/api-reference.md`

## Known risks
- Low risk: docs-only guidance plus content assertions
- The playbook is intentionally scoped to Copilot/VS Code habits and does not modify runtime code or shared instruction surfaces already owned by open PRs

## Sponsor
- `djtelicloud`

## Agent provenance
- `Agent-Assisted-By: GitHub Copilot | model=GPT-5.6 Sol | model-source=user-reported | surface=VS Code | role=documentation`
- Grok planning consult: thinking route on API plane, model `grok-4.5`, cost `$0.189874`, latency `106.06s`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and generated OKF artifacts only; no runtime or auth changes.
> 
> **Overview**
> Adds a **VS Code Copilot Agent Playbook** to the OKF bundle: stable `:4765` vs Forge `:4766`, mandatory caller habits (`workspace_context`, `X-Client-ID`, credential notices, `cli_first` / `same_plane` fallback), a mode map, self-verification, and when to use Forge.
> 
> The OKF **index** registers the new topic and navigation link. **Generated** `api-reference.md` (and the Control Center public mirror) pick up `architecture_consistency_sweep` and `plan_swarm_campaign` from the existing Python surface. **Tests** assert the playbook text covers the contract and that the index lists it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14347588b6e59f4209323549c210e893309d7d7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->