### PR TITLE
feat(discover): expose composed caller for attribution proof

### DIFF
--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -45,7 +45,12 @@ from ..utils import (
 from xai_sdk.chat import user
 from xai_sdk.tools import code_execution, web_search as xai_web_search, x_search as xai_x_search
 
-from ..identity import get_active_client_id, principal_kind, scoped_session
+from ..identity import (
+    get_active_caller,
+    get_active_client_id,
+    principal_kind,
+    scoped_session,
+)
 
 logger = logging.getLogger("GrokMCP")
 
@@ -1021,6 +1026,9 @@ def _build_discover_request_context(*, contributor: bool) -> dict[str, Any]:
     return {
         "client_id_present": bool(client_id),
         "client_id_normalized": client_id,
+        # Composed telemetry/budget identity (e.g. http:anon|cursor), matching
+        # CallerContextMiddleware — not a security principal by itself.
+        "caller": get_active_caller(),
         "principal_kind": principal_kind(),
         "host_port": host_port,
         "surface": surface,

--- a/tests/test_service_workspace_boundary.py
+++ b/tests/test_service_workspace_boundary.py
@@ -292,15 +292,21 @@ async def test_discover_self_bootstrap_ok_with_client_id(monkeypatch):
             "setup_command": "unused",
         },
     )
-    principal = set_active_principal("http:anon")
-    caller = set_active_caller("http:anon|claude-code")
-    token = _ACTIVE_CLIENT_ID.set("claude-code")
+    principal_token = None
+    caller_token = None
+    client_token = None
     try:
+        principal_token = set_active_principal("http:anon")
+        caller_token = set_active_caller("http:anon|claude-code")
+        client_token = _ACTIVE_CLIENT_ID.set("claude-code")
         result = await grok_mcp_discover_self()
     finally:
-        _ACTIVE_CLIENT_ID.reset(token)
-        reset_active_caller(caller)
-        reset_active_principal(principal)
+        if client_token is not None:
+            _ACTIVE_CLIENT_ID.reset(client_token)
+        if caller_token is not None:
+            reset_active_caller(caller_token)
+        if principal_token is not None:
+            reset_active_principal(principal_token)
 
     assert result.data["request_context"]["client_id_present"] is True
     assert result.data["request_context"]["client_id_normalized"] == "claude-code"

--- a/tests/test_service_workspace_boundary.py
+++ b/tests/test_service_workspace_boundary.py
@@ -271,7 +271,13 @@ async def test_discover_self_bootstrap_warns_without_client_id(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_discover_self_bootstrap_ok_with_client_id(monkeypatch):
-    from src.identity import _ACTIVE_CLIENT_ID
+    from src.identity import (
+        _ACTIVE_CLIENT_ID,
+        reset_active_caller,
+        reset_active_principal,
+        set_active_caller,
+        set_active_principal,
+    )
 
     monkeypatch.setenv("UNIGROK_SERVICE_MODE", "stable")
     monkeypatch.delenv("WORKSPACE_ROOT", raising=False)
@@ -286,18 +292,42 @@ async def test_discover_self_bootstrap_ok_with_client_id(monkeypatch):
             "setup_command": "unused",
         },
     )
+    principal = set_active_principal("http:anon")
+    caller = set_active_caller("http:anon|claude-code")
     token = _ACTIVE_CLIENT_ID.set("claude-code")
     try:
         result = await grok_mcp_discover_self()
     finally:
         _ACTIVE_CLIENT_ID.reset(token)
+        reset_active_caller(caller)
+        reset_active_principal(principal)
 
     assert result.data["request_context"]["client_id_present"] is True
     assert result.data["request_context"]["client_id_normalized"] == "claude-code"
+    assert result.data["request_context"]["caller"] == "http:anon|claude-code"
+    assert result.data["request_context"]["principal_kind"] == "anon"
     warning_ids = {w["id"] for w in result.data["bootstrap"]["warnings"]}
     assert "missing_client_id" not in warning_ids
     if result.data["bootstrap"]["can_chat"]:
         assert result.data["bootstrap"]["status"] in {"OK", "WARN"}
+
+
+@pytest.mark.asyncio
+async def test_discover_self_exposes_null_caller_when_unbound(monkeypatch):
+    monkeypatch.setenv("UNIGROK_SERVICE_MODE", "stable")
+    monkeypatch.delenv("WORKSPACE_ROOT", raising=False)
+    monkeypatch.setattr(
+        "src.tools.system.grok_cli_plane_status",
+        lambda timeout_sec=5.0: {
+            "state": "ready",
+            "ready": True,
+            "binary": True,
+            "auth": "oauth",
+            "setup_command": "unused",
+        },
+    )
+    result = await grok_mcp_discover_self()
+    assert result.data["request_context"]["caller"] is None
 
 
 def test_markdown_inline_label_strips_backticks_and_control():


### PR DESCRIPTION
## Summary
- `grok_mcp_discover_self` `request_context` now includes `caller` from `get_active_caller()`.
- Exposes the same composed telemetry/budget identity HTTP middleware binds (e.g. `http:anon|cursor`).
- Agents can prove healthy client attribution without inferring it from separate principal/client fields.

## Test plan
- [x] `uv run pytest -q tests/test_service_workspace_boundary.py -k discover_self` (6 passed)
- [ ] CI green on the draft PR head

## Notes
- Separate from (#252)–(#263).
- @grok pre-fix and pre-PR gates: YES ship B / YES-DRAFT-PR (CLI, same_plane)

Made with [Cursor](https://cursor.com)