### PR TITLE
docs(codex): add theme-safe chat display fragment

### DIFF
--- a/.codex/chat-fragments/conversation-canvas.html
+++ b/.codex/chat-fragments/conversation-canvas.html
@@ -1,0 +1,139 @@
+<!--
+  Codex Desktop durable in-chat reference fragment.
+  Render this as a focused fragment, not as a full HTML document. The host
+  owns the theme; the variables below keep the display readable in both its
+  light and dark themes.
+-->
+<style>
+  #conversation-canvas {
+    --canvas-accent: var(--cyan, var(--primary));
+    --canvas-outcome: var(--teal, var(--viz-series-2));
+    color: var(--foreground);
+  }
+
+  #conversation-canvas .canvas-track {
+    stroke: var(--border);
+  }
+
+  #conversation-canvas .canvas-arrow {
+    stroke: var(--canvas-accent);
+  }
+
+  #conversation-canvas .canvas-node {
+    fill: var(--card);
+    stroke: var(--border);
+  }
+
+  #conversation-canvas .canvas-node-active {
+    fill: color-mix(in srgb, var(--canvas-accent) 18%, var(--card));
+    stroke: var(--canvas-accent);
+  }
+
+  #conversation-canvas .canvas-node-outcome {
+    fill: color-mix(in srgb, var(--canvas-outcome) 18%, var(--card));
+    stroke: var(--canvas-outcome);
+  }
+
+  #conversation-canvas .canvas-label {
+    fill: var(--card-foreground);
+  }
+</style>
+
+<section id="conversation-canvas" aria-label="Choose the next in-chat display">
+  <div class="viz-controls" aria-label="Display intent">
+    <button class="btn btn-primary" type="button" data-view="decide" aria-pressed="true">
+      <i data-lucide="git-compare-arrows" aria-hidden="true"></i>
+      Decide
+    </button>
+    <button class="btn" type="button" data-view="monitor" aria-pressed="false">
+      <i data-lucide="activity" aria-hidden="true"></i>
+      Monitor
+    </button>
+    <button class="btn" type="button" data-view="explain" aria-pressed="false">
+      <i data-lucide="lightbulb" aria-hidden="true"></i>
+      Explain
+    </button>
+  </div>
+
+  <svg viewBox="0 0 720 120" width="100%" height="120" role="img" aria-labelledby="canvas-title canvas-description">
+    <title id="canvas-title">A three-step in-chat display sequence</title>
+    <desc id="canvas-description">The selected view turns a starting point into a useful outcome through three visible steps.</desc>
+    <circle cx="56" cy="60" r="36" fill="var(--canvas-accent)" opacity="0.08" aria-hidden="true"></circle>
+    <circle cx="664" cy="60" r="36" fill="var(--canvas-outcome)" opacity="0.08" aria-hidden="true"></circle>
+    <path class="canvas-track" d="M218 60H278M442 60H502" fill="none" stroke-width="2" aria-hidden="true"></path>
+    <path class="canvas-arrow" d="M268 54L278 60L268 66M492 54L502 60L492 66" fill="none" stroke-width="2" aria-hidden="true"></path>
+    <rect class="canvas-node" x="22" y="24" width="196" height="72" rx="12" stroke-width="2"></rect>
+    <rect class="canvas-node canvas-node-active" x="278" y="24" width="164" height="72" rx="12" stroke-width="2"></rect>
+    <rect class="canvas-node canvas-node-outcome" x="502" y="24" width="196" height="72" rx="12" stroke-width="2"></rect>
+    <text class="canvas-label" x="120" y="66" text-anchor="middle" data-step="0">Inputs</text>
+    <text class="canvas-label" x="360" y="66" text-anchor="middle" data-step="1">Tradeoff</text>
+    <text class="canvas-label" x="600" y="66" text-anchor="middle" data-step="2">Decision</text>
+  </svg>
+
+  <div class="viz-row">
+    <span class="viz-badge" data-label>Decision view</span>
+    <span class="text-muted" data-detail>Turn a multi-step choice into one visible decision.</span>
+    <button class="btn btn-ghost" type="button" data-action>Build this view</button>
+  </div>
+</section>
+
+<script>
+  (() => {
+    const root = document.getElementById("conversation-canvas");
+    const views = {
+      decide: {
+        label: "Decision view",
+        steps: ["Inputs", "Tradeoff", "Decision"],
+        detail: "Turn a multi-step choice into one visible decision.",
+        prompt: "Create an in-chat decision display for the current task. Show the inputs, the key tradeoff, and the recommended decision."
+      },
+      monitor: {
+        label: "Status view",
+        steps: ["Signal", "Delta", "Next check"],
+        detail: "Make changing work visible without a wall of updates.",
+        prompt: "Create an in-chat status display for the current task. Show the most important signal, what changed, and the next verification."
+      },
+      explain: {
+        label: "Explainer view",
+        steps: ["Question", "Visual", "Takeaway"],
+        detail: "Turn a complex idea into one memorable picture.",
+        prompt: "Create an in-chat explainer for the current task. Show the question, the clearest visual model, and the takeaway."
+      }
+    };
+
+    const buttons = root.querySelectorAll("[data-view]");
+    const steps = root.querySelectorAll("[data-step]");
+    const label = root.querySelector("[data-label]");
+    const detail = root.querySelector("[data-detail]");
+    const action = root.querySelector("[data-action]");
+    let selected = "decide";
+
+    const select = (view) => {
+      selected = view;
+      const choice = views[view];
+      buttons.forEach((button) => {
+        const active = button.dataset.view === view;
+        button.classList.toggle("btn-primary", active);
+        button.setAttribute("aria-pressed", String(active));
+      });
+      steps.forEach((step, index) => {
+        step.textContent = choice.steps[index];
+      });
+      label.textContent = choice.label;
+      detail.textContent = choice.detail;
+    };
+
+    buttons.forEach((button) => {
+      button.addEventListener("click", () => select(button.dataset.view));
+    });
+
+    action.addEventListener("click", async () => {
+      if (window.openai?.sendFollowUpMessage) {
+        await window.openai.sendFollowUpMessage({
+          title: "Build in-chat display",
+          prompt: views[selected].prompt
+        });
+      }
+    });
+  })();
+</script>

