### PR TITLE
fix(swarm): contain sandbox target paths under work

### DIFF
--- a/src/swarm/sandbox.py
+++ b/src/swarm/sandbox.py
@@ -136,9 +136,24 @@ class SwarmSandbox:
 
     # ── Target file plumbing ─────────────────────────────────────────────────
 
+    def _contained_work_path(self, rel: str) -> Path:
+        """Resolve a work-relative path; refuse escapes outside ``self.work``."""
+        work = self.work.resolve()
+        candidate = Path(str(rel or ""))
+        if not str(rel or "").strip() or candidate.is_absolute():
+            raise SandboxError(f"target {rel!r} escapes sandbox work dir")
+        path = (work / candidate).resolve()
+        try:
+            path.relative_to(work)
+        except ValueError as exc:
+            raise SandboxError(
+                f"target {rel!r} escapes sandbox work dir"
+            ) from exc
+        return path
+
     @property
     def target_path(self) -> Path:
-        return self.work / self.target_rel
+        return self._contained_work_path(self.target_rel)
 
     def read_target(self) -> bytes:
         return self.target_path.read_bytes()

--- a/tests/test_swarm_sandbox.py
+++ b/tests/test_swarm_sandbox.py
@@ -112,6 +112,21 @@ class TestSandbox:
         with pytest.raises(SandboxError, match="missing"):
             sb.create()
 
+    def test_target_rel_parent_escape_refused(self, workspace, tmp_path):
+        sb = SwarmSandbox(workspace, tmp_path / "wr", "../escape.py")
+        with pytest.raises(SandboxError, match="escapes"):
+            sb.create()
+
+    def test_target_rel_absolute_escape_refused(self, workspace, tmp_path):
+        sb = SwarmSandbox(workspace, tmp_path / "wr", "/tmp/escape.py")
+        with pytest.raises(SandboxError, match="escapes"):
+            sb.create()
+
+    def test_write_target_refuses_escaped_rel(self, sandbox):
+        sandbox.target_rel = "../escape.py"
+        with pytest.raises(SandboxError, match="escapes"):
+            sandbox.write_target(b"should-not-land")
+
     def test_child_env_scrubs_secrets(self, sandbox, monkeypatch):
         monkeypatch.setenv("XAI_API_KEY", "xai-secret")
         monkeypatch.setenv("XAI_MANAGEMENT_API_KEY", "mgmt-secret")


### PR DESCRIPTION
## Summary
- `SwarmSandbox.target_path` now resolves through a containment helper that refuses empty, absolute, and `..` escape paths outside the sandbox work dir.
- Blocks `read_target` / `write_target` escapes even if a stored `target_rel` is hostile.
- Adds unit coverage for parent escape, absolute escape, and write refusal.

## Test plan
- [x] `uv run pytest -q tests/test_swarm_sandbox.py` (28 passed)
- [ ] CI green on the draft PR head

## Notes
- Separate from (#252)–(#260).
- @grok pre-fix and pre-PR gates: YES / YES-DRAFT-PR (CLI, same_plane)

Made with [Cursor](https://cursor.com)