### PR TITLE
fix(routing): CLI-Fallback metered cost honesty

### DIFF
--- a/src/metrics.py
+++ b/src/metrics.py
@@ -64,6 +64,22 @@ def _plane_name(value: Any) -> str:
     return text or "unknown"
 
 
+def _metered_cost_usd(row: Dict[str, Any]) -> Optional[float]:
+    """Exact/partial API spend visible on a telemetry row.
+
+    Pure API rows always contribute. CLI-Fallback rows may carry metered spend
+    from a failed API attempt before subscription recovery — only report when
+    the persisted cost is positive so pure-subscription zeros stay hidden.
+    """
+    plane = _plane_name(row.get("chosen_plane"))
+    cost = _safe_float(row.get("cost"))
+    if plane == "API":
+        return cost
+    if plane == "CLI-Fallback" and cost > 0:
+        return cost
+    return None
+
+
 def _is_auxiliary_telemetry(row: Dict[str, Any]) -> bool:
     return str(row.get("intent") or "").strip() in _AUXILIARY_TELEMETRY_INTENTS
 
@@ -93,9 +109,9 @@ def _aggregate(rows: List[Dict[str, Any]], plane: Optional[str] = None) -> Dict[
     verified = [row for row in outcome_rows if row.get("success") in (0, 1)]
     successes = sum(1 for row in verified if row.get("success") == 1)
     api_cost = sum(
-        _safe_float(row.get("cost"))
+        cost
         for row in selected
-        if _plane_name(row.get("chosen_plane")) == "API"
+        if (cost := _metered_cost_usd(row)) is not None
     )
     token_total = 0
     exact_token_rows = 0
@@ -196,7 +212,7 @@ def _recent_routes(rows: List[Dict[str, Any]], limit: int = 12) -> List[Dict[str
                 None if raw_success not in (0, 1) else raw_success == 1
             ),
             "latency_sec": _safe_float(row.get("latency")),
-            "cost_usd": _safe_float(row.get("cost")) if _plane_name(row.get("chosen_plane")) == "API" else None,
+            "cost_usd": _metered_cost_usd(row),
             "tokens": max(0, _safe_int(meta.get("tokens"))),
             "routing": routing,
         })

--- a/src/utils.py
+++ b/src/utils.py
@@ -11058,6 +11058,22 @@ async def _save_task_memory_safe(
         logging.getLogger("GrokMCP").warning(f"Task memory save failed: {exc}")
 
 
+def _receipt_billing_class(
+    attempts: Optional[List[Any]],
+    *,
+    default: str = "subscription",
+) -> str:
+    """Top-level receipt billing class for a turn.
+
+    Any physical metered attempt means metered spend may have occurred, even
+    when recovery finished on the CLI subscription plane (CLI-Fallback).
+    """
+    for item in attempts or []:
+        if isinstance(item, dict) and item.get("billing_class") == "metered":
+            return "metered"
+    return default
+
+
 def _telemetry_usage_kwargs(
     *,
     plane: str,
@@ -12727,7 +12743,7 @@ async def orchestrate(
                 },
                 "resolved_plane": "CLI",
                 "fallback_occurred": True,
-                "billing_class": "subscription",
+                "billing_class": _receipt_billing_class(physical_attempts),
                 "fallback_selection": cli_selection_receipt,
                 "attempts": list(physical_attempts),
                 "failure": api_failure_evidence,
@@ -12792,7 +12808,7 @@ async def orchestrate(
                 },
                 "resolved_plane": "CLI",
                 "fallback_occurred": True,
-                "billing_class": "subscription",
+                "billing_class": _receipt_billing_class(physical_attempts),
                 "attempts": list(physical_attempts),
                 "failure": _routing_failure_evidence(e),
                 "fallback_failure": _routing_failure_evidence(cli_err),

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -74,6 +74,41 @@ def test_structured_metrics_separate_api_billing_from_cli_subscription():
     assert snapshot["usage"]["data_quality"]["routing_receipt_rows"] == 1
 
 
+def test_cli_fallback_metered_spend_counts_in_api_cost():
+    """API→CLI recovery rows must not hide prior metered spend."""
+    now = datetime(2026, 7, 10, 12, 0, 0)
+    rows = [
+        _row(
+            created_at=now,
+            plane="CLI-Fallback",
+            latency=2.5,
+            cost=0.004,
+            metadata=(
+                '{"model":"grok-composer-2.5-fast","tokens":40,'
+                '"token_kind":"partial","billing_source":"partial","caller":"cursor",'
+                '"routing":{"billing_class":"metered","why_detail":"api_to_cli_fallback",'
+                '"attempts":[{"plane":"API","billing_class":"metered","cost_usd":0.004},'
+                '{"plane":"CLI","billing_class":"subscription","cost_usd":0.0}]}}'
+            ),
+        ),
+        _row(
+            created_at=now,
+            plane="CLI-Fallback",
+            latency=1.0,
+            cost=0.0,
+            metadata='{"model":"grok-composer-2.5-fast","billing_source":"subscription_unmetered","caller":"cursor"}',
+        ),
+    ]
+
+    snapshot = build_metrics_snapshot(rows, now=now)
+    today = snapshot["usage"]["today"]
+    assert today["summary"]["api_cost_usd"] == pytest.approx(0.004)
+    assert today["planes"]["CLI-Fallback"]["api_cost_usd"] == pytest.approx(0.004)
+    costly = next(r for r in today["recent_routes"] if r.get("cost_usd"))
+    assert costly["cost_usd"] == pytest.approx(0.004)
+    assert costly["plane"] == "CLI-Fallback"
+
+
 def test_structured_metrics_empty_period_is_null_not_fake_zero():
     now = datetime(2026, 7, 10, 12, 0, 0)
     snapshot = build_metrics_snapshot([], now=now)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2434,6 +2434,8 @@ class TestSymmetricXaiPlaneFailover:
         assert layer.plane == "CLI-Fallback"
         assert layer.finish_reason == "fallback"
         assert layer.routing_receipt["why_detail"] == "api_to_cli_fallback"
+        # Prior API attempt was metered even though recovery finished on CLI.
+        assert layer.routing_receipt["billing_class"] == "metered"
         assert [item["plane"] for item in layer.routing_receipt["attempts"]] == [
             "API",
             "CLI",
@@ -2442,6 +2444,7 @@ class TestSymmetricXaiPlaneFailover:
             "unknown_after_failure"
         )
         assert layer.routing_receipt["attempts"][0]["cost_usd"] is None
+        assert layer.routing_receipt["attempts"][0]["billing_class"] == "metered"
         assert layer.routing_receipt["attempts"][1]["billing_source"] == (
             "subscription_unmetered"
         )


### PR DESCRIPTION
## Summary
- After API→CLI recovery, derive `billing_class` from physical attempts so a metered API attempt is not mislabeled `subscription`.
- Count positive `CLI-Fallback` telemetry costs in `api_cost_usd` / recent routes so recovery rows do not hide prior API spend.
- Add focused metrics + orchestrate coverage.

## Test plan
- [x] `uv run pytest -q tests/test_metrics.py::test_structured_metrics_separate_api_billing_from_cli_subscription tests/test_metrics.py::test_cli_fallback_metered_spend_counts_in_api_cost tests/test_utils.py::TestSymmetricXaiPlaneFailover::test_explicit_api_start_can_recover_on_cli_when_policy_crosses`
- [ ] Supervisor: confirm Control Center /metrics still show pure CLI rows as $0

## Risks
Low — receipt/metrics honesty only; no routing behavior change.

Human sponsor: djtelicloud

Made with [Cursor](https://cursor.com)