### PR TITLE
fix(tools): clear_chat_history under principal scope

### DIFF
--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -419,9 +419,22 @@ async def clear_chat_history(session: str = "default") -> str:
     """Delete the history mapping and cascades messages for a chat session."""
     async with GrokInvocationContext("utility", logger, append_signature=False) as ctx:
         import re
-        session = scoped_session(session)
-        if not re.match(r"^[a-zA-Z0-9_\-:]+$", session) or ".." in session or "/" in session or "\\" in session:
-            return ctx.format_output(f"Error: Invalid session name '{session}'. Only alphanumeric, dashes, underscores, and colons are allowed.")
+        # Validate the caller-supplied logical name BEFORE scoped_session.
+        # Principals are percent-encoded into the store key (e.g. http%3Aanon),
+        # so a post-scope alphanumeric allowlist falsely rejects every HTTP
+        # namespaced clear.
+        logical = (session or "default").strip() or "default"
+        if (
+            not re.match(r"^[a-zA-Z0-9_\-:]+$", logical)
+            or ".." in logical
+            or "/" in logical
+            or "\\" in logical
+        ):
+            return ctx.format_output(
+                f"Error: Invalid session name '{logical}'. "
+                "Only alphanumeric, dashes, underscores, and colons are allowed."
+            )
+        session = scoped_session(logical)
 
         await store.delete_session(session)
         try:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -982,6 +982,30 @@ async def test_clear_chat_history_sanitization():
 
 
 @pytest.mark.asyncio
+async def test_clear_chat_history_allows_percent_encoded_principal_scope():
+    """HTTP principals are quote()-encoded into store keys; clear must still work."""
+    from src.identity import (
+        _ACTIVE_CLIENT_ID,
+        reset_active_principal,
+        set_active_principal,
+    )
+
+    principal_token = set_active_principal("http:anon")
+    client_token = _ACTIVE_CLIENT_ID.set("cursor")
+    try:
+        with patch(
+            "src.tools.system.store.delete_session", new_callable=AsyncMock
+        ) as mock_delete:
+            res = await clear_chat_history("default")
+        assert "Cleared history for session" in res
+        mock_delete.assert_awaited_once_with("http%3Aanon:cursor:default")
+        assert "Error: Invalid session name" not in res
+    finally:
+        _ACTIVE_CLIENT_ID.reset(client_token)
+        reset_active_principal(principal_token)
+
+
+@pytest.mark.asyncio
 async def test_agent_tool_reports_progress_via_ctx(monkeypatch):
     """With an injected FastMCP Context, the agent tool adapts progress events
     onto ctx.report_progress: depth events carry n-of-max progress, tool


### PR DESCRIPTION
## Summary
- Validate the logical session name before `scoped_session` so percent-encoded HTTP principals (`http%3Aanon:…`) no longer false-fail the clear allowlist.
- Keep traversal / path separators blocked on the caller-supplied name.
- Add a principal+client scoped clear regression test.

## Test plan
- [x] `uv run pytest -q tests/test_server.py::test_clear_chat_history_sanitization tests/test_server.py::test_clear_chat_history_allows_percent_encoded_principal_scope tests/test_server.py::test_clear_chat_history`
- [ ] Supervisor: clear a session over HTTP with `X-Client-ID` bound and confirm delete hits the encoded store key

## Risks
Low — destructive tool path only; traversal still rejected.

Human sponsor: djtelicloud

Made with [Cursor](https://cursor.com)