### PR TITLE
test(agent): lock IDE modes, planes, and discover_self catalog

### DIFF
--- a/.agents/skills/using-unigrok/SKILL.md
+++ b/.agents/skills/using-unigrok/SKILL.md
@@ -22,8 +22,12 @@ Call `agent` with:
 - `model` (optional): pin a **live catalog** Grok model id such as `grok-4.5`
   or API coding slug `grok-build-0.1`; leave unset to let routing choose.
   Never invent ids from product names. The Grok Build IDE product is not the
-  same identity as `grok-build-0.1`. Prefer `plane` + `fallback_policy` when
-  the billing plane must not cross (`cli` vs `api`, `cli_first` default).
+  same identity as `grok-build-0.1`.
+- `plane` (optional): `auto` (default policy, usually `cli_first`), `cli`
+  (SuperGrok subscription), or `api` (metered developer API). Only these three
+  public plane values exist — never invent foreign provider planes.
+- `fallback_policy` (optional): `cross_plane` (default, bounded recovery) or
+  `same_plane` (forbid billing-boundary cross).
 - `session` (optional): a stable, project-qualified key such as
   `owner-repo:task` for multi-turn continuity. Do not reuse a generic session
   key across repositories.

--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -2974,6 +2974,26 @@ async def raw_get_session_history(session: str) -> str
 
 Get local chat history for a session — lets agent recall prior context.
 
+## tools/consistency.py {#tools-consistency}
+
+### Function: `architecture_consistency_sweep` {#tools-consistency-architecture_consistency_sweep}
+
+```python
+async def architecture_consistency_sweep(target_paths: List[str], rules_paths: List[str], ctx: Optional[Context]=None) -> Dict[str, Any]
+```
+
+**Keywords:** architecture, consistency, sweep
+
+Perform a wide-pass consistency sweep across target code and rule documents.
+
+This tool reads the provided files, runs a deep reasoning pass using Grok,
+and returns a scored consistency report indicating where the codebase has
+drifted from the authoritative claims in the rules_paths.
+
+Args:
+    target_paths: A list of paths to target source files to audit.
+    rules_paths: A list of paths to authoritative documents (e.g. docs/ide-setup.md).
+
 ## tools/faq.py {#tools-faq}
 
 ### Function: `lookup_unigrok_faq` {#tools-faq-lookup_unigrok_faq}
@@ -3384,6 +3404,24 @@ List recent swarm tasks newest-first as a JSON array (id, effective
 status incl. staleness override, target, focus node, generations run,
 spend). The Playground's task picker consumes this — read-only, no gate:
 on a service that never ran a swarm it simply returns [].
+
+### Function: `plan_swarm_campaign` {#tools-swarm-plan_swarm_campaign}
+
+```python
+async def plan_swarm_campaign(target_paths: List[str], test_roots: List[str]=['tests'], max_targets: int=5) -> Dict[str, Any]
+```
+
+**Keywords:** plan, swarm, campaign
+
+Perform a wide-pass analysis to find swarmable hotspot functions.
+
+Deterministically maps files/functions to available tests and categorizes
+them into a campaign plan without executing any code.
+
+Args:
+    target_paths: Workspace-relative paths to files or directories to scan.
+    test_roots: Workspace-relative paths where tests live (default: ["tests"]).
+    max_targets: Maximum number of swarm-ready targets to rank and return.
 
 ## tools/system.py {#tools-system}
 

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -2974,6 +2974,26 @@ async def raw_get_session_history(session: str) -> str
 
 Get local chat history for a session — lets agent recall prior context.
 
