### PR TITLE
fix(supervisor): honor exact-head Codex fallback

### DIFF
--- a/scripts/supervisor_approval.py
+++ b/scripts/supervisor_approval.py
@@ -210,9 +210,14 @@ def decide_gate(
     if inferred == "medium" and declared == "low":
         return GateDecision("failure", "runtime or non-documentation path requires risk: medium")
 
+    # Codex Approval is published only by the owner-dispatched workflow after
+    # it verifies the current PR head. It is the documented fallback when the
+    # Cursor Approver cannot approve (for example, a cursor-authored PR), and
+    # also remains the authority for high-risk packets.
+    if statuses.get("Codex Approval", "").lower() == "success":
+        return GateDecision("success", "exact-head Codex Approval")
+
     if declared == "high":
-        if statuses.get("Codex Approval", "").lower() == "success":
-            return GateDecision("success", "high-risk packet has exact-head Codex Approval")
         return GateDecision("pending", "high-risk packet is waiting for exact-head Codex Approval")
 
     failed = _check_failure(checks, REQUIRED_CI_CHECKS + CURSOR_CHECKS + (CURSOR_APPROVER_CHECK,))

--- a/scripts/supervisor_approval.py
+++ b/scripts/supervisor_approval.py
@@ -221,7 +221,13 @@ def decide_gate(
             return GateDecision("success", "exact-head Codex Approval")
         return GateDecision("pending", "high-risk packet is waiting for exact-head Codex Approval")
 
-    failed = _check_failure(checks, REQUIRED_CI_CHECKS + CURSOR_CHECKS + (CURSOR_APPROVER_CHECK,))
+    # Exact-head Codex Approval substitutes for the Cursor Approver only.
+    # Keep CI + Security/Bugbot fatal either way; skip Approver failure/pending
+    # when Codex has already satisfied that slot.
+    required_checks = REQUIRED_CI_CHECKS + CURSOR_CHECKS
+    if not codex_approval:
+        required_checks = required_checks + (CURSOR_APPROVER_CHECK,)
+    failed = _check_failure(checks, required_checks)
     if failed:
         return GateDecision("failure", f"required check failed: {failed}")
 
@@ -232,7 +238,7 @@ def decide_gate(
     ]
     approver_state = _state_for_check(checks, CURSOR_APPROVER_CHECK)
     cursor_approval = approver_state == "success" or statuses.get("Cursor Approval", "").lower() == "success"
-    if approver_state not in {"success", "missing"}:
+    if not codex_approval and approver_state not in {"success", "missing"}:
         missing.append(CURSOR_APPROVER_CHECK)
     if not cursor_approval and not codex_approval:
         missing.append("Cursor approval")

--- a/scripts/supervisor_approval.py
+++ b/scripts/supervisor_approval.py
@@ -211,13 +211,14 @@ def decide_gate(
         return GateDecision("failure", "runtime or non-documentation path requires risk: medium")
 
     # Codex Approval is published only by the owner-dispatched workflow after
-    # it verifies the current PR head. It is the documented fallback when the
-    # Cursor Approver cannot approve (for example, a cursor-authored PR), and
-    # also remains the authority for high-risk packets.
-    if statuses.get("Codex Approval", "").lower() == "success":
-        return GateDecision("success", "exact-head Codex Approval")
+    # it verifies the current PR head. High-risk packets still short-circuit on
+    # that exact-head status. For low/medium, it is only a Cursor Approver
+    # fallback after required CI + Security/Bugbot evidence is green.
+    codex_approval = statuses.get("Codex Approval", "").lower() == "success"
 
     if declared == "high":
+        if codex_approval:
+            return GateDecision("success", "exact-head Codex Approval")
         return GateDecision("pending", "high-risk packet is waiting for exact-head Codex Approval")
 
     failed = _check_failure(checks, REQUIRED_CI_CHECKS + CURSOR_CHECKS + (CURSOR_APPROVER_CHECK,))
@@ -233,11 +234,13 @@ def decide_gate(
     cursor_approval = approver_state == "success" or statuses.get("Cursor Approval", "").lower() == "success"
     if approver_state not in {"success", "missing"}:
         missing.append(CURSOR_APPROVER_CHECK)
-    if not cursor_approval:
+    if not cursor_approval and not codex_approval:
         missing.append("Cursor approval")
     if missing:
         return GateDecision("pending", "waiting for " + ", ".join(dict.fromkeys(missing)))
 
+    if codex_approval:
+        return GateDecision("success", "exact-head Codex Approval")
     return GateDecision("success", f"Cursor failover approved for risk: {declared}")
 
 

--- a/tests/test_supervisor_approval.py
+++ b/tests/test_supervisor_approval.py
@@ -52,12 +52,23 @@ def test_high_control_plane_packet_stays_with_codex():
     assert "Codex Approval" in decision.description
 
 
+def test_exact_head_codex_approval_is_a_safe_cursor_fallback():
+    decision = decide_gate(
+        declared="low",
+        inferred="low",
+        checks={},
+        statuses={"Codex Approval": "success"},
+    )
+    assert decision.state == "success"
+    assert decision.description == "exact-head Codex Approval"
+
+
 def test_high_path_cannot_be_declared_medium():
     decision = decide_gate(
         declared="medium",
         inferred="high",
         checks=_checks(),
-        statuses={},
+        statuses={"Codex Approval": "success"},
     )
     assert decision.state == "failure"
 

--- a/tests/test_supervisor_approval.py
+++ b/tests/test_supervisor_approval.py
@@ -63,6 +63,32 @@ def test_exact_head_codex_approval_is_a_safe_cursor_fallback():
     assert decision.description == "exact-head Codex Approval"
 
 
+def test_codex_fallback_ignores_failed_cursor_approver():
+    checks = _checks(cursor=False)
+    checks["Cursor Approval Agent: Pull Request Router and Approver"] = "failure"
+    decision = decide_gate(
+        declared="medium",
+        inferred="medium",
+        checks=checks,
+        statuses={"Codex Approval": "success"},
+    )
+    assert decision.state == "success"
+    assert decision.description == "exact-head Codex Approval"
+
+
+def test_codex_fallback_ignores_in_progress_cursor_approver():
+    checks = _checks(cursor=False)
+    checks["Cursor Approval Agent: Pull Request Router and Approver"] = "in_progress"
+    decision = decide_gate(
+        declared="low",
+        inferred="low",
+        checks=checks,
+        statuses={"Codex Approval": "success"},
+    )
+    assert decision.state == "success"
+    assert decision.description == "exact-head Codex Approval"
+
+
 def test_low_medium_codex_fallback_still_requires_ci():
     decision = decide_gate(
         declared="low",

--- a/tests/test_supervisor_approval.py
+++ b/tests/test_supervisor_approval.py
@@ -56,6 +56,41 @@ def test_exact_head_codex_approval_is_a_safe_cursor_fallback():
     decision = decide_gate(
         declared="low",
         inferred="low",
+        checks=_checks(cursor=False),
+        statuses={"Codex Approval": "success"},
+    )
+    assert decision.state == "success"
+    assert decision.description == "exact-head Codex Approval"
+
+
+def test_low_medium_codex_fallback_still_requires_ci():
+    decision = decide_gate(
+        declared="low",
+        inferred="low",
+        checks={},
+        statuses={"Codex Approval": "success"},
+    )
+    assert decision.state == "pending"
+    assert "waiting for" in decision.description
+
+
+def test_low_medium_codex_fallback_fails_on_red_ci():
+    checks = _checks(cursor=False)
+    checks["build (3.11)"] = "failure"
+    decision = decide_gate(
+        declared="medium",
+        inferred="medium",
+        checks=checks,
+        statuses={"Codex Approval": "success"},
+    )
+    assert decision.state == "failure"
+    assert "required check failed" in decision.description
+
+
+def test_high_codex_approval_still_short_circuits():
+    decision = decide_gate(
+        declared="high",
+        inferred="high",
         checks={},
         statuses={"Codex Approval": "success"},
     )


### PR DESCRIPTION
## Summary

Implement the documented exact-head Codex fallback without weakening the low/medium safety gates. High-risk packets use the owner-dispatched Codex Approval path. Low/medium packets still require green CI, Bugbot, and Security evidence; Codex Approval substitutes only for a blocked, failed, or in-progress Cursor Approver.

## Risk

risk: high

This changes Supervisor Approval routing, a protected control-plane surface.

## Test plan

- [x] uv run pytest -q tests/test_supervisor_approval.py (19 passed on the current head)
- [x] python3 scripts/check_agent_attribution.py --base-ref origin/main --head HEAD
- [ ] Full required CI on the current head

## Integration receipt

- Exact commit: 61a5b541ecfc277fe3424e89968b13dbc5824630
- Changed paths: scripts/supervisor_approval.py; tests/test_supervisor_approval.py
- Risk: high — requires exact-head Codex Approval and protected landing
- Human sponsor: djtelicloud
- Canonical provider/model provenance: OpenAI Codex | model=unverified | model-source=unverified | surface=Codex Desktop | role=implementation; Cursor Agent | model=unverified | model-source=unverified | surface=Cursor Cloud | role=implementation

Agent-Assisted-By: OpenAI Codex | model=unverified | model-source=unverified | surface=Codex Desktop | role=implementation
Agent-Assisted-By: Cursor Agent | model=unverified | model-source=unverified | surface=Cursor Cloud | role=implementation