### PR TITLE
fix(security): confine public admin surfaces

### DIFF
--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -429,11 +429,11 @@ with ?format=prometheus.
 The JSON shape needs no extra dependencies and any JSON-capable collector
 can scrape it; the Prometheus variant renders the SAME snapshot as text
 exposition 0.0.4 via stdlib string building (see
-_render_prometheus_metrics). Auth-protected like every non-probe route
-(the auth middleware only exempts /healthz and /readyz). Combines the
-telemetry table (per-plane and per-caller aggregates) with in-process
-runtime state: circuit breakers, the timed-thread gauge, and the routing
-advisor's current view.
+_render_prometheus_metrics). Available only over the verified local
+operator path; bearer or OAuth status scope never grants remote access to
+its cross-caller aggregates. Combines the telemetry table (per-plane and
+per-caller aggregates) with in-process runtime state: circuit breakers,
+the timed-thread gauge, and the routing advisor's current view.
 
 ### Function: `public_agent` {#http_server-public_agent}
 

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -429,11 +429,11 @@ with ?format=prometheus.
 The JSON shape needs no extra dependencies and any JSON-capable collector
 can scrape it; the Prometheus variant renders the SAME snapshot as text
 exposition 0.0.4 via stdlib string building (see
-_render_prometheus_metrics). Auth-protected like every non-probe route
-(the auth middleware only exempts /healthz and /readyz). Combines the
-telemetry table (per-plane and per-caller aggregates) with in-process
-runtime state: circuit breakers, the timed-thread gauge, and the routing
-advisor's current view.
+_render_prometheus_metrics). Available only over the verified local
+operator path; bearer or OAuth status scope never grants remote access to
+its cross-caller aggregates. Combines the telemetry table (per-plane and
+per-caller aggregates) with in-process runtime state: circuit breakers,
+the timed-thread gauge, and the routing advisor's current view.
 
 ### Function: `public_agent` {#http_server-public_agent}
 

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -453,7 +453,7 @@ _PUBLIC_AUTH_EXEMPT_PATHS = (
 # are local operator surfaces. They stay convenient at localhost, including
 # when client bearer keys are configured, but are never exempt in Cloud Run or
 # when reached through a non-loopback Host.
-_LOCAL_OPERATOR_PATHS = ("/runtimez",)
+_LOCAL_OPERATOR_PATHS = ("/runtimez", "/metrics")
 _LOCAL_OPERATOR_PREFIXES = ("/ui", "/docs")
 
 
@@ -517,8 +517,8 @@ def _is_local_operator_request(scope: Dict[str, Any]) -> bool:
 
 def _request_may_bypass_auth(scope: Dict[str, Any]) -> bool:
     # The broad development bypass is stricter than the operator-static
-    # exemption: an asserted Docker proxy boundary may expose /ui and
-    # /runtimez, but it never disables auth for /mcp, /v1, or /metrics.
+    # exemption: an asserted Docker proxy boundary may expose /ui, /runtimez,
+    # and local-only /metrics, but it never disables auth for /mcp or /v1.
     return _allow_unauthenticated() and _is_direct_loopback_request(scope)
 
 
@@ -1586,12 +1586,19 @@ async def metrics(request: Request) -> Response:
     The JSON shape needs no extra dependencies and any JSON-capable collector
     can scrape it; the Prometheus variant renders the SAME snapshot as text
     exposition 0.0.4 via stdlib string building (see
-    _render_prometheus_metrics). Auth-protected like every non-probe route
-    (the auth middleware only exempts /healthz and /readyz). Combines the
-    telemetry table (per-plane and per-caller aggregates) with in-process
-    runtime state: circuit breakers, the timed-thread gauge, and the routing
-    advisor's current view.
+    _render_prometheus_metrics). Available only over the verified local
+    operator path; bearer or OAuth status scope never grants remote access to
+    its cross-caller aggregates. Combines the telemetry table (per-plane and
+    per-caller aggregates) with in-process runtime state: circuit breakers,
+    the timed-thread gauge, and the routing advisor's current view.
     """
+    if not _is_verified_local_request(request.scope):
+        return _json_error(
+            "Metrics are available only to a verified local operator.",
+            status_code=403,
+            code="forbidden",
+        )
+
     try:
         rows = await store.get_telemetry_stats()
     except Exception as exc:
@@ -2317,10 +2324,9 @@ def create_public_mcp() -> FastMCP:
         return path.read_text(encoding="utf-8")
 
     # Expose status and onboarding helper tools to the HTTP /mcp endpoint
-    from .tools.system import grok_mcp_status, grok_mcp_discover_self, grok_mcp_restart_container
+    from .tools.system import grok_mcp_status, grok_mcp_discover_self
     mcp.add_tool(grok_mcp_status, name="grok_mcp_status")
     mcp.add_tool(grok_mcp_discover_self, name="grok_mcp_discover_self")
-    mcp.add_tool(grok_mcp_restart_container, name="grok_mcp_restart_container")
 
     # Repository evidence is useful to IDE agents developing UniGrok, but it
     # must never become part of the globally registered stable service or a

--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -45,7 +45,12 @@ from ..utils import (
 from xai_sdk.chat import user
 from xai_sdk.tools import code_execution, web_search as xai_web_search, x_search as xai_x_search
 
-from ..identity import get_active_client_id, principal_kind, scoped_session
+from ..identity import (
+    get_active_client_id,
+    get_active_principal,
+    principal_kind,
+    scoped_session,
+)
 
 logger = logging.getLogger("GrokMCP")
 
@@ -1378,6 +1383,24 @@ async def grok_mcp_restart_container() -> SystemResult:
     Only works if running in a context where docker compose is available and enabled.
     """
     async with GrokInvocationContext("utility", logger, append_signature=False) as ctx:
