### PR TITLE
fix(http): forward OAuth MCP disconnects

### DIFF
--- a/src/http_server.py
+++ b/src/http_server.py
@@ -549,6 +549,7 @@ class GatewayAuthMiddleware:
 
         body = b""
         if path == "/mcp" and scope.get("method") == "POST":
+            original_receive = receive
             messages = []
             while True:
                 message = await receive()
@@ -556,14 +557,17 @@ class GatewayAuthMiddleware:
                 if message.get("type") != "http.request" or not message.get("more_body"):
                     break
             body = b"".join(message.get("body", b"") for message in messages)
-            replayed = False
+            replay_index = 0
 
             async def replay_receive():
-                nonlocal replayed
-                if replayed:
-                    return {"type": "http.request", "body": b"", "more_body": False}
-                replayed = True
-                return {"type": "http.request", "body": body, "more_body": False}
+                nonlocal replay_index
+                if replay_index < len(messages):
+                    message = messages[replay_index]
+                    replay_index += 1
+                    return message
+                # Stateful Streamable HTTP transports keep receiving after
+                # the request body so they can observe the real disconnect.
+                return await original_receive()
 
             receive = replay_receive
 

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -351,6 +351,66 @@ def test_oauth_introspection_enforces_surface_and_tool_scopes(monkeypatch):
     )
 
 
+@pytest.mark.asyncio
+async def test_oauth_mcp_body_replay_forwards_original_disconnect(monkeypatch):
+    monkeypatch.delenv("UNIGROK_API_KEYS", raising=False)
+    monkeypatch.delenv("UNIGROK_ALLOW_UNAUTHENTICATED", raising=False)
+    monkeypatch.setenv(
+        "UNIGROK_OAUTH_INTROSPECTION_URL",
+        "https://control.grokmcp.org/oauth/introspect",
+    )
+    document = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "agent", "arguments": {}},
+        }
+    ).encode()
+    source_messages = [
+        {"type": "http.request", "body": document[:20], "more_body": True},
+        {"type": "http.request", "body": document[20:], "more_body": False},
+        {"type": "http.disconnect"},
+    ]
+    received = []
+
+    async def allow(_token, required_scope):
+        assert required_scope == "unigrok:connect unigrok:invoke"
+        return {"active": True, "scope": required_scope, "sub": "service:review"}
+
+    async def downstream(scope, receive, _send):
+        assert scope["unigrok.oauth"]["sub"] == "service:review"
+        received.extend([await receive(), await receive(), await receive()])
+
+    async def original_receive():
+        return source_messages.pop(0)
+
+    async def send(_message):
+        return None
+
+    monkeypatch.setattr("src.http_server._introspect_oauth_token", allow)
+    middleware = GatewayAuthMiddleware(downstream, bound_host="0.0.0.0")
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/mcp",
+        "query_string": b"",
+        "scheme": "https",
+        "client": ("203.0.113.10", 50000),
+        "server": ("mcp.grokmcp.org", 443),
+        "headers": [(b"authorization", b"Bearer oauth-token")],
+    }
+
+    await middleware(scope, original_receive, send)
+
+    assert received == [
+        {"type": "http.request", "body": document[:20], "more_body": True},
+        {"type": "http.request", "body": document[20:], "more_body": False},
+        {"type": "http.disconnect"},
+    ]
+    assert source_messages == []
+
+
 def test_oauth_metadata_challenge_omits_mcp_document_for_query_variant(monkeypatch):
     monkeypatch.setenv("UNIGROK_RUNTIME", "cloudrun")
     monkeypatch.delenv("UNIGROK_API_KEYS", raising=False)


### PR DESCRIPTION
## Summary

Prevents authenticated Streamable HTTP MCP requests from hanging after OAuth body inspection. The middleware now replays the original ASGI request messages once, then resumes the real receive channel so the transport can observe the client disconnect.

## Changes

- Preserve the original ASGI receive callable before OAuth request-body inspection.
- Replay each original request message exactly once without collapsing chunk boundaries.
- Forward all subsequent receive calls to the original channel.
- Add a regression covering a chunked MCP request followed by the real disconnect.

## Head and handoff evidence

- Exact head SHA reviewed/tested: `45919ae23135dd94dab056afb6c49a2c6510a8c8`
- Base SHA: `68495e2f5ac4c45853dc99a956bff590c30da477`
- Accountable GitHub contributor / human sponsor: `djtelicloud`
- Submitting branch: `codex/oauth-mcp-receive-forwarding`
- Changed paths: `src/http_server.py`, `tests/test_http_server.py`
- Trust boundary: OAuth-authenticated POST `/mcp` ASGI receive handling.
- Known residual risk: full-body buffering remains existing behavior; post-body transport lifetime now follows the ASGI server's real receive channel.

### Agent and model provenance

| Role | Provider product | Model | Model source | Surface | Evidence |
| --- | --- | --- | --- | --- | --- |
| Implementation | OpenAI Codex | GPT-5 | user-reported | Codex Desktop | exact-head commit trailer |
| Advisory review | xAI Grok | grok-4.5 | provider-session | UniGrok CLI | exact-head `APPROVE DRAFT`; CLI, same-plane, subscription, $0.00, no fallback |

## Fact-check checklist

- [x] No docs or configuration claims changed.
- [x] Endpoint names in this packet match `src/http_server.py`.
- [x] No environment variables or destructive commands added.

## Testing

- [x] `uv run pytest -q tests/test_http_server.py tests/test_public_mcp_transport_security.py` — 119 passed.
- [x] `uv run pytest -q` — 2128 passed.
- [x] `uv run python -m compileall -q src evals main.py`.
- [x] `uv run ruff check src/http_server.py tests/test_http_server.py`.
- [x] `BASE_SHA=$(git merge-base origin/main HEAD) HEAD_SHA=$(git rev-parse HEAD) uv run python scripts/check_agent_attribution.py`.
- [x] `git diff --check origin/main...HEAD`.
- [x] Results and Grok review apply to exact head `45919ae23135dd94dab056afb6c49a2c6510a8c8`.
- [x] This PR comes from the submitting agent's task branch.

## Risk

risk: high

This changes authentication-adjacent request transport behavior. It is intentionally left draft for exact-head Codex approval and supervisor review.

## Security

- [x] No secrets, tokens, or machine-specific absolute paths in the diff.
- [x] The changed OAuth trust boundary has a fail-closed regression test.
- [x] Contributor-controlled text is not used as workflow or authorization evidence.

## Codex/project-admin landing gate

- [ ] Required CI and CODEOWNER review pass on the current head.
- [ ] Codex disposition applies to the current head.
- [ ] Required `Supervisor Approval` status is present on the current head.
- [ ] Exact-head `Codex Approval` is present.
- [ ] Landing/merge receipt is captured by the integration owner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth-gated ASGI receive handling on POST /mcp; scope introspection is unchanged, but incorrect replay could still affect long-lived MCP sessions or disconnect behavior.
> 
> **Overview**
> Fixes **authenticated POST `/mcp`** requests that could **hang** after `GatewayAuthMiddleware` reads the body for OAuth scope checks. The middleware no longer collapses the request into a single synthetic `http.request`; it **replays each captured ASGI message once** (chunk boundaries preserved), then **delegates further `receive()` calls to the original channel** so Streamable HTTP can see **`http.disconnect`**.
> 
> Adds **`test_oauth_mcp_body_replay_forwards_original_disconnect`** to assert chunked body replay plus disconnect forwarding after OAuth introspection succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a895d4f67acf9c07ff3ec3d5faabd575ac3e0972. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->