### PR TITLE
fix(http): abort API stream after client cancel

### DIFF
--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -3889,7 +3889,7 @@ Snapshot of timed-thread pressure (consumed by grok_mcp_status).
 ### Function: `run_blocking` {#utils-run_blocking}
 
 ```python
-async def run_blocking(fn: Callable, *args, timeout: Optional[float]=None, **kwargs)
+async def run_blocking(fn: Callable, *args, timeout: Optional[float]=None, cancel_event: Optional[threading.Event]=None, **kwargs)
 ```
 
 **Keywords:** run, blocking
@@ -3902,6 +3902,11 @@ with the shared pool eight stuck calls would permanently occupy every
 worker and deadlock all SDK bridging in the server. The dedicated threads
 are capped (UNIGROK_MAX_TIMED_THREADS, default 64): at capacity the call
 fails fast with RuntimeError instead of spawning yet another thread.
+
+Optional ``cancel_event`` is set when the awaiter times out or is
+cancelled so cooperative callables (API ``chat.stream``) can stop
+consuming the metered upstream instead of running to completion after
+the client disconnects.
 
 ### Function: `communicate_with_timeout` {#utils-communicate_with_timeout}
 

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -3889,7 +3889,7 @@ Snapshot of timed-thread pressure (consumed by grok_mcp_status).
 ### Function: `run_blocking` {#utils-run_blocking}
 
 ```python
-async def run_blocking(fn: Callable, *args, timeout: Optional[float]=None, **kwargs)
+async def run_blocking(fn: Callable, *args, timeout: Optional[float]=None, cancel_event: Optional[threading.Event]=None, **kwargs)
 ```
 
 **Keywords:** run, blocking
@@ -3902,6 +3902,11 @@ with the shared pool eight stuck calls would permanently occupy every
 worker and deadlock all SDK bridging in the server. The dedicated threads
 are capped (UNIGROK_MAX_TIMED_THREADS, default 64): at capacity the call
 fails fast with RuntimeError instead of spawning yet another thread.
+
+Optional ``cancel_event`` is set when the awaiter times out or is
+cancelled so cooperative callables (API ``chat.stream``) can stop
+consuming the metered upstream instead of running to completion after
+the client disconnects.
 
 ### Function: `communicate_with_timeout` {#utils-communicate_with_timeout}
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -538,7 +538,13 @@ def get_runtime_stats() -> Dict[str, int]:
         }
 
 
-async def run_blocking(fn: Callable, *args, timeout: Optional[float] = None, **kwargs):
+async def run_blocking(
+    fn: Callable,
+    *args,
+    timeout: Optional[float] = None,
+    cancel_event: Optional[threading.Event] = None,
+    **kwargs,
+):
     """Run blocking SDK/local work on a bounded executor.
 
     Timed calls get a dedicated daemon thread instead of a shared-pool worker:
@@ -547,6 +553,11 @@ async def run_blocking(fn: Callable, *args, timeout: Optional[float] = None, **k
     worker and deadlock all SDK bridging in the server. The dedicated threads
     are capped (UNIGROK_MAX_TIMED_THREADS, default 64): at capacity the call
     fails fast with RuntimeError instead of spawning yet another thread.
+
+    Optional ``cancel_event`` is set when the awaiter times out or is
+    cancelled so cooperative callables (API ``chat.stream``) can stop
+    consuming the metered upstream instead of running to completion after
+    the client disconnects.
     """
     call = functools.partial(fn, *args, **kwargs)
     loop = asyncio.get_running_loop()