+        if get_active_principal():
+            err_msg = (
+                "Container restart is unavailable over HTTP/MCP. "
+                "Use a trusted unbound local stdio session."
+            )
+            return SystemResult(
+                response=err_msg,
+                text=f"# Docker Restart Status\n\n⛔ {err_msg}",
+                data={"status": "http_forbidden"},
+                model="unknown",
+                finish_reason="error",
+                cost_usd=0.0,
+                tokens=0,
+                latency_sec=ctx.elapsed,
+                route="utility",
+                plane="local",
+            )
+
         enabled = os.environ.get("UNIGROK_ENABLE_CONTAINER_RESTART", "").strip().lower() in ("1", "true")
         if not enabled:
             err_msg = "Container restart is disabled on this server. Enable it by setting UNIGROK_ENABLE_CONTAINER_RESTART=1."

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -434,7 +434,7 @@ def test_oauth_metadata_challenge_omits_mcp_document_for_query_variant(monkeypat
     assert response.headers["WWW-Authenticate"] == 'Bearer scope="unigrok:connect"'
 
 
-def test_oauth_introspection_allows_valid_status_token(monkeypatch):
+def test_oauth_status_token_does_not_grant_metrics_operator_access(monkeypatch):
     monkeypatch.setenv("UNIGROK_RUNTIME", "cloudrun")
     monkeypatch.delenv("UNIGROK_API_KEYS", raising=False)
     monkeypatch.setenv(
@@ -450,7 +450,8 @@ def test_oauth_introspection_allows_valid_status_token(monkeypatch):
     with TestClient(create_app(), base_url="https://mcp.grokmcp.org") as client:
         response = client.get("/metrics", headers={"Authorization": "Bearer token-value"})
 
-    assert response.status_code == 200
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "forbidden"
 
 
 def test_oauth_subject_cannot_evade_budget_attribution_with_client_headers():
@@ -691,7 +692,7 @@ def test_trusted_compose_proxy_never_bypasses_inference_auth(monkeypatch):
     assert ui.status_code == 200
     assert runtime.status_code == 200
     assert inference.status_code == 401
-    assert metrics.status_code == 401
+    assert metrics.status_code == 200
 
 
 def test_readyz_accepts_cli_auth_without_xai_api_key(monkeypatch, tmp_path):
@@ -1092,7 +1093,6 @@ async def test_public_mcp_exposes_only_agent():
         "review_pull_request",
         "grok_mcp_status",
         "grok_mcp_discover_self",
-        "grok_mcp_restart_container",
     ]
 
 
@@ -1776,20 +1776,31 @@ def test_agent_stream_error_still_terminates_with_done(monkeypatch):
     assert body.rstrip().endswith("data: [DONE]")
 
 
-def test_metrics_is_auth_protected(monkeypatch):
-    """/metrics sits behind the bearer auth like every non-probe route: 401
-    without a token, 200 with a configured key."""
-    monkeypatch.delenv("UNIGROK_RUNTIME", raising=False)
+def test_metrics_is_verified_local_operator_only(monkeypatch):
+    """Bearer authentication alone never grants global metrics access."""
+    monkeypatch.setenv("UNIGROK_RUNTIME", "local")
     monkeypatch.setenv("UNIGROK_API_KEYS", "metrics-secret")
     monkeypatch.delenv("UNIGROK_ALLOW_UNAUTHENTICATED", raising=False)
 
-    with TestClient(create_app()) as client:
+    with TestClient(
+        create_app(),
+        base_url="https://gateway.example.com",
+        client=("203.0.113.20", 50000),
+    ) as client:
         denied = client.get("/metrics")
         allowed = client.get("/metrics", headers={"Authorization": "Bearer metrics-secret"})
+    with TestClient(
+        create_app(),
+        base_url="http://localhost:8080",
+        client=("127.0.0.1", 50000),
+    ) as client:
+        local = client.get("/metrics")
 
     assert denied.status_code == 401
-    assert allowed.status_code == 200
-    assert allowed.json()["format"] == "unigrok-json-v1"
+    assert allowed.status_code == 403
+    assert allowed.json()["error"]["code"] == "forbidden"
+    assert local.status_code == 200
+    assert local.json()["format"] == "unigrok-json-v1"
 
 
 def test_metrics_aggregates_planes_and_runtime(monkeypatch):
@@ -1808,7 +1819,11 @@ def test_metrics_aggregates_planes_and_runtime(monkeypatch):
 
     monkeypatch.setattr(http_module.store, "get_telemetry_stats", AsyncMock(return_value=rows))
 
-    with TestClient(create_app()) as client:
+    with TestClient(
+        create_app(),
+        base_url="http://localhost:8080",
+        client=("127.0.0.1", 50000),
+    ) as client:
         res = client.get("/metrics")
 
     assert res.status_code == 200
@@ -1839,7 +1854,11 @@ def test_metrics_survives_telemetry_read_failure(monkeypatch):
         AsyncMock(side_effect=RuntimeError("db offline")),
     )
 
