### PR TITLE
docs(okf): CLI model-switch session recovery truth

### DIFF
--- a/docs/ide-setup.md
+++ b/docs/ide-setup.md
@@ -325,6 +325,15 @@ selected route or plane.
 The local CLI plane works **inside the container**: the image bakes the Linux
 `grok` binary (version-pinned in the Dockerfile), while compose persists its
 machine-level OAuth session in the dedicated `unigrok-cli-auth` Docker volume.
+
+**Session continuity note:** UniGrok maps each logical MCP `session` name to a
+native CLI conversation id. The CLI binds an agent type to that native id, so
+composer/`fast` then planning/`reasoning` on the same logical session may hit
+`MODEL_SWITCH_INCOMPATIBLE_AGENT`. Current builds recover by opening a fresh
+native session and replaying server-side history (fork would keep the sticky
+agent). If you still see the raw CLI error after a mode switch, rebuild the
+stable image from current product `main` so recovery code is loaded.
+
 Authenticate that service identity once with:
 
 ```bash

--- a/docs/okf/agent-tool.md
+++ b/docs/okf/agent-tool.md
@@ -162,6 +162,12 @@ use live `tools/list` as the contract before assuming a tool exists.
   especially for pinned API models or explicit CLI-only review flows.
 - Qualify `session` by task or repository so repeated Copilot follow-ups stay
   attached to the same logical thread.
+- **CLI agent-type stickiness:** a native CLI conversation keeps one agent
+  type. Switching from composer/`fast` to planning/`reasoning` on the same
+  logical session can raise `MODEL_SWITCH_INCOMPATIBLE_AGENT`. Current UniGrok
+  recovers by replaying server history into a **fresh** native session id
+  (not a fork). Keep the logical `session` name stable; only change it if an
+  older image still surfaces the raw CLI error.
 
 ### Supplying local evidence
 

--- a/docs/okf/faq.md
+++ b/docs/okf/faq.md
@@ -235,6 +235,42 @@ What to do:
 This is not a CLI outage. Compatible CLI chat can still be Ready while
 API-only modes correctly refuse a CLI-only pin.
 
+## Why did CLI reasoning fail after a fast/composer turn on the same session? {#cli-model-switch-session}
+
+**Keywords:** MODEL_SWITCH_INCOMPATIBLE_AGENT, agent type sticky, native
+session, grok-build-plan, cursor agent, composer, reasoning, same_plane,
+session recovery, start_new_session
+
+The Grok CLI binds an **agent type** to each native CLI conversation. A
+`mode="fast"` / composer turn may leave the native session on agent type
+`cursor`. A later `mode="reasoning"` turn on the **same logical `session`**
+needs `grok-4.5` with agent type `grok-build-plan`. The CLI then rejects the
+model switch with `MODEL_SWITCH_INCOMPATIBLE_AGENT` and suggests starting a
+new native session.
+
+UniGrok recovers automatically when the stable service is on a build that
+includes the model-switch recovery path (`src/utils.py`):
+
+1. Detect `MODEL_SWITCH_INCOMPATIBLE_AGENT` (and related “couldn't set model /
+   requires agent” wording).
+2. Open a **fresh** native CLI `--session-id` (do not `--fork-session` — fork
+   keeps the sticky agent binding).
+3. Replay bounded **server-side** history into that fresh session so the
+   logical MCP `session` name still continues.
+
+What callers should do:
+
+1. Prefer keeping a stable logical `session` name; let UniGrok rebind the
+   native CLI id under the hood.
+2. If an older image still surfaces the raw CLI error, rebuild/restart the
+   stable container from current `main`, or use a **new** logical `session`
+   name for the planning turn as a temporary workaround.
+3. Do not treat this as a billing-plane failure — both turns can stay on CLI
+   with `fallback_policy="same_plane"`.
+
+Fresh sessions are always fine: `mode="reasoning"` + `plane="cli"` +
+`same_plane` succeeds when the live CLI catalog has a planning model.
+
 ## What should an IDE agent do when a credential plane is unavailable? {#credential-plane-actions}
 
 **Keywords:** credentials, missing api key, cli auth, install cli, permission

--- a/sites/unigrok-control-center/public/docs/okf/agent-tool.md
+++ b/sites/unigrok-control-center/public/docs/okf/agent-tool.md
@@ -162,6 +162,12 @@ use live `tools/list` as the contract before assuming a tool exists.
   especially for pinned API models or explicit CLI-only review flows.
 - Qualify `session` by task or repository so repeated Copilot follow-ups stay
   attached to the same logical thread.
+- **CLI agent-type stickiness:** a native CLI conversation keeps one agent
+  type. Switching from composer/`fast` to planning/`reasoning` on the same
+  logical session can raise `MODEL_SWITCH_INCOMPATIBLE_AGENT`. Current UniGrok
+  recovers by replaying server history into a **fresh** native session id
+  (not a fork). Keep the logical `session` name stable; only change it if an
+  older image still surfaces the raw CLI error.
 
 ### Supplying local evidence
 

--- a/sites/unigrok-control-center/public/docs/okf/faq.md
+++ b/sites/unigrok-control-center/public/docs/okf/faq.md
@@ -235,6 +235,42 @@ What to do:
 This is not a CLI outage. Compatible CLI chat can still be Ready while
 API-only modes correctly refuse a CLI-only pin.
 
+## Why did CLI reasoning fail after a fast/composer turn on the same session? {#cli-model-switch-session}
+
+**Keywords:** MODEL_SWITCH_INCOMPATIBLE_AGENT, agent type sticky, native
+session, grok-build-plan, cursor agent, composer, reasoning, same_plane,
+session recovery, start_new_session
+
+The Grok CLI binds an **agent type** to each native CLI conversation. A
+`mode="fast"` / composer turn may leave the native session on agent type
+`cursor`. A later `mode="reasoning"` turn on the **same logical `session`**
+needs `grok-4.5` with agent type `grok-build-plan`. The CLI then rejects the
+model switch with `MODEL_SWITCH_INCOMPATIBLE_AGENT` and suggests starting a
+new native session.
+
+UniGrok recovers automatically when the stable service is on a build that
+includes the model-switch recovery path (`src/utils.py`):
+
+1. Detect `MODEL_SWITCH_INCOMPATIBLE_AGENT` (and related “couldn't set model /
+   requires agent” wording).
+2. Open a **fresh** native CLI `--session-id` (do not `--fork-session` — fork
+   keeps the sticky agent binding).
+3. Replay bounded **server-side** history into that fresh session so the
+   logical MCP `session` name still continues.
+
+What callers should do:
+
+1. Prefer keeping a stable logical `session` name; let UniGrok rebind the
+   native CLI id under the hood.
+2. If an older image still surfaces the raw CLI error, rebuild/restart the
+   stable container from current `main`, or use a **new** logical `session`
+   name for the planning turn as a temporary workaround.
+3. Do not treat this as a billing-plane failure — both turns can stay on CLI
+   with `fallback_policy="same_plane"`.
+
+Fresh sessions are always fine: `mode="reasoning"` + `plane="cli"` +
+`same_plane` succeeds when the live CLI catalog has a planning model.
+
 ## What should an IDE agent do when a credential plane is unavailable? {#credential-plane-actions}
 
 **Keywords:** credentials, missing api key, cli auth, install cli, permission


### PR DESCRIPTION
## Summary
Documents live dual-plane behavior when CLI native sessions hit sticky agent types (`MODEL_SWITCH_INCOMPATIBLE_AGENT`) and how UniGrok recovers.

## Why
Composer/`fast` then planning/`reasoning` on the same logical session leaves agent type `cursor` while `grok-4.5` requires `grok-build-plan`. Recovery is already Live on main (`02a54ad`); stable needed a rebuild. Callers need a clear habit: keep logical session names; rebuild if raw CLI error returns.

## Changes
- `docs/okf/faq.md` — new FAQ section for CLI model-switch session recovery
- `docs/okf/agent-tool.md` — mode/plane habit note
- `docs/ide-setup.md` — session continuity note for operators

## Live verification (this session)
| Case | Result |
|------|--------|
| fast + cli + same_plane | OK |
| reasoning + cli + same_plane (fresh) | OK |
| thinking + cli + same_plane | fail-closed (correct) |
| fast→reasoning same session (pre-rebuild) | raw MODEL_SWITCH error |
| fast→reasoning same session (post-rebuild) | OK (attempt1 error, attempt2 recovered) |
| unit tests `cli_model_switch` | 2 passed |

## Tests
- Docs-only; local unit tests for recovery already on main: `uv run pytest tests/test_utils.py -k 'cli_model_switch or model_switch'` → 2 passed

## Human sponsor
djtelicloud

## Ready for supervisor?
Yes — docs only after live matrix.

Head: `9535f1bf4e799654e1f6d4d7f70673c8107df2db`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or routing code touched.
> 
> **Overview**
> Documents how **CLI agent-type stickiness** interacts with logical MCP `session` names when callers move from composer/`fast` to planning/`reasoning` on the same thread, including the `MODEL_SWITCH_INCOMPATIBLE_AGENT` failure mode and UniGrok’s recovery (fresh native `--session-id`, no `--fork-session`, replay bounded server-side history).
> 
> Adds a dedicated FAQ entry (`#cli-model-switch-session`) with keywords and caller habits (keep logical `session`, rebuild stable image if raw CLI error persists, not a billing-plane issue under `same_plane`). **`docs/okf/agent-tool.md`** gains a mode/plane habit bullet; **`docs/ide-setup.md`** adds an operator **session continuity** note. The same OKF content is mirrored under **`sites/unigrok-control-center/public/docs/okf/`** for the Control Center bundle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be178f9da5a0b24090764354c76081718f2962d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->