### PR TITLE
docs(claude): tighten runtime contract wording

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,13 @@ invokes the headless CLI with
 `--output-format json` or `streaming-json`, per-session `--session-id` creation
 and `--resume` continuation (with `--fork-session` on collision — the native id
 is stored per session, not a deterministic hash of the name), optional
-`--json-schema`, `--effort`, and `--max-turns`, plus a `grok models` probe for
-plane readiness. Native CLI sessions are the continuity mechanism;
+`--json-schema`, `--effort`, and `--max-turns`. `--session-id` names a new
+native CLI conversation; `--resume` continues an existing one; and
+`--fork-session --session-id ...` is the safe continuation path when the
+resumed session is busy. CLI-plane readiness comes from the bounded
+`grok models` probe that confirms the grok.com login state, while service
+readiness is exposed separately at `GET /readyz`. Native CLI sessions are the
+continuity mechanism;
 the old `grok sessions list` scrape and fragile regex session sync are gone.
 Still-unintegrated CLI surfaces include `grok agent stdio|serve|leader` and
 `--best-of-n`. Treat the CLI as ground truth when unifying the two planes.
@@ -60,7 +65,7 @@ model/cost metadata. Modes: `auto` (default), `fast`, `reasoning`, `thinking`,
 - `src/server.py` — MCP server / tool registration
 - `src/http_server.py` — Streamable HTTP + `/healthz`, `/ui/` test bench
 - `src/cli.py` — `unigrok-mcp` entry point (`main.py` → `src.cli:main`)
-- `src/utils.py` — plane routing (`_call_plane`), session sync
+- `src/utils.py` — plane routing (`_call_plane`), CLI session continuity
 - `src/tools/` — agent tool implementations
 - `src/storage.py`, `src/jobs.py` — session state / async jobs
 - `tests/` — pytest suite (`asyncio_mode = auto`)
@@ -73,6 +78,7 @@ model/cost metadata. Modes: `auto` (default), `fast`, `reasoning`, `thinking`,
 uv run python main.py init        # bootstrap .env + print IDE configs
 docker compose up --build -d      # start shared service on :4765
 curl -s http://localhost:4765/healthz
+curl -s http://localhost:4765/readyz
 uv run pytest -q                  # full test suite
 ./scripts/land                    # test and land committed task work to main
 ```

--- a/tests/test_claude_md_runtime_contract.py
+++ b/tests/test_claude_md_runtime_contract.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_claude_md_documents_cli_readiness_and_session_continuity() -> None:
+    text = (ROOT / "CLAUDE.md").read_text(encoding="utf-8")
+
+    assert "`grok models` probe" in text
+    assert "`GET /readyz`" in text
+    assert "`--session-id` names a new" in text
+    assert "`--resume` continues an existing one" in text
+    assert "`--fork-session --session-id ...`" in text
+    assert "CLI session continuity" in text


### PR DESCRIPTION
## Summary
- tighten `CLAUDE.md` wording around CLI-plane readiness and native session continuity
- distinguish `--session-id`, `--resume`, and `--fork-session`
- add a focused string-contract test for the Claude runtime guidance

## Why this was overlooked
The repo audit already called out stale `CLAUDE.md` wording around readiness and native sessions, but the active PR traffic was concentrated elsewhere. This lane stays off all current PR-owned files while fixing a concrete doc inconsistency the audit had already surfaced.

## Exact head
- `60c8ab34967145da1c0436261265ec7051b9a54e`

## Changed paths
- `CLAUDE.md`
- `tests/test_claude_md_runtime_contract.py`

## Verification
- `uv run pytest -q tests/test_claude_md_runtime_contract.py tests/test_release_hygiene.py`
- `uv run python scripts/check_agent_attribution.py --base-ref origin/main --head HEAD`

## Known risks
- Low risk: documentation wording plus a dedicated string-contract test only
- No runtime code, generated docs, or active PR-owned surfaces changed

## Sponsor
- `djtelicloud`

## Agent provenance
- `Agent-Assisted-By: GitHub Copilot | model=GPT-5.6 Sol | model-source=user-reported | surface=VS Code | role=documentation`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a string-contract test only; no runtime, auth, or API behavior changes.
> 
> **Overview**
> Aligns **Claude Code** guidance in `CLAUDE.md` with how the dual-plane runtime actually behaves, without changing application code.
> 
> The dual-plane section now **separates CLI-plane readiness** (bounded `grok models` probe / grok.com login) from **service readiness** (`GET /readyz`), and spells out native session flags: `--session-id` for new conversations, `--resume` for continuation, and `--fork-session --session-id ...` when the resumed session is busy. The `src/utils.py` bullet is renamed from “session sync” to **CLI session continuity**, and the common-commands block adds a `curl` example for `/readyz`.
> 
> A new **`tests/test_claude_md_runtime_contract.py`** locks those phrases in place so future doc edits cannot silently drop the contract strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b25301247d80a807916dea00b6441a2cf019004. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->