--- a/.codex/desktop-session-contract.md
+++ b/.codex/desktop-session-contract.md
@@ -39,6 +39,24 @@
   user or applicable project instructions authorize parallel agents. Preserve
   one integration owner and non-overlapping path ownership.
 
+## In-chat visual artifacts
+
+- Small interactive answers belong in a focused HTML fragment, not a full
+  webpage. The reference fragment is
+  [`.codex/chat-fragments/conversation-canvas.html`](chat-fragments/conversation-canvas.html).
+  It shows the intended three-step pattern: choose an intent, see the flow,
+  then request one bounded follow-up.
+- The chat host owns its light or dark theme. Scope custom CSS to the artifact
+  root and use its semantic variables (`--foreground`, `--card`, `--border`,
+  `--primary`) with UniGrok's `--cyan` and `--teal` only as optional accents.
+  Never set black text or a dark background as a fixed default.
+- Keep a fragment self-contained: no external network calls, scripts, fonts,
+  or assets. Its one permitted integration is a checked
+  `window.openai?.sendFollowUpMessage` call that turns the selected state into
+  a clear next request.
+- Use the in-app Browser for a real local web page or app. Use Markdown,
+  images, PDFs, or docs when a static result is clearer than interaction.
+
 ## Codex collaboration modes
 
 - **Default mode** favors execution: make safe, scoped assumptions, implement

--- a/.codex/memory/active-work.md
+++ b/.codex/memory/active-work.md
@@ -7,6 +7,14 @@ Live. The remote MCP and Control Center remain live in `us-central1` with
 east-region rollback assets. Stage 1 live generation and training remain
 blocked.
 
