### PR TITLE
fix(http): align readyz API auth with usable-key gate

### DIFF
--- a/src/http_server.py
+++ b/src/http_server.py
@@ -58,6 +58,7 @@ from .utils import (
     grok_cli_plane_status,
     credential_plane_contract,
     is_cloudrun_runtime,
+    xai_api_key_configured,
     new_request_id,
     reset_request_id,
     redact_secrets,
@@ -1128,9 +1129,9 @@ async def readyz(_: Request) -> JSONResponse:
         cli_plane = {"ready": False}
     checks: Dict[str, bool] = {
         # Compatibility note: this public key predates the dual-plane runtime.
-        # API credentials are checked for presence only; the CLI branch is a
-        # live OAuth probe.
-        "model_auth": bool(os.environ.get("XAI_API_KEY", "").strip())
+        # API credentials use the usable-key gate (placeholder sentinels are
+        # not configured); the CLI branch is a live OAuth probe.
+        "model_auth": xai_api_key_configured()
         or bool(cli_plane.get("ready")),
         "state_dir_writable": False,
         "database": False,
@@ -1193,7 +1194,7 @@ async def runtimez(request: Request) -> JSONResponse:
                 ),
             },
             "api_plane": {
-                "xai_api_key": bool(os.environ.get("XAI_API_KEY", "").strip()),
+                "xai_api_key": xai_api_key_configured(),
             },
             "gateway_auth": {
                 "enabled": _auth_is_active() and not _request_may_bypass_auth(request.scope),

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -718,6 +718,50 @@ def test_readyz_accepts_cli_auth_without_xai_api_key(monkeypatch, tmp_path):
     assert res.json()["checks"]["model_auth"] is True
 
 
+def test_readyz_rejects_placeholder_xai_api_key_without_cli(monkeypatch, tmp_path):
+    """Placeholder sentinel is non-empty but unusable — do not report ready."""
+    monkeypatch.delenv("UNIGROK_RUNTIME", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XAI_API_KEY", "your_xai_api_key_here")
+    monkeypatch.setattr(
+        "src.http_server.grok_cli_plane_status",
+        lambda **_: {
+            "state": "missing_binary",
+            "ready": False,
+            "binary": False,
+            "auth": "unknown",
+            "setup_command": "grok login",
+        },
+    )
+
+    with TestClient(create_app()) as client:
+        res = client.get("/readyz")
+
+    assert res.status_code == 503
+    assert res.json()["checks"]["model_auth"] is False
+
+
+def test_runtimez_reports_placeholder_xai_api_key_as_absent(monkeypatch):
+    monkeypatch.delenv("UNIGROK_RUNTIME", raising=False)
+    monkeypatch.setenv("XAI_API_KEY", "your_xai_api_key_here")
+    monkeypatch.setattr(
+        "src.http_server.grok_cli_plane_status",
+        lambda **_: {
+            "state": "missing_binary",
+            "ready": False,
+            "binary": False,
+            "auth": "unknown",
+            "setup_command": "grok login",
+        },
+    )
+
+    with TestClient(create_app()) as client:
+        res = client.get("/runtimez")
+
+    assert res.status_code == 200
+    assert res.json()["api_plane"]["xai_api_key"] is False
+
+
 def test_readyz_body_stays_boolean_on_failure(monkeypatch):
     """The auth-exempt probe must not disclose exception text or filesystem
     paths; failures are logged server-side and the body carries booleans only."""


### PR DESCRIPTION
## Summary
- `/readyz` `model_auth` and `/runtimez` `api_plane.xai_api_key` now use `xai_api_key_configured()`.
- Placeholder `your_xai_api_key_here` no longer reports a usable API plane.
- CLI OAuth readiness still satisfies `model_auth` when the subscription plane is ready.

## Test plan
- [x] `uv run pytest -q tests/test_http_server.py -k 'readyz or runtimez_reports_placeholder or runtimez_reports_no_secret'` (5 passed)
- [ ] CI green on the draft PR head

## Notes
- Separate from (#252)–(#262).
- @grok pre-fix and pre-PR gates: YES / YES-DRAFT-PR (CLI, same_plane)

Made with [Cursor](https://cursor.com)