### PR TITLE
fix(ui): stop painting SUCCESS for failed agent turns

### DIFF
--- a/.github/agent-identities.json
+++ b/.github/agent-identities.json
@@ -42,6 +42,18 @@
       },
       "product": "Copilot",
       "provider": "GitHub"
+    },
+    {
+      "credit_name": "Cursor Composer",
+      "github_identity": null,
+      "product": "Composer",
+      "provider": "Cursor"
+    },
+    {
+      "credit_name": "Cursor",
+      "github_identity": null,
+      "product": "Cursor",
+      "provider": "Cursor"
     }
   ],
   "agent_identity_markers": [

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,6 +23,8 @@ this repository unless the verified registry explicitly says otherwise:
 | Google Gemini | Google | Gemini | `Agent-Assisted-By` |
 | xAI Grok | xAI | Grok | `Agent-Assisted-By` or advisory `Agent-Reviewed-By` |
 | GitHub Copilot | GitHub | Copilot in a local IDE | `Agent-Assisted-By` |
+| Cursor Composer | Cursor | Composer | `Agent-Assisted-By` |
+| Cursor | Cursor | Cursor Automations / Agent | `Agent-Assisted-By` |
 
 Exact or qualified model labels, surfaces, roles, and evidence belong in each
 commit and pull request. See [the attribution policy](docs/agent-attribution.md)

--- a/docs/agent-attribution.md
+++ b/docs/agent-attribution.md
@@ -21,6 +21,7 @@ help uses a repeatable `Agent-Assisted-By` trailer. Advisory review uses
 Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=user-reported | surface=Codex Desktop | role=implementation
 Agent-Assisted-By: Anthropic Claude | model=Fable 5 Ultracode | model-source=user-reported | surface=Claude Code | role=research
 Agent-Assisted-By: Google Gemini | model=Gemini 3.1 Pro | model-source=user-reported | surface=Antigravity | role=data-design
+Agent-Assisted-By: Cursor Composer | model=Grok 4.5 | model-source=provider-session | surface=Cursor | role=implementation
 Agent-Reviewed-By: xAI Grok | model=grok-4.5 | model-source=runtime-receipt | surface=UniGrok CLI | role=advisory-review | evidence=receipt-sha256:0123456789abcdef
 ```
 

--- a/mcp_ui/app.js
+++ b/mcp_ui/app.js
@@ -1,9 +1,9 @@
-import { parseMarkdown, sanitizeHref } from "./markdown.js?v=grok-v0.6.0-r10";
+import { parseMarkdown, sanitizeHref } from "./markdown.js?v=grok-v0.6.0-r11";
 
 // Must match the <meta name="unigrok-ui-version"> baked into index.html and
 // src/version.py UI_ASSET_VERSION; a mismatch means the browser paired a
 // cached page with a different script build (the stale-skew failure class).
-const UI_ASSET_VERSION = "grok-v0.6.0-r10";
+const UI_ASSET_VERSION = "grok-v0.6.0-r11";
 
 const LAYOUT_KEY = "unigrok.mcp.console.layout.v2";
 
@@ -1896,17 +1896,25 @@ function renderFactsPane(method, response, elapsed) {
     return;
   }
 
-  // A FastMCP tool exception arrives as result.isError with the message in
-  // content[0].text — that is a failed run, never a SUCCESS receipt.
-  if (response.result?.isError) {
-    const status = setText("factStatus", "TOOL ERROR");
-    if (status) status.style.color = "var(--red)";
-  } else {
-    const status = setText("factStatus", "SUCCESS");
-    if (status) status.style.color = "var(--teal)";
-  }
-
   const payload = extractToolPayload(response);
+  // Status must reflect AgentResult.finish_reason too: credential/plane
+  // failures return a normal tools/call payload (not result.isError), so a
+  // green SUCCESS receipt would lie about the outcome.
+  let statusLabel = "SUCCESS";
+  let statusColor = "var(--teal)";
+  if (response.result?.isError) {
+    statusLabel = "TOOL ERROR";
+    statusColor = "var(--red)";
+  } else if (payload.finish_reason === "error") {
+    statusLabel = "FAILED";
+    statusColor = "var(--red)";
+  } else if (payload.finish_reason === "fallback" || payload.degraded === true) {
+    statusLabel = "DEGRADED";
+    statusColor = "var(--orange)";
+  }
+  const status = setText("factStatus", statusLabel);
+  if (status) status.style.color = statusColor;
+
   setText("factTokens", payload.tokens || "-");
   // The wire may deliver cost as a number or a serialized string; only a
   // finite value renders as currency.
@@ -1967,8 +1975,14 @@ async function callAgent(prompt) {
       addMessageBubble("error", `Tool error: ${payload.response || payload.text || "unknown tool failure"}`);
       return;
     }
-
     const answer = payload.text || payload.response || "No response field returned.";
+    // finish_reason=error is a completed tools/call with a failed agent turn
+    // (e.g. credential-setup) — show it as an error bubble, not an agent answer.
+    if (payload.finish_reason === "error") {
+      addMessageBubble("error", answer);
+      return;
+    }
+
     addMessageBubble("agent", answer);
     renderCitations(payload.citations);
   } catch (err) {

--- a/mcp_ui/app.js
+++ b/mcp_ui/app.js
@@ -1896,7 +1896,7 @@ function renderFactsPane(method, response, elapsed) {
     return;
   }
 
-  const payload = extractToolPayload(response);
+  const payload = extractToolPayload(response) || {};
   // Status must reflect AgentResult.finish_reason too: credential/plane
   // failures return a normal tools/call payload (not result.isError), so a
   // green SUCCESS receipt would lie about the outcome.

--- a/mcp_ui/index.html
+++ b/mcp_ui/index.html
@@ -7,9 +7,9 @@
     <meta name="unigrok-ui-regions" content="navigation,workbench,rpc-inspector,rpc-logs,result-facts" />
     <!-- Version handshake: app.js compares this against its own build constant
          and self-heals a stale-cached page with one revalidating reload. -->
-    <meta name="unigrok-ui-version" content="grok-v0.6.0-r10" />
-  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r10" />
-  <link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r10" />
+    <meta name="unigrok-ui-version" content="grok-v0.6.0-r11" />
+  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r11" />
+  <link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r11" />
   </head>
   <body>
     <main class="app-shell">
@@ -523,6 +523,6 @@ docker compose up --build -d</code></pre>
 
       </section>
     </main>
-  <script type="module" src="./app.js?v=grok-v0.6.0-r10"></script>
+  <script type="module" src="./app.js?v=grok-v0.6.0-r11"></script>
   </body>
 </html>

--- a/mcp_ui/swarm.html
+++ b/mcp_ui/swarm.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>UniGrok Swarm Optimizer — Pareto Playground</title>
-  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r10" />
+  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r11" />
   <style>
     /* Page vocabulary aliases onto the shared UniGrok tokens (tokens.css) so
        the Swarm Optimizer and the Control Center read as one product. */
@@ -270,6 +270,6 @@
     hidden. "Verified" means: the task's own <code>test_target</code> passed.
   </div>
 
-  <script src="./swarm.js?v=grok-v0.6.0-r10"></script>
+  <script src="./swarm.js?v=grok-v0.6.0-r11"></script>
 </body>
 </html>

--- a/mcp_ui/swarm.js
+++ b/mcp_ui/swarm.js
@@ -10,7 +10,7 @@
 // Must match src/version.py UI_ASSET_VERSION and the query token on the
 // swarm.js reference in swarm.html. The sample uses the same token so a
 // revalidated page cannot pair new logic with a heuristically cached payload.
-const UI_ASSET_VERSION = "grok-v0.6.0-r10";
+const UI_ASSET_VERSION = "grok-v0.6.0-r11";
 
 const $ = (id) => document.getElementById(id);
 const SVG_NS = "http://www.w3.org/2000/svg";

--- a/src/version.py
+++ b/src/version.py
@@ -7,4 +7,4 @@ __version__ = "0.6.0"
 # runtime handshake in app.js).
 # Bump the -rN suffix whenever any /ui asset changes; a pytest asserts every
 # copy of this string agrees so HTML and JS can never skew apart silently.
-UI_ASSET_VERSION = "grok-v0.6.0-r10"
+UI_ASSET_VERSION = "grok-v0.6.0-r11"

--- a/tests/test_agent_attribution.py
+++ b/tests/test_agent_attribution.py
@@ -235,6 +235,8 @@ def test_registry_and_visible_credits_cover_all_provider_products() -> None:
     registry = attribution.load_registry(REGISTRY)
     expected = {
         "Anthropic Claude",
+        "Cursor",
+        "Cursor Composer",
         "GitHub Copilot",
         "Google Gemini",
         "OpenAI Codex",

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -486,6 +486,7 @@ def test_mcp_ui_error_surfaces_tell_the_truth():
     assert 'id="factFinishReason"' in index.text
     assert 'id="factDegraded"' in index.text
     assert "payload.finish_reason" in script.text
+    assert "extractToolPayload(response) || {}" in script.text
     # AgentResult finish_reason=error is a normal tools/call payload — must not
     # paint SUCCESS, and the transcript must use an error bubble.
     assert 'payload.finish_reason === "error"' in script.text

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -47,9 +47,9 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert index.status_code == 200
     assert "<title>UniGrok Gateway Console v0.6.0</title>" in index.text
     assert '<span class="version-badge">v0.6.0</span>' in index.text
-    assert 'script type="module" src="./app.js?v=grok-v0.6.0-r10"' in index.text
-    assert '<link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r10" />' in index.text
-    assert '<link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r10" />' in index.text
+    assert 'script type="module" src="./app.js?v=grok-v0.6.0-r11"' in index.text
+    assert '<link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r11" />' in index.text
+    assert '<link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r11" />' in index.text
     assert "Console" in index.text
     assert 'id="surfaceModeBadge"' in index.text
     assert 'id="tab-btn-schemas"' not in index.text
@@ -463,7 +463,7 @@ def test_mcp_ui_markdown_renderer_is_shared_and_escape_first():
     assert "\\u000E-\\u001F" in renderer.text
     # app.js imports the shared renderer at the current cache-bust version and
     # no longer defines its own.
-    assert 'from "./markdown.js?v=grok-v0.6.0-r10"' in script.text
+    assert 'from "./markdown.js?v=grok-v0.6.0-r11"' in script.text
     assert "import { parseMarkdown" in script.text
     assert "function parseMarkdown" not in script.text
     assert "renderMarkdownInto" in script.text
@@ -486,6 +486,11 @@ def test_mcp_ui_error_surfaces_tell_the_truth():
     assert 'id="factFinishReason"' in index.text
     assert 'id="factDegraded"' in index.text
     assert "payload.finish_reason" in script.text
+    # AgentResult finish_reason=error is a normal tools/call payload — must not
+    # paint SUCCESS, and the transcript must use an error bubble.
+    assert 'payload.finish_reason === "error"' in script.text
+    assert 'statusLabel = "FAILED"' in script.text
+    assert 'statusLabel = "DEGRADED"' in script.text
     assert "failing checks" in script.text
     assert "describeNotReady" in script.text
     # The connection-lost wording is reserved for actual fetch failures.


### PR DESCRIPTION
## Summary
- Control Center receipt status now reflects `AgentResult.finish_reason`: `FAILED` for `error`, `DEGRADED` for `fallback` / `degraded=true`, otherwise `SUCCESS` / `TOOL ERROR`.
- Playground transcript uses an error bubble when `finish_reason === \"error\"` instead of presenting credential/plane failures as agent answers.
- Bumps UI asset cache token `r10` → `r11` so browsers pick up the honesty fix.

## Test plan
- [x] `uv run pytest -q tests/test_mcp_ui.py` (27 passed)
- [ ] CI green on the draft PR head
- [ ] Manual: force a credential-setup / plane error in Control Center and confirm receipt shows FAILED (not SUCCESS) and an error bubble

## Notes
- Separate from (#252); does not stack onto that branch.
- @grok pre-fix and pre-PR gates: YES-DRAFT-PR (CLI, same_plane)


Made with [Cursor](https://cursor.com)


## Exact-head supervisor handoff
- Head: `0be312a6493f320718e12160eb62c61ba6e398c7`
- Focused validation: `uv run pytest -q tests/test_mcp_ui.py tests/test_agent_attribution.py` — 40 passed.
- Human sponsor: `djtelicloud`.
- Provenance: xAI Grok implementation/advisory review; OpenAI Codex integration.

risk: medium
