### PR TITLE
fix(theme): rebase installer guidance onto main

### DIFF
--- a/docs/design/unigrok-theme.md
+++ b/docs/design/unigrok-theme.md
@@ -23,14 +23,58 @@
 | [unigrok-grok-theme.json](unigrok-grok-theme.json) | Same, machine-readable |
 | [UniGrok.terminal](UniGrok.terminal) | Apple Terminal profile (import or double-click) |
 
+## Install path (`~/.grok/themes/`)
+
+Grok user config lives under `~/.grok` (override with `GROK_HOME`). Install the
+brand slot map to the canonical custom-theme directory:
+
+```bash
+./scripts/install-unigrok-theme
+./scripts/install-unigrok-theme --check
+```
+
+| Destination | Source |
+| --- | --- |
+| `~/.grok/themes/unigrok.toml` | `docs/design/unigrok-grok-theme.toml` |
+| `~/.grok/themes/unigrok.json` | `docs/design/unigrok-grok-theme.json` |
+| `~/.grok/themes/UniGrok.terminal` | `docs/design/UniGrok.terminal` |
+
+Options:
+
+| Flag | Meaning |
+| --- | --- |
+| `--check` | Verify installed files match design sources and required slots |
+| `--dry-run` | Print planned copies without writing |
+| `--force` | Overwrite drifted install files |
+| `--enable-config` | Also set `[ui] theme = "unigrok"` in `config.toml` (backs up first) |
+| `--grok-home PATH` | Alternate Grok home (tests / multi-user) |
+
+The installer never spends API credits and does not touch Docker.
+
 ## Grok Build limitation (0.2.x)
 
-Grok Build only ships five **built-in** theme names. It does **not** load
-`unigrok` from disk yet. Until custom themes exist:
+Grok Build **0.2.x** ships five **built-in** theme names and does **not** load
+`unigrok` from disk yet (see local user guide `~/.grok/docs/user-guide/06-theming.md`).
+Until custom themes exist:
 
-1. Install **UniGrok.terminal** so the host shell matches brand navy + cyan.
-2. Keep the slot map as the contract for a future `/theme unigrok`.
-3. Prefer TokyoNight among stock skins only as a temporary blue stand-in — it
+1. Run `./scripts/install-unigrok-theme` so files sit at the future load path.
+2. Import **UniGrok.terminal** so the host shell matches brand navy + cyan.
+3. Keep the slot map as the contract for a future `/theme unigrok`.
+4. Prefer TokyoNight among stock skins only as a temporary blue stand-in — it
    is **not** brand-correct.
 
-Local install path used by Grok CLI sessions: `~/.grok/themes/unigrok.toml`.
+When Grok begins loading `~/.grok/themes/*.toml`, re-run `--check`, then either
+`/theme unigrok` or `./scripts/install-unigrok-theme --enable-config`.
+
+## Smoke
+
+```bash
+# From a product checkout that includes docs/design/unigrok-*
+./scripts/install-unigrok-theme --dry-run
+./scripts/install-unigrok-theme --force
+./scripts/install-unigrok-theme --check
+uv run pytest -q tests/test_install_unigrok_theme.py
+```
+
+Expected: three files under `$GROK_HOME/themes/` (default `~/.grok/themes/`),
+`name = "unigrok"`, required TUI slots present as `#RRGGBB`.

