### PR TITLE
fix(security): redact GitHub PATs, JWTs, and AIza keys

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1145,6 +1145,19 @@ _SECRET_PATTERNS = (
     (re.compile(r"\b(xai-[A-Za-z0-9_\-]{8,}|sk-proj-[A-Za-z0-9_\-]{8,}|sk-[A-Za-z0-9_\-]{8,})\b"), "[REDACTED_KEY]"),
     (re.compile(r"(?i)\b(bearer\s+)[A-Za-z0-9._~+/=\-]{8,}"), r"\1[REDACTED_TOKEN]"),
     (re.compile(r"(?i)\b([A-Z0-9_]*API_KEY\s*=\s*)[^\s'\"\n]+"), r"\1[REDACTED]"),
+    # Align with intelligence_payloads high-value shapes so job/log/tool
+    # redaction cannot leak tokens already treated as secrets elsewhere.
+    (
+        re.compile(r"\b(github_pat_[A-Za-z0-9_]{10,}|gh[pousr]_[A-Za-z0-9]{10,})\b"),
+        "[REDACTED_TOKEN]",
+    ),
+    (
+        re.compile(
+            r"\beyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b"
+        ),
+        "[REDACTED_JWT]",
+    ),
+    (re.compile(r"\bAIza[A-Za-z0-9_-]{25,}\b"), "[REDACTED_KEY]"),
 )
 
 _TASK_STOPWORDS = {
@@ -1268,13 +1281,25 @@ def load_grok_prompt(prompt_ref: str) -> str:
 
 def redact_secrets(text: str) -> str:
     redacted = str(text or "")
-    if "xai-" not in redacted and "sk-" not in redacted:
-        # This guard must remain a conservative superset of the two
-        # case-insensitive regexes below. False positives only cost a regex
-        # pass; a false negative could leak a credential.
-        folded = redacted.lower()
-        if "bearer" not in folded and "api_key" not in folded:
-            return redacted
+    # Fast path: skip regex work only when none of the pattern families'
+    # needles appear. False positives only cost a regex pass; a false
+    # negative could leak a credential.
+    folded = redacted.lower()
+    if not (
+        "xai-" in folded
+        or "sk-" in folded
+        or "bearer" in folded
+        or "api_key" in folded
+        or "github_pat_" in folded
+        or "ghp_" in folded
+        or "gho_" in folded
+        or "ghu_" in folded
+        or "ghs_" in folded
+        or "ghr_" in folded
+        or "eyj" in folded
+        or "aiza" in folded
+    ):
+        return redacted
     for pattern, replacement in _SECRET_PATTERNS:
         redacted = pattern.sub(replacement, redacted)
     return redacted

--- a/tests/test_intelligence_upgrade.py
+++ b/tests/test_intelligence_upgrade.py
@@ -114,12 +114,37 @@ def test_redact_secrets_strips_keys_and_bearer_tokens():
     assert "[REDACTED" in redacted
 
 
+def test_redact_secrets_strips_github_jwt_and_google_keys():
+    jwt = (
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+        "eyJzdWIiOiIxMjM0NTY3ODkwIn0."
+        "signaturepaddingvalue12"
+    )
+    text = (
+        f"token=github_pat_11AAAAAAAABBBBBBBBBB "
+        f"classic=ghp_abcdefghijklmnopqrst "
+        f"google=AIzaSyA-abcdefghijklmnopqrstuv "
+        f"jwt={jwt}"
+    )
+    redacted = redact_secrets(text)
+    assert "github_pat_" not in redacted
+    assert "ghp_" not in redacted
+    assert "AIza" not in redacted
+    assert "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" not in redacted
+    assert "[REDACTED" in redacted
+
+
 @pytest.mark.parametrize(
     ("text", "secret"),
     [
         ("Authorization: BEARER abc.defghi123456", "abc.defghi123456"),
         ("Authorization: Bearer\tabc.defghi123456", "abc.defghi123456"),
         ("OpenAI_Api_Key = secretvalue123", "secretvalue123"),
+        ("ghs_abcdefghijklmnopqrst", "ghs_abcdefghijklmnopqrst"),
+        (
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signaturepaddingvalue12",
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+        ),
     ],
 )
 def test_redact_secrets_fast_path_preserves_case_and_whitespace_coverage(text, secret):


### PR DESCRIPTION
## Summary
- `redact_secrets` now redacts GitHub PATs (`github_pat_` / `ghp_`…), JWTs (`eyJ…`), and Google `AIza…` keys.
- Fast-path needles widened so those families are not skipped before regex work.
- Aligns high-value coverage with shapes already treated as secrets in intelligence payloads.

## Test plan
- [x] `uv run pytest -q tests/test_intelligence_upgrade.py -k redact_secrets` (8 passed)
- [ ] CI green on the draft PR head

## Notes
- Separate from (#252)–(#261).
- @grok pre-fix and pre-PR gates: YES / YES-DRAFT-PR (CLI, same_plane)

Made with [Cursor](https://cursor.com)