### PR TITLE
docs(codex): refresh integration coordinator handoff

### DIFF
--- a/.codex/memory/active-work.md
+++ b/.codex/memory/active-work.md
@@ -1,112 +1,60 @@
 # Codex Active Work
 
-Last updated: 2026-07-15
-Owner: Codex
-Status: GitHub and security are clean. Brand-specific rehydrate next steps are
-Live. The remote MCP and Control Center remain live in `us-central1` with
-east-region rollback assets. Stage 1 live generation and training remain
-blocked.
-
-## Current Codex review packet
-
-- Draft PR #225 preserves the sponsor-approved, theme-safe in-chat conversation
-  canvas as a Codex-only reference fragment. It changes no MCP runtime,
-  release, cloud, or deployment behavior. The focused contract tests and the
-  attribution check passed; it remains pending normal exact-head review and
-  protected integration.
+Last updated: 2026-07-16
+Owner: Codex integration coordinator
+Status: GitHub, security, local runtimes, and the hosted product are clean.
+The contributor queue is empty. Stage 1 live generation and training remain
+blocked behind their existing exact-head authorization gates.
 
 This is the project-scoped handoff for new Codex chats. Verify drift-prone Git,
 CI, runtime, DNS, cloud, and benchmark state live before acting. Never record
 credentials, OAuth codes, tokens, or private keys here.
 
-## Verified campaign state
+## Current integration state
 
