### PR TITLE
fix(jobs): do not false-stale live tasks

### DIFF
--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -968,7 +968,7 @@ gateway's X-Caller / MCP clientInfo); None stays None.
 ### Method: `JobManager.describe` {#jobs-jobmanager-describe}
 
 ```python
-def JobManager.describe(cls, row: Dict[str, Any]) -> Dict[str, Any]
+def JobManager.describe(self, row: Dict[str, Any]) -> Dict[str, Any]
 ```
 
 **Keywords:** job, manager, describe

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -968,7 +968,7 @@ gateway's X-Caller / MCP clientInfo); None stays None.
 ### Method: `JobManager.describe` {#jobs-jobmanager-describe}
 
 ```python
-def JobManager.describe(cls, row: Dict[str, Any]) -> Dict[str, Any]
+def JobManager.describe(self, row: Dict[str, Any]) -> Dict[str, Any]
 ```
 
 **Keywords:** job, manager, describe

--- a/src/jobs.py
+++ b/src/jobs.py
@@ -278,12 +278,20 @@ class JobManager:
             except Exception as persist_err:
                 logger.error(f"Distill job {job_id}: could not persist error: {persist_err}")
 
-    @staticmethod
-    def _is_stale(row: Dict[str, Any]) -> bool:
+    def _is_stale(self, row: Dict[str, Any]) -> bool:
         """A queued/running row not touched within the job timeout: the task
         that owned it did not survive (restart/crash), so the row can never
-        finish on its own."""
+        finish on its own.
+
+        Live tasks owned by this process are never stale: long defer calls and
+        semaphore waits do not heartbeat ``updated_at``, so a pure timestamp
+        check would false-stale in-flight work and invite client resubmits.
+        """
         if str(row.get("status")) not in ("queued", "running"):
+            return False
+        job_id = str(row.get("id") or "")
+        task = self._tasks.get(job_id) if job_id else None
+        if task is not None and not task.done():
             return False
         try:
             updated = datetime.fromisoformat(str(row.get("updated_at")))
@@ -291,11 +299,10 @@ class JobManager:
             return True
         return (datetime.now() - updated).total_seconds() > _job_timeout_sec()
 
-    @classmethod
-    def describe(cls, row: Dict[str, Any]) -> Dict[str, Any]:
+    def describe(self, row: Dict[str, Any]) -> Dict[str, Any]:
         """Public view of a job row (what get_research_job returns)."""
         status = str(row.get("status") or "unknown")
-        if cls._is_stale(row):
+        if self._is_stale(row):
             status = "stale"
         view: Dict[str, Any] = {
             "job_id": row.get("id"),

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -410,7 +410,7 @@ class TestDistillJob:
 
         row = await kstore.get_job(view["job_id"])
         assert row["caller"] == "codex-cli"
-        assert JobManager.describe(row)["caller"] == "codex-cli"
+        assert JobManager().describe(row)["caller"] == "codex-cli"
 
     @pytest.mark.asyncio
     async def test_distill_job_caller_falls_back_to_bound_context(self, kstore, monkeypatch):

--- a/tests/test_multiagent.py
+++ b/tests/test_multiagent.py
@@ -296,7 +296,7 @@ class TestJobCaller:
 
         row = await cstore.get_job(view["job_id"])
         assert row["caller"] == "codex-cli"
-        assert JobManager.describe(row)["caller"] == "codex-cli"
+        assert JobManager().describe(row)["caller"] == "codex-cli"
 
     @pytest.mark.asyncio
     async def test_job_caller_falls_back_to_bound_context(self, cstore, monkeypatch):
@@ -323,7 +323,7 @@ class TestJobCaller:
 
         row = await cstore.get_job(view["job_id"])
         assert row["caller"] is None
-        assert "caller" not in JobManager.describe(row)
+        assert "caller" not in JobManager().describe(row)
 
     @pytest.mark.asyncio
     async def test_create_job_itself_falls_back_to_bound_context(self, cstore):

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -211,7 +211,7 @@ class TestJobRequestId:
 
         row = await ostore.get_job(view["job_id"])
         assert row["request_id"] == "rid-job-1"
-        assert JobManager.describe(row)["request_id"] == "rid-job-1"
+        assert JobManager().describe(row)["request_id"] == "rid-job-1"
 
     @pytest.mark.asyncio
     async def test_job_without_request_id_stays_none(self, ostore, monkeypatch):
@@ -223,7 +223,7 @@ class TestJobRequestId:
 
         row = await ostore.get_job(view["job_id"])
         assert row["request_id"] is None
-        assert "request_id" not in JobManager.describe(row)
+        assert "request_id" not in JobManager().describe(row)
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_phase5.py
+++ b/tests/test_phase5.py
@@ -313,20 +313,44 @@ class TestJobManager:
         fresh in-flight rows and terminal rows are untouched."""
         old = (datetime.now() - timedelta(seconds=_job_timeout_sec() + 60)).isoformat()
         fresh = datetime.now().isoformat()
+        manager = JobManager()
 
         stale_row = {"id": "j1", "status": "running", "updated_at": old, "model": "m", "created_at": old}
-        assert JobManager.describe(stale_row)["status"] == "stale"
+        assert manager.describe(stale_row)["status"] == "stale"
 
         fresh_row = {"id": "j2", "status": "running", "updated_at": fresh, "model": "m", "created_at": fresh}
-        assert JobManager.describe(fresh_row)["status"] == "running"
+        assert manager.describe(fresh_row)["status"] == "running"
 
         done_row = {
             "id": "j3", "status": "done", "updated_at": old, "model": "m",
             "created_at": old, "result": "r", "cost": 0.1,
         }
-        described = JobManager.describe(done_row)
+        described = manager.describe(done_row)
         assert described["status"] == "done"
         assert described["result"] == "r"
+
+    def test_live_task_not_false_stale_without_heartbeat(self):
+        """Long defer / queue wait must not look stale while this process owns it."""
+        from unittest.mock import MagicMock
+
+        old = (datetime.now() - timedelta(seconds=_job_timeout_sec() + 60)).isoformat()
+        manager = JobManager()
+        live = MagicMock()
+        live.done.return_value = False
+        manager._tasks["live-job"] = live
+        try:
+            row = {
+                "id": "live-job",
+                "status": "running",
+                "updated_at": old,
+                "model": "m",
+                "created_at": old,
+            }
+            assert manager.describe(row)["status"] == "running"
+            live.done.return_value = True
+            assert manager.describe(row)["status"] == "stale"
+        finally:
+            manager._tasks.pop("live-job", None)
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Job status views no longer mark `queued`/`running` rows as `stale` while this process still owns an unfinished asyncio task for that job.
- Restart/crash rows (no live task) still become stale via the existing `updated_at` timeout.
- Regression coverage for long-running jobs without heartbeats.

## Test plan
- [x] `uv run pytest -q tests/test_phase5.py::TestJobManager`
- [ ] Supervisor: submit research job, wait past prior false-stale window while still running, confirm status stays `running`

## Risks
Low — view-layer honesty only; does not change job execution.

Human sponsor: djtelicloud

Made with [Cursor](https://cursor.com)