-    with TestClient(create_app()) as client:
+    with TestClient(
+        create_app(),
+        base_url="http://localhost:8080",
+        client=("127.0.0.1", 50000),
+    ) as client:
         res = client.get("/metrics")
 
     assert res.status_code == 200

--- a/tests/test_multiagent.py
+++ b/tests/test_multiagent.py
@@ -843,7 +843,11 @@ class TestMetricsSegmentation:
             http_module.store, "get_telemetry_stats", AsyncMock(return_value=rows)
         )
 
-        with TestClient(create_app()) as client:
+        with TestClient(
+            create_app(),
+            base_url="http://localhost:8080",
+            client=("127.0.0.1", 50000),
+        ) as client:
             res = client.get("/metrics")
 
         assert res.status_code == 200

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -524,7 +524,11 @@ class TestPrometheusRendering:
             http_module.store, "get_telemetry_stats", AsyncMock(return_value=rows)
         )
 
-        with TestClient(create_app()) as client:
+        with TestClient(
+            create_app(),
+            base_url="http://localhost:8080",
+            client=("127.0.0.1", 50000),
+        ) as client:
             prom = client.get("/metrics?format=prometheus")
             default = client.get("/metrics")
 
@@ -600,7 +604,11 @@ class TestTaskRagPrometheusRendering:
         monkeypatch.setattr(
             http_module.store, "get_telemetry_stats", AsyncMock(return_value=[])
         )
