### PR TITLE
fix(memory): align notes write gate with git tools

### DIFF
--- a/src/workspace_memory.py
+++ b/src/workspace_memory.py
@@ -149,9 +149,14 @@ def verified_landing_receipt(repo: Path, landed_sha: str) -> tuple[Dict[str, Any
 
 
 def _note_write_enabled() -> bool:
+    """Same write gate as git mutators: local runtime + ENABLE_GIT_WRITE=1.
+
+    Contributor Docker often sets UNIGROK_RUNTIME=http; notes must not claim
+    write while git_commit/git_apply_patch refuse under that runtime.
+    """
     return (
         workspace_memory_mode() != "off"
-        and get_unigrok_runtime() != "cloudrun"
+        and get_unigrok_runtime() == "local"
         and os.environ.get("ENABLE_GIT_WRITE") == "1"
     )
 
@@ -179,7 +184,7 @@ def _note_envelope(row: Dict[str, Any]) -> Dict[str, Any]:
 def _write_git_note(repo: Path, row: Dict[str, Any]) -> None:
     if not _note_write_enabled():
         raise WorkspaceMemoryError(
-            "Git Notes mirror requires ENABLE_GIT_WRITE=1 outside Cloud Run"
+            "Git Notes mirror requires UNIGROK_RUNTIME=local and ENABLE_GIT_WRITE=1"
         )
     lock_path = _common_git_dir(repo) / "unigrok-memory.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_git_write_gate_honesty.py
+++ b/tests/test_git_write_gate_honesty.py
@@ -1,0 +1,25 @@
+"""Notes write gate must match git mutator gate (local + ENABLE_GIT_WRITE)."""
+
+from __future__ import annotations
+
+import pytest
+
+from src import workspace_memory as wm
+
+
+def test_note_write_disabled_under_http_runtime(monkeypatch):
+    monkeypatch.setenv("UNIGROK_SERVICE_MODE", "contributor")
+    monkeypatch.setenv("UNIGROK_WORKSPACE_MEMORY", "mirror")
+    monkeypatch.setenv("UNIGROK_RUNTIME", "http")
+    monkeypatch.setenv("ENABLE_GIT_WRITE", "1")
+    assert wm._note_write_enabled() is False
+
+
+def test_note_write_enabled_only_for_local(monkeypatch):
+    monkeypatch.setenv("UNIGROK_SERVICE_MODE", "contributor")
+    monkeypatch.setenv("UNIGROK_WORKSPACE_MEMORY", "mirror")
+    monkeypatch.setenv("UNIGROK_RUNTIME", "local")
+    monkeypatch.setenv("ENABLE_GIT_WRITE", "1")
+    assert wm._note_write_enabled() is True
+    monkeypatch.setenv("ENABLE_GIT_WRITE", "0")
+    assert wm._note_write_enabled() is False


### PR DESCRIPTION
## Summary
- Align `_note_write_enabled` with git mutators: require `UNIGROK_RUNTIME=local` and `ENABLE_GIT_WRITE=1` (not write-capable under contributor Docker `http` runtime).
- Add focused regression coverage; keep separate from Ready pack #252–#285.

@grok APPROVE / YES-DRAFT-PR

## Test plan
- [x] `uv run pytest -q tests/test_git_write_gate_honesty.py tests/test_workspace_memory.py`
- [ ] @grok APPROVE / YES-DRAFT-PR on this exact HEAD

Made with [Cursor](https://cursor.com)