### PR TITLE
fix(knowledge): bind caller on facts; scope forget_fact

### DIFF
--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -3108,7 +3108,7 @@ Commit explicit paths only. Requires local git write mode.
 ### Function: `remember_fact` {#tools-knowledge-remember_fact}
 
 ```python
-async def remember_fact(fact: str, scope: str='global') -> Dict[str, Any]
+async def remember_fact(fact: str, scope: str='global', ctx: Optional[Context]=None) -> Dict[str, Any]
 ```
 
 **Keywords:** remember, fact
@@ -3146,12 +3146,15 @@ Args:
 ### Function: `forget_fact` {#tools-knowledge-forget_fact}
 
 ```python
-async def forget_fact(fact_id: int) -> Dict[str, Any]
+async def forget_fact(fact_id: int, ctx: Optional[Context]=None) -> Dict[str, Any]
 ```
 
 **Keywords:** forget, fact
 
 Permanently delete one fact from the workspace knowledge memory.
+
+When the request has a bound caller identity, only that caller's facts
+may be deleted (foreign or legacy-unowned ids look like `not_found`).
 
 Args:
     fact_id: The id returned by `remember_fact` or `search_knowledge`.
@@ -4531,7 +4534,7 @@ Release a failed lease into bounded backoff without discarding it.
 ### Method: `GrokSessionStore.save_fact` {#utils-groksessionstore-save_fact}
 
 ```python
-async def GrokSessionStore.save_fact(self, fact: str, scope: str='global', source: str='') -> Optional[int]
+async def GrokSessionStore.save_fact(self, fact: str, scope: str='global', source: str='', caller: Optional[str]=None) -> Optional[int]
 ```
 
 **Keywords:** grok, session, store, save, fact
@@ -4542,6 +4545,9 @@ Deduped on exact (scope, fact) text: re-saving an existing fact
 touches it (uses+1, last_used_at bump) instead of inserting a
 duplicate, so re-distilling a session never multiplies rows. Returns
 the row id (existing or new); None for empty facts.
+
+``caller`` (or the active caller) is recorded on insert so
+forget_fact can scope deletes when a requester identity is bound.
 
 ### Method: `GrokSessionStore.search_facts` {#utils-groksessionstore-search_facts}
 
@@ -4575,12 +4581,15 @@ actually injected into a prompt).
 ### Method: `GrokSessionStore.delete_fact` {#utils-groksessionstore-delete_fact}
 
 ```python
-async def GrokSessionStore.delete_fact(self, fact_id: int) -> bool
+async def GrokSessionStore.delete_fact(self, fact_id: int, caller: Optional[str]=None) -> bool
 ```
 
 **Keywords:** grok, session, store, delete, fact
 
 Remove one fact (and its index row); True when a row was deleted.
+
+When ``caller`` is bound, only that caller's rows delete. Legacy rows
+with a NULL caller look like ``not_found`` to bound requesters.
 
 ### Method: `GrokSessionStore.list_facts` {#utils-groksessionstore-list_facts}
 

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -3108,7 +3108,7 @@ Commit explicit paths only. Requires local git write mode.
 ### Function: `remember_fact` {#tools-knowledge-remember_fact}
 
 ```python
-async def remember_fact(fact: str, scope: str='global') -> Dict[str, Any]
+async def remember_fact(fact: str, scope: str='global', ctx: Optional[Context]=None) -> Dict[str, Any]
 ```
 
 **Keywords:** remember, fact
@@ -3146,12 +3146,15 @@ Args:
 ### Function: `forget_fact` {#tools-knowledge-forget_fact}
 
 ```python
-async def forget_fact(fact_id: int) -> Dict[str, Any]
+async def forget_fact(fact_id: int, ctx: Optional[Context]=None) -> Dict[str, Any]
 ```
 
 **Keywords:** forget, fact
 
 Permanently delete one fact from the workspace knowledge memory.
