### PR TITLE
fix(land-status): report origin sync and fetch age

### DIFF
--- a/scripts/land-status.py
+++ b/scripts/land-status.py
@@ -7,6 +7,7 @@ import json
 import re
 import subprocess
 import sys
+import time
 from pathlib import Path
 from urllib.error import URLError
 from urllib.request import urlopen
@@ -25,11 +26,64 @@ def tree_id(repo: Path, revision: str) -> str | None:
         return None
 
 
+def format_age(seconds: float) -> str:
+    """Render elapsed time as a coarse, human-readable age."""
+
+    if seconds < 60:
+        return f"~{int(seconds)}s ago"
+    if seconds < 3600:
+        return f"~{int(seconds // 60)}m ago"
+    if seconds < 86400:
+        return f"~{int(seconds // 3600)}h ago"
+    return f"~{int(seconds // 86400)}d ago"
+
+
+def origin_sync_line(primary: Path, main_head: str) -> str:
+    """Compare visible main against last-fetched origin/main, all offline."""
+
+    try:
+        git(primary, "rev-parse", "--verify", "refs/remotes/origin/main")
+    except LandError:
+        return "origin/main not found (unfetched or local-only repo)"
+    try:
+        counts = git(
+            primary,
+            "rev-list",
+            "--left-right",
+            "--count",
+            f"{main_head}...refs/remotes/origin/main",
+        )
+    except LandError:
+        # Degrade just this line; details stay out of shared logs.
+        return "origin/main comparison failed"
+    ahead, _, behind = counts.partition("\t")
+    return f"{ahead} ahead / {behind} behind origin/main"
+
+
+def fetch_age_line(repo: Path) -> str:
+    """Report the most recent FETCH_HEAD write across all worktrees."""
+
+    git_dir = common_git_dir(repo)
+    candidates = [git_dir / "FETCH_HEAD", *git_dir.glob("worktrees/*/FETCH_HEAD")]
+    latest: float | None = None
+    for candidate in candidates:
+        try:
+            mtime = candidate.stat().st_mtime
+        except OSError:
+            continue
+        if latest is None or mtime > latest:
+            latest = mtime
+    if latest is None:
+        return "never fetched"
+    return f"last fetch {format_age(time.time() - latest)}"
+
+
 def main() -> int:
     repo = Path(git(Path.cwd(), "rev-parse", "--show-toplevel"))
     primary = main_worktree(repo)
     main_head = git(primary, "rev-parse", "HEAD")
     print(f"Visible main: {main_head} ({primary})")
+    print(f"Origin sync: {origin_sync_line(primary, main_head)} ({fetch_age_line(repo)})")
     marker = common_git_dir(repo) / "unigrok-land" / "runtime-head"
     try:
         runtime_head = marker.read_text(encoding="utf-8").strip()

--- a/tests/test_land_workflow.py
+++ b/tests/test_land_workflow.py
@@ -165,6 +165,68 @@ def test_land_status_missing_marker_cannot_resolve_unknown_ref(repo_with_agent):
     )
 
 
+def test_land_status_reports_origin_sync_and_fetch_age(repo_with_agent):
+    main, agent = repo_with_agent
+    new = commit(agent, "remote-only change\n")
+    git(main, "update-ref", "refs/remotes/origin/main", new)
+    write(main / ".git" / "FETCH_HEAD", f"{new}\t\tbranch 'main' of example\n")
+
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "land-status.py")],
+        cwd=main,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    assert "Origin sync: 0 ahead / 1 behind origin/main" in result.stdout
+    assert "last fetch ~" in result.stdout
+
+
+def test_land_status_reports_in_sync_and_ahead_of_origin(repo_with_agent):
+    main, agent = repo_with_agent
+    base = git(main, "rev-parse", "HEAD")
+    git(main, "update-ref", "refs/remotes/origin/main", base)
+
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "land-status.py")],
+        cwd=main,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    assert "Origin sync: 0 ahead / 0 behind origin/main" in result.stdout
+
+    commit(agent, "agent change\n")
+    git(main, "merge", "--ff-only", "codex/task")
+
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "land-status.py")],
+        cwd=main,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    assert "Origin sync: 1 ahead / 0 behind origin/main" in result.stdout
+
+
+def test_land_status_handles_missing_origin_main(repo_with_agent):
+    main, _ = repo_with_agent
+
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "land-status.py")],
+        cwd=main,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+    assert "Origin sync: origin/main not found" in result.stdout
+    assert "never fetched" in result.stdout
+
+
 def test_land_refuses_behind_reviewed_head(repo_with_agent, monkeypatch):
     main, agent = repo_with_agent
     write(main / "main-only.txt", "other agent\n")


### PR DESCRIPTION
## What

`land-status` reads only local refs, so a session booting from an unfetched or stale clone gets a confidently-worded dead universe — this misled a real Claude boot report today (main had moved while the snapshot said otherwise). Adds one output line after `Visible main`:

```
Origin sync: 0 ahead / 2 behind origin/main (last fetch ~3h ago)
```

- Ahead/behind vs `refs/remotes/origin/main` via `rev-list --left-right --count` — pure local ref reads, **no network I/O** added; the script stays fetch-free for offline/quiet use.
- Fetch age from the newest `FETCH_HEAD` mtime across the shared git dir **and all linked worktrees** (FETCH_HEAD is per-worktree; verified empirically in this repo).
- Graceful degradation: `origin/main not found (unfetched or local-only repo)`, `never fetched`, and a no-exception-text `origin/main comparison failed` fallback (CodeQL contract strings kept out).

## Changed paths

- `scripts/land-status.py` (+54)
- `tests/test_land_workflow.py` (+62): behind, in-sync/ahead, and missing-origin cases, in the existing subprocess harness (offline via `git update-ref refs/remotes/origin/main`).

## Tests

- Full suite in the task worktree at base `55e1d54`: **2149 passed**.
- Focused `tests/test_land_workflow.py`: 18 passed.
- `scripts/check_agent_attribution.py --base-ref origin/main --head HEAD`: passed.

## Risks

- **High-risk surface per AGENTS.md (land scripts): Codex/human landing gate only — do not route through the low/medium autoland path.**
- Output consumers: only additive line; the two pre-existing land-status stdout assertions still pass; `Origin sync:` label intended as stable.
- FETCH_HEAD mtime is an approximation (pull also writes it); absence maps cleanly to `never fetched`.

## Handoff

- Human sponsor: David Johnston (@djtelicloud)
- Exact head: `23f0982d5a1b8bb716b838586e1b8e9ae327d6bd` — ready for supervisor.

Agent-Assisted-By: Anthropic Claude | model=Fable 5 | model-source=user-reported | surface=Claude Code | role=implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the land landing-gate status script (high-attention surface per project docs); change is additive stdout only with graceful fallbacks and no new network I/O.
> 
> **Overview**
> **`land-status`** now prints an **`Origin sync:`** line right after **`Visible main`**, so local “main” can be read against the last-known remote without any new network calls.
> 
> The line combines offline ahead/behind counts vs **`refs/remotes/origin/main`** (via **`rev-list --left-right --count`**) with fetch recency from the newest **`FETCH_HEAD`** mtime across the shared git dir and linked worktrees. Helpers **`format_age`**, **`origin_sync_line`**, and **`fetch_age_line`** handle missing **`origin/main`**, never-fetched repos, and a generic comparison failure without leaking exception text.
> 
> **`tests/test_land_workflow.py`** adds three subprocess tests for behind origin, in-sync/ahead, and missing **`origin/main`** / **`never fetched`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23f0982d5a1b8bb716b838586e1b8e9ae327d6bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->