### PR TITLE
fix(security): deny bound provider file reads

### DIFF
--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -567,6 +567,10 @@ async def xai_get_file(file_id: str) -> str:
 
 async def xai_get_file_content(file_id: str, max_bytes: int = 500000) -> str:
     """Download the raw content of an uploaded file from xAI."""
+    if get_active_principal() is not None:
+        raise PermissionError(
+            "Provider file content is unavailable to bound HTTP/MCP principals."
+        )
     async with GrokInvocationContext("utility", logger, append_signature=False) as ctx:
         def _get_bytes():
             client = get_xai_client()

--- a/src/utils.py
+++ b/src/utils.py
@@ -13342,18 +13342,23 @@ def _build_custom_tools(include_escalation: bool = False) -> list:
             ))
 
         # 3. get_file_content
-        custom_tools.append(sdk_tool(
-            name="get_file_content",
-            description="Download the raw text content of an uploaded file from xAI using its file ID.",
-            parameters={
-                "type": "object",
-                "properties": {
-                    "file_id": {"type": "string", "description": "The ID of the file to download."},
-                    "max_bytes": {"type": "integer", "description": "Max bytes to download (default 4000)."}
-                },
-                "required": ["file_id"]
-            }
-        ))
+        # Provider file IDs live in a shared server-side xAI account. Until
+        # durable file ownership is tracked, a bound HTTP/MCP principal must
+        # never be offered a tool that can dereference another caller's ID.
+        # Trusted unbound stdio/operator use retains the historical surface.
+        if get_active_principal() is None:
+            custom_tools.append(sdk_tool(
+                name="get_file_content",
+                description="Download the raw text content of an uploaded file from xAI using its file ID.",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "file_id": {"type": "string", "description": "The ID of the file to download."},
+                        "max_bytes": {"type": "integer", "description": "Max bytes to download (default 4000)."}
+                    },
+                    "required": ["file_id"]
+                }
+            ))
 
         # 4. read_local_file
         if allow_local_tools:

--- a/tests/test_intelligence_upgrade.py
+++ b/tests/test_intelligence_upgrade.py
@@ -311,6 +311,26 @@ def test_cloudrun_tool_advertising_omits_local_tools(monkeypatch):
     assert "git_apply_patch" not in names
 
 
+def test_bound_principal_tool_advertising_omits_shared_provider_file_read(monkeypatch):
+    from src.identity import reset_active_principal, set_active_principal
+
+    monkeypatch.setenv("UNIGROK_RUNTIME", "cloudrun")
+    principal_token = set_active_principal("oauth:service:tenant-a")
+    try:
+        names = _tool_names()
+    finally:
+        reset_active_principal(principal_token)
+
+    assert "get_file_content" not in names
+    assert "generate_image" in names
+
+
+def test_unbound_operator_tool_advertising_keeps_provider_file_read(monkeypatch):
+    monkeypatch.setenv("UNIGROK_RUNTIME", "cloudrun")
+
+    assert "get_file_content" in _tool_names()
+
+
 def test_local_tool_advertising_gates_mutating_git(monkeypatch):
     monkeypatch.setenv("UNIGROK_RUNTIME", "local")
     monkeypatch.delenv("ENABLE_GIT_WRITE", raising=False)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1037,6 +1037,22 @@ async def test_agent_tool_ctx_hidden_from_schema():
 
 
 @pytest.mark.asyncio
+async def test_bound_principal_cannot_read_shared_provider_file_content():
+    from src.identity import reset_active_principal, set_active_principal
+    from src.tools.system import xai_get_file_content
+
+    principal_token = set_active_principal("oauth:service:tenant-a")
+    try:
+        with patch("src.tools.system.get_xai_client") as get_client:
+            with pytest.raises(PermissionError, match="bound HTTP/MCP principals"):
+                await xai_get_file_content("file-owned-by-tenant-b")
+    finally:
+        reset_active_principal(principal_token)
+
+    get_client.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_grok_mcp_restart_container_gating(monkeypatch, tmp_path):
     from src.tools.system import grok_mcp_restart_container
     from src.identity import reset_active_principal, set_active_principal


### PR DESCRIPTION
## Summary
- Omit `get_file_content` from AgentLoop custom tools whenever an HTTP/MCP principal is bound.
- Deny direct internal execution for any bound principal before contacting xAI.
- Preserve trusted unbound stdio/operator behavior.

## Security invariant
Provider file IDs live in the shared server-side xAI account. Until durable file ownership exists, public callers cannot dereference any provider file ID, including unknown or cross-tenant IDs.

## Validation
- Focused bound/unbound advertising and direct-denial tests: 4 passed.
- `git diff --check`.

## Exact-head handoff
- Head: `3d128aae5e87153c81786aeb02e901f3b968863b`
- Paths: `src/utils.py`, `src/tools/system.py`, `tests/test_intelligence_upgrade.py`, `tests/test_server.py`
- Human sponsor: `djtelicloud`
- Provenance: OpenAI Codex implementation; xAI Grok 4.5 advisory security review.

risk: high

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security fix on multi-tenant file access: failure would leak arbitrary provider file content via guessed IDs until durable ownership exists.
> 
> **Overview**
> **Blocks cross-tenant reads of shared xAI file IDs** for HTTP/MCP callers. Provider uploads sit in one server-side account, so any bound principal could otherwise dereference another tenant’s `file_id`.
> 
> When `get_active_principal()` is set, **`get_file_content` is no longer advertised** in AgentLoop custom tools (`_build_custom_tools`), and **`xai_get_file_content` raises `PermissionError`** before calling xAI. **Unbound stdio/operator sessions** keep the prior behavior.
> 
> Tests cover tool advertising with/without a principal and assert the xAI client is not contacted on denied reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d128aae5e87153c81786aeb02e901f3b968863b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

