### PR TITLE
feat(cursor): add UniGrok Canvas/hive session hooks

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "command": ".cursor/hooks/session-unigrok-env.py",
+        "timeout": 5
+      }
+    ],
+    "beforeMCPExecution": [
+      {
+        "command": ".cursor/hooks/before-unigrok-agent.py",
+        "matcher": "agent",
+        "timeout": 5
+      }
+    ]
+  }
+}

--- a/.cursor/hooks/before-unigrok-agent.py
+++ b/.cursor/hooks/before-unigrok-agent.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""beforeMCPExecution: tip when calling UniGrok `agent` (fail-open, never block)."""
+from __future__ import annotations
+
+import json
+import sys
+
+
+TIP = (
+    "Cursor surface tip: rich UI → Canvas (.canvas.tsx); hive votes → "
+    "plane=cli mode=fast index-diff; sponsor status → Ready/Live/Blocked."
+)
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        payload = {}
+
+    tool = str(payload.get("tool_name") or payload.get("toolName") or "")
+    # Matcher already filters, but keep fail-open for unexpected shapes.
+    if "agent" not in tool.lower() and tool != "":
+        sys.stdout.write(json.dumps({"permission": "allow"}))
+        return 0
+
+    sys.stdout.write(
+        json.dumps(
+            {
+                "permission": "allow",
+                "agent_message": TIP,
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.cursor/hooks/session-unigrok-env.py
+++ b/.cursor/hooks/session-unigrok-env.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""sessionStart: set Cursor×UniGrok session env (fail-open).
+
+Note: additional_context on sessionStart is documented but has known IDE race
+bugs; env is the reliable channel for follow-on hooks.
+"""
+from __future__ import annotations
+
+import json
+import sys
+
+def main() -> int:
+    try:
+        json.load(sys.stdin)
+    except Exception:
+        pass
+    out = {
+        "env": {
+            "UNIGROK_CURSOR_SURFACE": "canvas",
+            "UNIGROK_CURSOR_CLIENT": "cursor",
+        },
+        # Best-effort; may be dropped by IDE race — env above is the durable bit.
+        "additional_context": (
+            "Cursor×UniGrok: prefer Canvas for rich UI beside chat; "
+            "Mermaid for small diagrams; never raw HTML widgets. "
+            "Hive polls: UniGrok agent plane=cli mode=fast index-diff. "
+            "Human radio: Ready / Live / Blocked."
+        ),
+    }
+    sys.stdout.write(json.dumps(out))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Adds project Cursor hooks: `sessionStart` sets `UNIGROK_CURSOR_SURFACE` / `UNIGROK_CURSOR_CLIENT` env (reliable channel).
- `beforeMCPExecution` matcher `agent` returns a fail-open Canvas/hive tip via `agent_message` — never blocks.
- Demonstrates a Cursor-native surface peers do not package the same way; pairs with Live `cursor-canvas-artifacts` rule.

## Risk
`risk: low`

## Test plan
- [ ] `python3 .cursor/hooks/session-unigrok-env.py` with `{}` stdin returns JSON env
- [ ] `before-unigrok-agent.py` with agent tool_name returns allow + agent_message
- [ ] Hooks settings / Hooks output channel shows hooks loaded after land
- [ ] MCP agent calls still succeed (fail-open)

## Live proof
- Local script smoke passed before push
- HEAD: `eec9f440aff915e5406eb72e992c74bcb9c4b188`

Made with [Cursor](https://cursor.com)