### PR TITLE
fix(knowledge): scope distill_session like agent/chat

### DIFF
--- a/src/jobs.py
+++ b/src/jobs.py
@@ -16,7 +16,7 @@ import uuid
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
-from .identity import get_active_caller, normalize_caller
+from .identity import get_active_caller, normalize_caller, scoped_session
 from .utils import (
     AGENTIC_TOOLS_SCHEMA,
     _DISTILL_SYS_PROMPT,
@@ -193,6 +193,9 @@ class JobManager:
         session_name = str(session or "").strip()
         if not session_name:
             return {"error": "Input Validation Error: session must not be empty."}
+        # Defense in depth with distill_session: always namespace under the
+        # bound principal/client before loading history or persisting source.
+        session_name = scoped_session(session_name) or session_name
         job_id = uuid.uuid4().hex
         model = await resolve_model("coding")
         caller = normalize_caller(caller) or get_active_caller()

--- a/src/tools/knowledge.py
+++ b/src/tools/knowledge.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, Optional
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
 
-from ..identity import caller_from_mcp_context
+from ..identity import caller_from_mcp_context, scoped_session
 from ..jobs import get_job_manager
 from ..utils import (
     _normalize_fact_scope,
@@ -128,6 +128,10 @@ async def distill_session(session: str, ctx: Optional[Context] = None) -> Dict[s
     name = str(session or "").strip()
     if not name:
         return {"error": "Input Validation Error: session must not be empty."}
+    # Match agent/chat: namespace by principal + X-Client-ID so short names
+    # resolve to the caller's stored history and foreign fully-qualified
+    # session ids cannot be distilled across client labels.
+    name = scoped_session(name) or name
     # ctx is FastMCP-injected (hidden from the tool schema): the clientInfo
     # name identifies which agent submitted the job on the persisted row —
     # same attribution as submit_research_job.

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -435,6 +435,29 @@ class TestDistillJob:
         res = await manager.submit_distill("  ")
         assert "Input Validation Error" in res["error"]
 
+    @pytest.mark.asyncio
+    async def test_submit_distill_scopes_session_defense_in_depth(
+        self, kstore, monkeypatch
+    ):
+        from src.identity import (
+            _ACTIVE_CLIENT_ID,
+            reset_active_principal,
+            set_active_principal,
+        )
+
+        monkeypatch.setattr(JobManager, "_run_distill_job", AsyncMock(return_value=None))
+        manager = JobManager(job_store=kstore)
+        principal = set_active_principal("http:anon")
+        client = _ACTIVE_CLIENT_ID.set("cursor")
+        try:
+            view = await manager.submit_distill("sess-scoped")
+        finally:
+            _ACTIVE_CLIENT_ID.reset(client)
+            reset_active_principal(principal)
+        await manager.wait(view["job_id"])
+        row = await kstore.get_job(view["job_id"])
+        assert row["prompt"] == "[distill] session:http%3Aanon:cursor:sess-scoped"
+
 
 class TestAutoDistill:
     @pytest.mark.asyncio
@@ -778,6 +801,60 @@ class TestKnowledgeTools:
         )
         await distill_session("my-session", ctx=ctx)
         assert manager.submit_distill.call_args.kwargs["caller"] == "claude-code"
+
+    @pytest.mark.asyncio
+    async def test_distill_session_scopes_short_name_to_principal_client(
+        self, monkeypatch
+    ):
+        """agent/chat store under principal:client:name; distill must match."""
+        from src.identity import (
+            _ACTIVE_CLIENT_ID,
+            reset_active_principal,
+            set_active_principal,
+        )
+
+        manager = MagicMock()
+        manager.submit_distill = AsyncMock(
+            return_value={"job_id": "j-scope", "status": "queued", "kind": "distill"}
+        )
+        monkeypatch.setattr("src.tools.knowledge.get_job_manager", lambda: manager)
+        principal = set_active_principal("http:anon")
+        client = _ACTIVE_CLIENT_ID.set("cursor")
+        try:
+            await distill_session("my-session")
+        finally:
+            _ACTIVE_CLIENT_ID.reset(client)
+            reset_active_principal(principal)
+        manager.submit_distill.assert_awaited_once_with(
+            "http%3Aanon:cursor:my-session", caller=None
+        )
+
+    @pytest.mark.asyncio
+    async def test_distill_session_reprefixes_foreign_fully_qualified_name(
+        self, monkeypatch
+    ):
+        """A peer client's FQ session name must not be readable as-is."""
+        from src.identity import (
+            _ACTIVE_CLIENT_ID,
+            reset_active_principal,
+            set_active_principal,
+        )
+
+        manager = MagicMock()
+        manager.submit_distill = AsyncMock(
+            return_value={"job_id": "j-iso", "status": "queued", "kind": "distill"}
+        )
+        monkeypatch.setattr("src.tools.knowledge.get_job_manager", lambda: manager)
+        principal = set_active_principal("http:anon")
+        client = _ACTIVE_CLIENT_ID.set("vscode")
+        try:
+            await distill_session("http%3Aanon:cursor:peer-secret")
+        finally:
+            _ACTIVE_CLIENT_ID.reset(client)
+            reset_active_principal(principal)
+        submitted = manager.submit_distill.call_args.args[0]
+        assert submitted.startswith("http%3Aanon:vscode:")
+        assert submitted != "http%3Aanon:cursor:peer-secret"
 
     @pytest.mark.asyncio
     async def test_distill_session_ctx_hidden_from_schema(self):


### PR DESCRIPTION
## Summary
- `distill_session` now applies `scoped_session` so short names match the principal+client namespace used by `agent`/`chat`.
- `JobManager.submit_distill` applies the same namespace as defense in depth before loading history.
- Foreign fully-qualified session names from another `X-Client-ID` are re-prefixed and cannot be distilled as-is.

## Test plan
- [x] `uv run pytest -q tests/test_knowledge.py -k 'distill_session or submit_distill_scopes or distill_job or distill_validates'` (10 passed)
- [ ] CI green on the draft PR head

## Notes
- Separate from (#252)–(#257).
- @grok pre-fix and pre-PR gates: YES / YES-DRAFT-PR (CLI, same_plane)

Made with [Cursor](https://cursor.com)