@@ -591,8 +602,18 @@ async def run_blocking(fn: Callable, *args, timeout: Optional[float] = None, **k
             with _TIMED_THREADS_LOCK:
                 _TIMED_THREADS_IN_FLIGHT -= 1
             raise
-        return await asyncio.wait_for(future, timeout=timeout)
-    return await loop.run_in_executor(_local_executor(), call)
+        try:
+            return await asyncio.wait_for(future, timeout=timeout)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            if cancel_event is not None:
+                cancel_event.set()
+            raise
+    try:
+        return await loop.run_in_executor(_local_executor(), call)
+    except asyncio.CancelledError:
+        if cancel_event is not None:
+            cancel_event.set()
+        raise
 
 
 def _owned_descendant_pids(root_pid: int) -> List[int]:
@@ -10940,6 +10961,12 @@ async def _call_plane(
                 event_loop,
             )
 
+        # Cooperative abort for SSE disconnect / await cancellation: the
+        # asyncio task cancel alone cannot stop the dedicated run_blocking
+        # thread. The stream loop polls this event; sample() remains
+        # uninterruptible until the SDK exposes a hard abort.
+        api_cancel_event = threading.Event()
+
         def _call_api():
             client = get_xai_client()
             chat_params = {"model": model_name}
@@ -10979,6 +11006,10 @@ async def _call_plane(
                 # accounting below is identical to the sample() path.
                 final_response = None
                 for final_response, chunk in grok.stream():
+                    if api_cancel_event.is_set():
+                        raise RuntimeError(
+                            "API stream aborted after client disconnect or timeout"
+                        )
                     delta = str(getattr(chunk, "content", "") or "")
                     if delta:
                         _forward_delta(delta)
@@ -10995,6 +11026,7 @@ async def _call_plane(
             response = await run_blocking(
                 _call_api,
                 timeout=_env_timeout("UNIGROK_API_CALL_TIMEOUT", 180.0),
+                cancel_event=api_cancel_event,
             )
         except Exception as exc:
             record_xai_failure(model_name)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4780,6 +4780,45 @@ class TestTimedThreadCap:
         assert stats["timed_threads_in_flight"] == 0
         assert stats["timed_threads_peak"] >= 1
 
+    @pytest.mark.asyncio
+    async def test_run_blocking_sets_cancel_event_on_timeout(self):
+        """Timed-out awaiters must signal cooperative workers to stop."""
+        from src.utils import run_blocking
+
+        cancel_event = threading.Event()
+        hang = threading.Event()
+        try:
+            with pytest.raises(asyncio.TimeoutError):
+                await run_blocking(
+                    hang.wait, timeout=0.05, cancel_event=cancel_event
+                )
+            assert cancel_event.is_set()
+        finally:
+            hang.set()
+
+    @pytest.mark.asyncio
+    async def test_run_blocking_sets_cancel_event_on_task_cancel(self):
+        from src.utils import run_blocking
+
+        cancel_event = threading.Event()
+        started = threading.Event()
+        hang = threading.Event()
+
+        def _block():
+            started.set()
+            hang.wait(timeout=5.0)
+            return "done"
+
+        task = asyncio.create_task(
+            run_blocking(_block, timeout=5.0, cancel_event=cancel_event)
+        )
+        assert await asyncio.to_thread(started.wait, 1.0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert cancel_event.is_set()
+        hang.set()
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Next#9 — Real memory: stable partition key, tool-trace persistence + replay,


### PR DESCRIPTION
## Summary
- `run_blocking` accepts an optional `cancel_event` set on `TimeoutError` / `CancelledError`.
- API `chat.stream()` polls that event and aborts instead of running to completion after SSE disconnect cancels the asyncio task.
- `sample()` / AgentLoop remain uninterruptible until the SDK exposes a hard abort (documented in code).

## Test plan
- [x] `uv run pytest -q tests/test_utils.py::TestTimedThreadCap::test_run_blocking_sets_cancel_event_on_timeout tests/test_utils.py::TestTimedThreadCap::test_run_blocking_sets_cancel_event_on_task_cancel tests/test_utils.py::TestTimedThreadCap::test_counter_decrements_on_normal_completion`
- [ ] Supervisor: disconnect mid-stream OpenAI SSE turn and confirm stream worker stops promptly

## Risks
Medium-low — cooperative only; non-stream `sample()` path unchanged. Does not reclaim already-billed tokens from chunks already received.

Human sponsor: djtelicloud

Made with [Cursor](https://cursor.com)