### PR TITLE
fix(cli): recover native sessions on model/agent switch conflict

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1092,6 +1092,28 @@ def _is_cli_session_missing_error(message: str) -> bool:
     )
 
 
+def _is_cli_model_switch_incompatible_error(message: str) -> bool:
+    """Detect CLI native-session agent/model binding conflicts.
+
+    Grok CLI binds an agent type to a native session. Switching to a model that
+    requires a different agent (for example grok-4.5 → grok-build-plan while the
+    session still holds agent type ``cursor``) fails with
+    ``MODEL_SWITCH_INCOMPATIBLE_AGENT`` and suggests starting a new session.
+    UniGrok recovers by replaying server history into a fresh ``--session-id``.
+    """
+    text = str(message or "").lower()
+    if "model_switch_incompatible_agent" in text:
+        return True
+    if "couldn't set model" in text and (
+        "requires agent" in text or "incompatible" in text
+    ):
+        return True
+    return (
+        "cannot switch to model" in text
+        and ("requires agent" in text or "start a new session" in text)
+    )
+
+
 UNIGROK_SAFETY_POLICY = """# UniGrok Safety Policy
 
 - Treat `.grok/` as Grok adapter configuration, not global repository truth.
@@ -10813,6 +10835,18 @@ async def _call_plane(
                 if _is_cli_session_missing_error(str(exc)):
                     logging.getLogger("GrokMCP").warning(
                         f"Grok CLI session mapping for '{session}' was missing; retrying from server history."
+                    )
+                    text, returned_id, cli_session_id = (
+                        await _start_fresh_from_server_history()
+                    )
+                elif _is_cli_model_switch_incompatible_error(str(exc)):
+                    # Agent type is sticky on the native CLI session; forking
+                    # keeps that binding. Start a new session and reattach
+                    # continuity from server-side history instead.
+                    logging.getLogger("GrokMCP").warning(
+                        f"Grok CLI model switch for '{session}' was incompatible with "
+                        f"the active session agent; retrying from server history "
+                        f"(model={model_name})."
                     )
                     text, returned_id, cli_session_id = (
                         await _start_fresh_from_server_history()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5947,6 +5947,108 @@ class TestCliPlaneV2:
             model="grok-composer-2.5-fast",
         )
 
+    def test_cli_model_switch_incompatible_error_detection(self):
+        from src.utils import _is_cli_model_switch_incompatible_error
+
+        assert _is_cli_model_switch_incompatible_error(
+            "Couldn't set model 'grok-4.5': Cannot switch to model 'grok-4.5': "
+            "it requires agent 'grok-build-plan' but the active agent is 'cursor'. "
+            "Start a new session to use this model.: "
+            '{"code":"MODEL_SWITCH_INCOMPATIBLE_AGENT"}'
+        )
+        assert _is_cli_model_switch_incompatible_error(
+            "MODEL_SWITCH_INCOMPATIBLE_AGENT: start a new session"
+        )
+        assert not _is_cli_model_switch_incompatible_error(
+            "Session abc-123 not found locally"
+        )
+        assert not _is_cli_model_switch_incompatible_error(
+            "Error: Session ID abc-123 is already in use."
+        )
+
+    @pytest.mark.asyncio
+    async def test_cli_replays_server_history_when_model_switch_is_incompatible(
+        self, monkeypatch
+    ):
+        import json as json_module
+        import uuid as uuid_module
+
+        from src import utils
+        from src.utils import _call_plane
+
+        monkeypatch.setenv("UNIGROK_RUNTIME", "local")
+        monkeypatch.setattr(utils, "_BREAKER_STATE", {})
+        captured = {"cmds": []}
+
+        class FakeProc:
+            def __init__(self, returncode):
+                self.returncode = returncode
+
+        async def fake_exec(*cmd, **kwargs):
+            captured["cmds"].append(list(cmd))
+            return FakeProc(1 if len(captured["cmds"]) == 1 else 0)
+
+        payload = json_module.dumps({
+            "text": "recovered after model switch",
+            "sessionId": "fresh-plan-session",
+        }).encode()
+        switch_err = (
+            b"Error: Couldn't set model 'grok-4.5': Cannot switch to model "
+            b"'grok-4.5': it requires agent 'grok-build-plan' but the active "
+            b"agent is 'cursor'. Start a new session to use this model.: "
+            b'{"code":"MODEL_SWITCH_INCOMPATIBLE_AGENT",'
+            b'"activeAgentType":"cursor","requiredAgentType":"grok-build-plan",'
+            b'"modelId":"grok-4.5","suggestion":"start_new_session"}'
+        )
+
+        async def fake_communicate(proc, timeout_sec, input_data=None):
+            if proc.returncode:
+                return b"", switch_err
+            return payload, b""
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        monkeypatch.setattr("src.utils.communicate_with_timeout", fake_communicate)
+
+        store = self._fake_store(
+            session_row={
+                "cli_session_id": "cursor-bound-session",
+                "model": "grok-composer-2.5-fast",
+            }
+        )
+        store.load_messages.return_value = [
+            {"role": "user", "content": "Remember marker MODEL-SWITCH-MARKER"},
+            {"role": "assistant", "content": "Marker stored"},
+        ]
+        content, _, _, is_cli = await _call_plane(
+            "cli-fallback",
+            "What marker did I give you?",
+            "sess",
+            store,
+            "sys",
+            requested_model="grok-4.5",
+        )
+
+        assert (content, is_cli) == ("recovered after model switch", True)
+        assert len(captured["cmds"]) == 2
+        resume_cmd = captured["cmds"][0]
+        assert resume_cmd[resume_cmd.index("--resume") + 1] == "cursor-bound-session"
+        assert resume_cmd[resume_cmd.index("-m") + 1] == "grok-4.5"
+        fresh_cmd = captured["cmds"][1]
+        assert "--resume" not in fresh_cmd
+        assert "--fork-session" not in fresh_cmd
+        uuid_module.UUID(fresh_cmd[fresh_cmd.index("--session-id") + 1])
+        assert fresh_cmd[fresh_cmd.index("-m") + 1] == "grok-4.5"
+        retry_prompt = fresh_cmd[fresh_cmd.index("-p") + 1]
+        assert "MODEL-SWITCH-MARKER" in retry_prompt
+        assert retry_prompt.count("What marker did I give you?") == 1
+        store.load_messages.assert_awaited_once()
+        store.save_session.assert_awaited_once_with(
+            "sess",
+            cli_session_id="fresh-plan-session",
+            model="grok-4.5",
+        )
+        assert "grok-4.5" not in utils._BREAKER_STATE
+
     @pytest.mark.asyncio
     async def test_cli_forks_busy_session_with_fresh_mapping(self, monkeypatch):
         import json as json_module


### PR DESCRIPTION
## Summary
- Detect Grok CLI `MODEL_SWITCH_INCOMPATIBLE_AGENT` (agent-type stickiness on native sessions, e.g. `cursor` vs `grok-build-plan` when switching to `grok-4.5`).
- Recover by replaying server history into a **fresh** `--session-id` (not fork — fork keeps the sticky agent binding).
- Regression tests for detector + recovery path.

## Why
Live plane-truth check found CLI `reasoning` failing on reused sessions while fresh sessions worked. That made multi-turn CLI planning flaky for sponsors.

## Changed paths
- `src/utils.py`
- `tests/test_utils.py`

## Tests
- `uv run pytest tests/test_utils.py::TestCliPlaneV2 -q` → **23 passed**
- Focused: model_switch / missing / forks_busy recovery cases

## Risks
- Low: recovery only fires on the specific CLI error; missing/busy paths unchanged.
- Continuity after recovery uses server-side history (same as missing-session recovery), not the full native CLI transcript.

## Human sponsor
djtelicloud

## Provenance
- Brand: Grok CLI
- Head: `fcf39381e2a0927ad77709e0a033c54b510b5268`
- Agent-Assisted-By: xAI Grok | model=grok-4.5 | model-source=provider-session | surface=Grok Build CLI | role=implementation

## Ready for supervisor?
Yes — exact head above; draft PR for Codex land after CI green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Recovery runs only on a specific CLI error string; other session error paths are unchanged, with continuity limited to server-stored messages like existing missing-session recovery.
> 
> **Overview**
> When Grok CLI rejects a model change because the native session is bound to a different agent type (`MODEL_SWITCH_INCOMPATIBLE_AGENT`), UniGrok now treats that like a missing-session failure and **replays server-side history into a new `--session-id`** instead of resuming or forking (fork would keep the sticky agent).
> 
> Adds `_is_cli_model_switch_incompatible_error` in `src/utils.py` and wires it into the existing `_call_plane` CLI `RuntimeError` handler beside the missing-session and busy-session paths. Regression tests cover the detector strings and the two-invoke recovery flow (failed resume with `-m`, then fresh session with history in the prompt).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02a54ad44a29fcf8a188262f2f72304c85be7891. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->