### PR TITLE
fix(storage): atomic chat history append

### DIFF
--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -4592,6 +4592,19 @@ async def GrokSessionStore.list_facts(self, limit: int=20, scope: Optional[str]=
 
 Most recent facts first (the grok://knowledge resource view).
 
+### Method: `GrokSessionStore.save_messages` {#utils-groksessionstore-save_messages}
+
+```python
+async def GrokSessionStore.save_messages(self, session_name: str, messages: List[Dict[str, Any]]) -> None
+```
+
+**Keywords:** grok, session, store, save, messages
+
+Insert one or more messages atomically (single BEGIN IMMEDIATE).
+
+Used by append_and_save_history so a user+assistant turn cannot be
+half-persisted or interleaved with a concurrent turn's pair.
+
 ### Method: `GrokSessionStore.replace_messages` {#utils-groksessionstore-replace_messages}
 
 ```python

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -4592,6 +4592,19 @@ async def GrokSessionStore.list_facts(self, limit: int=20, scope: Optional[str]=
 
 Most recent facts first (the grok://knowledge resource view).
 
+### Method: `GrokSessionStore.save_messages` {#utils-groksessionstore-save_messages}
+
+```python
+async def GrokSessionStore.save_messages(self, session_name: str, messages: List[Dict[str, Any]]) -> None
+```
+
+**Keywords:** grok, session, store, save, messages
+
+Insert one or more messages atomically (single BEGIN IMMEDIATE).
+
+Used by append_and_save_history so a user+assistant turn cannot be
+half-persisted or interleaved with a concurrent turn's pair.
+
 ### Method: `GrokSessionStore.replace_messages` {#utils-groksessionstore-replace_messages}
 
 ```python

--- a/src/storage.py
+++ b/src/storage.py
@@ -276,6 +276,9 @@ class SessionStoreProtocol(Protocol):
         content: str,
         metadata: Optional[dict] = None,
     ) -> None: ...
+    async def save_messages(
+        self, session_name: str, messages: List[Dict[str, Any]]
+    ) -> None: ...
     async def replace_messages(
         self, session_name: str, messages: List[Dict[str, Any]]
     ) -> None: ...

--- a/src/utils.py
+++ b/src/utils.py
@@ -2808,7 +2808,7 @@ class GrokSessionStore:
                 """)
                 await self._conn.commit()
             except Exception:
-                await self._conn.rollback()
+                await self._conn.rollback()  # preserve atomicity before surfacing the error
                 raise
 
             # User version migrations

--- a/src/utils.py
+++ b/src/utils.py
@@ -6520,25 +6520,57 @@ class GrokSessionStore:
                 rows = await cursor.fetchall()
                 return [dict(r) for r in rows]
 
-    @_with_write_retry_async
     async def save_message(self, session_name: str, role: str, content: str, metadata: Optional[dict] = None):
+        await self.save_messages(
+            session_name,
+            [{"role": role, "content": content, "metadata": metadata}],
+        )
+
+    @_with_write_retry_async
+    async def save_messages(
+        self, session_name: str, messages: List[Dict[str, Any]]
+    ) -> None:
+        """Insert one or more messages atomically (single BEGIN IMMEDIATE).
+
+        Used by append_and_save_history so a user+assistant turn cannot be
+        half-persisted or interleaved with a concurrent turn's pair.
+        """
         await self._ensure_initialized()
+        rows = list(messages or [])
+        if not rows:
+            return
         async with self._lock:
             await self._conn.execute("BEGIN IMMEDIATE;")
             try:
-                async with self._conn.execute("SELECT 1 FROM sessions WHERE session_name = ?", (session_name,)) as cursor:
+                async with self._conn.execute(
+                    "SELECT 1 FROM sessions WHERE session_name = ?", (session_name,)
+                ) as cursor:
                     exists = await cursor.fetchone()
                 now_str = datetime.now().isoformat()
                 if not exists:
                     await self._conn.execute(
                         "INSERT INTO sessions (session_name, last_active) VALUES (?, ?)",
-                        (session_name, now_str)
+                        (session_name, now_str),
                     )
-                meta_str = json.dumps(metadata, separators=(',', ':')) if metadata else None
-                await self._conn.execute(
-                    "INSERT INTO messages (session_name, role, content, timestamp, metadata) VALUES (?, ?, ?, ?, ?)",
-                    (session_name, role, content, now_str, meta_str)
-                )
+                for msg in rows:
+                    metadata = msg.get("metadata")
+                    meta_str = (
+                        json.dumps(metadata, separators=(",", ":"))
+                        if metadata
+                        else None
+                    )
+                    await self._conn.execute(
+                        "INSERT INTO messages "
+                        "(session_name, role, content, timestamp, metadata) "
+                        "VALUES (?, ?, ?, ?, ?)",
+                        (
+                            session_name,
+                            msg.get("role"),
+                            msg.get("content"),
+                            now_str,
+                            meta_str,
+                        ),
+                    )
                 await self._conn.commit()
             except Exception:
                 await self._conn.rollback()
@@ -7098,8 +7130,13 @@ async def append_and_save_history(session: str, history: list, prompt: str, repl
 
     active_store = store_param if store_param is not None else store
     try:
-        await active_store.save_message(session, "user", prompt)
-        await active_store.save_message(session, "assistant", reply, metadata=metadata)
+        await active_store.save_messages(
+            session,
+            [
+                {"role": "user", "content": prompt},
+                {"role": "assistant", "content": reply, "metadata": metadata},
+            ],
+        )
     except Exception as e:
         logging.getLogger("GrokMCP").warning(f"Failed to append/save SQLite chat history for session '{session}': {e}")
 

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -645,7 +645,7 @@ _PROTOCOL_MEMBERS = (
     "save_fact", "search_facts", "touch_facts", "delete_fact", "count_facts",
     "list_facts",
     "get_session", "save_session", "delete_session", "list_sessions",
-    "save_message", "replace_messages", "load_messages",
+    "save_message", "save_messages", "replace_messages", "load_messages",
     "create_job", "update_job", "get_job", "list_jobs",
     "create_swarm_task", "update_swarm_task", "get_swarm_task",
     "list_swarm_tasks", "insert_swarm_candidate", "list_swarm_candidates",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5051,11 +5051,52 @@ class TestAtomicSaveHistory:
         messages = await store.load_messages("sess-rollback")
         assert [m["content"] for m in messages] == ["original"]
 
+    @pytest.mark.asyncio
+    async def test_save_messages_rolls_back_atomically(self, store):
+        """A mid-batch failure must not leave a half-written user turn."""
+        await store.save_message("sess-pair", "user", "seed")
+
+        with pytest.raises(TypeError):
+            await store.save_messages(
+                "sess-pair",
+                [
+                    {"role": "user", "content": "orphan-risk"},
+                    {
+                        "role": "assistant",
+                        "content": "x",
+                        "metadata": {"bad": object()},
+                    },
+                ],
+            )
+
+        messages = await store.load_messages("sess-pair")
+        assert [m["content"] for m in messages] == ["seed"]
+
+    @pytest.mark.asyncio
+    async def test_concurrent_append_keeps_contiguous_pairs(self, store):
+        """Concurrent turns must not interleave as userA,userB,assistantA,..."""
+        session = "sess-pairs"
+
+        async def one_turn(n: int) -> None:
+            await append_and_save_history(
+                session, [], f"q{n}", f"a{n}", store
+            )
+
+        await asyncio.gather(*(one_turn(i) for i in range(12)))
+        messages = await store.load_messages(session)
+        assert len(messages) == 24
+        for i in range(0, 24, 2):
+            assert messages[i]["role"] == "user"
+            assert messages[i + 1]["role"] == "assistant"
+            q = messages[i]["content"]
+            a = messages[i + 1]["content"]
+            assert q.startswith("q") and a.startswith("a")
+            assert q[1:] == a[1:]
+
     def test_pattern_cache_is_deleted(self):
         """pattern_cache was write-only dead weight (zero callers) — removed."""
         assert not hasattr(GrokSessionStore, "get_cached_pattern")
         assert not hasattr(GrokSessionStore, "save_cached_pattern")
-
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Phase 4 concurrency — read pool + passive connection recovery


### PR DESCRIPTION
## Summary
- Persist each user+assistant turn via `GrokSessionStore.save_messages` in a single `BEGIN IMMEDIATE` transaction so a crash cannot orphan a user row and concurrent turns cannot interleave pairs.
- Keep `save_message` as a thin wrapper; extend `SessionStoreProtocol` accordingly.
- Add rollback + concurrent-pair unit coverage.

## Test plan
- [x] `uv run pytest -q tests/test_utils.py::TestAtomicSaveHistory tests/test_utils.py::TestHistoryHelpers::test_append_and_save_history tests/test_observability.py::TestSessionStoreProtocol`
- [ ] Supervisor: confirm no orphan user rows under kill mid-turn / concurrent append stress if desired

## Risks
Low — storage write path only; same insert semantics as before, batched.

Human sponsor: djtelicloud

Made with [Cursor](https://cursor.com)