### PR TITLE
docs(rehydrate): fetch-first freshness guard at boot

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -29,7 +29,8 @@ Full intent map: **Human language** below. Layout for CLI/TUI hosts:
   [`.agents/skills/session-rehydrate/SKILL.md`](skills/session-rehydrate/SKILL.md).
 - Continuity lives in git/disk: private
   `../unigrok-intelligence/codex/continuity/active-work-latest.md` (if present),
-  open PR notes, and `./scripts/land-status` — not chat memory.
+  open PR notes, and `git fetch origin --prune` + `./scripts/land-status`
+  (local-refs snapshot; fetch first) — not chat memory.
 - **Brand next steps are mandatory after the status table.** Every brand must
   know its own strengths and offer **1–2 plain-title next smartest tasks** it
   can actually do (problem or benefit), not a table-only “ready.” Details and
@@ -132,7 +133,8 @@ Not live / Blocked / Who (brand)** plus the **task title**.
 - **Supervisor done (user language)**: **Live** only after protected integration succeeds (`LANDED TO MAIN` internally). Else **Not live** / **Blocked** with one plain reason.
 - **Protect main and peers**: Never overwrite dirty main. Never remove peers’ live scratchpads. Your own finished scratchpad **must** go when the task ends.
 - **Cursor Cloud**: GitHub coding needs no laptop UniGrok env/tunnel. Optional Grok = hosted twin only when connected.
-- **Status Check**: Prefer `./scripts/land-status` silently. Many leftover trees = hygiene debt; clean yours before starting more.
+- **Status Check**: Prefer `git fetch origin --prune` then
+  `./scripts/land-status` silently — the script reads only local refs. Many leftover trees = hygiene debt; clean yours before starting more.
 - **`.worktrees/` is local only** (gitignored scratch).
 - **Workspace Memory**: For implementation, debugging, architecture, and review work, use `.agents/skills/unigrok-workspace-memory/SKILL.md` when available. Recall with the agent worktree's own full HEAD. After `scripts/land` succeeds, record one concise landed outcome; never write Git Notes directly. Memory mirror failure is reportable but does not undo a verified landing.
 

--- a/.agents/skills/session-rehydrate/SKILL.md
+++ b/.agents/skills/session-rehydrate/SKILL.md
@@ -83,13 +83,19 @@ hive/land authority for public installs.
 
 ### 3. Live gates
 
-From product root:
+From product root — **fetch first**; `land-status` reads only local refs, so
+its snapshot is point-in-time on a moving repo:
 
 ```bash
+git fetch origin --prune
 ./scripts/land-status
 ```
 
-Note: visible main, worktrees, stable/forge readiness.
+Note: visible main, worktrees, stable/forge readiness. State fetch age and
+whether local `main` is behind `origin/main` (`git rev-list --count
+main..origin/main`); if the fetch fails, say so and label the report a stale
+local-refs snapshot instead of presenting it as live.
+
 Primary shared checkout should stay on **clean `main`**. Implementation uses
 **agent-prefixed worktrees** only — under `<repo>/.worktrees/…` or
 `/tmp/unigrok-…` (or provider homes like `~/.gemini/…/worktrees`,

--- a/.claude/skills/session-rehydrate/SKILL.md
+++ b/.claude/skills/session-rehydrate/SKILL.md
@@ -76,13 +76,19 @@ hive/land authority for public installs.
 
 ### 3. Live gates
 
-From product root:
+From product root — **fetch first**; `land-status` reads only local refs, so
+its snapshot is point-in-time on a moving repo:
 
 ```bash
+git fetch origin --prune
 ./scripts/land-status
 ```
 
-Note: visible main, worktrees, stable/forge readiness.
+Note: visible main, worktrees, stable/forge readiness. State fetch age and
+whether local `main` is behind `origin/main` (`git rev-list --count
+main..origin/main`); if the fetch fails, say so and label the report a stale
+local-refs snapshot instead of presenting it as live.
+
 Primary shared checkout should stay on **clean `main`**. Implementation uses
 **agent-prefixed worktrees** only — under `<repo>/.worktrees/…` or
 `/tmp/unigrok-…` (or provider homes like `~/.gemini/…/worktrees`,


### PR DESCRIPTION
## What

The session-rehydrate boot law told agents to run `./scripts/land-status` and report state, but never to refresh from origin first — so a fresh session faithfully reports a dead universe on this fast-moving repo (observed live today: main advanced twice during a single audit pass while local refs stood still). Doc-only fix:

- **Live gates** section now prescribes `git fetch origin --prune` before `./scripts/land-status`, requires stating fetch age / behind-count, and — failure-tolerant — if the fetch fails (offline), the report must be labeled a stale local-refs snapshot instead of presented as live.
- Same guard added to the two `.agents/AGENTS.md` bullets that cite land-status for status checks.

Companion to #286 (which makes land-status itself print origin sync); each stands alone.

## Changed paths

- `.claude/skills/session-rehydrate/SKILL.md` and `.agents/skills/session-rehydrate/SKILL.md` — both hand-maintained copies edited identically (they are string-invariant-tested, not generated).
- `.agents/AGENTS.md` — Continuity and Status Check bullets.

## Tests

- Full suite at base `55e1d54`: **2146 passed**; targeted `tests/test_release_hygiene.py`: 21 passed.
- `scripts/generate_okf.py --check`: exit 0 (skills/AGENTS.md are not OKF inputs — no-op proven).
- `scripts/check_agent_attribution.py --base-ref origin/main --head HEAD`: passed.

## Risks

- Doc-only; no runtime surface. `Bash(git fetch:*)` is already allowlisted in `.claude/settings.json`, so the prescribed fetch won't stall Claude boots on a permission prompt.

## Handoff

- Human sponsor: David Johnston (@djtelicloud)
- Exact head: `7d247a554be60c3d776ffbff53789336ba6d8b86` — ready for supervisor.

Agent-Assisted-By: Anthropic Claude | model=Fable 5 | model-source=user-reported | surface=Claude Code | role=documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent boot procedures; no runtime, auth, or land-script behavior is modified.
> 
> **Overview**
> Agents were told to run `./scripts/land-status` at session boot without refreshing from origin first, so rehydrate could report stale local refs as if they were live on a fast-moving repo.
> 
> **Live gates** in both `.agents` and `.claude` `session-rehydrate` skills now require `git fetch origin --prune` before `./scripts/land-status`, explain that the script only reads local refs, and require reporting fetch age and how far local `main` is behind `origin/main`. If fetch fails, the boot report must be labeled a **stale local-refs snapshot**, not presented as live.
> 
> **`.agents/AGENTS.md`** updates the Continuity and Status Check bullets to the same fetch-then-`land-status` pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d247a554be60c3d776ffbff53789336ba6d8b86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->