### PR TITLE
docs(copilot): add HTML artifact instruction

### DIFF
--- a/.github/instructions/copilot-html-artifacts.instructions.md
+++ b/.github/instructions/copilot-html-artifacts.instructions.md
@@ -1,0 +1,12 @@
+---
+description: "Use when the user asks GitHub Copilot in VS Code to show HTML, render a visual artifact, display rich formatted output, or preview a chat result as HTML. Prefer HTML artifact files plus VS Code Integrated Browser over raw HTML in chat."
+name: "Copilot HTML Artifacts"
+---
+# Copilot HTML artifacts
+
+- In VS Code Copilot chat, prefer Markdown for inline responses. Do not assume raw HTML will render correctly in the chat surface.
+- When the user wants real HTML output, create an `.html` artifact instead of forcing HTML into chat.
+- For one-off visual output, place the artifact outside the repository unless the user explicitly asks for a tracked file.
+- Tell the user to open the artifact with VS Code's **Open in Integrated Browser** for the most reliable in-IDE rendering path.
+- If styling or interactivity matters, include the minimal CSS or JavaScript the artifact needs.
+- If the user wants a reusable in-IDE application surface rather than a one-off artifact, recommend a VS Code webview or extension instead of chat HTML.

--- a/tests/test_copilot_html_artifact_instruction.py
+++ b/tests/test_copilot_html_artifact_instruction.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_copilot_html_instruction_prefers_artifacts_and_integrated_browser() -> None:
+    text = (
+        ROOT
+        / ".github"
+        / "instructions"
+        / "copilot-html-artifacts.instructions.md"
+    ).read_text(encoding="utf-8")
+
+    assert "Use when the user asks GitHub Copilot in VS Code to show HTML" in text
+    assert "raw HTML will render correctly in the chat surface" in text
+    assert "create an `.html` artifact" in text
+    assert "Open in Integrated Browser" in text
+    assert "outside the repository" in text
+    assert "VS Code webview or extension" in text


### PR DESCRIPTION
## Summary
- add a repo-shared Copilot file instruction for HTML/rendering requests in VS Code
- prefer `.html` artifact files plus the Integrated Browser instead of assuming raw chat HTML will render
- cover the supported safe path without touching `.github/copilot-instructions.md`, which is already owned by another PR

## Why this path
This PR is for a **repo-shared workspace customization** in VS Code Copilot.

Personal `.copilot` paths are real in VS Code Copilot (for example user-profile locations such as `~/.copilot/instructions`, and personal skills under `~/.copilot/skills/...`). The narrower point here is that a **repo-root `.copilot/` folder is not a default workspace discovery path** for this instruction type, while `.github/instructions/*.instructions.md` is a documented workspace path. This keeps the change effective and non-colliding.

## Changed paths
- `.github/instructions/copilot-html-artifacts.instructions.md`
- `tests/test_copilot_html_artifact_instruction.py`

## Verification
- `uv run pytest -q tests/test_copilot_html_artifact_instruction.py tests/test_release_hygiene.py`
- `uv run python scripts/check_agent_attribution.py --base-ref origin/main --head HEAD`

## Known risks
- This is guidance only; it does not change runtime behavior or force a renderer.
- VS Code chat surface behavior can still vary by client version, so the instruction intentionally points to artifact files plus the Integrated Browser as the reliable path.

## Generated files
- None

## Sponsor
- djtelicloud (chat requester)

## Agent provenance
- Agent-Assisted-By: GitHub Copilot | model=GPT-5.6 Sol | model-source=user-reported | surface=VS Code | role=documentation
- Exact head SHA: fe57abce41c3573ba0f72e695a31ae55c3645458
