### PR TITLE
fix(authz): scope session listings to principal

### DIFF
--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -590,6 +590,30 @@ subordinate label that separates one principal's IDEs; it never provides
 the security boundary by itself. Non-HTTP callers preserve the historical
 unscoped behavior unless their transport binds one of these context vars.
 
+### Function: `principal_session_prefix` {#identity-principal_session_prefix}
+
+```python
+def principal_session_prefix() -> Optional[str]
+```
+
+**Keywords:** principal, session, prefix
+
+Percent-encoded principal prefix used as the session security boundary.
+
+Returns ``None`` when no principal is bound (stdio / unscoped callers keep
+the historical global session view). Client labels are intentionally
+omitted — they are subordinate and must not widen or shrink authz.
+
+### Function: `filter_sessions_for_principal` {#identity-filter_sessions_for_principal}
+
+```python
+def filter_sessions_for_principal(rows: Optional[List[Dict[str, Any]]]) -> List[Dict[str, Any]]
+```
+
+**Keywords:** filter, sessions, for, principal
+
+Keep only session rows owned by the active principal, when bound.
+
 ### Function: `normalize_caller` {#identity-normalize_caller}
 
 ```python
@@ -3461,7 +3485,7 @@ async def list_chat_sessions() -> str
 
 **Keywords:** list, chat, sessions
 
-List all chat sessions stored under the SQLite session store.
+List chat sessions visible to the active principal (or all when unscoped).
 
 ### Function: `get_chat_history` {#tools-system-get_chat_history}
 

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -590,6 +590,30 @@ subordinate label that separates one principal's IDEs; it never provides
 the security boundary by itself. Non-HTTP callers preserve the historical
 unscoped behavior unless their transport binds one of these context vars.
 
+### Function: `principal_session_prefix` {#identity-principal_session_prefix}
+
+```python
+def principal_session_prefix() -> Optional[str]
+```
+
+**Keywords:** principal, session, prefix
+
+Percent-encoded principal prefix used as the session security boundary.
+
+Returns ``None`` when no principal is bound (stdio / unscoped callers keep
+the historical global session view). Client labels are intentionally
+omitted — they are subordinate and must not widen or shrink authz.
+
+### Function: `filter_sessions_for_principal` {#identity-filter_sessions_for_principal}
+
+```python
+def filter_sessions_for_principal(rows: Optional[List[Dict[str, Any]]]) -> List[Dict[str, Any]]
+```
+
+**Keywords:** filter, sessions, for, principal
+
+Keep only session rows owned by the active principal, when bound.
+
 ### Function: `normalize_caller` {#identity-normalize_caller}
 
 ```python
@@ -3461,7 +3485,7 @@ async def list_chat_sessions() -> str
 
 **Keywords:** list, chat, sessions
 
-List all chat sessions stored under the SQLite session store.
+List chat sessions visible to the active principal (or all when unscoped).
 
 ### Function: `get_chat_history` {#tools-system-get_chat_history}
 

--- a/src/identity.py
+++ b/src/identity.py
@@ -12,7 +12,7 @@ import contextvars
 import hashlib
 import json
 import re
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
 
@@ -55,6 +55,34 @@ def scoped_session(session: Optional[str]) -> Optional[str]:
     if namespace and session and not session.startswith(f"{namespace}:"):
         return f"{namespace}:{session}"
     return session
+
+
+def principal_session_prefix() -> Optional[str]:
+    """Percent-encoded principal prefix used as the session security boundary.
+
+    Returns ``None`` when no principal is bound (stdio / unscoped callers keep
+    the historical global session view). Client labels are intentionally
+    omitted — they are subordinate and must not widen or shrink authz.
+    """
+    principal = get_active_principal()
+    if not principal:
+        return None
+    return f"{quote(principal, safe='-._~')}:"
+
+
+def filter_sessions_for_principal(
+    rows: Optional[List[Dict[str, Any]]],
+) -> List[Dict[str, Any]]:
+    """Keep only session rows owned by the active principal, when bound."""
+    items = list(rows or [])
+    prefix = principal_session_prefix()
+    if prefix is None:
+        return items
+    return [
+        row
+        for row in items
+        if str(row.get("session_name") or "").startswith(prefix)
+    ]
 
 
 def normalize_caller(value: Any) -> Optional[str]:

--- a/src/tools/resources.py
+++ b/src/tools/resources.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, Optional
 
 from mcp.server.fastmcp import FastMCP
 