+## tools/consistency.py {#tools-consistency}
+
+### Function: `architecture_consistency_sweep` {#tools-consistency-architecture_consistency_sweep}
+
+```python
+async def architecture_consistency_sweep(target_paths: List[str], rules_paths: List[str], ctx: Optional[Context]=None) -> Dict[str, Any]
+```
+
+**Keywords:** architecture, consistency, sweep
+
+Perform a wide-pass consistency sweep across target code and rule documents.
+
+This tool reads the provided files, runs a deep reasoning pass using Grok,
+and returns a scored consistency report indicating where the codebase has
+drifted from the authoritative claims in the rules_paths.
+
+Args:
+    target_paths: A list of paths to target source files to audit.
+    rules_paths: A list of paths to authoritative documents (e.g. docs/ide-setup.md).
+
 ## tools/faq.py {#tools-faq}
 
 ### Function: `lookup_unigrok_faq` {#tools-faq-lookup_unigrok_faq}
@@ -3384,6 +3404,24 @@ List recent swarm tasks newest-first as a JSON array (id, effective
 status incl. staleness override, target, focus node, generations run,
 spend). The Playground's task picker consumes this — read-only, no gate:
 on a service that never ran a swarm it simply returns [].
+
+### Function: `plan_swarm_campaign` {#tools-swarm-plan_swarm_campaign}
+
+```python
+async def plan_swarm_campaign(target_paths: List[str], test_roots: List[str]=['tests'], max_targets: int=5) -> Dict[str, Any]
+```
+
+**Keywords:** plan, swarm, campaign
+
+Perform a wide-pass analysis to find swarmable hotspot functions.
+
+Deterministically maps files/functions to available tests and categorizes
+them into a campaign plan without executing any code.
+
+Args:
+    target_paths: Workspace-relative paths to files or directories to scan.
+    test_roots: Workspace-relative paths where tests live (default: ["tests"]).
+    max_targets: Maximum number of swarm-ready targets to rank and return.
 
 ## tools/system.py {#tools-system}
 

--- a/skills/using-unigrok/SKILL.md
+++ b/skills/using-unigrok/SKILL.md
@@ -22,8 +22,12 @@ Call `agent` with:
 - `model` (optional): pin a **live catalog** Grok model id such as `grok-4.5`
   or API coding slug `grok-build-0.1`; leave unset to let routing choose.
   Never invent ids from product names. The Grok Build IDE product is not the
-  same identity as `grok-build-0.1`. Prefer `plane` + `fallback_policy` when
-  the billing plane must not cross (`cli` vs `api`, `cli_first` default).
+  same identity as `grok-build-0.1`.
+- `plane` (optional): `auto` (default policy, usually `cli_first`), `cli`
+  (SuperGrok subscription), or `api` (metered developer API). Only these three
+  public plane values exist — never invent foreign provider planes.
+- `fallback_policy` (optional): `cross_plane` (default, bounded recovery) or
+  `same_plane` (forbid billing-boundary cross).
 - `session` (optional): a stable, project-qualified key such as
   `owner-repo:task` for multi-turn continuity. Do not reuse a generic session
   key across repositories.

