### PR TITLE
fix(telemetry): redact secrets in intent column

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -3754,13 +3754,18 @@ class GrokSessionStore:
             meta["routing"] = clean_routing
         meta_str = json.dumps(meta, separators=(",", ":")) if meta else None
         now_str = datetime.now().isoformat()
+        # Intent is often a prompt prefix from orchestrate. Redact+bound at
+        # write time so secrets/PII never land at-rest even though /metrics
+        # deliberately omits intent from exports. Exact labels like
+        # "history-compaction" stay unchanged (short, no secret patterns).
+        clean_intent = redact_secrets(str(intent or "")).strip()[:100]
         async with self._lock:
             await self._conn.execute("BEGIN IMMEDIATE;")
             try:
                 cursor = await self._conn.execute(
                     "INSERT INTO telemetry (intent, chosen_plane, success, latency, cost, context_id, metadata, created_at) "
                     "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                    (intent, chosen_plane, success_value, latency, cost, context_id, meta_str, now_str)
+                    (clean_intent, chosen_plane, success_value, latency, cost, context_id, meta_str, now_str)
                 )
                 telemetry_id = int(cursor.lastrowid)
                 if normalized_attempt_rows:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -284,6 +284,31 @@ async def test_save_telemetry_persists_usage_provenance(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_save_telemetry_redacts_secrets_in_intent(tmp_path):
+    """Prompt prefixes must not land at-rest with live credentials."""
+    store = GrokSessionStore(db_path=tmp_path / "intent-redact.db")
+    try:
+        secret = "xai-1234567890abcdef"
+        await store.save_telemetry(
+            f"deploy with {secret} please",
+            "API",
+            1,
+            0.5,
+            0.001,
+        )
+        await store.save_telemetry("history-compaction", "API", 1, 0.1, 0.0)
+        rows = {row["intent"]: row for row in await store.get_telemetry_stats()}
+        leaked = next(
+            intent for intent in rows if "deploy with" in intent or "REDACTED" in intent
+        )
+        assert secret not in leaked
+        assert "[REDACTED_KEY]" in leaked
+        assert "history-compaction" in rows
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
 async def test_save_telemetry_persists_partial_cross_plane_usage(tmp_path):
     store = GrokSessionStore(db_path=tmp_path / "partial-usage.db")
     try:


### PR DESCRIPTION
## Summary
- Redact and bound `telemetry.intent` inside `save_telemetry` before INSERT so prompt prefixes cannot land at-rest with live credentials.
- Preserve short operational labels such as `history-compaction`.
- Add a unit test that an `xai-` key in the intent is replaced with `[REDACTED_KEY]`.

## Test plan
- [x] `uv run pytest -q tests/test_metrics.py::test_save_telemetry_redacts_secrets_in_intent tests/test_metrics.py::test_save_telemetry_persists_usage_provenance tests/test_metrics.py::test_unverified_rows_preserve_usage_without_fabricating_failure`
- [ ] Supervisor: confirm Control Center /metrics still omits intent and compaction rows still match

## Risks
Low — write-path privacy only; export shape unchanged.

Human sponsor: djtelicloud

Made with [Cursor](https://cursor.com)