### PR TITLE
docs(public-intelligence): terminal markdown authoring pack v0

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -26,6 +26,13 @@ changes or user-requested live updates. Required boot summaries, safety prompts,
 and blocking questions are explicit exceptions.
 - Prefer UniGrok MCP CLI/`fast` for hard judgment; keep visible output tiny.
   Insider silent-think doctrine is private (not public default).
+- **Terminal markdown (layout law):** when the host is a CLI/TUI, author user-
+  facing replies as portable GFM structure (short lead line, sparse bullets or
+  small tables, fenced dumps, paths/links). Do not use raw HTML as the primary
+  chat UI. Themes paint colors; agents do not invent color languages. Full
+  guide: [docs/public-intelligence/packs/v0-terminal-markdown-authoring.md](../docs/public-intelligence/packs/v0-terminal-markdown-authoring.md).
+  Human radio (Ready/Live/titles) remains the content law — this is only how
+  that text is shaped.
 - **Public intelligence packs:** distilled gym wins for clones live under
   `docs/public-intelligence/`. After Live work, ask once: promote a scrubbed
   pack/skill? Never auto-sync private intelligence or raw memory to public.

--- a/docs/public-intelligence/README.md
+++ b/docs/public-intelligence/README.md
@@ -44,4 +44,5 @@ manifest, and open a product PR. Never force-push private history public.
 
 - Public vs private git: [docs/design/public-private-git-split.md](../design/public-private-git-split.md)
 - Human language for agents: [.agents/AGENTS.md](../../.agents/AGENTS.md)
+- Terminal markdown authoring (CLI/TUI layout): [packs/v0-terminal-markdown-authoring.md](packs/v0-terminal-markdown-authoring.md)
 - Insider capsules (not public consumer DB): [docs/okf/intelligence-capsule-v1.md](../okf/intelligence-capsule-v1.md)

--- a/docs/public-intelligence/packs/manifest.json
+++ b/docs/public-intelligence/packs/manifest.json
@@ -79,6 +79,32 @@
         "Session or task-RAG database dumps",
         "Contributor workspace memory rows"
       ]
+    },
+    {
+      "pack_id": "terminal-markdown-authoring",
+      "version": "v0",
+      "title": "Terminal markdown authoring",
+      "summary": "Portable GFM structure for CLI/TUI chat; human radio is content, themes paint colors; Grok host notes (no HTML webview).",
+      "audience": "public_and_contributor",
+      "body_path": "docs/public-intelligence/packs/v0-terminal-markdown-authoring.md",
+      "source_gym": "Grok Build CLI/TUI sessions clarifying markdown vs HTML artifacts; multi-brand terminal agents (Grok, Claude Code, Codex CLI).",
+      "promoted_from": [
+        ".agents/AGENTS.md",
+        "docs/public-intelligence/packs/v0-human-radio-and-cloud-boundary.md",
+        "Grok user-guide theming (md_* slots)"
+      ],
+      "scrub": {
+        "secrets": true,
+        "private_paths": true,
+        "raw_memory": true,
+        "unreviewed_logs": true
+      },
+      "never_includes": [
+        "API keys or OAuth secrets",
+        "Private unigrok-intelligence playbooks",
+        "Session or task-RAG database dumps",
+        "Contributor workspace memory rows"
+      ]
     }
   ]
 }

--- a/docs/public-intelligence/packs/v0-human-radio-and-cloud-boundary.md
+++ b/docs/public-intelligence/packs/v0-human-radio-and-cloud-boundary.md
@@ -42,6 +42,10 @@ change or finish line, emit one short status:
 For long or continuously monitored work, reuse that format only when the state
 changes. Expand only when the human asks for technical detail.
 
+**Terminal layout:** when speaking in a CLI/TUI, shape that line and any short
+follow-up with portable markdown (not HTML). See
+[v0-terminal-markdown-authoring.md](v0-terminal-markdown-authoring.md).
+
 ## 2. Cursor Cloud vs laptop UniGrok
 
 | Mode | UniGrok |

