### PR TITLE
fix(security): fence provider files for bound principals

### DIFF
--- a/src/tools/chats.py
+++ b/src/tools/chats.py
@@ -8,7 +8,7 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field
 from ..models.results import ChatResult, AgentResult, ReflectionResult
-from ..identity import caller_from_mcp_context, scoped_session
+from ..identity import caller_from_mcp_context, get_active_principal, scoped_session
 
 from ..utils import (
     store,
@@ -692,6 +692,19 @@ async def chat_with_files(
         model: Grok model id (default `grok-4.5`).
         system_prompt: Optional system instruction prepended to the conversation.
     """
+    if get_active_principal() is not None:
+        error_msg = (
+            "Provider files are unavailable to bound HTTP/MCP principals."
+        )
+        return ChatResult(
+            response=error_msg,
+            text=error_msg,
+            finish_reason="error",
+            cost_usd=0.0,
+            model=model,
+            route="unknown",
+            plane="API",
+        )
     if not file_ids:
         error_msg = "Input Validation Error: file_ids must contain at least one uploaded file ID."
         return ChatResult(

--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -500,6 +500,10 @@ async def xai_upload_file(file_path: str) -> Dict[str, Any]:
         A dict with `file_id` (pass it to `chat_with_files`/`xai_get_file_content`),
         `filename`, `size_bytes`, and a human-readable `summary`.
     """
+    if get_active_principal() is not None:
+        raise PermissionError(
+            "Provider files are unavailable to bound HTTP/MCP principals."
+        )
     async with GrokInvocationContext("utility", logger, append_signature=False) as ctx:
         resolved_path = _resolve_workspace_file(file_path, enforce_ignore_policy=True)
         validate_local_input(
@@ -529,6 +533,10 @@ async def xai_upload_file(file_path: str) -> Dict[str, Any]:
 
 async def xai_list_files() -> str:
     """List all files uploaded to xAI from this account."""
+    if get_active_principal() is not None:
+        raise PermissionError(
+            "Provider files are unavailable to bound HTTP/MCP principals."
+        )
     async with GrokInvocationContext("utility", logger, append_signature=False) as ctx:
         def _list():
             client = get_xai_client()
@@ -548,6 +556,10 @@ async def xai_list_files() -> str:
 
 async def xai_get_file(file_id: str) -> str:
     """Retrieve metadata of a file uploaded to xAI."""
+    if get_active_principal() is not None:
+        raise PermissionError(
+            "Provider files are unavailable to bound HTTP/MCP principals."
+        )
     async with GrokInvocationContext("utility", logger, append_signature=False) as ctx:
         def _get():
             client = get_xai_client()
@@ -569,7 +581,7 @@ async def xai_get_file_content(file_id: str, max_bytes: int = 500000) -> str:
     """Download the raw content of an uploaded file from xAI."""
     if get_active_principal() is not None:
         raise PermissionError(
-            "Provider file content is unavailable to bound HTTP/MCP principals."
+            "Provider files are unavailable to bound HTTP/MCP principals."
         )
     async with GrokInvocationContext("utility", logger, append_signature=False) as ctx:
         def _get_bytes():
@@ -592,6 +604,10 @@ async def xai_get_file_content(file_id: str, max_bytes: int = 500000) -> str:
 
 async def xai_delete_file(file_id: str) -> str:
     """Delete an uploaded file from xAI."""
+    if get_active_principal() is not None:
+        raise PermissionError(
+            "Provider files are unavailable to bound HTTP/MCP principals."
+        )
     async with GrokInvocationContext("utility", logger, append_signature=False) as ctx:
         def _delete():
             client = get_xai_client()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1053,6 +1053,27 @@ async def test_bound_principal_cannot_read_shared_provider_file_content():
 
 
 @pytest.mark.asyncio
+async def test_bound_principal_cannot_list_get_or_delete_provider_files():
+    from src.identity import reset_active_principal, set_active_principal
+    from src.tools.system import xai_delete_file, xai_get_file, xai_list_files
+
+    principal_token = set_active_principal("oauth:service:tenant-a")
+    try:
+        with patch("src.tools.system.get_xai_client") as get_client:
+            for coro in (
+                xai_list_files(),
+                xai_get_file("file-owned-by-tenant-b"),
+                xai_delete_file("file-owned-by-tenant-b"),
+            ):
+                with pytest.raises(PermissionError, match="bound HTTP/MCP principals"):
+                    await coro
+    finally:
+        reset_active_principal(principal_token)
+
+    get_client.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_grok_mcp_restart_container_gating(monkeypatch, tmp_path):
     from src.tools.system import grok_mcp_restart_container
     from src.identity import reset_active_principal, set_active_principal


### PR DESCRIPTION
## Summary
- Extends #273: bound HTTP/MCP principals cannot list/get/delete/upload provider files or use `chat_with_files`.
- Completes the shared-account file fence beyond content reads.

## Test plan
- [x] `uv run pytest -q tests/test_server.py::test_bound_principal_cannot_read_shared_provider_file_content tests/test_server.py::test_bound_principal_cannot_list_get_or_delete_provider_files`
- [ ] CI green on the draft PR head

## Notes
- Complements landed #273; separate from Ready (#252)–(#272).
- @grok pre-fix and pre-PR gates: APPROVE / YES-DRAFT-PR (API, same_plane)

Made with [Cursor](https://cursor.com)