+
+When the request has a bound caller identity, only that caller's facts
+may be deleted (foreign or legacy-unowned ids look like `not_found`).
 
 Args:
     fact_id: The id returned by `remember_fact` or `search_knowledge`.
@@ -4531,7 +4534,7 @@ Release a failed lease into bounded backoff without discarding it.
 ### Method: `GrokSessionStore.save_fact` {#utils-groksessionstore-save_fact}
 
 ```python
-async def GrokSessionStore.save_fact(self, fact: str, scope: str='global', source: str='') -> Optional[int]
+async def GrokSessionStore.save_fact(self, fact: str, scope: str='global', source: str='', caller: Optional[str]=None) -> Optional[int]
 ```
 
 **Keywords:** grok, session, store, save, fact
@@ -4542,6 +4545,9 @@ Deduped on exact (scope, fact) text: re-saving an existing fact
 touches it (uses+1, last_used_at bump) instead of inserting a
 duplicate, so re-distilling a session never multiplies rows. Returns
 the row id (existing or new); None for empty facts.
+
+``caller`` (or the active caller) is recorded on insert so
+forget_fact can scope deletes when a requester identity is bound.
 
 ### Method: `GrokSessionStore.search_facts` {#utils-groksessionstore-search_facts}
 
@@ -4575,12 +4581,15 @@ actually injected into a prompt).
 ### Method: `GrokSessionStore.delete_fact` {#utils-groksessionstore-delete_fact}
 
 ```python
-async def GrokSessionStore.delete_fact(self, fact_id: int) -> bool
+async def GrokSessionStore.delete_fact(self, fact_id: int, caller: Optional[str]=None) -> bool
 ```
 
 **Keywords:** grok, session, store, delete, fact
 
 Remove one fact (and its index row); True when a row was deleted.
+
+When ``caller`` is bound, only that caller's rows delete. Legacy rows
+with a NULL caller look like ``not_found`` to bound requesters.
 
 ### Method: `GrokSessionStore.list_facts` {#utils-groksessionstore-list_facts}
 

--- a/src/storage.py
+++ b/src/storage.py
@@ -205,13 +205,19 @@ class SessionStoreProtocol(Protocol):
 
     # ── Knowledge facts ──────────────────────────────────────────────────────
     async def save_fact(
-        self, fact: str, scope: str = "global", source: str = ""
+        self,
+        fact: str,
+        scope: str = "global",
+        source: str = "",
+        caller: Optional[str] = None,
     ) -> Optional[int]: ...
     async def search_facts(
         self, query: str, scope: Optional[str] = None, limit: int = 5
     ) -> List[Dict[str, Any]]: ...
     async def touch_facts(self, fact_ids: List[int]) -> None: ...