--- a/tests/test_agent_mode_plane_contract.py
+++ b/tests/test_agent_mode_plane_contract.py
@@ -1,0 +1,197 @@
+"""Hermetic locks for Grok IDE agent modes, planes, and discover_self models.
+
+Complements dual-plane model-discipline tests: this module locks the public
+``agent`` / ``public_agent`` surface (modes + plane + fallback_policy), mode
+dials, and the discover_self include_models plane map — Grok IDE superpowers.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+from typing import Literal, get_args, get_origin, get_type_hints
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.http_server import MODE_DIAL_PORTS, public_agent
+from src.tools.chats import agent as stdio_agent
+
+ROOT = Path(__file__).resolve().parents[1]
+
+AGENT_MODES = frozenset({"auto", "fast", "reasoning", "thinking", "research"})
+AGENT_PLANES = frozenset({"auto", "cli", "api"})
+FALLBACK_POLICIES = frozenset({"same_plane", "cross_plane"})
+FOREIGN_PLANE_NAMES = frozenset({"openai", "anthropic", "gemini", "vertex", "sol"})
+
+
+def _literal_values(annotation) -> set[str]:
+    """Extract string Literal members; unwrap Optional[Literal[...]]."""
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+    if origin is None:
+        return set()
+    # Optional[X] / Union[X, None]
+    if type(None) in args:
+        non_none = tuple(a for a in args if a is not type(None))
+        if len(non_none) == 1:
+            annotation = non_none[0]
+            origin = get_origin(annotation)
+            args = get_args(annotation) if origin is not None else ()
+    if origin is Literal:
+        return {a for a in args if isinstance(a, str)}
+    out: set[str] = set()
+    for a in args:
+        if get_origin(a) is Literal:
+            out.update(x for x in get_args(a) if isinstance(x, str))
+    return out
+
+
+def test_stdio_agent_mode_plane_fallback_literals() -> None:
+    hints = get_type_hints(stdio_agent)
+    assert _literal_values(hints["mode"]) == AGENT_MODES
+    assert _literal_values(hints["plane"]) == AGENT_PLANES
+    assert _literal_values(hints["fallback_policy"]) == FALLBACK_POLICIES
+    assert FOREIGN_PLANE_NAMES.isdisjoint(_literal_values(hints["plane"]))
+
+
+def test_public_agent_mode_plane_fallback_match_stdio() -> None:
+    pub = get_type_hints(public_agent)
+    std = get_type_hints(stdio_agent)
+    assert _literal_values(pub["mode"]) == _literal_values(std["mode"]) == AGENT_MODES
+    assert _literal_values(pub["plane"]) == _literal_values(std["plane"]) == AGENT_PLANES
+    assert (
+        _literal_values(pub["fallback_policy"])
+        == _literal_values(std["fallback_policy"])
+        == FALLBACK_POLICIES
+    )
+
+
+def test_mode_dial_ports_map_only_to_agent_modes() -> None:
+    assert MODE_DIAL_PORTS
+    for port, mode in MODE_DIAL_PORTS.items():
+        assert isinstance(port, int)
+        assert mode in AGENT_MODES, (port, mode)
+    assert set(MODE_DIAL_PORTS.values()) == AGENT_MODES
+
+
+def test_using_unigrok_skill_documents_modes_and_planes() -> None:
+    skill = (
+        ROOT / ".agents" / "skills" / "using-unigrok" / "SKILL.md"
+    ).read_text(encoding="utf-8")
+    public = (ROOT / "skills" / "using-unigrok" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    assert skill == public
+    for mode in sorted(AGENT_MODES):
+        assert mode in skill
+    for token in ("cli", "api", "same_plane", "cross_plane", "cli_first"):
+        assert token in skill
+
+
+def test_agent_docstrings_name_all_modes() -> None:
+    doc = inspect.getdoc(stdio_agent) or ""
+    for mode in AGENT_MODES:
+        assert mode in doc
+    assert "cli" in doc and "api" in doc
+    assert "same_plane" in doc and "cross_plane" in doc
+
+
+class _NullCtx:
+    def __init__(self) -> None:
+        self.logger = MagicMock()
+        self.elapsed = 0.0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    def format_output(self, text: str) -> str:
+        return text
+
+
+@pytest.mark.asyncio
+async def test_discover_self_include_models_exposes_cli_and_api_planes_only() -> None:
+    from src.tools import system as system_mod
+
+    catalog = {
+        "xai_api": [{"id": "grok-build-0.1"}],
+        "grok_cli": [{"id": "grok-4.5"}],
+        "local_profiles": [],
+        "default_cli_model": "grok-4.5",
+        "warnings": [],
+        "sources": {"xai_api": "t", "grok_cli": "t", "local_profiles": "t"},
+        "availability": {"xai_api": True, "grok_cli": True},
+    }
+    cred = {
+        "policy": "cli_first",
+        "preferred_plane": "CLI",
+        "effective_plane": "CLI",
+        "api": {"available": True, "state": "configured"},
+        "cli": {"available": True, "state": "ready"},
+    }
+    bootstrap = {
+        "status": "OK",
+        "can_chat": True,
+        "can_spend_api": True,
+        "can_mutate_workspace": False,
+        "can_use_swarm": False,
+        "surfaces": {
+            "canonical_mcp": "http://localhost:4765/mcp",
+            "ui": "http://localhost:4765/ui/",
+        },
+        "next_actions": [],
+    }
+    okf = {"root": "index.md", "files": ["index.md"]}
+
+    with (
+        patch.object(system_mod, "credential_plane_contract", return_value=cred),
+        patch.object(
+            system_mod, "build_model_catalog", new=AsyncMock(return_value=catalog)
+        ),
+        patch.object(system_mod, "load_okf_manifest", return_value=okf),
+        patch.object(
+            system_mod,
+            "_build_discover_request_context",
+            return_value={
+                "surface": "stable_core",
+                "mode_dials_enabled": False,
+                "client_id_normalized": "test",
+            },
+        ),
+        patch.object(
+            system_mod, "_build_discover_bootstrap", return_value=bootstrap
+        ),
+        patch.object(system_mod.PathResolver, "get_workspace_root", return_value=None),
+        patch.object(system_mod.PathResolver, "contributor_mode", return_value=False),
+        patch.object(system_mod, "GrokInvocationContext", return_value=_NullCtx()),
+        patch.object(
+            system_mod,
+            "run_blocking",
+            new=AsyncMock(
+                return_value={
+                    "state": "ready",
+                    "ready": True,
+                    "binary": True,
+                    "auth": "oauth_verified",
+                }
+            ),
+        ),
+    ):
+        result = await system_mod.grok_mcp_discover_self(include_models=True)
+
+    data = getattr(result, "data", None)
+    assert isinstance(data, dict)
+    mc = data.get("model_catalog")
+    assert isinstance(mc, dict)
+    planes = mc["planes"]
+    assert set(planes.keys()) == {"CLI", "API"}
+    assert FOREIGN_PLANE_NAMES.isdisjoint(k.lower() for k in planes)
+    assert "shared_model_ids" in mc
+    assert mc["routing"]["policy"] == "cli_first"
+    # Mode dials on discover_self still only name agent modes
+    dials = data.get("mode_dials", {}).get("ports", {})
+    for mode in dials.values():
+        assert mode in AGENT_MODES


### PR DESCRIPTION
## Summary

Non-colliding **Grok IDE** improvement after deep-think on superpowers/modes:

| Superpower | Lock |
| --- | --- |
| Modes `auto/fast/reasoning/thinking/research` | stdio + public `agent` Literals + mode dials |
| Planes `auto/cli/api` only | type hints; no foreign providers |
| `fallback_policy` | `same_plane` / `cross_plane` |
| `discover_self(include_models=true)` | model map exposes **CLI + API** only |
| `using-unigrok` | explicit `plane` + `fallback_policy` bullets |

Complements Live #195 (catalog/routing pins) without touching Cursor/ide-setup peers.

## Tests

```bash
UNI_GROK_TESTING=1 uv run pytest tests/test_agent_mode_plane_contract.py -q
```

6 passed.

## Human sponsor

David Johnston / djtelicloud

Ready for supervisor?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and documentation changes only; no runtime routing or auth logic is modified in this diff.
> 
> **Overview**
> Adds **hermetic contract tests** in `tests/test_agent_mode_plane_contract.py` so the public Grok IDE surface cannot drift: stdio `agent` and HTTP `public_agent` must share the same `mode`, `plane`, and `fallback_policy` Literals; phoneword **mode dials** must map only to those five modes; `using-unigrok` skill copies must stay in sync and mention every mode and plane token; docstrings must name the full mode/plane set; and `grok_mcp_discover_self(include_models=True)` must expose model planes **CLI + API only** (no foreign provider names).
> 
> **Docs:** `using-unigrok` SKILL (`.agents` and `skills` mirrors) now documents **`plane`** (`auto` / `cli` / `api`) and **`fallback_policy`** (`cross_plane` / `same_plane`) as first-class bullets instead of folding them into the model line. OKF **api-reference** gains entries for `architecture_consistency_sweep` and `plan_swarm_campaign` (synced to the control-center public docs copy).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54bfe3e227879dff834686ecfd20ab2ff9e75d4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->