### PR TITLE
fix(security): deny stateful responses for bound principals

### DIFF
--- a/src/tools/chats.py
+++ b/src/tools/chats.py
@@ -8,7 +8,7 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field
 from ..models.results import ChatResult, AgentResult, ReflectionResult
-from ..identity import caller_from_mcp_context, scoped_session
+from ..identity import caller_from_mcp_context, get_active_principal, scoped_session
 
 from ..utils import (
     store,
@@ -512,6 +512,19 @@ async def stateful_chat(
     Returns:
         ChatResult containing execution metadata and responses.
     """
+    if get_active_principal() is not None:
+        error_msg = (
+            "Stored provider responses are unavailable to bound HTTP/MCP principals."
+        )
+        return ChatResult(
+            response=error_msg,
+            text=error_msg,
+            finish_reason="error",
+            cost_usd=0.0,
+            model=model,
+            route="stateful",
+            plane="API",
+        )
     async with GrokInvocationContext(model, logger, append_signature=True) as ctx:
         chat_params = {"model": model, "store_messages": True}
         if response_id:
@@ -556,6 +569,10 @@ async def retrieve_stateful_response(response_id: str) -> str:
     Args:
         response_id: ID returned by a prior `stateful_chat` call.
     """
+    if get_active_principal() is not None:
+        raise PermissionError(
+            "Stored provider responses are unavailable to bound HTTP/MCP principals."
+        )
     async with GrokInvocationContext("utility", logger, append_signature=False) as ctx:
         def _get_stored():
             client = get_xai_client()
@@ -575,6 +592,10 @@ async def delete_stateful_response(response_id: str) -> str:
     Args:
         response_id: ID of the stored response to remove.
     """
+    if get_active_principal() is not None:
+        raise PermissionError(
+            "Stored provider responses are unavailable to bound HTTP/MCP principals."
+        )
     async with GrokInvocationContext("utility", logger, append_signature=False) as ctx:
         def _delete_stored():
             client = get_xai_client()

--- a/tests/test_stateful_response_principal.py
+++ b/tests/test_stateful_response_principal.py
@@ -1,0 +1,31 @@
+"""Bound principals cannot touch shared-account stateful completions."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from src.identity import reset_active_principal, set_active_principal
+from src.tools.chats import (
+    delete_stateful_response,
+    retrieve_stateful_response,
+    stateful_chat,
+)
+
+
+@pytest.mark.asyncio
+async def test_bound_principal_cannot_use_stateful_responses():
+    token = set_active_principal("oauth:service:tenant-a")
+    try:
+        with patch("src.tools.chats.get_xai_client") as get_client:
+            with pytest.raises(PermissionError, match="bound HTTP/MCP principals"):
+                await retrieve_stateful_response("resp-foreign")
+            with pytest.raises(PermissionError, match="bound HTTP/MCP principals"):
+                await delete_stateful_response("resp-foreign")
+            blocked = await stateful_chat("hello")
+            assert blocked.finish_reason == "error"
+            assert "bound HTTP/MCP principals" in blocked.response
+    finally:
+        reset_active_principal(token)
+    get_client.assert_not_called()


### PR DESCRIPTION
## Summary
- Bound HTTP/MCP principals cannot create/retrieve/delete shared-account stateful completions.
- Matches the provider-files principal fence pattern until an ownership map exists.

## Test plan
- [x] `uv run pytest -q tests/test_stateful_response_principal.py`
- [ ] CI green on the draft PR head

## Notes
- Separate from Ready (#252)–(#272) and landed #273.
- @grok pre-fix and pre-PR gates: APPROVE / YES-DRAFT-PR (API, same_plane)

Made with [Cursor](https://cursor.com)