-    async def delete_fact(self, fact_id: int) -> bool: ...
+    async def delete_fact(
+        self, fact_id: int, caller: Optional[str] = None
+    ) -> bool: ...
     async def count_facts(self) -> int: ...
     async def list_facts(
         self, limit: int = 20, scope: Optional[str] = None

--- a/src/tools/knowledge.py
+++ b/src/tools/knowledge.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, Optional
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
 
-from ..identity import caller_from_mcp_context
+from ..identity import caller_from_mcp_context, get_active_caller, normalize_caller
 from ..jobs import get_job_manager
 from ..utils import (
     _normalize_fact_scope,
@@ -20,6 +20,12 @@ from ..utils import (
     store,
     sync_fact_to_collection,
 )
+
+
+def _fact_requester(ctx: Optional[Context] = None) -> Optional[str]:
+    """Match remember/forget attribution: MCP clientInfo, else bound caller."""
+    explicit = caller_from_mcp_context(ctx) if ctx is not None else None
+    return normalize_caller(explicit) or get_active_caller()
 
 logger = logging.getLogger("GrokMCP")
 
@@ -43,7 +49,9 @@ def _fact_view(row: Dict[str, Any]) -> Dict[str, Any]:
     return view
 
 
-async def remember_fact(fact: str, scope: str = "global") -> Dict[str, Any]:
+async def remember_fact(
+    fact: str, scope: str = "global", ctx: Optional[Context] = None
+) -> Dict[str, Any]:
     """Save one durable fact to the local workspace knowledge memory.
 
     Facts are distilled knowledge — decisions, constraints, preferences,
@@ -63,7 +71,9 @@ async def remember_fact(fact: str, scope: str = "global") -> Dict[str, Any]:
     # _normalize_fact_scope) so the stored row, the cloud mirror, and the
     # echoed result all agree on the same value.
     scope_value = _normalize_fact_scope(scope)
-    fact_id = await store.save_fact(text, scope=scope_value, source="manual")
+    fact_id = await store.save_fact(
+        text, scope=scope_value, source="manual", caller=_fact_requester(ctx)
+    )
     if fact_id is None:
         return {"error": "Input Validation Error: fact must not be empty."}
     # Best-effort cloud mirror — a no-op unless UNIGROK_COLLECTIONS=1 and
@@ -100,8 +110,13 @@ async def search_knowledge(query: str, limit: int = 5) -> Dict[str, Any]:
     return {"facts": results, "count": len(results)}
 
 
-async def forget_fact(fact_id: int) -> Dict[str, Any]:
+async def forget_fact(
+    fact_id: int, ctx: Optional[Context] = None
+) -> Dict[str, Any]:
     """Permanently delete one fact from the workspace knowledge memory.
+
+    When the request has a bound caller identity, only that caller's facts
+    may be deleted (foreign or legacy-unowned ids look like `not_found`).
 
     Args:
         fact_id: The id returned by `remember_fact` or `search_knowledge`.
@@ -110,7 +125,7 @@ async def forget_fact(fact_id: int) -> Dict[str, Any]:
         target = int(fact_id)
     except (TypeError, ValueError):
         return {"error": "Input Validation Error: fact_id must be an integer."}
-    deleted = await store.delete_fact(target)
+    deleted = await store.delete_fact(target, caller=_fact_requester(ctx))
     return {"fact_id": target, "status": "deleted" if deleted else "not_found"}
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -3533,19 +3533,27 @@ class GrokSessionStore:
             if version < 18:
                 # Knowledge rows record the saving caller so forget_fact can
                 # refuse foreign deletes when a requester identity is bound.
+                # Tolerate legacy fixtures that stamped v7+ without the table.
                 await self._conn.execute("BEGIN IMMEDIATE;")
                 try:
-                    try:
+                    async with self._conn.execute(
+                        "SELECT 1 FROM sqlite_master "
+                        "WHERE type = 'table' AND name = 'knowledge'"
+                    ) as cursor:
+                        has_knowledge = await cursor.fetchone() is not None
+                    if has_knowledge:
+                        try:
+                            await self._conn.execute(
+                                "ALTER TABLE knowledge ADD COLUMN caller "
+                                "TEXT DEFAULT NULL;"
+                            )
+                        except aiosqlite.OperationalError as ddl_err:
+                            if "duplicate column" not in str(ddl_err).lower():
+                                raise
                         await self._conn.execute(
-                            "ALTER TABLE knowledge ADD COLUMN caller TEXT DEFAULT NULL;"
+                            "CREATE INDEX IF NOT EXISTS idx_knowledge_caller_id "
+                            "ON knowledge(caller, id DESC);"
                         )
-                    except aiosqlite.OperationalError as ddl_err:
-                        if "duplicate column" not in str(ddl_err).lower():
-                            raise
-                    await self._conn.execute(
-                        "CREATE INDEX IF NOT EXISTS idx_knowledge_caller_id "
-                        "ON knowledge(caller, id DESC);"
-                    )
                     await self._conn.execute("PRAGMA user_version = 18;")
                     await self._conn.commit()
                 except Exception:

--- a/src/utils.py
+++ b/src/utils.py
@@ -1309,7 +1309,7 @@ def _bounded_redacted(text: str, limit: int) -> str:
 
 
 _PROVIDER_CONTENT_WITHHELD = "[CONTENT_WITHHELD_BY_SECRET_GUARD]"
-_SESSION_STORE_SCHEMA_HEAD = 17
+_SESSION_STORE_SCHEMA_HEAD = 18
 _PROVIDER_HARVEST_MAX_LEASE_SECONDS = 300.0
 _PROVIDER_HARVEST_MAX_BACKOFF_SECONDS = 86_400.0
 _PROVIDER_HARVEST_CORRUPT_SCAN_OVERHEAD = 25
@@ -3525,6 +3525,28 @@ class GrokSessionStore:
                             "refusing to stamp v17"
                         )
                     await self._conn.execute("PRAGMA user_version = 17;")
+                    await self._conn.commit()
+                except Exception:
+                    await self._conn.rollback()
+                    raise
+
+            if version < 18:
+                # Knowledge rows record the saving caller so forget_fact can
+                # refuse foreign deletes when a requester identity is bound.
+                await self._conn.execute("BEGIN IMMEDIATE;")
+                try:
+                    try:
+                        await self._conn.execute(
+                            "ALTER TABLE knowledge ADD COLUMN caller TEXT DEFAULT NULL;"
+                        )
+                    except aiosqlite.OperationalError as ddl_err:
+                        if "duplicate column" not in str(ddl_err).lower():
+                            raise
+                    await self._conn.execute(
+                        "CREATE INDEX IF NOT EXISTS idx_knowledge_caller_id "
+                        "ON knowledge(caller, id DESC);"
+                    )
+                    await self._conn.execute("PRAGMA user_version = 18;")
                     await self._conn.commit()
                 except Exception:
                     await self._conn.rollback()
@@ -6230,6 +6252,7 @@ class GrokSessionStore:
         fact: str,
         scope: str = "global",
         source: str = "",
+        caller: Optional[str] = None,
     ) -> Optional[int]:
         """Persist one distilled fact, redacted and bounded at rest.
 
@@ -6237,6 +6260,9 @@ class GrokSessionStore:
         touches it (uses+1, last_used_at bump) instead of inserting a
         duplicate, so re-distilling a session never multiplies rows. Returns
         the row id (existing or new); None for empty facts.
+
+        ``caller`` (or the active caller) is recorded on insert so
+        forget_fact can scope deletes when a requester identity is bound.
         """
         await self._ensure_initialized()
         text = _bounded_redacted(str(fact or ""), 1000)
