### PR TITLE
fix(supervisor): require published security check evidence

### DIFF
--- a/scripts/supervisor_approval.py
+++ b/scripts/supervisor_approval.py
@@ -69,11 +69,7 @@ CURSOR_CHECKS = (
 )
 
 CURSOR_APPROVER_CHECK = "Cursor Approval Agent: Pull Request Router and Approver"
-
-# Cursor Security Reviewer automation id (posts PR reviews; often no named check-run).
-SECURITY_REVIEWER_AUTOMATION_IDS = (
-    "f12530a3-7ff4-11f1-ba66-0e7d0216e441",
-)
+CURSOR_APPROVER_ACTORS = frozenset({"cursor", "cursor[bot]"})
 
 # Bugbot concludes NEUTRAL when it finds nothing actionable; treat as pass.
 BUGBOT_PASSING_CONCLUSIONS = frozenset({"success", "neutral"})
@@ -88,15 +84,13 @@ def _is_passing_check(name: str, state: str) -> bool:
 
 def augment_cursor_evidence(
     checks: dict[str, str],
-    reviews: list[dict[str, Any]],
 ) -> dict[str, str]:
-    """Normalize Cursor Automation evidence into the gate's expected check names.
+    """Normalize only evidence that GitHub actually published.
 
-    Live observation: Security Reviewer and Approver often leave PR reviews (or
-    exit clean) without publishing the exact GitHub check-run names the gate
-    historically required. Bugbot also reports NEUTRAL when clean. Without this
-    normalization, Supervisor Approval stays pending forever on green Ready
-    packets.
+    The live Security Reviewer currently publishes no durable exact-head clean
+    receipt. Until it emits the named check-run on the current head, that
+    required check must remain missing and the low/medium failover path must
+    stay pending. Bugbot completion and unrelated PR text are not substitutes.
     """
 
     out = dict(checks)
@@ -104,26 +98,6 @@ def augment_cursor_evidence(
     bugbot = _state_for_check(out, "Cursor Bugbot")
     if bugbot in BUGBOT_PASSING_CONCLUSIONS:
         out["Cursor Bugbot"] = "success"
-
-    security_name = "Cursor Security Agent: Security Reviewer"
-    security_state = _state_for_check(out, security_name)
-    security_blocked = False
-    security_seen = False
-    for item in reviews:
-        body = item.get("body") or ""
-        if not any(aid in body for aid in SECURITY_REVIEWER_AUTOMATION_IDS):
-            continue
-        security_seen = True
-        if item.get("state") == "CHANGES_REQUESTED":
-            security_blocked = True
-
-    if security_blocked:
-        out[security_name] = "failure"
-    elif security_state == "success" or security_seen:
-        out[security_name] = "success"
-    elif security_state == "missing" and bugbot in BUGBOT_PASSING_CONCLUSIONS:
-        # Security automation ran/exited without a published check-run.
-        out[security_name] = "success"
 
     return out
 
@@ -187,7 +161,7 @@ def _check_failure(checks: dict[str, str], names: tuple[str, ...]) -> str | None
 
 def has_exact_cursor_approval(reviews: list[dict[str, Any]], head_sha: str) -> bool:
     return any(
-        item.get("user", {}).get("login") in {"cursor", "cursor[bot]"}
+        item.get("user", {}).get("login") in CURSOR_APPROVER_ACTORS
         and item.get("state") == "APPROVED"
         and item.get("commit_id") == head_sha
         for item in reviews
@@ -347,7 +321,7 @@ def evaluate_pr(client: GitHubClient, repository: str, pr_number: int) -> tuple[
     if has_exact_cursor_approval(reviews, head_sha):
         statuses["Cursor Approval"] = "success"
 
-    checks = augment_cursor_evidence(checks, reviews)
+    checks = augment_cursor_evidence(checks)
 
     body = pr.get("body") or ""
     declared = declared_risk(body, labels)

--- a/scripts/supervisor_approval.py
+++ b/scripts/supervisor_approval.py
@@ -161,7 +161,7 @@ def _check_failure(checks: dict[str, str], names: tuple[str, ...]) -> str | None
 
 def has_exact_cursor_approval(reviews: list[dict[str, Any]], head_sha: str) -> bool:
     return any(
-        item.get("user", {}).get("login") in CURSOR_APPROVER_ACTORS
+        (item.get("user") or {}).get("login") in CURSOR_APPROVER_ACTORS
         and item.get("state") == "APPROVED"
         and item.get("commit_id") == head_sha
         for item in reviews

--- a/tests/test_supervisor_approval.py
+++ b/tests/test_supervisor_approval.py
@@ -252,7 +252,7 @@ def test_cursor_approval_must_match_the_current_head():
     assert has_exact_cursor_approval(reviews, "new")
 
 
-def test_bugbot_neutral_and_missing_security_check_can_pass():
+def test_bugbot_neutral_and_missing_security_check_stays_pending():
     raw = {
         "build (3.11)": "success",
         "build (3.12)": "success",
@@ -262,7 +262,7 @@ def test_bugbot_neutral_and_missing_security_check_can_pass():
         "docker": "success",
         "Cursor Bugbot": "neutral",
     }
-    checks = augment_cursor_evidence(raw, reviews=[])
+    checks = augment_cursor_evidence(raw)
     decision = decide_gate(
         declared="low",
         inferred="low",
@@ -270,11 +270,12 @@ def test_bugbot_neutral_and_missing_security_check_can_pass():
         statuses={"Cursor Approval": "success"},
     )
     assert checks["Cursor Bugbot"] == "success"
-    assert checks["Cursor Security Agent: Security Reviewer"] == "success"
-    assert decision.state == "success"
+    assert "Cursor Security Agent: Security Reviewer" not in checks
+    assert decision.state == "pending"
+    assert "Security Reviewer" in decision.description
 
 
-def test_security_reviewer_changes_requested_blocks_gate():
+def test_named_security_check_success_can_pass():
     raw = {
         "build (3.11)": "success",
         "build (3.12)": "success",
@@ -283,19 +284,36 @@ def test_security_reviewer_changes_requested_blocks_gate():
         "evals-offline": "success",
         "docker": "success",
         "Cursor Bugbot": "success",
+        "Cursor Security Agent: Security Reviewer": "success",
     }
-    reviews = [
-        {
-            "state": "CHANGES_REQUESTED",
-            "body": "<!-- CURSOR_AUTOMATION_ID: f12530a3-7ff4-11f1-ba66-0e7d0216e441 | RUN_ID: x -->\nblock",
-        }
-    ]
-    checks = augment_cursor_evidence(raw, reviews=reviews)
+    checks = augment_cursor_evidence(raw)
     decision = decide_gate(
         declared="low",
         inferred="low",
         checks=checks,
         statuses={"Cursor Approval": "success"},
     )
+    assert checks["Cursor Security Agent: Security Reviewer"] == "success"
+    assert decision.state == "success"
+
+
+def test_named_security_check_failure_blocks_gate():
+    raw = {
+        "build (3.11)": "success",
+        "build (3.12)": "success",
+        "Project Site": "success",
+        "Control Cloud Run Image": "success",
+        "evals-offline": "success",
+        "docker": "success",
+        "Cursor Bugbot": "success",
+        "Cursor Security Agent: Security Reviewer": "failure",
+    }
+    checks = augment_cursor_evidence(raw)
+    decision = decide_gate(
+        declared="low",
+        inferred="low",
+        checks=checks,
+        statuses={"Cursor Approval": "success"},
+    )
+    assert checks["Cursor Security Agent: Security Reviewer"] == "failure"
     assert decision.state == "failure"
-    assert "Security Reviewer" in decision.description

--- a/tests/test_supervisor_approval.py
+++ b/tests/test_supervisor_approval.py
@@ -252,6 +252,11 @@ def test_cursor_approval_must_match_the_current_head():
     assert has_exact_cursor_approval(reviews, "new")
 
 
+def test_cursor_approval_tolerates_missing_review_author():
+    reviews = [{"user": None, "state": "APPROVED", "commit_id": "current"}]
+    assert not has_exact_cursor_approval(reviews, "current")
+
+
 def test_bugbot_neutral_and_missing_security_check_stays_pending():
     raw = {
         "build (3.11)": "success",


### PR DESCRIPTION
## Summary

Makes the supervisor gate fail closed unless GitHub publishes a real Security Reviewer check for the current PR head.

## Root cause

The gate treated clean Bugbot evidence, and previously untrusted PR text, as proof that the separate Cursor Security Reviewer ran. Live verification showed that Cursor Security Reviewer is enabled and succeeds on PRs, but clean runs publish no GitHub issue comment, review, or named check-run. Absence therefore cannot be authenticated as success.

## Changes

- stop synthesizing Security Reviewer success from Bugbot or PR text
- preserve Bugbot neutral-to-success normalization
- require the exact named GitHub Security Reviewer check for low/medium failover
- keep current-head Cursor Approver authentication separate
- tolerate GitHub review payloads with a null author
- add focused pass, failure, missing-evidence, and null-author tests

## Operational impact

This is intentionally fail closed. Low/medium Cursor failover remains pending until the external Security Reviewer publishes the named check. The exact-head Codex path for high-risk work remains available.

## Head and handoff evidence

- Exact head: `6d480a6e57b33355a69bdfd96f5e7fd2b14e94cb`
- Changed paths: `scripts/supervisor_approval.py`, `tests/test_supervisor_approval.py`
- Risk: high
- Accountable GitHub contributor: djtelicloud
- Human sponsor: djtelicloud

### Agent and model provenance

| Role | Provider product | Model | Model source | Surface |
| --- | --- | --- | --- | --- |
| implementation and integration repair | OpenAI Codex | GPT-5 | user-reported | Codex Desktop |
| advisory review | xAI Grok | grok-4.5 | provider-session | UniGrok CLI |

## Verification

- `uv run pytest -q tests/test_supervisor_approval.py` — 21 passed
- `uv run python scripts/check_agent_attribution.py --base-ref origin/main --head HEAD` — passed
- `git diff --check origin/main...HEAD` — passed
- Prior exact head passed the full suite: 2,128 tests
- Live GitHub and signed-in Cursor Security Agents evidence checked on PRs 249 and 250