### PR TITLE
fix(theme): close installer product path guard gaps

### DIFF
--- a/scripts/install_unigrok_theme.py
+++ b/scripts/install_unigrok_theme.py
@@ -141,9 +141,17 @@ def _is_inside_product(path: Path, repo: Path) -> bool:
 
 
 def _reject_product_write_path(path: Path, *, repo: Path | None, label: str) -> int | None:
-    """Keep installer writes out of the product checkout, including via symlinks."""
+    """Keep installer writes out of the product checkout, including via symlinks.
 
-    if repo is None or not _is_inside_product(path, repo):
+    Always protect the checkout that contains this installer (``_repo_root()``),
+    and also the ``--repo`` root when it differs. A mismatched ``--repo`` must
+    not open writes into the real product tree via ``--grok-home``.
+    """
+
+    roots = {_repo_root().resolve()}
+    if repo is not None:
+        roots.add(repo.expanduser().resolve())
+    if not any(_is_inside_product(path, root) for root in roots):
         return None
     print(
         f"error: {label} must not resolve inside the product checkout; "
@@ -319,10 +327,27 @@ def install(
 
 def check(*, repo: Path, grok_home: Path) -> int:
     themes = grok_home / "themes"
+    rejected = _reject_git_home(grok_home, repo=repo)
+    if rejected is not None:
+        return rejected
+    rejected = _reject_product_write_path(
+        themes,
+        repo=repo,
+        label="theme directory",
+    )
+    if rejected is not None:
+        return rejected
     sources = _sources(repo)
     ok = True
     for src, dest_name in sources:
         dest = themes / dest_name
+        rejected = _reject_product_write_path(
+            dest,
+            repo=repo,
+            label="theme destination",
+        )
+        if rejected is not None:
+            return rejected
         if not src.is_file():
             print(f"FAIL source missing: {src}")
             ok = False

--- a/tests/test_install_unigrok_theme.py
+++ b/tests/test_install_unigrok_theme.py
@@ -176,6 +176,30 @@ def test_reject_nested_path_inside_product_checkout(tmp_path: Path) -> None:
 
 
 @pytest.mark.skipif(not DESIGN_TOML.is_file(), reason="theme design artifacts not on this checkout")
+def test_install_rejects_installer_checkout_when_repo_differs(tmp_path: Path) -> None:
+    """A mismatched --repo must not allow writes into the script checkout."""
+    grok_home = REPO / ".grok-theme-install-mismatched-repo"
+    other_repo = tmp_path / "other-product"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--repo",
+            str(other_repo),
+            "--grok-home",
+            str(grok_home),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert "inside the product checkout" in result.stderr
+    assert not grok_home.exists()
+
+
+@pytest.mark.skipif(not DESIGN_TOML.is_file(), reason="theme design artifacts not on this checkout")
 def test_install_rejects_symlinked_theme_directory_inside_product(tmp_path: Path) -> None:
     grok_home = tmp_path / "grok-home"
     grok_home.mkdir()
@@ -186,6 +210,32 @@ def test_install_rejects_symlinked_theme_directory_inside_product(tmp_path: Path
         [
             sys.executable,
             str(SCRIPT),
+            "--repo",
+            str(REPO),
+            "--grok-home",
+            str(grok_home),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert "theme directory must not resolve inside the product checkout" in result.stderr
+    assert not target.exists()
+
+
+@pytest.mark.skipif(not DESIGN_TOML.is_file(), reason="theme design artifacts not on this checkout")
+def test_check_rejects_symlinked_theme_directory_inside_product(tmp_path: Path) -> None:
+    grok_home = tmp_path / "grok-home"
+    grok_home.mkdir()
+    target = REPO / ".grok-theme-check-symlink-target"
+    (grok_home / "themes").symlink_to(target)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--check",
             "--repo",
             str(REPO),
             "--grok-home",


### PR DESCRIPTION
## Repair handoff

- Follow-up to: #246, which became Live before its completed Autofix could update the merged head.
- Exact head: `24701bf0269e1adb64773cd066d87057c845405d`
- Changed paths: `scripts/install_unigrok_theme.py`, `tests/test_install_unigrok_theme.py`
- Fix: reject installer-checkout writes even with a mismatched `--repo`, and apply equivalent path guards to `--check`.
- Verification: `uv run pytest -q` (2,125 passed); focused theme tests (13 passed); Ruff; compile; diff check; attribution check. Required CI, CodeQL, and Bugbot are green.
- Risk: medium — strengthens opt-in local installer safety without altering normal user-config locations.
- Cost: $0
- Human sponsor: djtelicloud
- Ready for Codex land? No — ready for independent exact-head review; Supervisor Approval remains pending.