### PR TITLE
fix(http): disable proxy env on credential-bearing httpx clients

### DIFF
--- a/src/http_server.py
+++ b/src/http_server.py
@@ -248,7 +248,11 @@ async def _introspect_oauth_token(token: str, required_scope: str) -> Optional[D
     if not url or not token or len(token) > 8_192:
         return None
     try:
-        async with httpx.AsyncClient(timeout=5.0, follow_redirects=False) as client:
+        async with httpx.AsyncClient(
+            timeout=5.0,
+            follow_redirects=False,
+            trust_env=False,
+        ) as client:
             response = await client.post(
                 url,
                 headers={
@@ -1843,7 +1847,11 @@ async def post_xai_chat(payload: Dict[str, Any]) -> Response:
         return _json_error("XAI_API_KEY is not configured.", status_code=503, code="service_unavailable")
     url = os.environ.get("XAI_API_BASE_URL", XAI_BASE_URL).rstrip("/") + "/chat/completions"
     try:
-        async with httpx.AsyncClient(timeout=120.0) as client:
+        async with httpx.AsyncClient(
+            timeout=120.0,
+            follow_redirects=False,
+            trust_env=False,
+        ) as client:
             response = await client.post(url, json=_xai_payload(payload), headers=_xai_headers())
         if response.status_code >= 400:
             return _json_error(
@@ -1881,7 +1889,11 @@ async def stream_xai_chat(payload: Dict[str, Any]) -> AsyncIterator[bytes]:
         pool=10.0,
     )
     try:
-        async with httpx.AsyncClient(timeout=stream_timeout) as client:
+        async with httpx.AsyncClient(
+            timeout=stream_timeout,
+            follow_redirects=False,
+            trust_env=False,
+        ) as client:
             async with client.stream("POST", url, json=_xai_payload(payload), headers=_xai_headers()) as response:
                 if response.status_code >= 400:
                     await response.aread()

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -318,7 +318,11 @@ async def fetch_provider_api_usage() -> Dict[str, Any]:
         }
     }
     try:
-        async with httpx.AsyncClient(timeout=8.0) as client:
+        async with httpx.AsyncClient(
+            timeout=8.0,
+            follow_redirects=False,
+            trust_env=False,
+        ) as client:
             response = await client.post(
                 f"https://management-api.x.ai/v1/billing/teams/{team_id}/usage",
                 headers={"Authorization": f"Bearer {management_key}"},

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -1839,3 +1839,48 @@ async def test_post_xai_chat_502_bad_gateway_on_errors(monkeypatch):
     body_json = json.loads(res_json.body.decode())
     assert body_json["error"]["type"] == "bad_gateway"
     assert body_json["error"]["message"].startswith("Upstream returned invalid JSON.")
+
+
+def test_credential_bearing_httpx_clients_disable_proxy_env():
+    """Bearer-carrying httpx clients must not inherit HTTPS_PROXY/HTTP_PROXY.
+
+    Matches the subordinate-provider contract in src/providers/base.py
+    (trust_env=False, follow_redirects=False).
+    """
+    import ast
+
+    root = Path(__file__).resolve().parents[1]
+    sources = (
+        root / "src" / "http_server.py",
+        root / "src" / "metrics.py",
+    )
+    found = 0
+    for path in sources:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            is_async_client = (
+                isinstance(func, ast.Attribute)
+                and func.attr == "AsyncClient"
+                and isinstance(func.value, ast.Name)
+                and func.value.id == "httpx"
+            )
+            if not is_async_client:
+                continue
+            found += 1
+            keywords = {
+                kw.arg: kw.value
+                for kw in node.keywords
+                if kw.arg is not None
+            }
+            trust = keywords.get("trust_env")
+            redirects = keywords.get("follow_redirects")
+            assert isinstance(trust, ast.Constant) and trust.value is False, (
+                f"{path.name}:{node.lineno} AsyncClient missing trust_env=False"
+            )
+            assert isinstance(redirects, ast.Constant) and redirects.value is False, (
+                f"{path.name}:{node.lineno} AsyncClient missing follow_redirects=False"
+            )
+    assert found >= 4, f"expected ≥4 credential-bearing AsyncClient sites, found {found}"

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -1910,11 +1910,11 @@ def test_credential_bearing_httpx_clients_disable_proxy_env():
     import ast
 
     root = Path(__file__).resolve().parents[1]
-    sources = (
+    sources = [
         root / "src" / "http_server.py",
         root / "src" / "metrics.py",
         root / "src" / "providers" / "base.py",
-    )
+    ]
     found = 0
     for path in sources:
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -1853,6 +1853,7 @@ def test_credential_bearing_httpx_clients_disable_proxy_env():
     sources = (
         root / "src" / "http_server.py",
         root / "src" / "metrics.py",
+        root / "src" / "providers" / "base.py",
     )
     found = 0
     for path in sources:
@@ -1883,4 +1884,4 @@ def test_credential_bearing_httpx_clients_disable_proxy_env():
             assert isinstance(redirects, ast.Constant) and redirects.value is False, (
                 f"{path.name}:{node.lineno} AsyncClient missing follow_redirects=False"
             )
-    assert found >= 4, f"expected ≥4 credential-bearing AsyncClient sites, found {found}"
+    assert found >= 5, f"expected ≥5 credential-bearing AsyncClient sites, found {found}"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -212,7 +212,11 @@ async def test_provider_usage_accepts_sdk_management_alias(monkeypatch):
             captured.update(url=url, headers=headers, json=json)
             return FakeResponse()
 
-    monkeypatch.setattr("src.metrics.httpx.AsyncClient", lambda **kwargs: FakeClient())
+    def capture_client(**kwargs):
+        captured["client_kwargs"] = kwargs
+        return FakeClient()
+
+    monkeypatch.setattr("src.metrics.httpx.AsyncClient", capture_client)
     monkeypatch.delenv("XAI_MANAGEMENT_API_KEY", raising=False)
     monkeypatch.setenv("XAI_MANAGEMENT_KEY", "sdk-management-test-key")
     monkeypatch.setenv("UNIGROK_XAI_TEAM_ID", "team-test")
@@ -224,6 +228,8 @@ async def test_provider_usage_accepts_sdk_management_alias(monkeypatch):
     assert captured["headers"] == {
         "Authorization": "Bearer sdk-management-test-key"
     }
+    assert captured["client_kwargs"]["trust_env"] is False
+    assert captured["client_kwargs"]["follow_redirects"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Set `trust_env=False` and explicit `follow_redirects=False` on the four credential-bearing `httpx.AsyncClient` constructions in `src/http_server.py` (OAuth introspection, `/v1` chat post/stream) and `src/metrics.py` (management usage probe).
- Aligns those paths with the subordinate-provider contract in `src/providers/base.py` so `HTTPS_PROXY`/`HTTP_PROXY` cannot silently siphon Bearer credentials.
- Adds an AST contract test plus a runtime kwargs assertion for the management-usage client.

## Test plan
- [x] `uv run pytest -q tests/test_http_server.py::test_credential_bearing_httpx_clients_disable_proxy_env tests/test_metrics.py::test_provider_usage_accepts_sdk_management_alias tests/test_http_server.py::test_post_xai_chat_502_bad_gateway_on_errors`
- [ ] CI green on the draft PR head

## Verification
- Focused tests: 3 passed
- @grok pre-fix and pre-PR gates: YES-DRAFT-PR (CLI plane, same_plane)
- HEAD: will match push tip


Made with [Cursor](https://cursor.com)