+from ..identity import filter_sessions_for_principal, scoped_session
 from ..jobs import get_job_manager
 from ..utils import (
     PathResolver,
@@ -118,11 +119,13 @@ def register_resource_primitives(mcp: FastMCP):
 
     @mcp.resource(
         "grok://sessions",
-        description="All stored chat sessions (name, model, last_active).",
+        description="Chat sessions visible to the active principal (name, model, last_active).",
         mime_type="application/json",
     )
     async def sessions_resource() -> str:
-        return _to_json(await store.list_sessions())
+        return _to_json(
+            filter_sessions_for_principal(await store.list_sessions())
+        )
 
     @mcp.resource(
         "grok://sessions/{name}",
@@ -130,7 +133,7 @@ def register_resource_primitives(mcp: FastMCP):
         mime_type="application/json",
     )
     async def session_history_resource(name: str) -> str:
-        return _to_json(await load_history(name, store))
+        return _to_json(await load_history(scoped_session(name), store))
 
     @mcp.resource(
         "grok://jobs/{job_id}",
@@ -189,7 +192,7 @@ def register_resource_primitives(mcp: FastMCP):
         sections.append("## Git\n" + await _workspace_git_summary())
 
         try:
-            sessions = await store.list_sessions()
+            sessions = filter_sessions_for_principal(await store.list_sessions())
         except Exception as exc:
             logger.debug(f"workspace resource: session listing failed: {exc}")
             sessions = []

--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -46,6 +46,7 @@ from xai_sdk.chat import user
 from xai_sdk.tools import code_execution, web_search as xai_web_search, x_search as xai_x_search
 
 from ..identity import (
+    filter_sessions_for_principal,
     get_active_client_id,
     get_active_principal,
     principal_kind,
@@ -151,7 +152,7 @@ async def grok_mcp_status(view: Literal["text", "json"] = "text") -> str:
         except Exception:
             pass
 
-        sessions = await store.list_sessions()
+        sessions = filter_sessions_for_principal(await store.list_sessions())
 
         # Compute SQLite File Sizes
         db_size_kb = 0
@@ -383,9 +384,9 @@ async def grok_mcp_status(view: Literal["text", "json"] = "text") -> str:
 
 
 async def list_chat_sessions() -> str:
-    """List all chat sessions stored under the SQLite session store."""
+    """List chat sessions visible to the active principal (or all when unscoped)."""
     async with GrokInvocationContext("utility", logger, append_signature=False) as ctx:
-        sessions = await store.list_sessions()
+        sessions = filter_sessions_for_principal(await store.list_sessions())
         if not sessions:
             return ctx.format_output("No chat sessions found.")
 

--- a/tests/test_multiagent.py
+++ b/tests/test_multiagent.py
@@ -960,6 +960,28 @@ class TestClientIdDerivation:
             http_module._ACTIVE_CLIENT_ID.reset(client_token)
             reset_active_principal(principal_token)
 
+    def test_filter_sessions_for_principal_uses_principal_not_client(self):
+        from src.identity import filter_sessions_for_principal
+
+        import src.http_server as http_module
+
+        rows = [
+            {"session_name": "oauth%3Agithub%3A42:vscode:a"},
+            {"session_name": "oauth%3Agithub%3A42:cursor:b"},
+            {"session_name": "oauth%3Agithub%3A99:vscode:c"},
+        ]
+        principal_token = set_active_principal("oauth:github:42")
+        client_token = http_module._ACTIVE_CLIENT_ID.set("vscode")
+        try:
+            visible = filter_sessions_for_principal(rows)
+            assert [r["session_name"] for r in visible] == [
+                "oauth%3Agithub%3A42:vscode:a",
+                "oauth%3Agithub%3A42:cursor:b",
+            ]
+        finally:
+            http_module._ACTIVE_CLIENT_ID.reset(client_token)
+            reset_active_principal(principal_token)
+
     def test_scoped_session_untouched_without_client(self):
         import src.http_server as http_module
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -121,6 +121,41 @@ async def test_list_chat_sessions_populated():
 
 
 @pytest.mark.asyncio
+async def test_list_chat_sessions_filters_to_active_principal():
+    """With a bound principal, other principals' session rows must not leak."""
+    from src.identity import reset_active_principal, set_active_principal
+
+    token = set_active_principal("oauth:github:42")
+    try:
+        with patch("src.server.store.list_sessions", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = [
+                {
+                    "session_name": "oauth%3Agithub%3A42:vscode:mine",
+                    "model": "grok-4.5",
+                    "last_active": "2026-07-16T00:00:00",
+                },
+                {
+                    "session_name": "oauth%3Agithub%3A99:vscode:theirs",
+                    "model": "grok-4.3",
+                    "last_active": "2026-07-16T00:00:01",
+                },
+                {
+                    "session_name": "http%3Aanon:cursor:shared",
+                    "model": "grok-composer-2.5-fast",
+                    "last_active": "2026-07-16T00:00:02",
+                },
+            ]
+            res = await list_chat_sessions()
+        assert "oauth%3Agithub%3A42:vscode:mine" in res
+        assert "oauth%3Agithub%3A99:vscode:theirs" not in res
+        assert "http%3Aanon:cursor:shared" not in res
+        assert "grok-4.5" in res
+        assert "grok-4.3" not in res
+    finally:
+        reset_active_principal(token)
+
+
+@pytest.mark.asyncio
 async def test_clear_chat_history():
     """clear_chat_history clears local SQLite store and JSON backups."""
     with patch("src.server.store.delete_session", new_callable=AsyncMock) as mock_delete, \


### PR DESCRIPTION
## Summary
- Filter `list_chat_sessions`, `grok://sessions`, workspace Active Sessions, and status session counts to the active principal prefix.
- Scope `grok://sessions/{name}` through `scoped_session` so history reads match chat tools.
- Unscoped/stdio callers keep the historical global list; client-id is not an authz boundary.

## Test plan
- [x] `uv run pytest -q tests/test_server.py::test_list_chat_sessions_empty tests/test_server.py::test_list_chat_sessions_populated tests/test_server.py::test_list_chat_sessions_filters_to_active_principal tests/test_multiagent.py::TestClientIdDerivation::test_filter_sessions_for_principal_uses_principal_not_client tests/test_phase5.py::TestResourcesAndPrompts::test_session_history_resource_reads_store`
- [ ] Supervisor: two HTTP principals on one store — each list shows only own sessions

## Risks
Low — read-path authz; unscoped local behavior unchanged.

Human sponsor: djtelicloud

Made with [Cursor](https://cursor.com)