@@ -6246,6 +6272,7 @@ class GrokSessionStore:
         # rest like fact/source (see _normalize_fact_scope).
         scope_value = _normalize_fact_scope(scope)
         source_value = _bounded_redacted(str(source or ""), 200)
+        owner = normalize_caller(caller) or get_active_caller()
         terms = " ".join(_task_terms(text))
         now_str = datetime.now().isoformat()
         async with self._lock:
@@ -6264,9 +6291,9 @@ class GrokSessionStore:
                     )
                 else:
                     cursor = await self._conn.execute(
-                        "INSERT INTO knowledge (scope, fact, source, terms, created_at, last_used_at, uses) "
-                        "VALUES (?, ?, ?, ?, ?, ?, 0)",
-                        (scope_value, text, source_value, terms, now_str, now_str),
+                        "INSERT INTO knowledge (scope, fact, source, terms, created_at, last_used_at, uses, caller) "
+                        "VALUES (?, ?, ?, ?, ?, ?, 0, ?)",
+                        (scope_value, text, source_value, terms, now_str, now_str, owner),
                     )
                     fact_id = int(cursor.lastrowid)
                     if self._knowledge_fts:
@@ -6413,12 +6440,31 @@ class GrokSessionStore:
             await self._on_write_completed()
 
     @_with_write_retry_async
