### PR TITLE
docs(cursor): add alwaysApply Canvas artifact surface rule

### DIFF
--- a/.cursor/rules/cursor-canvas-artifacts.mdc
+++ b/.cursor/rules/cursor-canvas-artifacts.mdc
@@ -1,0 +1,56 @@
+---
+description: Cursor Canvas and chat artifact surfaces — rich UI without raw HTML
+alwaysApply: true
+---
+
+# Cursor canvas & chat artifacts
+
+Cursor chat is **not** an HTML widget host. Pasted `<div>` / `<iframe>` becomes
+plain text. For HTML-like rich UI, use the product surfaces below.
+
+Canonical skill: `~/.cursor/skills-cursor/canvas/SKILL.md` (Canvas SDK:
+`cursor/canvas` only).
+
+## Ranked surfaces (smartest → fallback)
+
+| Rank | Surface | Use when |
+|------|---------|----------|
+| 1 | **Canvas** (`.canvas.tsx`) | Standalone analytical / interactive artifact beside chat |
+| 2 | **Markdown + Mermaid** | Small in-chat diagrams (` ```mermaid `) |
+| 3 | **GenerateImage** | User explicitly asked for an image/mockup |
+| 4 | **Browser MCP** | Live page verify/navigate — not an in-chat widget |
+| 5 | **open_resource** | Open a real file/URL in the IDE |
+
+If you catch yourself writing a large markdown table of MCP/tool results → **stop
+and use a Canvas**.
+
+## Canvas law (cool tricks that matter)
+
+1. **Managed path only** (IDE will not pick up other locations):
+
+```text
+~/.cursor/projects/<workspace>/canvases/<name>.canvas.tsx
+```
+
+2. Exactly **one** `.canvas.tsx` file per canvas — no helper modules, CSS, or npm.
+3. Import **only** `cursor/canvas`. Embed data inline. **No `fetch()`**.
+4. Prefer SDK building blocks (`Stack`, `Card`, `Table`, `BarChart`, `Select`,
+   `Toggle`, `useCanvasState`, `computeDAGLayout`, …) over hand-rolled chrome.
+5. Flat minimal design: no gradients, box-shadows, emoji decoration, or rainbow.
+6. When you create/update a canvas, **markdown-link the absolute path** in chat
+   so the user can open it beside the conversation.
+7. Do **not** replace a user-owned HTML dashboard deliverable with a Canvas —
+   edit their HTML file instead.
+
+## Anti-patterns
+
+- Raw HTML / iframes in the chat bubble expecting a rendered widget
+- Committing managed `~/.cursor/projects/.../canvases/*` into the git repo as
+  the runtime surface (repo rules teach; the IDE compiles the managed path)
+- Wrong path, subfolders, or non-`.canvas.tsx` extensions
+- Touching `docs/ide-setup.md` or open sibling `.cursor/rules/*` PRs from this
+  packet
+
+## Non-collision
+
+New file only: `.cursor/rules/cursor-canvas-artifacts.mdc`.


### PR DESCRIPTION
## Summary
- Adds `.cursor/rules/cursor-canvas-artifacts.mdc` so every Cursor agent ranks Canvas → Mermaid → GenerateImage → Browser → open_resource.
- Codifies cool tricks missed earlier: managed `canvases/*.canvas.tsx` path, `cursor/canvas`-only imports, no raw HTML widgets, absolute-path link in chat.
- Does **not** commit IDE-managed `~/.cursor/projects/.../canvases` files into git (runtime stays local; rule teaches).

## Risk
`risk: low`

## Test plan
- [ ] Diff vs main is one file
- [ ] After land, agents prefer Canvas for standalone rich UI
- [ ] No collision with open `.cursor/rules/*` packets (#194/#197/#203/#204/#207/#210)

## Live proof
- Demo canvas exercised in chat (path gate, open_resource, Mermaid, GenerateImage, HTML dead-end)
- Hive: KEEP L1/L5/L6 · CLI · $0
- HEAD: `dfd244c655e7c35514c1fdba20920d7ed315486e`

Made with [Cursor](https://cursor.com)