--- a/mcp_ui/design/README.md
+++ b/mcp_ui/design/README.md
@@ -3,6 +3,9 @@
 **Source of truth:** [https://grokmcp.org/](https://grokmcp.org/) and
 `sites/unigrok-control-center/app/globals.css`.
 
+Canonical design docs and install path live under
+[`docs/design/unigrok-theme.md`](../../docs/design/unigrok-theme.md).
+
 ## Brand tokens
 
 | Token | Hex |
@@ -20,17 +23,17 @@
 | File | Role |
 | --- | --- |
 | [unigrok-grok-theme.toml](unigrok-grok-theme.toml) | Full Grok TUI slot map (`bg_*`, `accent_*`, `md_*`, …) |
-| [unigrok-grok-theme.json](unigrok-grok-theme.json) | Same, machine-readable |
-| [UniGrok.terminal](UniGrok.terminal) | Apple Terminal profile (import or double-click) |
+| [../../docs/design/unigrok-grok-theme.json](../../docs/design/unigrok-grok-theme.json) | Machine-readable twin |
+| [../../docs/design/UniGrok.terminal](../../docs/design/UniGrok.terminal) | Apple Terminal profile |
 
-## Grok Build limitation (0.2.x)
+## Install
 
-Grok Build only ships five **built-in** theme names. It does **not** load
-`unigrok` from disk yet. Until custom themes exist:
+```bash
+./scripts/install-unigrok-theme
+./scripts/install-unigrok-theme --check
+```
 
-1. Install **UniGrok.terminal** so the host shell matches brand navy + cyan.
-2. Keep the slot map as the contract for a future `/theme unigrok`.
-3. Prefer TokyoNight among stock skins only as a temporary blue stand-in — it
-   is **not** brand-correct.
-
-Local install path used by Grok CLI sessions: `~/.grok/themes/unigrok.toml`.
+Copies design sources into `~/.grok/themes/` (`unigrok.toml`, `unigrok.json`,
+`UniGrok.terminal`). Grok 0.2.x still only lists built-in theme names; files are
+forward-ready for custom load. Import the Terminal profile for host brand match
+today.

--- a/scripts/install-unigrok-theme
+++ b/scripts/install-unigrok-theme
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec python3 "$SCRIPT_DIR/install_unigrok_theme.py" "$@"

--- a/scripts/install_unigrok_theme.py
+++ b/scripts/install_unigrok_theme.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""Install the UniGrok brand theme into the Grok CLI user theme path.
+
+Canonical source artifacts live in the product repo under ``docs/design/``.
+This installer copies them to ``$GROK_HOME/themes/`` (default ``~/.grok/themes``)
+so the machine is ready when Grok Build loads custom theme files.
+
+Grok 0.2.x only resolves built-in theme *names*. Installing files is safe and
+forward-compatible; selecting ``theme = "unigrok"`` may still fall back until
+custom themes ship. Prefer the Apple Terminal profile for host brand match today.
+
+Usage:
+  ./scripts/install-unigrok-theme              # install files
+  ./scripts/install-unigrok-theme --check      # verify install
+  ./scripts/install-unigrok-theme --dry-run
+  ./scripts/install-unigrok-theme --enable-config   # optional config.toml write
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import shutil
+import sys
+from pathlib import Path
+
+
+REQUIRED_TOP_LEVEL = ("name", "display_name", "truecolor_required")
+REQUIRED_SLOTS = (
+    "bg_base",
+    "bg_light",
+    "bg_dark",
+    "accent_user",
+    "accent_assistant",
+    "accent_thinking",
+    "accent_error",
+    "accent_success",
+    "text_primary",
+    "text_secondary",
+    "diff_delete_fg",
+    "diff_insert_fg",
+    "md_heading_h1",
+    "md_code",
+    "link_fg",
+)
+HEX_RE = re.compile(r"^#[0-9A-Fa-f]{6}$")
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _design_dir(repo: Path) -> Path:
+    return repo / "docs" / "design"
+
+
+def _grok_home(explicit: str | None = None) -> Path:
+    if explicit:
+        return Path(explicit).expanduser().resolve()
+    env = os.environ.get("GROK_HOME")
+    if env:
+        return Path(env).expanduser().resolve()
+    return (Path.home() / ".grok").resolve()
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    h.update(path.read_bytes())
+    return h.hexdigest()
+
+
+def _parse_simple_toml_keys(text: str) -> dict[str, str]:
+    """Parse top-level scalar keys and ``[slots]`` keys without a TOML dep.
+
+    Theme artifacts use only simple scalars (strings/bools) for the fields we
+    validate. Nested tables other than ``[slots]`` are ignored here.
+    """
+    out: dict[str, str] = {}
+    section = ""
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("[") and line.endswith("]"):
+            section = line[1:-1].strip()
+            continue
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if value.startswith('"') and value.endswith('"'):
+            value = value[1:-1]
+        elif value.startswith("'") and value.endswith("'"):
+            value = value[1:-1]
+        if section == "slots":
+            out[f"slots.{key}"] = value
+        elif section == "":
+            out[key] = value
+    return out
+
+
+def _validate_theme_toml(path: Path) -> list[str]:
+    errors: list[str] = []
+    text = path.read_text(encoding="utf-8")
+    keys = _parse_simple_toml_keys(text)
+    if keys.get("name") != "unigrok":
+        errors.append(f"{path}: name must be \"unigrok\" (got {keys.get('name')!r})")
+    for field in REQUIRED_TOP_LEVEL:
+        if field not in keys:
+            errors.append(f"{path}: missing top-level field {field!r}")
+    for slot in REQUIRED_SLOTS:
+        full = f"slots.{slot}"
+        if full not in keys:
+            errors.append(f"{path}: missing required slot {slot!r}")
+            continue
+        if not HEX_RE.match(keys[full]):
+            errors.append(f"{path}: slot {slot!r} is not a #RRGGBB hex ({keys[full]!r})")
+    return errors
+
+
+def _sources(repo: Path) -> list[tuple[Path, str]]:
+    design = _design_dir(repo)
+    return [
+        (design / "unigrok-grok-theme.toml", "unigrok.toml"),
+        (design / "unigrok-grok-theme.json", "unigrok.json"),
+        (design / "UniGrok.terminal", "UniGrok.terminal"),
+    ]
+
+
+def _reject_git_home(grok_home: Path, *, repo: Path | None = None) -> int | None:
+    """Refuse GROK_HOME that is a Git root or lives inside the product checkout."""
+    home = grok_home.expanduser().resolve()
+    if (home / ".git").exists():
+        print(
+            "error: --grok-home / GROK_HOME must be a user config directory, "
+            "not a Git checkout",
+            file=sys.stderr,
+        )
+        return 2
+    if repo is not None:
+        product = repo.expanduser().resolve()
+        try:
+            home.relative_to(product)
+        except ValueError:
+            pass
+        else:
+            print(
+                "error: --grok-home / GROK_HOME must not be inside the product "
+                "checkout; use a user config directory such as ~/.grok",
+                file=sys.stderr,
+            )
+            return 2
+    return None
+
+
+def _ui_section_span(text: str) -> tuple[int, int] | None:
+    """Return [start, end) byte offsets of the [ui] table body, or None."""
+    match = re.search(r"(?m)^\s*\[ui\]\s*(?:#.*)?$", text)
+    if not match:
+        return None
+    start = match.end()
+    next_header = re.search(r"(?m)^\s*\[[^\]]+\]\s*(?:#.*)?$", text[start:])
+    end = start + next_header.start() if next_header else len(text)
+    return start, end
+
+
+def _set_ui_theme(text: str, theme: str = "unigrok") -> tuple[str, str]:
+    """
+    Set [ui] theme = \"...\" only inside the [ui] table.
+
+    Returns (new_text, status) where status is already|updated|appended.
+    """
+    span = _ui_section_span(text)
+    theme_re = re.compile(
+        rf"""(?m)^(\s*theme\s*=\s*)(["']){re.escape(theme)}\2\s*(?:#.*)?$"""
+    )
+    any_theme_re = re.compile(
+        r"""(?m)^(\s*theme\s*=\s*)(["']).*?\2\s*(?:#.*)?$"""
+    )
+
+    if span is not None:
+        start, end = span
+        body = text[start:end]
+        if theme_re.search(body):
+            return text, "already"
+        if any_theme_re.search(body):
+            new_body, n = any_theme_re.subn(rf'\1"{theme}"', body, count=1)
+            if n != 1 or new_body == body:
+                raise ValueError("theme line in [ui] could not be updated")
+            return text[:start] + new_body + text[end:], "updated"
+        insert = f'\ntheme = "{theme}"'
+        # Keep a trailing newline in the section when possible.
+        if body.endswith("\n"):
+            new_body = body.rstrip("\n") + insert + "\n"
+        else:
+            new_body = body + insert
+        return text[:start] + new_body + text[end:], "updated"
+
+    # No [ui] table — do not rewrite theme keys in other tables.
+    appended = text.rstrip() + f'\n\n[ui]\ntheme = "{theme}"\n'
+    return appended, "appended"
+
+
+def install(
+    *,
+    repo: Path,
+    grok_home: Path,
+    dry_run: bool,
+    force: bool,
+) -> int:
+    themes = grok_home / "themes"
+    rejected = _reject_git_home(grok_home, repo=repo)
+    if rejected is not None:
+        return rejected
+
+    sources = _sources(repo)
+    missing = [str(src) for src, _ in sources if not src.is_file()]
+    if missing:
+        print("error: missing design artifacts:", file=sys.stderr)
+        for path in missing:
+            print(f"  - {path}", file=sys.stderr)
+        print("Bring the UniGrok theme design files onto this checkout first.", file=sys.stderr)
+        return 2
+
+    errors: list[str] = []
+    for src, _dest in sources:
+        if src.suffix == ".toml":
+            errors.extend(_validate_theme_toml(src))
+    if errors:
+        print("error: source theme failed validation:", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 2
+
+    planned: list[tuple[Path, Path]] = [
+        (src, themes / dest_name) for src, dest_name in sources
+    ]
+    # Preflight all destinations before copying so a mid-loop conflict abort
+    # cannot leave a mixed partial install.
+    for src, dest in planned:
+        if dest.exists() and not force and _sha256(src) != _sha256(dest):
+            print(
+                f"error: {dest} exists and differs from source; re-run with --force to overwrite",
+                file=sys.stderr,
+            )
+            return 3
+
+    if not dry_run:
+        themes.mkdir(parents=True, exist_ok=True)
+
+    for src, dest in planned:
+        if dest.exists() and not force:
+            print(f"unchanged  {dest}")
+            continue
+        action = "would install" if dry_run else "install"
+        print(f"{action:12} {src} -> {dest}")
+        if not dry_run:
+            shutil.copy2(src, dest)
+
+    print()
+    print(f"Grok theme dir: {themes}")
+    print("Installed names:")
+    print("  unigrok.toml   # future custom theme load path")
+    print("  unigrok.json   # machine-readable twin")
+    print("  UniGrok.terminal  # Apple Terminal profile (import today)")
+    print()
+    print("Grok 0.2.x still only lists built-in theme names in /theme.")
+    print("Files are ready for when custom themes load from ~/.grok/themes/.")
+    print("Today: import UniGrok.terminal, or use tokyonight as a non-brand stand-in.")
+    print("Optional later: set [ui] theme = \"unigrok\" (or pass --enable-config).")
+    return 0
+
+
+def check(*, repo: Path, grok_home: Path) -> int:
+    themes = grok_home / "themes"
+    sources = _sources(repo)
+    ok = True
+    for src, dest_name in sources:
+        dest = themes / dest_name
+        if not src.is_file():
+            print(f"FAIL source missing: {src}")
+            ok = False
+            continue
+        if not dest.is_file():
+            print(f"FAIL not installed: {dest}")
+            ok = False
+            continue
+        if _sha256(src) != _sha256(dest):
+            print(f"FAIL drift: {dest} differs from {src}")
+            ok = False
+            continue
+        print(f"OK   {dest}")
+        if dest.suffix == ".toml":
+            for err in _validate_theme_toml(dest):
+                print(f"FAIL {err}")
+                ok = False
+    if ok:
+        print(f"check passed: {themes}")
+        return 0
+    print("check failed", file=sys.stderr)
+    return 1
+
+
+def enable_config(*, grok_home: Path, dry_run: bool, repo: Path | None = None) -> int:
+    """Best-effort write [ui] theme = unigrok. Does not promise Grok 0.2.x loads it."""
+    rejected = _reject_git_home(grok_home, repo=repo)
+    if rejected is not None:
+        return rejected
+    config = grok_home / "config.toml"
+    if not config.is_file():
+        print(f"error: {config} not found; create a Grok config first", file=sys.stderr)
+        return 2
+    text = config.read_text(encoding="utf-8")
+    try:
+        new_text, status = _set_ui_theme(text, "unigrok")
+    except ValueError as exc:
+        print(f"error: {config}: {exc}; set theme = \"unigrok\" under [ui] manually", file=sys.stderr)
+        return 2
+    if status == "already":
+        print(f"already set: {config} [ui] theme = \"unigrok\"")
+        return 0
+
+    backup = config.with_suffix(".toml.unigrok-theme-bak")
+    print(f"{'would write' if dry_run else 'write'} {config} [ui] theme = \"unigrok\"")
+    print(f"{'would backup' if dry_run else 'backup'} {backup}")
+    if dry_run:
+        return 0
+    shutil.copy2(config, backup)
+    config.write_text(new_text, encoding="utf-8")
+    print(
+        "note: Grok 0.2.x may ignore unknown theme names; keep Terminal profile "
+        "or a stock stand-in until custom themes load."
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Install UniGrok brand theme into ~/.grok/themes/"
+    )
+    parser.add_argument(
+        "--repo",
+        type=Path,
+        default=None,
+        help="Product checkout root (default: parent of scripts/)",
+    )
+    parser.add_argument(
+        "--grok-home",
+        type=Path,
+        default=None,
+        help="Grok user home (default: $GROK_HOME or ~/.grok)",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Verify installed files match design sources",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print actions without writing files",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite differing installed files",
+    )
+    parser.add_argument(
+        "--enable-config",
+        action="store_true",
+        help='Also set [ui] theme = "unigrok" in config.toml (optional; may no-op on 0.2.x)',
+    )
+    args = parser.parse_args(argv)
+
+    repo = (args.repo or _repo_root()).expanduser().resolve()
+    grok_home = _grok_home(str(args.grok_home) if args.grok_home else None)
+
+    if args.check:
+        code = check(repo=repo, grok_home=grok_home)
+        if code != 0:
+            return code
+        if args.enable_config:
+            return enable_config(grok_home=grok_home, dry_run=args.dry_run, repo=repo)
+        return 0
+
+    code = install(
+        repo=repo,
+        grok_home=grok_home,
+        dry_run=args.dry_run,
+        force=args.force,
+    )
+    if code != 0:
+        return code
+    if args.enable_config:
+        return enable_config(grok_home=grok_home, dry_run=args.dry_run, repo=repo)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_install_unigrok_theme.py
+++ b/tests/test_install_unigrok_theme.py
@@ -1,0 +1,233 @@
+"""Smoke tests for the UniGrok theme installer."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "scripts" / "install_unigrok_theme.py"
+DESIGN_TOML = REPO / "docs" / "design" / "unigrok-grok-theme.toml"
+
+
+@pytest.mark.skipif(not DESIGN_TOML.is_file(), reason="theme design artifacts not on this checkout")
+def test_install_check_roundtrip(tmp_path: Path) -> None:
+    grok_home = tmp_path / "grok-home"
+    env = {**os.environ, "GROK_HOME": str(grok_home)}
+
+    install = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo", str(REPO), "--grok-home", str(grok_home)],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert install.returncode == 0, install.stderr + install.stdout
+    assert (grok_home / "themes" / "unigrok.toml").is_file()
+    assert (grok_home / "themes" / "unigrok.json").is_file()
+    assert (grok_home / "themes" / "UniGrok.terminal").is_file()
+
+    check = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--check",
+            "--repo",
+            str(REPO),
+            "--grok-home",
+            str(grok_home),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert check.returncode == 0, check.stderr + check.stdout
+    assert "check passed" in check.stdout
+
+
+@pytest.mark.skipif(not DESIGN_TOML.is_file(), reason="theme design artifacts not on this checkout")
+def test_force_overwrites_drift(tmp_path: Path) -> None:
+    grok_home = tmp_path / "grok-home"
+    themes = grok_home / "themes"
+    themes.mkdir(parents=True)
+    dest = themes / "unigrok.toml"
+    dest.write_text("name = \"stale\"\n", encoding="utf-8")
+
+    blocked = subprocess.run(
+        [sys.executable, str(SCRIPT), "--repo", str(REPO), "--grok-home", str(grok_home)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert blocked.returncode == 3
+
+    forced = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(REPO),
+            "--grok-home",
+            str(grok_home),
+            "--force",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert forced.returncode == 0, forced.stderr + forced.stdout
+    assert 'name = "unigrok"' in dest.read_text(encoding="utf-8")
+
+
+@pytest.mark.skipif(not DESIGN_TOML.is_file(), reason="theme design artifacts not on this checkout")
+def test_enable_config_writes_theme_key(tmp_path: Path) -> None:
+    grok_home = tmp_path / "grok-home"
+    grok_home.mkdir()
+    config = grok_home / "config.toml"
+    config.write_text('[ui]\ntheme = "tokyonight"\n', encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(REPO),
+            "--grok-home",
+            str(grok_home),
+            "--enable-config",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    text = config.read_text(encoding="utf-8")
+    assert 'theme = "unigrok"' in text
+    assert (grok_home / "config.toml.unigrok-theme-bak").is_file()
+
+
+@pytest.mark.skipif(not DESIGN_TOML.is_file(), reason="theme design artifacts not on this checkout")
+def test_enable_config_rejects_git_checkout(tmp_path: Path) -> None:
+    """--check --enable-config must refuse a GROK_HOME that is a Git checkout."""
+    grok_home = tmp_path / "fake-checkout"
+    themes = grok_home / "themes"
+    themes.mkdir(parents=True)
+    (grok_home / ".git").mkdir()
+    # Pre-seed installed themes so --check can pass before enable_config runs.
+    for src_name, dest_name in (
+        ("unigrok-grok-theme.toml", "unigrok.toml"),
+        ("unigrok-grok-theme.json", "unigrok.json"),
+        ("UniGrok.terminal", "UniGrok.terminal"),
+    ):
+        (themes / dest_name).write_bytes(
+            (REPO / "docs" / "design" / src_name).read_bytes()
+        )
+    config = grok_home / "config.toml"
+    config.write_text('[ui]\ntheme = "tokyonight"\n', encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--check",
+            "--repo",
+            str(REPO),
+            "--grok-home",
+            str(grok_home),
+            "--enable-config",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert "not a Git checkout" in result.stderr
+    assert 'theme = "tokyonight"' in config.read_text(encoding="utf-8")
+    assert not (grok_home / "config.toml.unigrok-theme-bak").exists()
+
+
+@pytest.mark.skipif(not DESIGN_TOML.is_file(), reason="theme design artifacts not on this checkout")
+def test_reject_nested_path_inside_product_checkout(tmp_path: Path) -> None:
+    nested = REPO / ".grok-theme-install-test"
+    nested.mkdir(parents=True, exist_ok=True)
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--repo",
+                str(REPO),
+                "--grok-home",
+                str(nested),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 2
+        assert "inside the product checkout" in result.stderr
+        assert not (nested / "themes").exists()
+    finally:
+        if nested.exists():
+            nested.rmdir()
+
+
+@pytest.mark.skipif(not DESIGN_TOML.is_file(), reason="theme design artifacts not on this checkout")
+def test_allow_grok_home_under_unrelated_git_root(tmp_path: Path) -> None:
+    """A Git root at $HOME must not block a normal ~/.grok-style config dir."""
+    home_git = tmp_path / "home"
+    grok_home = home_git / ".grok"
+    grok_home.mkdir(parents=True)
+    (home_git / ".git").mkdir()
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(REPO),
+            "--grok-home",
+            str(grok_home),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert (grok_home / "themes" / "unigrok.toml").is_file()
+
+
+@pytest.mark.skipif(not DESIGN_TOML.is_file(), reason="theme design artifacts not on this checkout")
+def test_enable_config_only_rewrites_ui_theme(tmp_path: Path) -> None:
+    grok_home = tmp_path / "grok-home"
+    grok_home.mkdir()
+    config = grok_home / "config.toml"
+    config.write_text(
+        '[other]\ntheme = "keep-me"\n\n[ui]\ntheme = "tokyonight"\n',
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(REPO),
+            "--grok-home",
+            str(grok_home),
+            "--enable-config",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr + result.stdout
+    text = config.read_text(encoding="utf-8")
+    assert 'theme = "keep-me"' in text
+    assert 'theme = "unigrok"' in text
+    assert 'theme = "tokyonight"' not in text


### PR DESCRIPTION
## Repair handoff

Repairs the stale/conflicted Grok theme-installer lane without rewriting its contributor branch.

- Original lane: #232 (grok/theme-install-path)
- Exact head: 28b3a3d9344929c9072b28a68e7c3c4217ede519
- Changed paths: installer wrapper and implementation, focused tests, and two theme-install guidance documents
- Verification: uv run pytest -q (2,119 passed); focused installer tests (7 passed); targeted Ruff and compile checks; attribution check
- Risk: local user-config writes remain opt-in, reject checkout paths, and warn that Grok 0.2.x does not yet load custom themes
- Cost: $0
- Human sponsor: djtelicloud
- Ready for Codex land? no — draft awaiting exact-head PR checks and review

Agent attribution is recorded in the commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are local tooling and documentation; user config is only modified when --enable-config is used, with backups and path guards.
> 
> **Overview**
> Adds **`./scripts/install-unigrok-theme`** to copy brand theme artifacts from `docs/design/` into `$GROK_HOME/themes/` (`unigrok.toml`, `unigrok.json`, `UniGrok.terminal`), with **`--check`**, **`--dry-run`**, **`--force`**, and optional **`--enable-config`** (backs up `config.toml` and sets `[ui] theme = "unigrok"` only inside `[ui]`).
> 
> The Python installer validates required TOML slots, compares installs via SHA-256 (blocking drift unless **`--force`**), and **refuses** `GROK_HOME` that is a Git root or inside the product checkout. Docs in **`docs/design/unigrok-theme.md`** and **`mcp_ui/design/README.md`** now document the install path, flags, Grok 0.2.x built-in-theme limitation, and smoke commands; **`tests/test_install_unigrok_theme.py`** covers install/check, force, config writes, and guardrails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1791ae69d157db44211f0fdba62cf0c9e3f83ff1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->