-    async def delete_fact(self, fact_id: int) -> bool:
-        """Remove one fact (and its index row); True when a row was deleted."""
+    async def delete_fact(
+        self, fact_id: int, caller: Optional[str] = None
+    ) -> bool:
+        """Remove one fact (and its index row); True when a row was deleted.
+
+        When ``caller`` is bound, only that caller's rows delete. Legacy rows
+        with a NULL caller look like ``not_found`` to bound requesters.
+        """
         await self._ensure_initialized()
+        requester = normalize_caller(caller)
         async with self._lock:
             await self._conn.execute("BEGIN IMMEDIATE;")
             try:
+                if requester:
+                    async with self._conn.execute(
+                        "SELECT caller FROM knowledge WHERE id = ?",
+                        (int(fact_id),),
+                    ) as cursor:
+                        row = await cursor.fetchone()
+                    if row is None:
+                        await self._conn.commit()
+                        return False
+                    if normalize_caller(row["caller"] if isinstance(row, dict) else row[0]) != requester:
+                        await self._conn.commit()
+                        return False
                 cursor = await self._conn.execute(
                     "DELETE FROM knowledge WHERE id = ?", (int(fact_id),)
                 )

--- a/tests/test_forget_fact_owner.py
+++ b/tests/test_forget_fact_owner.py
@@ -1,0 +1,41 @@
+"""Caller ownership for forget_fact."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.identity import reset_active_caller, set_active_caller
+from src.tools import knowledge as knowledge_tools
+from src.utils import GrokSessionStore
+
+
+@pytest.fixture
+async def kstore(tmp_path, monkeypatch):
+    store = GrokSessionStore(db_path=tmp_path / "facts.db")
+    monkeypatch.setattr(knowledge_tools, "store", store)
+    yield store
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_forget_fact_scopes_to_bound_caller(kstore):
+    token_a = set_active_caller("cursor")
+    try:
+        saved = await knowledge_tools.remember_fact("cursor-owned durable fact")
+    finally:
+        reset_active_caller(token_a)
+    fid = int(saved["fact_id"])
+
+    token_b = set_active_caller("vscode")
+    try:
+        foreign = await knowledge_tools.forget_fact(fid)
+    finally:
+        reset_active_caller(token_b)
+    assert foreign["status"] == "not_found"
+
+    token_a = set_active_caller("cursor")
+    try:
+        own = await knowledge_tools.forget_fact(fid)
+    finally:
+        reset_active_caller(token_a)
+    assert own["status"] == "deleted"

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -18,7 +18,7 @@ from src.utils import GrokSessionStore
 # The current schema head. Bump this alongside any new migration — the
 # sequential-chain test below will fail loudly if the source and this pin
 # ever disagree.
-SCHEMA_HEAD = 17
+SCHEMA_HEAD = 18
 
 # Every table a fully migrated store must carry (sqlite internals and the
 # optional knowledge_fts shadow tables excluded — FTS5 availability is a
@@ -574,10 +574,10 @@ class TestV17ProviderAttemptCertification:
 
     @pytest.mark.asyncio
     async def test_future_schema_head_is_rejected_without_schema_mutation(self, tmp_path):
-        db_path = tmp_path / "future-v18.db"
+        db_path = tmp_path / "future-v19.db"
         conn = sqlite3.connect(db_path)
         try:
-            conn.execute("PRAGMA user_version = 18;")
+            conn.execute("PRAGMA user_version = 19;")
             conn.commit()
             tables_before = {
                 row[0]
@@ -590,7 +590,7 @@ class TestV17ProviderAttemptCertification:
 
         store = GrokSessionStore(db_path=db_path)
         try:
-            with pytest.raises(RuntimeError, match="unsupported.*18"):
+            with pytest.raises(RuntimeError, match="unsupported.*19"):
                 await store._ensure_initialized()
             assert store._conn is None
             assert store._initialized is False
@@ -598,7 +598,7 @@ class TestV17ProviderAttemptCertification:
             await store.close()
         conn = sqlite3.connect(db_path)
         try:
-            assert conn.execute("PRAGMA user_version;").fetchone()[0] == 18
+            assert conn.execute("PRAGMA user_version;").fetchone()[0] == 19
             assert {
                 row[0]
                 for row in conn.execute(

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -428,7 +428,7 @@ class TestV16TelemetryAttempts:
         store = GrokSessionStore(db_path=db_path)
         try:
             await store._ensure_initialized()
-            assert await _fetch_version(store) == 17
+            assert await _fetch_version(store) == SCHEMA_HEAD
             assert await _fetch_columns(store, "telemetry_attempts") == {
                 "id",
                 "telemetry_id",
@@ -493,7 +493,7 @@ class TestV17ProviderAttemptCertification:
         try:
             with pytest.raises(RuntimeError, match="v17 columns"):
                 await store._ensure_initialized()
-            assert await _fetch_version(store) == 17
+            assert await _fetch_version(store) == SCHEMA_HEAD
         finally:
             await store.close()
 
@@ -514,7 +514,7 @@ class TestV17ProviderAttemptCertification:
         try:
             with pytest.raises(RuntimeError, match="v17 columns"):
                 await store._ensure_initialized()
-            assert await _fetch_version(store) == 17
+            assert await _fetch_version(store) == SCHEMA_HEAD
         finally:
             await store.close()
 
@@ -560,7 +560,7 @@ class TestV17ProviderAttemptCertification:
             await store.close()
         conn = sqlite3.connect(db_path)
         try:
-            assert conn.execute("PRAGMA user_version;").fetchone()[0] == 17
+            assert conn.execute("PRAGMA user_version;").fetchone()[0] == SCHEMA_HEAD
             assert (
                 conn.execute(
                     "SELECT sql FROM sqlite_master "

--- a/tests/test_provider_harvest.py
+++ b/tests/test_provider_harvest.py
@@ -1112,7 +1112,7 @@ async def test_v16_upgrades_to_v17_and_backfills_exact_terminal_artifact(tmp_pat
     store = GrokSessionStore(db_path)
     after = (await store.list_provider_attempts())[0]
     async with store._conn.execute("PRAGMA user_version;") as cursor:
-        assert (await cursor.fetchone())[0] == 17
+        assert (await cursor.fetchone())[0] == 18
     assert worker_episode_document(after) == expected_document
     assert after["harvest_document_digest"] == expected_digest
     assert after["harvest_episode_id"] == expected_episode_id

--- a/tests/test_swarm_storage.py
+++ b/tests/test_swarm_storage.py
@@ -88,7 +88,7 @@ class TestSwarmMigration:
         async with s._read_conn() as conn:
             async with conn.execute("PRAGMA user_version;") as cursor:
                 version = (await cursor.fetchone())[0]
-        assert version == 17
+        assert version == 18
         await s.close()
 
         # Reopen: migration gates must all no-op and the tables survive.
@@ -97,7 +97,7 @@ class TestSwarmMigration:
         assert (await s2.get_swarm_task("task-reopen"))["status"] == "queued"
         async with s2._read_conn() as conn:
             async with conn.execute("PRAGMA user_version;") as cursor:
-                assert (await cursor.fetchone())[0] == 17
+                assert (await cursor.fetchone())[0] == 18
         await s2.close()
 
 


### PR DESCRIPTION
## Summary
- Schema v18 adds `knowledge.caller`; `remember_fact` records the requester.
- Bound callers can `forget_fact` only on their own rows (legacy NULL owners look `not_found`).

## Test plan
- [x] `uv run pytest -q tests/test_forget_fact_owner.py tests/test_migrations.py::TestMigrationChain`
- [ ] CI green on the draft PR head

## Notes
- Schema v18 may need rebase if (#259) lands first with a different v18 migration.
- @grok pre-fix and pre-PR gates: APPROVE / YES-DRAFT-PR (API, same_plane)

Made with [Cursor](https://cursor.com)