### PR TITLE
docs(okf): document API-only thinking/research plane fail-closed

### DIFF
--- a/.agents/skills/using-unigrok/SKILL.md
+++ b/.agents/skills/using-unigrok/SKILL.md
@@ -45,8 +45,15 @@ search grounding was used.
 
 - Quick factual or single-file questions → `fast`.
 - Design reviews, audits, multi-step analysis → `reasoning`.
-- Tasks needing self-critique → `thinking`.
-- Current-events or source-cited answers → `research` (uses web + X search).
+- Tasks needing self-critique → `thinking` (**API-only**; use `plane="api"` or
+  `plane="auto"` with a configured server API key — never `plane="cli"` +
+  `fallback_policy="same_plane"`).
+- Current-events or source-cited answers → `research` (**API-only** multi-agent
+  fan-out; same plane rule as thinking). Vision routes follow the same rule.
+
+If a receipt shows `cli-incompatible` /
+`same_plane_capability_incompatible`, switch to API (or auto) rather than
+retrying the same CLI pin.
 
 ## Multi-agent / research fan-out (not local subagent spawn)
 

--- a/docs/okf/agent-tool.md
+++ b/docs/okf/agent-tool.md
@@ -114,11 +114,14 @@ Dedicated tool wrapping a ReAct AgentLoop in a schema-enforced reflection review
    cached live catalog filters API candidates; mature local evidence can
    replace a stable default only after clearing the quality margin.
 2. **Fast path (`fast`)**: Toolless single turn.
-3. **Reasoning path (`reasoning`)**: Enforces planning model.
-4. **Thinking path (`thinking`)**: Executes thinking loop with reflection review.
+3. **Reasoning path (`reasoning`)**: Enforces planning model. Compatible on the
+   CLI plane when the live CLI catalog has a planning model.
+4. **Thinking path (`thinking`)**: Executes thinking loop with reflection
+   review. **API-native** — not available as a CLI-only pin under
+   `fallback_policy="same_plane"`.
 5. **Research mode (`research`)**: Selects the live Grok 4.20 multi-agent model,
    triggers fan-out (agent count 4 or 16), and collects inline sources in
-   `citations`.
+   `citations`. **API-native** — same plane rule as thinking and vision.
 
 The `routing` object is the explanation source of truth. It never contains the
 prompt: only bounded features, model slugs, evidence counts, catalog state, and
@@ -150,7 +153,10 @@ use live `tools/list` as the contract before assuming a tool exists.
   model should spend effort before answering.
 - Use `mode="thinking"` only when you explicitly want the slower reflection
   loop; use `mode="research"` only when grounded fan-out is worth the extra
-  cost and latency.
+  cost and latency. Both are **API-only capabilities**: pair them with
+  `plane="api"` (or `plane="auto"` with a configured API key). Do not combine
+  them with `plane="cli"` + `fallback_policy="same_plane"` — that fails closed
+  with `same_plane_capability_incompatible` / `cli-incompatible`.
 - Leave `plane="auto"` for normal CLI-first behavior. Use
   `fallback_policy="same_plane"` when you must not cross the billing boundary,
   especially for pinned API models or explicit CLI-only review flows.

--- a/docs/okf/faq.md
+++ b/docs/okf/faq.md
@@ -204,6 +204,37 @@ CLI-first selection uses the model ids returned by the authenticated live
 still exists; the current catalog's default is preferred for reasoning and its
 composer model for coding.
 
+## Why did thinking or research fail on the CLI plane? {#api-only-modes}
+
+**Keywords:** thinking, research, vision, api-only, same_plane, cli plane,
+cli-incompatible, same_plane_capability_incompatible, deep think
+
+`mode="thinking"`, multi-agent `mode="research"`, and vision routes are
+**API-native**. They need the metered xAI API plane (and a configured
+`XAI_API_KEY` on the server), not the SuperGrok CLI subscription alone.
+
+If you call `agent` with `plane="cli"` and `fallback_policy="same_plane"` while
+requesting one of those capabilities, UniGrok **fails closed** before spend.
+The receipt looks like:
+
+- `finish_reason`: `error`
+- `model`: `cli-incompatible`
+- `routing.why_detail`: `same_plane_capability_incompatible`
+- message telling you to choose `plane="api"` or `plane="auto"`
+
+What to do:
+
+1. For deep-think / reflection: `mode="thinking"` with `plane="api"` (or
+   `plane="auto"` when the API key is configured so routing may land on API).
+2. For citation-backed research: `mode="research"` the same way — still
+   API-native.
+3. For subscription-only work: stay on CLI with `mode="fast"`, `mode="auto"`,
+   or `mode="reasoning"` (planning on the live CLI catalog). Do not pin
+   thinking/research to CLI under `same_plane`.
+
+This is not a CLI outage. Compatible CLI chat can still be Ready while
+API-only modes correctly refuse a CLI-only pin.
+
 ## What should an IDE agent do when a credential plane is unavailable? {#credential-plane-actions}
 
 **Keywords:** credentials, missing api key, cli auth, install cli, permission

