### PR TITLE
fix(http): fail-closed public MCP DNS-rebinding allowlist

### DIFF
--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -512,6 +512,10 @@ host. Production Cloud Run serves ``mcp.grokmcp.org`` (and similar), so
 authenticated /mcp traffic must allow the public hostname from
 ``UNIGROK_PUBLIC_MCP_URL`` or the optional override.
 
+Unsafe or non-HTTPS overrides are ignored: they must not expand the
+Host/Origin allowlist (OAuth metadata already rejects them via
+:func:`_public_mcp_resource`).
+
 ## hydration.py {#hydration}
 
 ### Class: `HydrationService` {#hydration-hydrationservice}

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -512,6 +512,10 @@ host. Production Cloud Run serves ``mcp.grokmcp.org`` (and similar), so
 authenticated /mcp traffic must allow the public hostname from
 ``UNIGROK_PUBLIC_MCP_URL`` or the optional override.
 
+Unsafe or non-HTTPS overrides are ignored: they must not expand the
+Host/Origin allowlist (OAuth metadata already rejects them via
+:func:`_public_mcp_resource`).
+
 ## hydration.py {#hydration}
 
 ### Class: `HydrationService` {#hydration-hydrationservice}

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -975,9 +975,13 @@ def _validated_public_mcp_resource(raw: str) -> Optional[str]:
     HTTP DNS-rebinding allowlist.
     """
     resource = _validated_https_url(raw)
-    if resource and not urlsplit(resource).path:
+    if not resource:
+        return None
+    path = urlsplit(resource).path
+    if not path:
         resource = f"{resource}/mcp"
-    if resource and urlsplit(resource).path == "/mcp":
+        path = "/mcp"
+    if path == "/mcp":
         return resource
     return None
 

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -981,7 +981,8 @@ def _validated_public_mcp_resource(raw: str) -> Optional[str]:
     resource = _validated_https_url(raw)
     if not resource:
         return None
-    path = urlsplit(resource).path
+    parsed = urlsplit(resource)
+    path = parsed.path
     if not path:
         resource = f"{resource}/mcp"
         path = "/mcp"

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -968,13 +968,22 @@ def _validated_https_url(value: str) -> Optional[str]:
     return f"https://{parsed.netloc}{normalized_path}"
 
 
-def _public_mcp_resource() -> Optional[str]:
-    resource = _validated_https_url(os.environ.get("UNIGROK_PUBLIC_MCP_URL", ""))
+def _validated_public_mcp_resource(raw: str) -> Optional[str]:
+    """Return a public ``…/mcp`` HTTPS resource, or ``None`` when unsafe.
+
+    Only global HTTPS hosts may publish OAuth metadata or widen the Streamable
+    HTTP DNS-rebinding allowlist.
+    """
+    resource = _validated_https_url(raw)
     if resource and not urlsplit(resource).path:
         resource = f"{resource}/mcp"
     if resource and urlsplit(resource).path == "/mcp":
         return resource
     return None
+
+
+def _public_mcp_resource() -> Optional[str]:
+    return _validated_public_mcp_resource(os.environ.get("UNIGROK_PUBLIC_MCP_URL", ""))
 
 
 def _oauth_protected_resource_metadata_url(
@@ -2138,6 +2147,10 @@ def public_mcp_transport_security(
     host. Production Cloud Run serves ``mcp.grokmcp.org`` (and similar), so
     authenticated /mcp traffic must allow the public hostname from
     ``UNIGROK_PUBLIC_MCP_URL`` or the optional override.
+
+    Unsafe or non-HTTPS overrides are ignored: they must not expand the
+    Host/Origin allowlist (OAuth metadata already rejects them via
+    :func:`_public_mcp_resource`).
     """
     hosts = [
         "127.0.0.1",
@@ -2155,16 +2168,18 @@ def public_mcp_transport_security(
         "http://[::1]",
         "http://[::1]:*",
     ]
-    raw = (public_mcp_url if public_mcp_url is not None else os.environ.get("UNIGROK_PUBLIC_MCP_URL", "")).strip()
-    if raw:
-        parsed = urlsplit(raw)
+    if public_mcp_url is None:
+        resource = _public_mcp_resource()
+    else:
+        resource = _validated_public_mcp_resource(public_mcp_url)
+    if resource:
+        parsed = urlsplit(resource)
         host = (parsed.hostname or "").lower()
         if host:
             hosts.append(host)
             if parsed.port:
                 hosts.append(f"{host}:{parsed.port}")
-            scheme = parsed.scheme if parsed.scheme in {"http", "https"} else "https"
-            origin = f"{scheme}://{host}"
+            origin = f"https://{host}"
             if parsed.port:
                 origin = f"{origin}:{parsed.port}"
             origins.append(origin)

--- a/tests/test_public_mcp_transport_security.py
+++ b/tests/test_public_mcp_transport_security.py
@@ -18,3 +18,28 @@ def test_public_mcp_transport_security_includes_public_hostname() -> None:
     )
     assert settings.allowed_hosts[-1] == "mcp.grokmcp.org"
     assert settings.allowed_origins[-1] == "https://mcp.grokmcp.org"
+
+
+def test_public_mcp_transport_security_rejects_non_https() -> None:
+    baseline = public_mcp_transport_security(public_mcp_url="")
+    settings = public_mcp_transport_security(
+        public_mcp_url="http://mcp.grokmcp.org/mcp",
+    )
+    assert settings.allowed_hosts == baseline.allowed_hosts
+    assert settings.allowed_origins == baseline.allowed_origins
+    assert "mcp.grokmcp.org" not in settings.allowed_hosts
+
+
+def test_public_mcp_transport_security_rejects_link_local_and_internal() -> None:
+    baseline = public_mcp_transport_security(public_mcp_url="")
+    for unsafe in (
+        "http://169.254.169.254/mcp",
+        "https://169.254.169.254/mcp",
+        "https://evil.internal/mcp",
+        "https://localhost/mcp",
+        "https://mcp.grokmcp.org/not-mcp",
+    ):
+        settings = public_mcp_transport_security(public_mcp_url=unsafe)
+        assert settings.allowed_hosts == baseline.allowed_hosts, unsafe
+        assert "169.254.169.254" not in settings.allowed_hosts
+        assert "evil.internal" not in settings.allowed_hosts


### PR DESCRIPTION
## Summary
- `public_mcp_transport_security()` no longer appends raw `UNIGROK_PUBLIC_MCP_URL` hosts into FastMCP DNS-rebinding allowlists.
- Public host expansion now uses the same fail-closed HTTPS `/mcp` validator as OAuth resource metadata (`_validated_public_mcp_resource`).
- Unsafe values (non-HTTPS, link-local, `.internal`, localhost, wrong path) leave the allowlist at localhost defaults.

## Test plan
- [x] `uv run pytest -q tests/test_public_mcp_transport_security.py` (+ related http_server filters): 7 passed
- [ ] CI green on the draft PR head

## Notes
- Separate from (#252) and (#253).
- @grok pre-fix and pre-PR gates: YES-DRAFT-PR (CLI, same_plane)


Made with [Cursor](https://cursor.com)