-        with TestClient(create_app()) as client:
+        with TestClient(
+            create_app(),
+            base_url="http://localhost:8080",
+            client=("127.0.0.1", 50000),
+        ) as client:
             payload = client.get("/metrics").json()
         task_rag = payload["routing_advisor"]["task_rag"]
         assert task_rag["mode"] == "off"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1039,6 +1039,7 @@ async def test_agent_tool_ctx_hidden_from_schema():
 @pytest.mark.asyncio
 async def test_grok_mcp_restart_container_gating(monkeypatch, tmp_path):
     from src.tools.system import grok_mcp_restart_container
+    from src.identity import reset_active_principal, set_active_principal
 
     # 1. Test disabled behavior
     monkeypatch.setenv("UNIGROK_ENABLE_CONTAINER_RESTART", "0")
@@ -1046,8 +1047,16 @@ async def test_grok_mcp_restart_container_gating(monkeypatch, tmp_path):
     assert res.data["status"] == "disabled"
     assert "disabled" in res.response
 
-    # 2. Test enabled behavior without a Compose project.
     monkeypatch.setenv("UNIGROK_ENABLE_CONTAINER_RESTART", "1")
+    principal_token = set_active_principal("http:key-1")
+    try:
+        res_http = await grok_mcp_restart_container()
+    finally:
+        reset_active_principal(principal_token)
+    assert res_http.data["status"] == "http_forbidden"
+    assert "unavailable over HTTP/MCP" in res_http.response
+
+    # 2. Test enabled behavior without a Compose project.
     invalid_root = tmp_path / "outside"
     invalid_root.mkdir()
     with patch("src.tools.system.PathResolver.get_service_root", return_value=invalid_root):


### PR DESCRIPTION
## Summary
- Restrict `/metrics` to verified local-operator requests; bearer and OAuth status credentials no longer expose global caller, route, timing, cost, provider, runtime, or advisor state remotely.
- Remove `grok_mcp_restart_container` from the stable HTTP MCP registry.
- Deny restart execution whenever an HTTP/MCP principal is bound, preserving only trusted unbound local stdio use.

## Root cause
Authentication was treated as authorization for two shared-service operator surfaces. Any authenticated principal could read global metrics, and a server-side restart flag could make the destructive restart tool callable through shared HTTP.

## Validation
- `uv run pytest -q tests/test_http_server.py tests/test_server.py` — 175 passed.
- Focused metrics/public-tool/restart tests — 7 passed.
- Full suite land gate rerun after local-client test repair.
- `git diff --check`.

## Exact-head handoff
- Head: `43190bbb534ce6d6bf397bde220487c407741b38`
- Paths: `src/http_server.py`, `src/tools/system.py`, `tests/test_http_server.py`, `tests/test_server.py`, `tests/test_multiagent.py`, `tests/test_observability.py`
- Human sponsor: `djtelicloud`
- Provenance: OpenAI Codex implementation; xAI Grok 4.5 advisory security review.
- Residual behavior: local verified operator metrics remain available; unbound trusted stdio restart remains feature-flagged and root-scoped.

risk: high

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authorization for `/metrics` (cross-caller operational data) and removes/blocks a destructive container restart path on shared HTTP/MCP; mistakes could leak operator telemetry or leave restart callable remotely.
> 
> **Overview**
> **Restricts `/metrics` to verified local operators** so valid bearer keys or OAuth `unigrok:status` tokens no longer expose global telemetry, per-caller aggregates, circuit breakers, or routing advisor state over remote or Cloud Run paths. The handler now returns **403 forbidden** unless the request passes `_is_verified_local_request`; local loopback (and trusted Docker proxy) scraping behavior is unchanged.
> 
> **Removes `grok_mcp_restart_container` from the stable HTTP `/mcp` tool list** and **blocks restart when an HTTP/MCP principal is bound**, returning `http_forbidden` so only unbound trusted local stdio can still use the feature-flagged, root-scoped restart path.
> 
> API reference docs are aligned with the new metrics and operator-access model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e08cef8d1983f9f954f3b8a3ccd3512adc83889. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