--- a/sites/unigrok-control-center/public/docs/okf/agent-tool.md
+++ b/sites/unigrok-control-center/public/docs/okf/agent-tool.md
@@ -114,11 +114,14 @@ Dedicated tool wrapping a ReAct AgentLoop in a schema-enforced reflection review
    cached live catalog filters API candidates; mature local evidence can
    replace a stable default only after clearing the quality margin.
 2. **Fast path (`fast`)**: Toolless single turn.
-3. **Reasoning path (`reasoning`)**: Enforces planning model.
-4. **Thinking path (`thinking`)**: Executes thinking loop with reflection review.
+3. **Reasoning path (`reasoning`)**: Enforces planning model. Compatible on the
+   CLI plane when the live CLI catalog has a planning model.
+4. **Thinking path (`thinking`)**: Executes thinking loop with reflection
+   review. **API-native** — not available as a CLI-only pin under
+   `fallback_policy="same_plane"`.
 5. **Research mode (`research`)**: Selects the live Grok 4.20 multi-agent model,
    triggers fan-out (agent count 4 or 16), and collects inline sources in
-   `citations`.
+   `citations`. **API-native** — same plane rule as thinking and vision.
 
 The `routing` object is the explanation source of truth. It never contains the
 prompt: only bounded features, model slugs, evidence counts, catalog state, and
@@ -150,7 +153,10 @@ use live `tools/list` as the contract before assuming a tool exists.
   model should spend effort before answering.
 - Use `mode="thinking"` only when you explicitly want the slower reflection
   loop; use `mode="research"` only when grounded fan-out is worth the extra
-  cost and latency.
+  cost and latency. Both are **API-only capabilities**: pair them with
+  `plane="api"` (or `plane="auto"` with a configured API key). Do not combine
+  them with `plane="cli"` + `fallback_policy="same_plane"` — that fails closed
+  with `same_plane_capability_incompatible` / `cli-incompatible`.
 - Leave `plane="auto"` for normal CLI-first behavior. Use
   `fallback_policy="same_plane"` when you must not cross the billing boundary,
   especially for pinned API models or explicit CLI-only review flows.

--- a/sites/unigrok-control-center/public/docs/okf/faq.md
+++ b/sites/unigrok-control-center/public/docs/okf/faq.md
@@ -204,6 +204,37 @@ CLI-first selection uses the model ids returned by the authenticated live
 still exists; the current catalog's default is preferred for reasoning and its
 composer model for coding.
 
+## Why did thinking or research fail on the CLI plane? {#api-only-modes}
+
+**Keywords:** thinking, research, vision, api-only, same_plane, cli plane,
+cli-incompatible, same_plane_capability_incompatible, deep think
+
+`mode="thinking"`, multi-agent `mode="research"`, and vision routes are
+**API-native**. They need the metered xAI API plane (and a configured
+`XAI_API_KEY` on the server), not the SuperGrok CLI subscription alone.
+
+If you call `agent` with `plane="cli"` and `fallback_policy="same_plane"` while
+requesting one of those capabilities, UniGrok **fails closed** before spend.
+The receipt looks like:
+
+- `finish_reason`: `error`
+- `model`: `cli-incompatible`
+- `routing.why_detail`: `same_plane_capability_incompatible`
+- message telling you to choose `plane="api"` or `plane="auto"`
+
+What to do:
+
+1. For deep-think / reflection: `mode="thinking"` with `plane="api"` (or
+   `plane="auto"` when the API key is configured so routing may land on API).
+2. For citation-backed research: `mode="research"` the same way — still
+   API-native.
+3. For subscription-only work: stay on CLI with `mode="fast"`, `mode="auto"`,
+   or `mode="reasoning"` (planning on the live CLI catalog). Do not pin
+   thinking/research to CLI under `same_plane`.
+
+This is not a CLI outage. Compatible CLI chat can still be Ready while
+API-only modes correctly refuse a CLI-only pin.
+
 ## What should an IDE agent do when a credential plane is unavailable? {#credential-plane-actions}
 
 **Keywords:** credentials, missing api key, cli auth, install cli, permission

--- a/skills/using-unigrok/SKILL.md
+++ b/skills/using-unigrok/SKILL.md
@@ -45,8 +45,15 @@ search grounding was used.
 
 - Quick factual or single-file questions → `fast`.
 - Design reviews, audits, multi-step analysis → `reasoning`.
-- Tasks needing self-critique → `thinking`.
-- Current-events or source-cited answers → `research` (uses web + X search).
+- Tasks needing self-critique → `thinking` (**API-only**; use `plane="api"` or
+  `plane="auto"` with a configured server API key — never `plane="cli"` +
+  `fallback_policy="same_plane"`).
+- Current-events or source-cited answers → `research` (**API-only** multi-agent
+  fan-out; same plane rule as thinking). Vision routes follow the same rule.
+
+If a receipt shows `cli-incompatible` /
+`same_plane_capability_incompatible`, switch to API (or auto) rather than
+retrying the same CLI pin.
 
 ## Multi-agent / research fan-out (not local subagent spawn)
 

