### PR TITLE
fix(http): block budgeted raw model proxy

### DIFF
--- a/src/http_server.py
+++ b/src/http_server.py
@@ -1908,13 +1908,10 @@ def _raw_proxy_policy_violation(
     if isinstance(n, bool) or not isinstance(n, int) or n != 1:
         return ("Raw model proxy requires n=1.", "invalid_request", 400)
 
-    max_tokens = payload.get(
-        "max_tokens",
-        _bounded_env_int("UNIGROK_RAW_PROXY_MAX_TOKENS", 32_768, 1, 131_072),
-    )
     max_allowed = _bounded_env_int(
         "UNIGROK_RAW_PROXY_MAX_TOKENS", 32_768, 1, 131_072
     )
+    max_tokens = payload.get("max_tokens", max_allowed)
     if (
         isinstance(max_tokens, bool)
         or not isinstance(max_tokens, int)

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -1881,10 +1881,73 @@ def _xai_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
         "tools",
         "tool_choice",
     }
-    return {key: value for key, value in payload.items() if key in allowed}
+    upstream = {key: value for key, value in payload.items() if key in allowed}
+    # Raw proxy calls are deliberately single-completion and carry a bounded
+    # output ceiling even when the client omits both fields. This limits one
+    # unbudgeted request independently of the caller-budget policy below.
+    upstream.setdefault("n", 1)
+    upstream.setdefault(
+        "max_tokens",
+        _bounded_env_int("UNIGROK_RAW_PROXY_MAX_TOKENS", 32_768, 1, 131_072),
+    )
+    return upstream
+
+
+def _raw_proxy_policy_violation(
+    payload: Dict[str, Any],
+) -> Optional[tuple[str, str, int]]:
+    """Fail closed while raw proxy spend cannot be reserved and settled."""
+    if os.environ.get("UNIGROK_CALLER_BUDGETS", "").strip():
+        return (
+            "Raw model proxy is unavailable while caller budgets are configured.",
+            "budget_enforcement_required",
+            403,
+        )
+
+    n = payload.get("n", 1)
+    if isinstance(n, bool) or not isinstance(n, int) or n != 1:
+        return ("Raw model proxy requires n=1.", "invalid_request", 400)
+
+    max_tokens = payload.get(
+        "max_tokens",
+        _bounded_env_int("UNIGROK_RAW_PROXY_MAX_TOKENS", 32_768, 1, 131_072),
+    )
+    max_allowed = _bounded_env_int(
+        "UNIGROK_RAW_PROXY_MAX_TOKENS", 32_768, 1, 131_072
+    )
+    if (
+        isinstance(max_tokens, bool)
+        or not isinstance(max_tokens, int)
+        or not 1 <= max_tokens <= max_allowed
+    ):
+        return (
+            f"Raw model proxy max_tokens must be 1..{max_allowed}.",
+            "invalid_request",
+            400,
+        )
+
+    tools = payload.get("tools", [])
+    if not isinstance(tools, list) or len(tools) > 32:
+        return (
+            "Raw model proxy accepts at most 32 tool definitions.",
+            "invalid_request",
+            400,
+        )
+    return None
+
+
+def _raw_proxy_policy_error(payload: Dict[str, Any]) -> Optional[Response]:
+    violation = _raw_proxy_policy_violation(payload)
+    if violation is None:
+        return None
+    message, code, status_code = violation
+    return _json_error(message, status_code=status_code, code=code)
 
 
 async def post_xai_chat(payload: Dict[str, Any]) -> Response:
+    policy_error = _raw_proxy_policy_error(payload)
+    if policy_error is not None:
+        return policy_error
     if not os.environ.get("XAI_API_KEY"):
         return _json_error("XAI_API_KEY is not configured.", status_code=503, code="service_unavailable")
     url = _xai_chat_completions_url()
@@ -1923,6 +1986,12 @@ async def post_xai_chat(payload: Dict[str, Any]) -> Response:
 
 
 async def stream_xai_chat(payload: Dict[str, Any]) -> AsyncIterator[bytes]:
+    violation = _raw_proxy_policy_violation(payload)
+    if violation is not None:
+        message, code, status_code = violation
+        yield _sse_error(message, code, status_code)
+        yield b"data: [DONE]\n\n"
+        return
     if not os.environ.get("XAI_API_KEY"):
         yield _sse_error("XAI_API_KEY is not configured.", "service_unavailable")
         yield b"data: [DONE]\n\n"
@@ -1998,6 +2067,10 @@ async def chat_completions(request: Request) -> Response:
                 status_code=500,
                 code="server_error",
             )
+
+    policy_error = _raw_proxy_policy_error(payload)
+    if policy_error is not None:
+        return policy_error
 
     known_models = set(await get_xai_model_ids())
     if model not in known_models:

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -1033,6 +1033,82 @@ def test_direct_xai_model_proxies(monkeypatch):
     mock_post.assert_awaited_once()
 
 
