### PR TITLE
fix(cli): persist native session id under logical lock

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -10879,20 +10879,35 @@ async def _call_plane(
 
         try:
             if session and store:
+                # Persist the native CLI mapping before releasing the logical
+                # lock so a concurrent same-session turn cannot resume the
+                # stale id and clobber the winner on save.
                 async with _cli_logical_session_lock(session):
-                    text, returned_id, cli_session_id, stored_cli_id = await _run_cli_mapped_session()
+                    text, returned_id, cli_session_id, stored_cli_id = (
+                        await _run_cli_mapped_session()
+                    )
+                    if use_native_cli_session:
+                        final_id = returned_id or cli_session_id
+                        if final_id and final_id != stored_cli_id:
+                            await store.save_session(
+                                session, cli_session_id=final_id, model=model_name
+                            )
             else:
-                text, returned_id, cli_session_id, stored_cli_id = await _run_cli_mapped_session()
+                text, returned_id, cli_session_id, stored_cli_id = (
+                    await _run_cli_mapped_session()
+                )
+                if use_native_cli_session:
+                    final_id = returned_id or cli_session_id
+                    if final_id and final_id != stored_cli_id:
+                        await store.save_session(
+                            session, cli_session_id=final_id, model=model_name
+                        )
         except RuntimeError as exc:
             if not _is_cli_session_in_use_error(str(exc)):
                 record_xai_failure(model_name)
             raise
 
         record_xai_success(model_name)
-        if use_native_cli_session:
-            final_id = returned_id or cli_session_id
-            if final_id and final_id != stored_cli_id:
-                await store.save_session(session, cli_session_id=final_id, model=model_name)
         # Subscription plane: the CLI exposes no token usage and has no
         # per-token price, so tokens/cost stay 0 by design.
         return text, 0, 0.0, True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5838,6 +5838,73 @@ class TestCliPlaneV2:
         )
 
     @pytest.mark.asyncio
+    async def test_cli_persists_native_session_id_under_logical_lock(
+        self, monkeypatch
+    ):
+        """Regression: save_session must run while the logical session lock
+        is still held, or concurrent turns can clobber the mapping."""
+        import json as json_module
+
+        from src import utils
+        from src.utils import _call_plane
+
+        monkeypatch.setenv("UNIGROK_RUNTIME", "local")
+        monkeypatch.setattr(
+            PathResolver, "get_grok_cli_path", staticmethod(lambda: "/tmp/grok")
+        )
+
+        class TrackingLock:
+            def __init__(self):
+                self._lock = asyncio.Lock()
+                self.held = False
+
+            async def __aenter__(self):
+                await self._lock.acquire()
+                self.held = True
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                self.held = False
+                self._lock.release()
+                return False
+
+        tracking = TrackingLock()
+        monkeypatch.setattr(utils, "_cli_logical_session_lock", lambda _s: tracking)
+
+        class FakeProc:
+            returncode = 0
+
+        async def fake_exec(*cmd, **kwargs):
+            return FakeProc()
+
+        payload = json_module.dumps({
+            "text": "hello from cli",
+            "sessionId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        }).encode()
+
+        async def fake_communicate(proc, timeout_sec, input_data=None):
+            return payload, b""
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        monkeypatch.setattr("src.utils.communicate_with_timeout", fake_communicate)
+
+        held_during_save = {"value": False}
+
+        async def save_session(session_name, **kwargs):
+            held_during_save["value"] = tracking.held
+
+        store = self._fake_store(session_row={})
+        store.save_session = AsyncMock(side_effect=save_session)
+
+        content, _, _, is_cli = await _call_plane(
+            "cli-fallback", "hi", "sess", store, "sys"
+        )
+        assert (content, is_cli) == ("hello from cli", True)
+        store.save_session.assert_awaited_once()
+        assert held_during_save["value"] is True
+        assert tracking.held is False
+
+    @pytest.mark.asyncio
     async def test_cli_resumes_stored_session_without_rewrite(self, monkeypatch):
         import json as json_module
 


### PR DESCRIPTION
## Summary
- Native CLI `cli_session_id` persistence now runs inside `_cli_logical_session_lock` immediately after the mapped CLI invoke.
- Prevents concurrent same-session turns from reading a stale mapping and clobbering each other on save.
- Adds a regression test that asserts `save_session` runs while the logical lock is held.

## Test plan
- [x] `uv run pytest -q tests/test_utils.py::TestCliPlaneV2 -k 'persist or fork or resume or assigns or missing or busy'` (6 passed)
- [ ] CI green on the draft PR head

## Notes
- Separate from (#252)–(#259).
- @grok pre-fix and pre-PR gates: YES / YES-DRAFT-PR (CLI, same_plane)

Made with [Cursor](https://cursor.com)