--- a/tests/test_agent_mode_plane_contract.py
+++ b/tests/test_agent_mode_plane_contract.py
@@ -87,6 +87,18 @@ def test_using_unigrok_skill_documents_modes_and_planes() -> None:
         assert mode in skill
     for token in ("cli", "api", "same_plane", "cross_plane", "cli_first"):
         assert token in skill
+    # Live product law: thinking/research are API-native under same_plane pins.
+    assert "API-only" in skill
+    assert "same_plane_capability_incompatible" in skill or "cli-incompatible" in skill
+
+
+def test_agent_tool_and_faq_document_api_only_mode_plane_law() -> None:
+    agent_tool = (ROOT / "docs" / "okf" / "agent-tool.md").read_text(encoding="utf-8")
+    faq = (ROOT / "docs" / "okf" / "faq.md").read_text(encoding="utf-8")
+    assert "API-native" in agent_tool or "API-only" in agent_tool
+    assert "same_plane_capability_incompatible" in agent_tool
+    assert "{#api-only-modes}" in faq
+    assert "cli-incompatible" in faq
 
 
 def test_agent_docstrings_name_all_modes() -> None:

--- a/tests/test_faq.py
+++ b/tests/test_faq.py
@@ -60,6 +60,23 @@ async def test_agent_faq_lookup_returns_verified_vscode_dual_lane_context():
 
 
 @pytest.mark.asyncio
+async def test_agent_faq_lookup_returns_api_only_mode_plane_guidance():
+    result = json.loads(
+        await lookup_unigrok_faq(
+            "Why did thinking or research fail on the CLI plane with same_plane?"
+        )
+    )
+
+    assert result["source_uri"] == "grok://faq"
+    assert result["count"] >= 1
+    assert result["matches"][0]["id"] == "api-only-modes"
+    excerpt = result["matches"][0]["answer_excerpt"]
+    assert "API-native" in excerpt or "API-only" in excerpt or "API" in excerpt
+    assert "same_plane" in excerpt
+    assert "cli-incompatible" in excerpt or "same_plane_capability_incompatible" in excerpt
+
+
+@pytest.mark.asyncio
 async def test_agent_faq_lookup_leaves_non_matches_for_normal_reasoning():
     result = json.loads(await lookup_unigrok_faq("Write a poem about ocean currents"))
 


### PR DESCRIPTION
## Summary
Overlooked **operator/docs gap** from the live dual-plane truth check: `mode=thinking` / `research` (and vision) are **API-native**, and `plane=cli` + `same_plane` correctly fails closed with `cli-incompatible` / `same_plane_capability_incompatible`. FAQ, agent-tool habits, and the public `using-unigrok` skill did not teach that, so agents retried the wrong pin.

## Why this packet (non-blocking)
- **Docs + skill + tests only** — no `src/` runtime change
- **Does not collide** with open peer PRs that thrash `api-reference`, Cursor rules, dual-supervisor land, or the CLI model-switch code fix (#218)
- Safe for any supervisor land order

## Changed paths
- `docs/okf/faq.md` — new `{#api-only-modes}` entry
- `docs/okf/agent-tool.md` — mode list + plane habits
- `sites/unigrok-control-center/public/docs/okf/{faq,agent-tool}.md` — mirrors
- `.agents/skills/using-unigrok/SKILL.md` + `skills/using-unigrok/SKILL.md` (kept identical)
- `tests/test_faq.py`, `tests/test_agent_mode_plane_contract.py`

## Tests
- `uv run pytest tests/test_faq.py tests/test_agent_mode_plane_contract.py -q` → **16 passed**

## Risks
- Low: documentation/skill only; FAQ lookup scoring may rank the new entry for related plane questions (intended)

## Human sponsor
djtelicloud

## Provenance
- Brand: Grok CLI
- Agent-Assisted-By: xAI Grok | model=grok-4.5 | model-source=provider-session | surface=Grok Build CLI | role=documentation

## Ready for supervisor?
Yes — exact head after push; independent of #218 code fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, skill, and test-only changes; no runtime routing changes. FAQ lookup may surface the new entry more often for plane-related questions, which is intended.
> 
> **Overview**
> Documents that **`thinking`**, **`research`**, and vision are **API-native** and must not be pinned to the CLI with `plane="cli"` and `fallback_policy="same_plane"` — that combination **fails closed** before spend with `cli-incompatible` / `same_plane_capability_incompatible`.
> 
> Adds FAQ anchor **`{#api-only-modes}`** with receipt fields and remediation (`plane="api"` or `plane="auto"` with a server API key; subscription-only alternatives). Updates **`agent-tool.md`** operational modes and Copilot plane habits; mirrors the same text under **Control Center** public OKF docs.
> 
> Aligns **`.agents/skills/using-unigrok/SKILL.md`** and **`skills/using-unigrok/SKILL.md`** (kept identical) with **API-only** mode guidance and receipt-based retry advice. Extends **`test_agent_mode_plane_contract.py`** and **`test_faq.py`** so docs and FAQ lookup stay locked to this product law.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02c91a2e284fccbae72cb2585e62fe32d49f45d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->