### PR TITLE
docs: document security/deploy env vars the server already reads

### DIFF
--- a/example.env
+++ b/example.env
@@ -31,6 +31,21 @@ UNIGROK_OAUTH_AUTHORIZATION_SERVERS=
 UNIGROK_OAUTH_SCOPES=unigrok:connect,unigrok:invoke,unigrok:review,unigrok:chat,unigrok:status
 UNIGROK_OAUTH_INTROSPECTION_URL=
 
+# Comma-separated browser Origins allowed to call the gateway (DNS-rebinding
+# guard). Blank allows none; non-browser clients that send no Origin are
+# unaffected. Set for a remote/hosted deployment reached from a browser.
+UNIGROK_ALLOWED_ORIGINS=
+
+# Declare a trusted loopback reverse-proxy (1/true/yes) when UNIGROK_RUNTIME=http
+# runs behind a local proxy. Separate from UNIGROK_ALLOW_UNAUTHENTICATED — normal
+# bearer auth stays active. Blank/off by default.
+UNIGROK_TRUSTED_LOOPBACK_PROXY=
+
+# Per-caller daily spend caps as JSON {principal: daily_usd}, e.g.
+# {"oauth-subject-123": 5.0}. Blank or malformed disables caps (warns, never
+# fails). Useful on a shared/hosted deployment.
+UNIGROK_CALLER_BUDGETS=
+
 # Optional state root. Cloud Run defaults to /tmp/uni-grok.
 UNIGROK_STATE_DIR=
 


### PR DESCRIPTION
Three env vars the server reads were missing from `example.env` (one is even named in an existing comment but never defined) — a gap for anyone doing a remote/hosted deploy.

Added to the remote-auth section with defaults + one-line purpose, verified against code:
- `UNIGROK_ALLOWED_ORIGINS` — `src/http_server.py` `_allowed_origins()`
- `UNIGROK_TRUSTED_LOOPBACK_PROXY` — `src/http_server.py`
- `UNIGROK_CALLER_BUDGETS` — `src/utils.py` `_caller_budgets()`

Docs-only, no runtime change. All three default blank/off. Attribution check passed. Draft for Codex's land gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Template-only documentation; defaults remain blank/off and server behavior is unchanged.
> 
> **Overview**
> **Docs-only:** `example.env` now lists three variables the gateway already reads but that were missing from the template (including one referenced in comments without a definition).
> 
> Adds **`UNIGROK_ALLOWED_ORIGINS`** (browser Origin allowlist / DNS-rebinding guard), **`UNIGROK_TRUSTED_LOOPBACK_PROXY`** (loopback reverse-proxy declaration for `UNIGROK_RUNTIME=http`, distinct from unauthenticated bypass), and **`UNIGROK_CALLER_BUDGETS`** (per-principal daily USD caps as JSON). Each entry is placed in the remote-auth section with blank defaults and a one-line purpose aligned with `http_server.py` and `utils.py`. No runtime or config-loading behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 028697f1c23c1ae7684a32b43a57d621b151c2b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->