-- The Stage 1 gate is a deterministic, transport-free structural exercise: 30
-  roots, 120 variants, 150 mechanically evaluated candidates, and 120 bounded
-  mock role attempts across the six declared packs.
-- Every prediction input carries its own TTL context. Exact request payloads,
-  trusted scenarios, executable oracle results, effect receipts, terminal
-  evidence, and confusion matrices are persisted in owner-private,
-  content-addressed artifacts and reconstruct cleanly in a fresh process.
-- Provider output cannot assign authority. Proposal validity, episode outcome,
-  TTL validity, effect observation, and completion are derived mechanically.
-- The attempt ledger is fail-closed under lease expiry, crash takeover,
-  duplicate work, missing artifacts, and exact-boundary completion. Started or
-  indeterminate work is never retried silently.
-- Executor code and every callable dependency are bound before execution;
-  post-bind injection is rejected before an attempt or injected call occurs.
-- Promise-only and unsolicited plan-shaped completions fail closed as errors;
-  unverified terminal text persists as `NULL`, explicit gateway failures as
-  `0`, and only a future receipt-bound verifier may write `1`. Schema v14
-  quarantines unsupported historical positives.
-- Routing, local semantic evidence, the v2 cloud mirror, caller metrics, and
-  status output all preserve the tri-state contract. Auxiliary history
-  compaction is excluded from task outcome rates, and an existing explicit v1
-  collection setting is safely redirected to v2.
-- Local verification passed 150 campaign tests and 1,480 repository tests,
-  plus Ruff, repository generation checks, JSON validation, and diff hygiene.
-- No live provider call, dataset write, model download, training run, or sealed
-  evaluation occurred while repairing or validating this gate.
-
-## Remaining authorization gates
-
-- Stage 2 is fail-closed. A new, bounded live Stage 1 manifest must separately
-  specify provider, call, cost, time, privacy, retry, and artifact limits and
-  receive Codex approval at its exact head before any live generation.
-- Any generated dataset must pass the mechanical gates and another exact-head
-  Codex review before training. Training and sealed evaluation require their
-  own later authorization and must remain structurally separate.
-- Stage 0.5 provider wiring uses Google ADC and the loopback UniGrok gateway;
-  never copy user credential files or secrets into the repository.
-
-## Latest maintainer sweep
-
-- Brand-specific rehydrate next steps landed through PR #173. Codex repaired
-  the workspace-resource per-document bound while preserving the 24,000
-  character total clamp, accepted one valid review cleanup, and
-  `scripts/land` certified exact content head
-  `b6d58b44a27bb75bdac1e0e7ea003d057cefba11` after 2,037 tests. Protected
-  merge commit `d277bf3b6948be1421943258e49a6554d36d9de5` is synchronized
-  locally and remotely.
-- Lane cleanup PR #175 is Live at
-  `8f4ed94b5bd0927bfa87c0888618e374d03716ad`; exact-main CI and all three
-  CodeQL analyzers passed. The checked GitHub state has zero open PRs,
-  code-scanning alerts, Dependabot alerts, secret-scanning alerts, or draft
-  advisories.
-- Five finished or superseded Grok scratchpads, one empty Antigravity
-  scratchpad, the first and rehydrated `agents/hydrate-data-function`
-  scratchpads, and `claude/hydrate-c23d9f` plus `claude/hydrate-0597fe` were
-  removed only after clean, process-free, and integrated-state checks.
-- Six residual unregistered Codex task directories were retired after the app
-  reported every owning task completed and unloaded, no process referenced any
-  directory, no directory remained in the Git worktree registry, and no unique
-  remote commit or open PR existed: `503b`, `8cf2`, `8de4`, `cd53`, `e9a9`, and
-  `fbfd`. The active `b161` Codex task and the primary `main` checkout were
-  explicitly excluded and reverified clean after removal.
-- Provider IDEs may automatically rehydrate a clean scratchpad after cleanup.
-  A clean zero-ahead worktree is not an orphan while any live process uses it.
-  Before supervisor removal, re-check process ownership, dirty state, unique
-  commits, and open task packets; never rely on this handoff as a live lock.
-- Always preserve the detached Codex thread worktree and the primary `main`
-  checkout. At the current verified sweep, no provider hydration scratchpad
-  remains; `agents/hydrate-data-function` and `claude/hydrate-0597fe` were
-  removed only after their processes stopped and all orphan checks passed.
-- Stable `:4765` and contributor `:4766` are ready. The contributor runtime
-  marker is `e05b265ddf5ffaf0e56f9c95dec2b15755fc123b` and matches the
-  current main tree. The continuity-only landing changed no runtime source, so
-  no additional restart was needed.
-- Remote MCP is live at 100% on ready `us-central1` revision
-  `unigrok-remote-mcp-7c7c30e`, image digest
-  `sha256:a377d3c89cea616360cabe5cf162f5ba187fffd25a8541004cd13d32f5b03f81`.
-  Public health, readiness, and OAuth protected-resource probes pass.
-- Control Center is live at 100% on ready `us-central1` revision
+- Protected `origin/main` and the protected local `main` checkout agree at
+  `142e62c7bbf2aa261dd701892bdf1081e39ab591`.
+- The open pull-request queue is empty. The latest Live task is the Cursor MCP
+  attribution smoke checklist; exact-main CI and the three CodeQL analyzers
+  passed.
+- Open Dependabot, code-scanning, secret-scanning, and draft security-advisory
+  counts are zero. Release and source version remain 0.6.0.
+- Stable `:4765` and contributor `:4766` are ready with usable model auth.
+  Their source marker is the prior runtime-bearing main revision; the two
+  later main commits are documentation-only, so no runtime restart is needed.
+- Remote MCP is Live at 100% on ready `us-central1` revision
+  `unigrok-remote-mcp-519bbdd`, image digest
+  `sha256:36ff1e1d81b4454ddaf421ff99e84a1b343ba9e54c1709b30ce12bd22a9aa396`.
+  Public health, readiness, OAuth protected-resource metadata, and protected
+  MCP rejection probes pass.
+- Control Center is Live at 100% on ready `us-central1` revision
   `unigrok-control-center-617e8cf`, image digest