+## Current Codex review packet
+
+- Draft PR #225 preserves the sponsor-approved, theme-safe in-chat conversation
+  canvas as a Codex-only reference fragment. It changes no MCP runtime,
+  release, cloud, or deployment behavior. The focused contract tests and the
+  attribution check passed; it remains pending normal exact-head review and
+  protected integration.
+
 This is the project-scoped handoff for new Codex chats. Verify drift-prone Git,
 CI, runtime, DNS, cloud, and benchmark state live before acting. Never record
 credentials, OAuth codes, tokens, or private keys here.

--- a/tests/test_codex_desktop_session_contract.py
+++ b/tests/test_codex_desktop_session_contract.py
@@ -3,11 +3,13 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 CONTRACT = ROOT / ".codex" / "desktop-session-contract.md"
+CONVERSATION_CANVAS = ROOT / ".codex" / "chat-fragments" / "conversation-canvas.html"
 
 REQUIRED_HEADINGS = (
     "## Purpose",
     "## Codex Desktop superpowers",
     "## Codex collaboration modes",
+    "## In-chat visual artifacts",
     "## UniGrok agent modes vs credential planes",
     "## Exact-head integration laws",
     "## Session start checklist",
@@ -23,6 +25,7 @@ REQUIRED_PHRASES = (
     "orthogonal",
     "Default mode",
     "Plan mode",
+    "conversation-canvas.html",
 )
 
 
@@ -34,3 +37,15 @@ def test_codex_desktop_session_contract_is_complete() -> None:
         assert heading in text
     for phrase in REQUIRED_PHRASES:
         assert phrase in text
+
+
+def test_conversation_canvas_uses_host_theme_tokens_and_bounded_follow_up() -> None:
+    text = CONVERSATION_CANVAS.read_text(encoding="utf-8")
+
+    assert '<section id="conversation-canvas"' in text
+    assert "color: var(--foreground);" in text
+    assert "var(--cyan, var(--primary))" in text
+    assert "var(--teal, var(--viz-series-2))" in text
+    assert "window.openai?.sendFollowUpMessage" in text
+    assert "fetch(" not in text
+    assert "https://" not in text


### PR DESCRIPTION
## What changed

- Adds a durable, focused Codex Desktop conversation-canvas fragment under `.codex/`.
- Documents theme-safe in-chat artifact rules in the Codex Desktop session contract.
- Locks the fragment to host semantic tokens and a bounded follow-up action.

## Why

The display must remain readable in both light and dark chat themes instead of inheriting a fixed black-on-dark palette.

## Validation

- `uv run pytest -q tests/test_codex_desktop_session_contract.py`
- `uv run python scripts/check_agent_attribution.py --base-ref origin/main --head HEAD`
- Wrapped-fragment render and JavaScript syntax validation.

## Handoff

- Head: `617488e4f2d944b9f8fc8606c53bd5e98c3b60bd`
- Changed paths: `.codex/chat-fragments/conversation-canvas.html`, `.codex/desktop-session-contract.md`, `.codex/memory/active-work.md`, `tests/test_codex_desktop_session_contract.py`
- Risk: documentation/reference artifact only; no MCP runtime or deployment behavior changes.
- Sponsor: repository owner approved the theme-aware in-chat display.
- Provenance: `Agent-Assisted-By: OpenAI Codex | model=unverified | model-source=unverified | surface=Codex Desktop | role=implementation`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and reference-only artifacts under `.codex/` with no runtime or deployment impact.
> 
> **Overview**
> Adds a **Codex-only reference** for small interactive in-chat HTML: `conversation-canvas.html` under `.codex/chat-fragments/`, with Decide / Monitor / Explain intents, a three-step SVG flow, host-theme CSS (`--foreground`, `--card`, etc.), and a single bounded `window.openai?.sendFollowUpMessage` action.
> 
> The **desktop session contract** gains an **In-chat visual artifacts** section (fragment vs full page, theme rules, no external assets/network, when to use Browser or static formats). **Active work** notes draft PR #225. **Contract tests** require the new heading and phrase, plus assertions that the fragment uses theme tokens, allows only the follow-up hook, and excludes `fetch` / `https://`.
> 
> No MCP, release, cloud, or deployment behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5c3d41d23fff1909ac044e9d6107515f50d5646. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->