### PR TITLE
fix(ui): tell the truth for zero-dollar agent costs

### DIFF
--- a/mcp_ui/app.js
+++ b/mcp_ui/app.js
@@ -1,9 +1,9 @@
-import { parseMarkdown, sanitizeHref } from "./markdown.js?v=grok-v0.6.0-r10";
+import { parseMarkdown, sanitizeHref } from "./markdown.js?v=grok-v0.6.0-r12";
 
 // Must match the <meta name="unigrok-ui-version"> baked into index.html and
 // src/version.py UI_ASSET_VERSION; a mismatch means the browser paired a
 // cached page with a different script build (the stale-skew failure class).
-const UI_ASSET_VERSION = "grok-v0.6.0-r10";
+const UI_ASSET_VERSION = "grok-v0.6.0-r12";
 
 const LAYOUT_KEY = "unigrok.mcp.console.layout.v2";
 
@@ -1909,13 +1909,21 @@ function renderFactsPane(method, response, elapsed) {
   const payload = extractToolPayload(response);
   setText("factTokens", payload.tokens || "-");
   // The wire may deliver cost as a number or a serialized string; only a
-  // finite value renders as currency.
+  // finite value renders as currency. cost===0 is real (CLI subscription or
+  // a free API turn) — never paint "-" which reads as "unknown".
   const rawCost = payload.cost_usd;
   const cost = typeof rawCost === "string" && rawCost.trim() !== "" ? Number(rawCost) : rawCost;
-  setText("factCost", typeof cost === "number" && Number.isFinite(cost) && cost !== 0 ? `$${cost.toFixed(5)}` : "-");
+  const billing = payload.billing_class || payload.routing?.billing_class || "";
+  let costLabel = "-";
+  if (typeof cost === "number" && Number.isFinite(cost)) {
+    costLabel = (cost === 0 && billing === "subscription")
+      ? "Subscription"
+      : `$${cost.toFixed(5)}`;
+  }
+  setText("factCost", costLabel);
   setText("factRoute", payload.route || "-");
   setText("factPlane", payload.plane || "-");
-  setText("factBilling", payload.billing_class || payload.routing?.billing_class || "-");
+  setText("factBilling", billing || "-");
   setText("factRequestedPlane", payload.requested_plane || payload.routing?.requested_plane || "-");
   setText("factModel", payload.model || "-");
   setText("factSelection", routingLabel(payload.routing?.why_detail || payload.why || "-"));

--- a/mcp_ui/app.js
+++ b/mcp_ui/app.js
@@ -1913,10 +1913,11 @@ function renderFactsPane(method, response, elapsed) {
   // a free API turn) — never paint "-" which reads as "unknown".
   const rawCost = payload.cost_usd;
   const cost = typeof rawCost === "string" && rawCost.trim() !== "" ? Number(rawCost) : rawCost;
-  const billing = payload.billing_class || payload.routing?.billing_class || "";
+  const rawBilling = payload.billing_class || payload.routing?.billing_class || "";
+  const billing = typeof rawBilling === "string" ? rawBilling.trim() : "";
   let costLabel = "-";
   if (typeof cost === "number" && Number.isFinite(cost)) {
-    const isSubscription = typeof billing === "string" && billing.trim().toLowerCase() === "subscription";
+    const isSubscription = billing.toLowerCase() === "subscription";
     costLabel = (cost === 0 && isSubscription)
       ? "Subscription"
       : `$${cost.toFixed(5)}`;

--- a/mcp_ui/app.js
+++ b/mcp_ui/app.js
@@ -1906,7 +1906,7 @@ function renderFactsPane(method, response, elapsed) {
     if (status) status.style.color = "var(--teal)";
   }
 
-  const payload = extractToolPayload(response);
+  const payload = extractToolPayload(response) || {};
   setText("factTokens", payload.tokens || "-");
   // The wire may deliver cost as a number or a serialized string; only a
   // finite value renders as currency. cost===0 is real (CLI subscription or
@@ -1916,7 +1916,8 @@ function renderFactsPane(method, response, elapsed) {
   const billing = payload.billing_class || payload.routing?.billing_class || "";
   let costLabel = "-";
   if (typeof cost === "number" && Number.isFinite(cost)) {
-    costLabel = (cost === 0 && billing === "subscription")
+    const isSubscription = typeof billing === "string" && billing.trim().toLowerCase() === "subscription";
+    costLabel = (cost === 0 && isSubscription)
       ? "Subscription"
       : `$${cost.toFixed(5)}`;
   }

--- a/mcp_ui/index.html
+++ b/mcp_ui/index.html
@@ -7,9 +7,9 @@
     <meta name="unigrok-ui-regions" content="navigation,workbench,rpc-inspector,rpc-logs,result-facts" />
     <!-- Version handshake: app.js compares this against its own build constant
          and self-heals a stale-cached page with one revalidating reload. -->
-    <meta name="unigrok-ui-version" content="grok-v0.6.0-r10" />
-  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r10" />
-  <link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r10" />
+    <meta name="unigrok-ui-version" content="grok-v0.6.0-r12" />
+  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r12" />
+  <link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r12" />
   </head>
   <body>
     <main class="app-shell">
@@ -523,6 +523,6 @@ docker compose up --build -d</code></pre>
 
       </section>
     </main>
-  <script type="module" src="./app.js?v=grok-v0.6.0-r10"></script>
+  <script type="module" src="./app.js?v=grok-v0.6.0-r12"></script>
   </body>
 </html>

--- a/mcp_ui/swarm.html
+++ b/mcp_ui/swarm.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>UniGrok Swarm Optimizer — Pareto Playground</title>
-  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r10" />
+  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r12" />
   <style>
     /* Page vocabulary aliases onto the shared UniGrok tokens (tokens.css) so
        the Swarm Optimizer and the Control Center read as one product. */
@@ -270,6 +270,6 @@
     hidden. "Verified" means: the task's own <code>test_target</code> passed.
   </div>
 
-  <script src="./swarm.js?v=grok-v0.6.0-r10"></script>
+  <script src="./swarm.js?v=grok-v0.6.0-r12"></script>
 </body>
 </html>

--- a/mcp_ui/swarm.js
+++ b/mcp_ui/swarm.js
@@ -10,7 +10,7 @@
 // Must match src/version.py UI_ASSET_VERSION and the query token on the
 // swarm.js reference in swarm.html. The sample uses the same token so a
 // revalidated page cannot pair new logic with a heuristically cached payload.
-const UI_ASSET_VERSION = "grok-v0.6.0-r10";
+const UI_ASSET_VERSION = "grok-v0.6.0-r12";
 
 const $ = (id) => document.getElementById(id);
 const SVG_NS = "http://www.w3.org/2000/svg";

--- a/src/version.py
+++ b/src/version.py
@@ -7,4 +7,4 @@ __version__ = "0.6.0"
 # runtime handshake in app.js).
 # Bump the -rN suffix whenever any /ui asset changes; a pytest asserts every
 # copy of this string agrees so HTML and JS can never skew apart silently.
-UI_ASSET_VERSION = "grok-v0.6.0-r10"
+UI_ASSET_VERSION = "grok-v0.6.0-r12"

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -496,8 +496,8 @@ def test_mcp_ui_fact_cost_tells_the_truth_for_zero():
     """cost_usd=0 must not render as '-' (unknown); subscription $0 says so."""
     with TestClient(create_app(), base_url="http://localhost:8080") as client:
         script = client.get("/ui/app.js")
-    assert "cost !== 0" not in script.text
-    assert 'billing.trim().toLowerCase() === "subscription"' in script.text
+    assert 'typeof rawBilling === "string" ? rawBilling.trim() : ""' in script.text
+    assert 'billing.toLowerCase() === "subscription"' in script.text
     assert "cost === 0 && isSubscription" in script.text
     assert '"Subscription"' in script.text
     assert "cost.toFixed(5)" in script.text

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -497,7 +497,8 @@ def test_mcp_ui_fact_cost_tells_the_truth_for_zero():
     with TestClient(create_app(), base_url="http://localhost:8080") as client:
         script = client.get("/ui/app.js")
     assert "cost !== 0" not in script.text
-    assert 'cost === 0 && billing === "subscription"' in script.text
+    assert 'billing.trim().toLowerCase() === "subscription"' in script.text
+    assert "cost === 0 && isSubscription" in script.text
     assert '"Subscription"' in script.text
     assert "cost.toFixed(5)" in script.text
 

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -47,9 +47,9 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert index.status_code == 200
     assert "<title>UniGrok Gateway Console v0.6.0</title>" in index.text
     assert '<span class="version-badge">v0.6.0</span>' in index.text
-    assert 'script type="module" src="./app.js?v=grok-v0.6.0-r10"' in index.text
-    assert '<link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r10" />' in index.text
-    assert '<link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r10" />' in index.text
+    assert 'script type="module" src="./app.js?v=grok-v0.6.0-r12"' in index.text
+    assert '<link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r12" />' in index.text
+    assert '<link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r12" />' in index.text
     assert "Console" in index.text
     assert 'id="surfaceModeBadge"' in index.text
     assert 'id="tab-btn-schemas"' not in index.text
@@ -463,7 +463,7 @@ def test_mcp_ui_markdown_renderer_is_shared_and_escape_first():
     assert "\\u000E-\\u001F" in renderer.text
     # app.js imports the shared renderer at the current cache-bust version and
     # no longer defines its own.
-    assert 'from "./markdown.js?v=grok-v0.6.0-r10"' in script.text
+    assert 'from "./markdown.js?v=grok-v0.6.0-r12"' in script.text
     assert "import { parseMarkdown" in script.text
     assert "function parseMarkdown" not in script.text
     assert "renderMarkdownInto" in script.text
@@ -490,6 +490,16 @@ def test_mcp_ui_error_surfaces_tell_the_truth():
     assert "describeNotReady" in script.text
     # The connection-lost wording is reserved for actual fetch failures.
     assert "No connection detected" in script.text
+
+
+def test_mcp_ui_fact_cost_tells_the_truth_for_zero():
+    """cost_usd=0 must not render as '-' (unknown); subscription $0 says so."""
+    with TestClient(create_app(), base_url="http://localhost:8080") as client:
+        script = client.get("/ui/app.js")
+    assert "cost !== 0" not in script.text
+    assert 'cost === 0 && billing === "subscription"' in script.text
+    assert '"Subscription"' in script.text
+    assert "cost.toFixed(5)" in script.text
 
 
 def test_mcp_ui_swarm_messages_tell_the_truth():


### PR DESCRIPTION
## Summary
- Control Center receipt `factCost` no longer paints `cost_usd=0` as unknown `-`.
- Subscription-backed \$0 shows `Subscription`; metered \$0 shows `$0.00000`.
- Bumps UI asset cache token `r10` → `r12` (skips `r11` reserved by (#253)).

## Test plan
- [x] `uv run pytest -q tests/test_mcp_ui.py` (28 passed)
- [ ] CI green on the draft PR head

## Notes
- Separate from (#252)–(#255).
- @grok pre-fix YES (CLI); pre-PR YES after CLI non-answer flake (API `same_plane`, \$0.0048)


Made with [Cursor](https://cursor.com)


## Exact-head supervisor handoff
- Head: `1472ec995e22b6d7a00b9bcdb6de5396d277d9e2`
- Focused validation: `uv run pytest -q tests/test_mcp_ui.py` — 28 passed.
- Human sponsor: `djtelicloud`.
- Provenance: xAI Grok implementation/advisory review; OpenAI Codex integration.

risk: medium

