### PR TITLE
docs(okf): refresh consistency tool reference

### DIFF
--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -2974,6 +2974,26 @@ async def raw_get_session_history(session: str) -> str
 
 Get local chat history for a session — lets agent recall prior context.
 
+## tools/consistency.py {#tools-consistency}
+
+### Function: `architecture_consistency_sweep` {#tools-consistency-architecture_consistency_sweep}
+
+```python
+async def architecture_consistency_sweep(target_paths: List[str], rules_paths: List[str], ctx: Optional[Context]=None) -> Dict[str, Any]
+```
+
+**Keywords:** architecture, consistency, sweep
+
+Perform a wide-pass consistency sweep across target code and rule documents.
+
+This tool reads the provided files, runs a deep reasoning pass using Grok,
+and returns a scored consistency report indicating where the codebase has
+drifted from the authoritative claims in the rules_paths.
+
+Args:
+    target_paths: A list of paths to target source files to audit.
+    rules_paths: A list of paths to authoritative documents (e.g. docs/ide-setup.md).
+
 ## tools/faq.py {#tools-faq}
 
 ### Function: `lookup_unigrok_faq` {#tools-faq-lookup_unigrok_faq}
@@ -3384,6 +3404,24 @@ List recent swarm tasks newest-first as a JSON array (id, effective
 status incl. staleness override, target, focus node, generations run,
 spend). The Playground's task picker consumes this — read-only, no gate:
 on a service that never ran a swarm it simply returns [].
+
+### Function: `plan_swarm_campaign` {#tools-swarm-plan_swarm_campaign}
+
+```python
+async def plan_swarm_campaign(target_paths: List[str], test_roots: List[str]=['tests'], max_targets: int=5) -> Dict[str, Any]
+```
+
+**Keywords:** plan, swarm, campaign
+
+Perform a wide-pass analysis to find swarmable hotspot functions.
+
+Deterministically maps files/functions to available tests and categorizes
+them into a campaign plan without executing any code.
+
+Args:
+    target_paths: Workspace-relative paths to files or directories to scan.
+    test_roots: Workspace-relative paths where tests live (default: ["tests"]).
+    max_targets: Maximum number of swarm-ready targets to rank and return.
 
 ## tools/system.py {#tools-system}
 

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -2974,6 +2974,26 @@ async def raw_get_session_history(session: str) -> str
 
 Get local chat history for a session — lets agent recall prior context.
 
+## tools/consistency.py {#tools-consistency}
+
+### Function: `architecture_consistency_sweep` {#tools-consistency-architecture_consistency_sweep}
+
+```python
+async def architecture_consistency_sweep(target_paths: List[str], rules_paths: List[str], ctx: Optional[Context]=None) -> Dict[str, Any]
+```
+
+**Keywords:** architecture, consistency, sweep
+
+Perform a wide-pass consistency sweep across target code and rule documents.
+
+This tool reads the provided files, runs a deep reasoning pass using Grok,
+and returns a scored consistency report indicating where the codebase has
+drifted from the authoritative claims in the rules_paths.
+
+Args:
+    target_paths: A list of paths to target source files to audit.
+    rules_paths: A list of paths to authoritative documents (e.g. docs/ide-setup.md).
+
 ## tools/faq.py {#tools-faq}
 
 ### Function: `lookup_unigrok_faq` {#tools-faq-lookup_unigrok_faq}
@@ -3384,6 +3404,24 @@ List recent swarm tasks newest-first as a JSON array (id, effective
 status incl. staleness override, target, focus node, generations run,
 spend). The Playground's task picker consumes this — read-only, no gate:
 on a service that never ran a swarm it simply returns [].
+
+### Function: `plan_swarm_campaign` {#tools-swarm-plan_swarm_campaign}
+
+```python
+async def plan_swarm_campaign(target_paths: List[str], test_roots: List[str]=['tests'], max_targets: int=5) -> Dict[str, Any]
+```
+
+**Keywords:** plan, swarm, campaign
+
+Perform a wide-pass analysis to find swarmable hotspot functions.
+
+Deterministically maps files/functions to available tests and categorizes
+them into a campaign plan without executing any code.
+
+Args:
+    target_paths: Workspace-relative paths to files or directories to scan.
+    test_roots: Workspace-relative paths where tests live (default: ["tests"]).
+    max_targets: Maximum number of swarm-ready targets to rank and return.
 
 ## tools/system.py {#tools-system}
 


### PR DESCRIPTION
Summary:
- regenerate the deterministic OKF API bundle for the merged consistency radar tool
- restore the required CI generation check on current main

Verification:
- OKF write and check pass
- diff hygiene pass
- attribution pass

Exact head: 7a38c9feaf17b661b14e75169e308cb6399f47bc
Changed paths: docs/okf/api-reference.md; sites/unigrok-control-center/public/docs/okf/api-reference.md
Risk: low; generated documentation only
Human sponsor: @djtelicloud

Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=user-reported | surface=Codex Desktop | role=implementation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Generated documentation only; no executable code paths change.
> 
> **Overview**
> Regenerates the deterministic OKF **API Reference** in `docs/okf/api-reference.md` and the mirrored Control Center copy under `sites/unigrok-control-center/public/docs/okf/`.
> 
> The bundle now documents **`architecture_consistency_sweep`** (`tools/consistency.py`) — wide-pass audit of target code against authoritative rule docs with a scored drift report — and **`plan_swarm_campaign`** (`tools/swarm.py`) — deterministic scan that maps hotspots to tests and returns a ranked campaign plan without running swarm code.
> 
> No runtime or MCP behavior changes; this keeps the generated inventory aligned with the public Python surface for CI and onboarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a38c9feaf17b661b14e75169e308cb6399f47bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->