### PR TITLE
docs(ide): add IDE-model fidelity and yolo guidance

### DIFF
--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -65,6 +65,14 @@ Example shape (fill with real live state, not this template text):
 2. Large-context pass on architecture vs dual-plane docs — report 1–2 fixable gaps.
 ```
 
-## 5. Verification Requirements
+## 5. Antigravity Calling UniGrok Models (Client Habit)
+
+When using the UniGrok MCP server to execute model operations, follow this strict client habit:
+1. **Model Discovery**: Call `grok_mcp_discover_self` when you need to understand available UniGrok model identities.
+2. **Explicit Routing**: Call the `agent` tool with an explicit `mode`, and optionally supply a `plane` and `fallback_policy`.
+3. **CLI-First Billing**: Prefer CLI-compatible work under `cli_first`. Use `same_plane` when billing boundaries must not be crossed.
+4. **Honest Attribution**: Never invent catalog membership from product names (e.g., UI name `grok-4.5` vs API slugs vs CLI live catalog). Keep attribution honest in commit trailers per `docs/agent-attribution.md`. Do not claim UniGrok runs Gemini/Google models as native inference planes.
+
+## 6. Verification Requirements
 * A Codex/project-admin session reviews the draft PR's exact current head and alone runs `scripts/land` from a `codex/*` integration branch before protected merge and local synchronization.
 * Use `.agents/skills/unigrok-workspace-memory/SKILL.md` for commit-anchored recall. Pass the Gemini worktree's own full HEAD; Codex records the verified outcome after landing.

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -247,8 +247,13 @@ check `codex mcp --help`. Keep the server name as `grok`; this repo's
 `.codex/mcp/grok-routing.json` and Codex intelligence config route to the
 `mcp__grok` tool namespace.)
 
-## Antigravity / Gemini (`settings.json` → MCP servers)
+## Antigravity / Gemini (`.gemini/settings.json`)
 
+Antigravity configures its MCP servers in the tracked project file `.gemini/settings.json`.
+The configuration natively sets `allowNonWorkspaceAccess: false` and restricts tool access to `mcp(grok/*)` to ensure the agent cannot mutate the host outside of the worktree.
+
+> [!WARNING]
+> **Tracked Configs Only**: Never replace the repository's `.gemini/config.json` or `.gemini/settings.json` with a private host credential file (like your `~/.gemini/config`). These files must remain public project configuration.
 ```json
 {
   "mcpServers": {

--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -264,6 +264,12 @@ check `codex mcp --help`. Keep the server name as `grok`; this repo's
 }
 ```
 
+> [!WARNING]
+> **Secret & Worktree Safety**
+> - **No Secrets in Configs**: Never copy `XAI_API_KEY`, Google ADC credentials, or host `~/.gemini/config` files into this repository or the IDE MCP config JSON. 
+> - **Isolated Worktrees**: Operate inside `.worktrees/gemini/<task>/` (or the provider home). Do not pollute Documents with loose checkouts or mutate the primary shared `main` checkout.
+
+
 > [!NOTE]
 > IDEs cache MCP schemas. After adding or changing a tool, reconnect the Forge
 > MCP entry or reload the IDE window (in Antigravity: **Developer: Reload


### PR DESCRIPTION
Source: PR #193 improvements copied into non-colliding Codex-owned lane for clean re-run and merge. Includes docs/ide-setup.md and .gemini/GEMINI.md updates.

- Exact source commit: f8b2d1c (derived from 193)
- Added empty retrigger commit 63e13fc to force fresh CI.
- No behavior changes outside docs/IDE guidance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only guidance; no code, auth, or deployment behavior changes.
> 
> **Overview**
> Documentation-only updates for **Antigravity / Gemini** agents and IDE setup—no runtime changes.
> 
> **`.gemini/GEMINI.md`** adds **§5 Antigravity Calling UniGrok Models**: discover models via `grok_mcp_discover_self`, route with explicit `agent` `mode` / `plane` / `fallback_policy`, prefer `cli_first` billing, and keep model attribution honest (no claiming Gemini runs as a UniGrok inference plane). Former verification section is renumbered to **§6**.
> 
> **`docs/ide-setup.md`** retitles the Antigravity block to **`.gemini/settings.json`**, documents tracked `allowNonWorkspaceAccess: false` and `mcp(grok/*)` scoping, and adds warnings against swapping tracked `.gemini/*` for private `~/.gemini/config`. Example MCP entries use **`unigrok`** / **`unigrok-forge`** with `httpUrl` and `X-Client-ID` headers, plus **Secret & Worktree Safety** (no keys in repo configs; work in `.worktrees/gemini/<task>/`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 938d80e3d3b104522ab9b0343f417ffcfa4b4295. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->