### PR TITLE
fix(routing): thread same_plane through chat and /v1

### DIFF
--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -2833,7 +2833,7 @@ Returns:
 ### Function: `chat` {#tools-chats-chat}
 
 ```python
-async def chat(prompt: str, session: Optional[str]=None, model: str='grok-build-0.1', system_prompt: Optional[str]=None, agent_count: Optional[int]=None, enable_agentic: bool=True, require_reasoning_level: Optional[Literal['low', 'medium', 'high']]=None) -> ChatResult
+async def chat(prompt: str, session: Optional[str]=None, model: str='grok-build-0.1', system_prompt: Optional[str]=None, agent_count: Optional[int]=None, enable_agentic: bool=True, require_reasoning_level: Optional[Literal['low', 'medium', 'high']]=None, plane: Literal['auto', 'cli', 'api']='auto', fallback_policy: Literal['same_plane', 'cross_plane']='cross_plane') -> ChatResult
 ```
 
 **Keywords:** chat
@@ -2852,6 +2852,11 @@ Args:
     agent_count: 4 or 16. Only valid with `grok-4.20-multi-agent`.
     enable_agentic: If True (default), runs through the ReAct AgentLoop.
     require_reasoning_level: Minimum required Grok reasoning level (low, medium, high).
+    plane: Starting credential plane. `auto` follows server policy; `cli`
+        starts on the SuperGrok subscription; `api` starts on the metered
+        developer API.
+    fallback_policy: `same_plane` forbids crossing the billing boundary;
+        `cross_plane` permits bounded recovery on the other xAI plane.
 
 ### Function: `grok_agent` {#tools-chats-grok_agent}
 

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -2833,7 +2833,7 @@ Returns:
 ### Function: `chat` {#tools-chats-chat}
 
 ```python
-async def chat(prompt: str, session: Optional[str]=None, model: str='grok-build-0.1', system_prompt: Optional[str]=None, agent_count: Optional[int]=None, enable_agentic: bool=True, require_reasoning_level: Optional[Literal['low', 'medium', 'high']]=None) -> ChatResult
+async def chat(prompt: str, session: Optional[str]=None, model: str='grok-build-0.1', system_prompt: Optional[str]=None, agent_count: Optional[int]=None, enable_agentic: bool=True, require_reasoning_level: Optional[Literal['low', 'medium', 'high']]=None, plane: Literal['auto', 'cli', 'api']='auto', fallback_policy: Literal['same_plane', 'cross_plane']='cross_plane') -> ChatResult
 ```
 
 **Keywords:** chat
@@ -2852,6 +2852,11 @@ Args:
     agent_count: 4 or 16. Only valid with `grok-4.20-multi-agent`.
     enable_agentic: If True (default), runs through the ReAct AgentLoop.
     require_reasoning_level: Minimum required Grok reasoning level (low, medium, high).
+    plane: Starting credential plane. `auto` follows server policy; `cli`
+        starts on the SuperGrok subscription; `api` starts on the metered
+        developer API.
+    fallback_policy: `same_plane` forbids crossing the billing boundary;
+        `cross_plane` permits bounded recovery on the other xAI plane.
 
 ### Function: `grok_agent` {#tools-chats-grok_agent}
 

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -1690,14 +1690,26 @@ def _resolve_agent_model(payload: Dict[str, Any]) -> Optional[str]:
 def _agent_turn_kwargs(payload: Dict[str, Any]) -> Dict[str, Any]:
     """Shared run_agent_turn kwargs for the OpenAI-compatible agent branch.
 
-    Accepts the extension fields `xai_model`, `mode`, and `thinking_mode` so
-    remote clients keep the full routing surface (same mode mapping as the
-    stdio `agent` tool).
+    Accepts the extension fields `xai_model`, `mode`, `thinking_mode`, `plane`,
+    and `fallback_policy` so remote clients keep the full routing surface
+    (same mode/plane mapping as the stdio `agent` tool).
     """
     mode = payload.get("mode")
     mode = mode.strip().lower() if isinstance(mode, str) else ""
     if mode not in _AGENT_MODES:
         mode = "auto"
+    plane = payload.get("plane")
+    plane = plane.strip().lower() if isinstance(plane, str) else "auto"
+    if plane not in ("auto", "cli", "api"):
+        plane = "auto"
+    fallback_policy = payload.get("fallback_policy")
+    fallback_policy = (
+        fallback_policy.strip().lower()
+        if isinstance(fallback_policy, str)
+        else "cross_plane"
+    )
+    if fallback_policy not in ("same_plane", "cross_plane"):
+        fallback_policy = "cross_plane"
     return {
         "session": _scoped_session(_session_from_payload(payload)),
         "messages": payload.get("messages") or [],
@@ -1712,6 +1724,8 @@ def _agent_turn_kwargs(payload: Dict[str, Any]) -> Dict[str, Any]:
         "cli_verbatim": True,
         "cli_allowed_tools": "",
         "cli_isolated": True,
+        "plane": plane,
+        "fallback_policy": fallback_policy,
     }
 
 