--- a/docs/public-intelligence/packs/v0-terminal-markdown-authoring.md
+++ b/docs/public-intelligence/packs/v0-terminal-markdown-authoring.md
@@ -1,0 +1,116 @@
+# Public pack v0 — Terminal markdown authoring
+
+**Audience:** public installers and contributor agents talking in a **terminal**  
+**Pack id:** `terminal-markdown-authoring` · **version:** `v0`
+
+How agents should shape user-facing replies when the host is a CLI/TUI (Grok
+Build, Claude Code CLI, Codex CLI, plain SSH) — not a browser HTML panel.
+
+This pack is about **structure** (markdown you write). It is **not** about
+picking theme colors. Human radio (**Ready for supervisor** / **Live** / brand
++ **Task titles, not numbers**) is the content law; this pack is the layout law.
+
+## 1. Two layers (do not mix them up)
+
+| Layer | Owner | What it is |
+| --- | --- | --- |
+| **Authoring** | Every terminal agent | Portable GFM/CommonMark structure in the reply |
+| **Paint** | Host theme / terminal | Colors for headings, code, links (e.g. Grok `md_*` theme slots) |
+
+Agents choose headings, lists, tables, fences, and links. Users choose themes.
+Do not invent a private color language or dump HTML/CSS as the primary UI.
+
+## 2. Portable terminal markdown (all terminal agents)
+
+Use this shape for most finish and status replies:
+
+1. **One lead line** — brand + status + plain task title (human radio).  
+2. **Optional short bullets or one small table** — only what the human needs.  
+3. **Optional fenced code** — errors, commands, excerpts.  
+4. **Optional path or link** — open elsewhere; do not fake a browser in chat.
+
+### Prefer
+
+- Short status lines and sparse bullets  
+- Small tables (few columns, short cells)  
+- Fenced blocks for multi-line source, logs, or commands  
+- File paths and `https://` links for “open this”  
+- One H2 (or none) and few H3s — deep heading trees waste width  
+
+### Avoid
+
+- Raw HTML/CSS as the primary chat UI (no in-stream webview)  
+- Progress essays, tool dumps, full diffs unless the human asked  
+- Huge tables, wide ASCII art, and walls of unfenced log  
+- Leading with ticket numbers instead of plain task titles  
+- Inventing host-only markup that other CLIs will show as garbage  
+
+### Width and monospaced reality
+
+Terminal scrollbacks fold, wrap, and truncate. Write for ~80–100 columns of
+useful content. Put long artifacts on disk and point to the path.
+
+## 3. Host appendix — Grok Build CLI/TUI
+
+When the host is **Grok Build** (Grok CLI TUI):
+
+- Chat is **GFM markdown** painted by the active theme (`md_heading_*`,
+  `md_code`, `md_text`, `md_muted`, `link_fg`, task checkboxes).  
+- User key **`r`** toggles raw markdown on a scrollback entry.  
+- **Images:** short session paths (e.g. `images/1.jpg`) after image tools —
+  clickable open, not embedded HTML.  
+- **Real HTML pages / exact layout demos:** write a `.html` file and open it in
+  the system browser; do not paste a full document into chat expecting a page.  
+- There is **no** general HTML artifact panel in the TUI.
+
+## 4. Host footnote — other terminals
+
+| Host | Note |
+| --- | --- |
+| Claude Code / Codex CLI | Their own markdown paint; same portable authoring still applies |
+| Plain SSH / bare terminal | Assume least: plain GFM, no fancy widgets |
+| Cursor / VS Code chat | May be richer; this pack is optional there — do not force TUI rules onto GUI-only surfaces |
+
+## 5. Worked examples
+
+**Good (terminal finish)**
+
+```text
+Grok: Ready for supervisor — terminal markdown authoring pack.
+
+- Docs-only; portable GFM + Grok host note
+- Tests: public pack suite green
+```
+
+**Bad**
+
+```text
+Here is the full HTML for the dashboard:
+<html><head><style>…thousands of lines…</style></head>…
+Also I ran 40 tools and here is every log line…
+```
+
+**Good (need a real page)**
+
+```text
+Grok: Ready for supervisor — dashboard mock HTML on disk.
+
+Open: docs/mocks/dashboard-preview.html
+(or: open that path in your browser)
+```
+
+## 6. How this fits human radio
+
+| Concern | Guide |
+| --- | --- |
+| What words to use | Human radio (`Ready` / `Live` / brand / plain titles) |
+| How to shape the text | **This pack** |
+| What colors appear | User theme / host — not the agent |
+
+Silent human radio still wins: tools and diffs stay off-chat unless asked.
+When you *do* speak, use this layout so every terminal host stays readable.
+
+## 7. Promote habit
+
+After a layout/gym win is **Live**, ask once: promote or bump this pack?
+Keep scrub rules: no secrets, no private paths, no raw memory.


### PR DESCRIPTION
## Summary
Adds a **public intelligence pack** for how agents shape user-facing text in **terminal** hosts (Grok Build TUI, Claude Code CLI, Codex CLI, plain SSH).

- **Portable layer:** GFM structure (lead line, sparse bullets/tables, fences, paths/links) — not HTML as primary UI  
- **Paint layer:** host themes own colors (e.g. Grok `md_*` slots); agents do not invent color languages  
- **Grok host note:** no HTML artifact webview; real pages = file + browser; images = short paths  
- Complements **human radio** (Ready/Live/titles = content law; this pack = layout law)

## Why
Grok CLI sessions clarified that chat is markdown + theme paint, not HTML. Other terminal brands share the same authoring constraints; GUI-only hosts can ignore the TUI footnotes.

## Changed paths
- `docs/public-intelligence/packs/v0-terminal-markdown-authoring.md` (new)
- `docs/public-intelligence/packs/manifest.json`
- `docs/public-intelligence/packs/v0-human-radio-and-cloud-boundary.md` (cross-link)
- `docs/public-intelligence/README.md`
- `.agents/AGENTS.md` (pointer under Communication discipline)

## Tests
- `uv run pytest tests/test_public_intelligence_packs.py -q` → **3 passed**

## Risks
- Low: docs/pack only; no runtime. Light edit to human-radio pack (one cross-link).

## Human sponsor
djtelicloud

## Provenance
- Brand: Grok CLI
- Agent-Assisted-By: xAI Grok | model=grok-4.5 | model-source=provider-session | surface=Grok Build CLI | role=documentation

## Ready for supervisor?
Yes — docs-only, independent of runtime plane PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and pack metadata only; no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds a **v0 public intelligence pack** that tells terminal agents how to **layout** user-facing replies (portable GFM: lead line, sparse bullets/tables, fences, paths/links) while **human radio** stays the content law and **host themes** own colors—not agent-invented HTML/CSS as the primary CLI/TUI UI.
> 
> Registers `terminal-markdown-authoring` in `packs/manifest.json`, cross-links from the human-radio pack and `docs/public-intelligence/README.md`, and adds a **Terminal markdown (layout law)** bullet in `.agents/AGENTS.md` pointing at the new pack. The pack includes Grok Build–specific notes (GFM + `md_*` theming, no in-chat HTML webview; real pages on disk + browser).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f868661c8ca12039c973dc122f3d183f59a2c511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->