### PR TITLE
fix(jobs): fail closed without API; declare metered plane

### DIFF
--- a/src/jobs.py
+++ b/src/jobs.py
@@ -27,6 +27,7 @@ from .utils import (
     _parse_structured,
     check_circuit_breaker,
     get_xai_client,
+    xai_api_key_configured,
     record_xai_success,
     redact_secrets,
     resolve_model,
@@ -125,6 +126,19 @@ class JobManager:
     ) -> None:
         timeout = _job_timeout_sec()
         try:
+            # Deferred research always burns the metered API plane (chat.defer).
+            # Fail closed before claiming a defer slot when no usable key is
+            # configured so CLI-only / same_plane callers get an honest error.
+            if not xai_api_key_configured():
+                await self._store.update_job(
+                    job_id,
+                    status="error",
+                    result=(
+                        "Research jobs require a usable metered API plane "
+                        "(XAI_API_KEY); they cannot run on the CLI subscription."
+                    ),
+                )
+                return
             # The slot gates the defer call: the row stays 'queued' while
             # waiting, so a burst of submissions never pins more than
             # UNIGROK_MAX_CONCURRENT_JOBS timed threads at once.
@@ -209,6 +223,16 @@ class JobManager:
 
     async def _run_distill_job(self, job_id: str, session: str, model: str) -> None:
         try:
+            if not xai_api_key_configured():
+                await self._store.update_job(
+                    job_id,
+                    status="error",
+                    result=(
+                        "Distill jobs require a usable metered API plane "
+                        "(XAI_API_KEY); they cannot run on the CLI subscription."
+                    ),
+                )
+                return
             async with self._defer_slots:
                 await self._store.update_job(job_id, status="running")
                 messages = await self._store.load_messages(session)
@@ -303,6 +327,9 @@ class JobManager:
             "model": row.get("model"),
             "created_at": row.get("created_at"),
             "updated_at": row.get("updated_at"),
+            # Deferred jobs always execute on the metered developer API.
+            "plane": "API",
+            "billing_class": "metered",
         }
         if row.get("caller"):
             # Submitting agent's identity (v8 column) — absent on old rows

--- a/tests/test_research_job_plane_honesty.py
+++ b/tests/test_research_job_plane_honesty.py
@@ -1,0 +1,32 @@
+"""Research/distill jobs always declare metered API and fail closed without a key."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.jobs import JobManager
+from src.utils import GrokSessionStore
+
+
+@pytest.mark.asyncio
+async def test_describe_surfaces_api_plane(tmp_path):
+    store = GrokSessionStore(db_path=tmp_path / "jobs.db")
+    await store.create_job("j1", prompt="p", model="grok-4.5", caller="cursor")
+    mgr = JobManager(store)
+    view = await mgr.get("j1")
+    assert view["plane"] == "API"
+    assert view["billing_class"] == "metered"
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_run_job_fails_closed_without_api_key(tmp_path, monkeypatch):
+    store = GrokSessionStore(db_path=tmp_path / "jobs2.db")
+    mgr = JobManager(store)
+    monkeypatch.setattr("src.jobs.xai_api_key_configured", lambda: False)
+    await store.create_job("j2", prompt="research me", model="grok-4.5")
+    await mgr._run_job("j2", "research me", "grok-4.5", None)
+    row = await store.get_job("j2")
+    assert row["status"] == "error"
+    assert "metered API" in (row.get("result") or "")
+    await store.close()


### PR DESCRIPTION
## Summary
- Research/distill jobs fail closed when no usable `XAI_API_KEY` before taking a defer slot.
- Job views always surface `plane=API` and `billing_class=metered`.

## Test plan
- [x] `uv run pytest -q tests/test_research_job_plane_honesty.py`
- [ ] CI green on the draft PR head

## Notes
- Separate from Ready (#259) caller scoping and (#272) live-task stale.
- @grok pre-fix and pre-PR gates: APPROVE / YES-DRAFT-PR (API, same_plane)

Made with [Cursor](https://cursor.com)