### PR TITLE
fix(ops): require exact-head Cursor approval

### DIFF
--- a/scripts/supervisor_approval.py
+++ b/scripts/supervisor_approval.py
@@ -126,6 +126,15 @@ def _check_failure(checks: dict[str, str], names: tuple[str, ...]) -> str | None
     return None
 
 
+def has_exact_cursor_approval(reviews: list[dict[str, Any]], head_sha: str) -> bool:
+    return any(
+        item.get("user", {}).get("login") in {"cursor", "cursor[bot]"}
+        and item.get("state") == "APPROVED"
+        and item.get("commit_id") == head_sha
+        for item in reviews
+    )
+
+
 def decide_gate(
     *,
     declared: str | None,
@@ -224,9 +233,8 @@ def evaluate_pr(client: GitHubClient, repository: str, pr_number: int) -> tuple[
         for item in check_runs
     }
     statuses = {item["context"]: item.get("state", "") for item in combined_status.get("statuses", [])}
-    for item in reviews:
-        if item.get("user", {}).get("login") in {"cursor", "cursor[bot]"} and item.get("state") == "APPROVED":
-            statuses["Cursor Approval"] = "success"
+    if has_exact_cursor_approval(reviews, head_sha):
+        statuses["Cursor Approval"] = "success"
 
     body = pr.get("body") or ""
     declared = declared_risk(body, labels)

--- a/scripts/supervisor_approval.py
+++ b/scripts/supervisor_approval.py
@@ -28,6 +28,7 @@ HIGH_RISK_PREFIXES = (
     ".github/rulesets/",
     "scripts/land",
     "scripts/land.py",
+    "scripts/supervisor_approval.py",
     "Dockerfile",
     "docker-compose.yml",
     ".openai/hosting.json",

--- a/tests/test_supervisor_approval.py
+++ b/tests/test_supervisor_approval.py
@@ -73,6 +73,7 @@ def test_risk_declaration_is_unambiguous():
     assert declared_risk("risk: low\nrisk: high", []) is None
     assert inferred_risk(["src/utils.py"]) == "medium"
     assert inferred_risk(["scripts/land"]) == "high"
+    assert inferred_risk(["scripts/supervisor_approval.py"]) == "high"
 
 
 def test_supervisor_status_event_does_not_retrigger_its_own_workflow():

--- a/tests/test_supervisor_approval.py
+++ b/tests/test_supervisor_approval.py
@@ -1,6 +1,11 @@
 from pathlib import Path
 
-from scripts.supervisor_approval import decide_gate, declared_risk, inferred_risk
+from scripts.supervisor_approval import (
+    has_exact_cursor_approval,
+    decide_gate,
+    declared_risk,
+    inferred_risk,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -75,3 +80,10 @@ def test_supervisor_status_event_does_not_retrigger_its_own_workflow():
         encoding="utf-8"
     )
     assert "github.event.context != 'Supervisor Approval'" in workflow
+
+
+def test_cursor_approval_must_match_the_current_head():
+    reviews = [{"user": {"login": "cursor[bot]"}, "state": "APPROVED", "commit_id": "old"}]
+    assert not has_exact_cursor_approval(reviews, "new")
+    reviews[0]["commit_id"] = "new"
+    assert has_exact_cursor_approval(reviews, "new")


### PR DESCRIPTION
## Summary

Require Cursor approval evidence to belong to the current PR head before `Supervisor Approval` can authorize low/medium failover.

risk: high

## Handoff

- Exact current head: `5825798cd6f27e6bf4a6c09183aab0067cd5fbc1`
- Risk: high (workflow/control-plane gate hardening)
- Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=provider-session | surface=Codex Desktop | role=integration

## Verification

- `uv run pytest -q tests/test_supervisor_approval.py` → 7 passed
- `uv run ruff check scripts/supervisor_approval.py tests/test_supervisor_approval.py`
- `git diff --check`

This is a Codex-owned follow-up to the merged Supervisor Gate implementation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Hardens a control-plane merge gate and changes when PRs can pass Supervisor Approval; incorrect logic could block or allow merges incorrectly.
> 
> **Overview**
> Tightens **Supervisor Approval** so low/medium Cursor failover only counts when Cursor’s **APPROVED** review is tied to the **current PR head SHA**, not an older commit after a push.
> 
> Adds `has_exact_cursor_approval` and uses it when synthesizing the `Cursor Approval` status in `evaluate_pr`. Treats changes to `scripts/supervisor_approval.py` as **high-risk** (same control-plane bucket as `scripts/land`), with tests for head matching and path inference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5825798cd6f27e6bf4a6c09183aab0067cd5fbc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->