-  `sha256:7519dc2aafb8b06fc972ddd18f5a39cf5704976c7c341752f0814c8d4fe16242`.
-  Homepage, public project API, and OAuth discovery probes pass.
-- Healthy east rollback assets remain `unigrok-remote-mcp-00004-54c` and
-  `unigrok-control-center-ab8d77b`; east is not an active global route.
-- Release, source, and plugin versions agree at 0.6.0. Publishing a new release,
-  accepting the `google-genai` 2.x migration, or changing the enabled empty
-  GitHub Wiki remains a maintainer decision. Stage 2 generation, dataset writes,
-  training, and sealed evaluation remain blocked by their existing exact-head
-  authorization gates.
+  `sha256:93b0191372cf45e104a08d3294735a9c240d3ed02a73bd8c64c9bda8598cd011`.
+  The homepage and `GET /api/public/v1/project` pass.
+- East-region rollback services remain healthy and are not the active global
+  route.
+
+## Scratchpad safety
+
+- Codex removed detached worktree `7812` only after proving it unloaded,
+  process-free, clean, and zero commits ahead of main.
+- Preserve the current detached coordinator worktree and the locked protected
+  `main` checkout.
+- Preserve `/Users/djtelicloud/Documents/agentixai/grok-mcp-server`: it has
+  active processes and uncommitted contributor work.
+- Provider IDEs may automatically rehydrate clean scratchpads. Before removing
+  any candidate, re-check task state, process ownership, dirty state, unique
+  commits, and open task packets. Never rely on this handoff as a live lock.
+
+## Product boundary
+
+- Coordinator work is limited to integration health, safe repairs, deployment
+  verification, and proven-orphan cleanup. Do not invent product priorities.
+- Stage 2 remains fail-closed. A new bounded live Stage 1 manifest must specify
+  provider, call, cost, time, privacy, retry, and artifact limits and receive
+  Codex approval at its exact head before live generation.
+- Any generated dataset needs mechanical gates and another exact-head Codex
+  review before training. Training and sealed evaluation require separate
+  authorization.
+- Publishing a new release, accepting the `google-genai` 2.x migration, or
+  changing the enabled empty GitHub Wiki remains a maintainer decision.

--- a/.codex/memory/active-work.md
+++ b/.codex/memory/active-work.md
@@ -40,7 +40,7 @@ credentials, OAuth codes, tokens, or private keys here.
   process-free, clean, and zero commits ahead of main.
 - Preserve the current detached coordinator worktree and the locked protected
   `main` checkout.
-- Preserve `/Users/djtelicloud/Documents/agentixai/grok-mcp-server`: it has
+- Preserve the sponsor's primary Documents checkout of this repo: it has
   active processes and uncommitted contributor work.
 - Provider IDEs may automatically rehydrate clean scratchpads. Before removing
   any candidate, re-check task state, process ownership, dirty state, unique


### PR DESCRIPTION
## What changed

Refreshes the Codex integration-coordinator handoff with the live July 16 state:

- empty contributor queue and green exact-main checks
- zero open security/dependency alerts
- ready local services and current Cloud Run revisions
- corrected Control Center public probe route
- scratchpad cleanup receipt and preserve boundaries
- unchanged Stage 1/Stage 2 authorization gates

## Why

The tracked handoff still described a closed draft and older cloud revisions, which could send a new coordinator toward obsolete work.

## Scope and risk

Documentation-only continuity update. No runtime, workflow, release, credential, or deployment behavior changes.

- Commit: `23d40fcf0dc6e0380e8af3eb03e522c2354840bb`
- Changed path: `.codex/memory/active-work.md`
- Risk: low
- Human sponsor: djtelicloud
- Agent provenance: OpenAI Codex, GPT-5, Codex Desktop, implementation

## Verification

- `git diff --check`
- `uv run python scripts/check_agent_attribution.py --base-ref origin/main --head HEAD`
- Live GitHub queue, CI, security, release, local runtime, public endpoint, and Cloud Run probes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only handoff refresh; no runtime, deployment, or authorization behavior changes.
> 
> **Overview**
> Updates `.codex/memory/active-work.md` from the July 15 maintainer sweep to a **July 16 integration-coordinator** handoff: empty PR queue, green CI/CodeQL, zero security alerts, current `origin/main` SHA, and refreshed Cloud Run revision/image digests for remote MCP and Control Center.
> 
> **Replaces** the stale “draft PR #225 / campaign verification” packet with a shorter **current integration state** section (local `:4765`/`:4766` readiness, note that recent main commits are docs-only so no restart). **Adds** scratchpad safety (worktree `7812` removal receipt, preserve coordinator worktree, protected `main`, sponsor Documents checkout) and a **product boundary** section that keeps Stage 1/2 fail-closed gates without re-listing the full Stage 1 mechanical campaign narrative.
> 
> **Fixes** Control Center public verification wording to **`GET /api/public/v1/project`** (was a vaguer “public project API” probe description).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4abd569f2b97dc60edd9e22c06c43f076df3dfc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->