### PR TITLE
fix(ops): prevent supervisor status self-trigger loop

### DIFF
--- a/.github/workflows/supervisor-approval.yml
+++ b/.github/workflows/supervisor-approval.yml
@@ -25,7 +25,7 @@ jobs:
       ${{
         github.event_name == 'pull_request_target' ||
         (github.event_name == 'check_run' && !contains(github.event.check_run.name, 'Supervisor Gate')) ||
-        github.event_name == 'status' ||
+        (github.event_name == 'status' && github.event.context != 'Supervisor Approval') ||
         github.event_name == 'workflow_dispatch'
       }}
     runs-on: ubuntu-latest

--- a/tests/test_supervisor_approval.py
+++ b/tests/test_supervisor_approval.py
@@ -1,4 +1,9 @@
+from pathlib import Path
+
 from scripts.supervisor_approval import decide_gate, declared_risk, inferred_risk
+
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def _checks(*, cursor=True):
@@ -63,3 +68,10 @@ def test_risk_declaration_is_unambiguous():
     assert declared_risk("risk: low\nrisk: high", []) is None
     assert inferred_risk(["src/utils.py"]) == "medium"
     assert inferred_risk(["scripts/land"]) == "high"
+
+
+def test_supervisor_status_event_does_not_retrigger_its_own_workflow():
+    workflow = (ROOT / ".github" / "workflows" / "supervisor-approval.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "github.event.context != 'Supervisor Approval'" in workflow


### PR DESCRIPTION
## Summary

Prevent the risk-aware Supervisor Gate from retriggering itself when it publishes the `Supervisor Approval` commit status.

## Handoff

- Exact current head: `4b5d5ee`
- Risk: high (workflow/control-plane fix)
- Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=integration

## Verification

- `uv run pytest -q tests/test_supervisor_approval.py` → 6 passed
- `uv run ruff check tests/test_supervisor_approval.py`
- Workflow YAML parses
- `git diff --check`

This is a Codex-owned follow-up to merged PR #236.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches control-plane workflow gating; incorrect filtering could skip legitimate re-evaluations or leave a loop unfixed.
> 
> **Overview**
> Stops the **Supervisor Gate** workflow from re-running when it posts its own **`Supervisor Approval`** commit status, which previously caused a self-trigger loop on every `status` event.
> 
> The `evaluate` job condition now runs on `status` only when `github.event.context != 'Supervisor Approval'`, while other triggers (`pull_request_target`, non–Supervisor Gate `check_run`, `workflow_dispatch`) are unchanged.
> 
> A regression test reads `supervisor-approval.yml` and asserts that guard string is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b5d5ee7cda4601c86fa788b06e33b2ec6d0be6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->