### PR TITLE
fix(http): fail-closed XAI_API_BASE_URL before bearer callout

### DIFF
--- a/src/http_server.py
+++ b/src/http_server.py
@@ -1818,6 +1818,23 @@ def _xai_headers() -> Dict[str, str]:
     return {"Authorization": f"Bearer {key}", "Content-Type": "application/json"}
 
 
+def _xai_chat_completions_url() -> Optional[str]:
+    """Return the chat-completions URL, or ``None`` when an override is unsafe.
+
+    ``XAI_API_BASE_URL`` is operator-controlled but credential-bearing: the
+    gateway attaches ``XAI_API_KEY``. Unset keeps the built-in xAI default.
+    A set-but-unsafe override fails closed (no silent fallback that would hide
+    a misconfiguration while still shipping the bearer token elsewhere).
+    """
+    raw = os.environ.get("XAI_API_BASE_URL", "").strip()
+    if not raw:
+        return f"{XAI_BASE_URL.rstrip('/')}/chat/completions"
+    base = _validated_https_url(raw)
+    if base is None:
+        return None
+    return f"{base.rstrip('/')}/chat/completions"
+
+
 def _xai_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
     allowed = {
         "model",
@@ -1841,7 +1858,13 @@ def _xai_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
 async def post_xai_chat(payload: Dict[str, Any]) -> Response:
     if not os.environ.get("XAI_API_KEY"):
         return _json_error("XAI_API_KEY is not configured.", status_code=503, code="service_unavailable")
-    url = os.environ.get("XAI_API_BASE_URL", XAI_BASE_URL).rstrip("/") + "/chat/completions"
+    url = _xai_chat_completions_url()
+    if url is None:
+        return _json_error(
+            "XAI_API_BASE_URL is not a public HTTPS endpoint.",
+            status_code=503,
+            code="service_unavailable",
+        )
     try:
         async with httpx.AsyncClient(timeout=120.0) as client:
             response = await client.post(url, json=_xai_payload(payload), headers=_xai_headers())
@@ -1871,7 +1894,14 @@ async def stream_xai_chat(payload: Dict[str, Any]) -> AsyncIterator[bytes]:
         yield _sse_error("XAI_API_KEY is not configured.", "service_unavailable")
         yield b"data: [DONE]\n\n"
         return
-    url = os.environ.get("XAI_API_BASE_URL", XAI_BASE_URL).rstrip("/") + "/chat/completions"
+    url = _xai_chat_completions_url()
+    if url is None:
+        yield _sse_error(
+            "XAI_API_BASE_URL is not a public HTTPS endpoint.",
+            "service_unavailable",
+        )
+        yield b"data: [DONE]\n\n"
+        return
     stream_timeout = httpx.Timeout(
         connect=10.0,
         read=_bounded_env_float(

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -1839,3 +1839,52 @@ async def test_post_xai_chat_502_bad_gateway_on_errors(monkeypatch):
     body_json = json.loads(res_json.body.decode())
     assert body_json["error"]["type"] == "bad_gateway"
     assert body_json["error"]["message"].startswith("Upstream returned invalid JSON.")
+
+
+def test_xai_chat_completions_url_defaults_and_rejects_unsafe_overrides(monkeypatch):
+    from src.http_server import XAI_BASE_URL, _xai_chat_completions_url
+
+    monkeypatch.delenv("XAI_API_BASE_URL", raising=False)
+    assert _xai_chat_completions_url() == f"{XAI_BASE_URL.rstrip('/')}/chat/completions"
+
+    monkeypatch.setenv("XAI_API_BASE_URL", "https://api.x.ai/v1")
+    assert _xai_chat_completions_url() == "https://api.x.ai/v1/chat/completions"
+
+    for unsafe in (
+        "http://api.x.ai/v1",
+        "https://169.254.169.254/v1",
+        "https://evil.internal/v1",
+        "https://localhost/v1",
+    ):
+        monkeypatch.setenv("XAI_API_BASE_URL", unsafe)
+        assert _xai_chat_completions_url() is None, unsafe
+
+
+@pytest.mark.asyncio
+async def test_post_xai_chat_rejects_unsafe_base_url_without_calling_out(monkeypatch):
+    from src.http_server import post_xai_chat
+    import json
+
+    called = {"post": False}
+
+    class ForbiddenClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def post(self, *args, **kwargs):
+            called["post"] = True
+            raise AssertionError("unsafe XAI_API_BASE_URL must not call out")
+
+    monkeypatch.setenv("XAI_API_KEY", "dummy-key")
+    monkeypatch.setenv("XAI_API_BASE_URL", "http://169.254.169.254/v1")
+    monkeypatch.setattr("src.http_server.httpx.AsyncClient", lambda **kwargs: ForbiddenClient())
+
+    res = await post_xai_chat({"model": "grok-4.3", "messages": []})
+    assert res.status_code == 503
+    body = json.loads(res.body.decode())
+    assert body["error"]["code"] == "service_unavailable"
+    assert "XAI_API_BASE_URL" in body["error"]["message"]
+    assert called["post"] is False

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -1947,7 +1947,7 @@ async def test_post_xai_chat_rejects_unsafe_base_url_without_calling_out(monkeyp
     body = json.loads(res.body.decode())
     assert body["error"]["code"] == "service_unavailable"
     assert "XAI_API_BASE_URL" in body["error"]["message"]
-    assert called["post"] is False
+    assert not called["post"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -1888,3 +1888,32 @@ async def test_post_xai_chat_rejects_unsafe_base_url_without_calling_out(monkeyp
     assert body["error"]["code"] == "service_unavailable"
     assert "XAI_API_BASE_URL" in body["error"]["message"]
     assert called["post"] is False
+
+
+@pytest.mark.asyncio
+async def test_stream_xai_chat_rejects_unsafe_base_url_without_calling_out(monkeypatch):
+    called = {"stream": False}
+
+    class ForbiddenClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        def stream(self, *args, **kwargs):
+            called["stream"] = True
+            raise AssertionError("unsafe XAI_API_BASE_URL must not call out")
+
+    monkeypatch.setenv("XAI_API_KEY", "dummy-key")
+    monkeypatch.setenv("XAI_API_BASE_URL", "http://169.254.169.254/v1")
+    monkeypatch.setattr("src.http_server.httpx.AsyncClient", lambda **kwargs: ForbiddenClient())
+
+    chunks = [
+        chunk
+        async for chunk in stream_xai_chat({"model": "grok-4.3", "messages": []})
+    ]
+    body = b"".join(chunks).decode("utf-8")
+    assert "XAI_API_BASE_URL is not a public HTTPS endpoint." in body
+    assert body.endswith("data: [DONE]\n\n")
+    assert called["stream"] is False


### PR DESCRIPTION
## Summary
- `/v1` chat post/stream resolve upstream via `_xai_chat_completions_url()`.
- Unset `XAI_API_BASE_URL` keeps the built-in `https://api.x.ai/v1` default.
- Set-but-unsafe overrides (non-HTTPS, link-local, `.internal`, localhost) return 503 without calling out with the bearer token.

## Test plan
- [x] `uv run pytest -q` focused XAI base URL tests (3 passed)
- [ ] CI green on the draft PR head

## Notes
- Separate from (#252), (#253), and (#254).
- @grok pre-fix and pre-PR gates: YES-DRAFT-PR (CLI, same_plane)


Made with [Cursor](https://cursor.com)