+def test_budgeted_raw_model_proxy_fails_closed_before_provider_lookup(monkeypatch):
+    monkeypatch.delenv("UNIGROK_RUNTIME", raising=False)
+    monkeypatch.delenv("UNIGROK_API_KEYS", raising=False)
+    monkeypatch.setenv("UNIGROK_CALLER_BUDGETS", '{"http:anon": 1.0}')
+    model_lookup = AsyncMock(
+        side_effect=AssertionError("blocked raw proxy must not query provider models")
+    )
+    monkeypatch.setattr("src.http_server.get_xai_model_ids", model_lookup)
+
+    with TestClient(create_app()) as client:
+        nonstream = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "grok-4.3",
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+        stream = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "grok-4.3",
+                "stream": True,
+                "messages": [{"role": "user", "content": "hello"}],
+            },
+        )
+
+    assert nonstream.status_code == 403
+    assert stream.status_code == 403
+    assert nonstream.json()["error"]["code"] == "budget_enforcement_required"
+    assert stream.json()["error"]["code"] == "budget_enforcement_required"
+    model_lookup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_raw_proxy_defense_blocks_direct_stream_and_nonstream(monkeypatch):
+    from src.http_server import post_xai_chat
+
+    monkeypatch.setenv("UNIGROK_CALLER_BUDGETS", '{"http:anon": 1.0}')
+    monkeypatch.setenv("XAI_API_KEY", "server-key")
+
+    nonstream = await post_xai_chat({"model": "grok-4.3", "messages": []})
+    chunks = [
+        chunk
+        async for chunk in stream_xai_chat(
+            {"model": "grok-4.3", "stream": True, "messages": []}
+        )
+    ]
+
+    assert nonstream.status_code == 403
+    body = b"".join(chunks).decode("utf-8")
+    assert "budget_enforcement_required" in body
+    assert body.endswith("data: [DONE]\n\n")
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"model": "grok-4.3", "messages": [], "n": 2},
+        {"model": "grok-4.3", "messages": [], "max_tokens": 32_769},
+        {"model": "grok-4.3", "messages": [], "tools": [{}] * 33},
+    ],
+)
+@pytest.mark.asyncio
+async def test_raw_proxy_request_effects_are_bounded(monkeypatch, payload):
+    from src.http_server import post_xai_chat
+
+    monkeypatch.delenv("UNIGROK_CALLER_BUDGETS", raising=False)
+    monkeypatch.setenv("UNIGROK_RAW_PROXY_MAX_TOKENS", "32768")
+    monkeypatch.setenv("XAI_API_KEY", "server-key")
+
+    response = await post_xai_chat(payload)
+
+    assert response.status_code == 400
+    assert json.loads(response.body)["error"]["code"] == "invalid_request"
+
+
 @pytest.mark.asyncio
 async def test_direct_xai_streaming_success_passes_through(monkeypatch):
     monkeypatch.setenv("XAI_API_KEY", "server-key")


### PR DESCRIPTION
## Summary
- Fail closed for every raw-model /v1 proxy request whenever caller budgets are configured.
- Apply the same denial to streaming, non-streaming, and direct helper paths before provider model lookup or network dispatch.
- Independently force n=1, cap max_tokens, and limit tool definitions for unbudgeted raw proxy requests.

## Security invariant
UNIGROK_CALLER_BUDGETS cannot be bypassed through a raw provider model. Raw proxying remains disabled until it has authenticated-principal reservation and durable settlement for both streaming and non-streaming calls.

## Validation
- Focused raw proxy route, streaming, and request-bound tests: 8 passed.
- Deterministic OKF bundle check passed.
- git diff check passed.

## Exact-head handoff
- Head: `5f40670f15012e192c201a716344b719c3c98f77`
- Paths: `src/http_server.py`, `tests/test_http_server.py`
- Human sponsor: `djtelicloud`
- Provenance: OpenAI Codex implementation; xAI Grok 4.5 advisory security review.

risk: high

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes gateway spend and budget enforcement on a credential-bearing upstream proxy path; misconfiguration could block legitimate raw API use or leave residual bypass risk if any path is missed.
> 
> **Overview**
> Closes a **budget bypass** on direct provider proxy routes: if **`UNIGROK_CALLER_BUDGETS`** is configured, every raw-model `/v1/chat/completions` call returns **403** `budget_enforcement_required` before model lookup or upstream I/O, for **non-streaming**, **streaming**, and the **`post_xai_chat` / `stream_xai_chat`** helpers.
> 
> When budgets are **not** configured, unbudgeted proxy spend is still capped: **`_xai_payload`** defaults **`n=1`** and **`max_tokens`** from **`UNIGROK_RAW_PROXY_MAX_TOKENS`** (bounded 1–131072), and **`_raw_proxy_policy_violation`** rejects **`n≠1`**, out-of-range **`max_tokens`**, or more than **32** tool definitions.
> 
> Tests cover budgeted fail-closed (including no provider model lookup), stream SSE errors, and invalid bounded payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f40670f15012e192c201a716344b719c3c98f77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