--- a/src/tools/chats.py
+++ b/src/tools/chats.py
@@ -216,6 +216,8 @@ async def chat(
     agent_count: Optional[int] = None,
     enable_agentic: bool = True,
     require_reasoning_level: Optional[Literal["low", "medium", "high"]] = None,
+    plane: Literal["auto", "cli", "api"] = "auto",
+    fallback_policy: Literal["same_plane", "cross_plane"] = "cross_plane",
 ) -> ChatResult:
     """Send a text prompt to a Grok model and return its reply.
 
@@ -231,6 +233,11 @@ async def chat(
         agent_count: 4 or 16. Only valid with `grok-4.20-multi-agent`.
         enable_agentic: If True (default), runs through the ReAct AgentLoop.
         require_reasoning_level: Minimum required Grok reasoning level (low, medium, high).
+        plane: Starting credential plane. `auto` follows server policy; `cli`
+            starts on the SuperGrok subscription; `api` starts on the metered
+            developer API.
+        fallback_policy: `same_plane` forbids crossing the billing boundary;
+            `cross_plane` permits bounded recovery on the other xAI plane.
     """
     session = scoped_session(session)
     validation_error = _validate_agent_count(model, agent_count)
@@ -264,6 +271,8 @@ async def chat(
         context_id=context_id,
         agent_count=agent_count,
         require_reasoning_level=require_reasoning_level,
+        requested_plane=plane,
+        fallback_policy=fallback_policy,
     )
 
     if session and layer.generation:

--- a/tests/test_chat_same_plane_thread.py
+++ b/tests/test_chat_same_plane_thread.py
@@ -1,0 +1,69 @@
+"""plane/fallback_policy must reach orchestrate and /v1 agent turns."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.http_server import _agent_turn_kwargs
+from src.tools import chats as chats_mod
+from src.utils import MetaLayer
+
+
+def test_agent_turn_kwargs_forwards_plane_and_fallback_policy():
+    kwargs = _agent_turn_kwargs(
+        {
+            "messages": [{"role": "user", "content": "hi"}],
+            "mode": "fast",
+            "plane": "cli",
+            "fallback_policy": "same_plane",
+        }
+    )
+    assert kwargs["plane"] == "cli"
+    assert kwargs["fallback_policy"] == "same_plane"
+    assert kwargs["enable_agentic"] is False
+
+
+def test_agent_turn_kwargs_defaults_and_sanitizes():
+    kwargs = _agent_turn_kwargs({"messages": []})
+    assert kwargs["plane"] == "auto"
+    assert kwargs["fallback_policy"] == "cross_plane"
+    bad = _agent_turn_kwargs(
+        {"messages": [], "plane": "nope", "fallback_policy": "whatever"}
+    )
+    assert bad["plane"] == "auto"
+    assert bad["fallback_policy"] == "cross_plane"
+
+
+@pytest.mark.asyncio
+async def test_chat_forwards_plane_policy_to_orchestrate(monkeypatch):
+    captured = {}
+
+    async def fake_orchestrate(**kwargs):
+        captured.update(kwargs)
+        return MetaLayer(
+            generation="ok",
+            finish_reason="final_answer",
+            route="fast",
+            plane="CLI",
+            model="grok-4.5",
+            cost_usd=0.0,
+            tokens=1,
+        )
+
+    monkeypatch.setattr("src.server.orchestrate", fake_orchestrate)
+    monkeypatch.setattr(
+        chats_mod,
+        "get_dynamic_context",
+        AsyncMock(return_value=("", False, None)),
+    )
+    result = await chats_mod.chat(
+        "hi",
+        enable_agentic=False,
+        plane="cli",
+        fallback_policy="same_plane",
+    )
+    assert result.finish_reason == "final_answer"
+    assert captured["requested_plane"] == "cli"
+    assert captured["fallback_policy"] == "same_plane"


### PR DESCRIPTION
## Summary
- Thread `fallback_policy=same_plane` through chat and OpenAI-compatible `/v1` so explicit plane requests do not silently cross credential planes.
- Add routing regression tests for same-plane threading.
- @grok APPROVE / YES-DRAFT-PR (pre-authorized for this draft).

## Test plan
- [x] `uv run pytest -q tests/test_chat_same_plane_thread.py`
- [x] `python3 scripts/check_agent_attribution.py --base-ref origin/main --head HEAD`


Made with [Cursor](https://cursor.com)