### PR TITLE
fix(cli): require OAuth for CLI catalog availability

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1871,16 +1871,30 @@ async def discover_grok_cli_models(timeout_sec: float = 5.0) -> Dict[str, Any]:
             warnings.append(
                 "Grok CLI reported API-key authentication; subscription plane is not independent."
             )
+        # Match grok_cli_plane_status: catalog "available" requires verified
+        # grok.com OAuth, not merely a zero exit with parseable model ids.
+        oauth_verified = "logged in with grok.com" in normalized_output
+        if proc.returncode == 0 and not oauth_verified and not api_key_conflict:
+            warnings.append(
+                "Grok CLI model listing succeeded without verified grok.com OAuth; "
+                "treating the subscription catalog as unavailable."
+            )
         if proc.returncode != 0:
             warnings.append(f"`grok models` exited with code {proc.returncode}.")
         if not parsed["models"]:
             warnings.append("Grok CLI model discovery returned no parseable models; using fallback CLI model ids.")
 
         default_model = parsed["default_model"] or model_ids[0]
+        available = (
+            proc.returncode == 0
+            and bool(parsed["models"])
+            and oauth_verified
+            and not api_key_conflict
+        )
         return {
             "models": [{"id": model_id, "default": model_id == default_model} for model_id in model_ids],
             "default_model": default_model,
-            "available": proc.returncode == 0 and bool(parsed["models"]) and not api_key_conflict,
+            "available": available,
             "warnings": _dedupe_preserve_order(warnings),
             "source": "grok_cli",
         }

--- a/tests/test_cli_catalog_oauth_ready.py
+++ b/tests/test_cli_catalog_oauth_ready.py
@@ -1,0 +1,88 @@
+"""CLI catalog availability must require the same OAuth predicate as plane ready."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.utils import discover_grok_cli_models
+
+
+@pytest.mark.asyncio
+async def test_catalog_unavailable_without_oauth_verified(monkeypatch):
+    monkeypatch.setattr("src.utils.is_cloudrun_runtime", lambda: False)
+    monkeypatch.setattr(
+        "src.utils.PathResolver.get_grok_cli_path",
+        staticmethod(lambda: "grok"),
+    )
+    monkeypatch.setattr("src.utils.grok_cli_oauth_env", lambda: {})
+
+    class FakeProc:
+        returncode = 0
+
+        def kill(self):
+            return None
+
+        async def wait(self):
+            return 0
+
+    async def fake_create(*_a, **_k):
+        return FakeProc()
+
+    async def fake_communicate(proc, timeout_sec, input_data=None):
+        body = (
+            b"Available models:\n"
+            b"grok-4.5 (default)\n"
+            b"grok-composer-2.5-fast\n"
+        )
+        return body, b""
+
+    monkeypatch.setattr(
+        "src.utils.asyncio.create_subprocess_exec", fake_create
+    )
+    monkeypatch.setattr("src.utils.communicate_with_timeout", fake_communicate)
+
+    result = await discover_grok_cli_models(timeout_sec=1.0)
+    assert result["available"] is False
+    assert any("verified grok.com OAuth" in w for w in result["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_catalog_available_with_oauth_verified(monkeypatch):
+    monkeypatch.setattr("src.utils.is_cloudrun_runtime", lambda: False)
+    monkeypatch.setattr(
+        "src.utils.PathResolver.get_grok_cli_path",
+        staticmethod(lambda: "grok"),
+    )
+    monkeypatch.setattr("src.utils.grok_cli_oauth_env", lambda: {})
+
+    class FakeProc:
+        returncode = 0
+
+        def kill(self):
+            return None
+
+        async def wait(self):
+            return 0
+
+    async def fake_create(*_a, **_k):
+        return FakeProc()
+
+    async def fake_communicate(proc, timeout_sec, input_data=None):
+        body = (
+            b"Logged in with grok.com\n"
+            b"Available models:\n"
+            b"grok-4.5 (default)\n"
+            b"grok-composer-2.5-fast\n"
+        )
+        return body, b""
+
+    monkeypatch.setattr(
+        "src.utils.asyncio.create_subprocess_exec", fake_create
+    )
+    monkeypatch.setattr("src.utils.communicate_with_timeout", fake_communicate)
+
+    result = await discover_grok_cli_models(timeout_sec=1.0)
+    assert result["available"] is True


### PR DESCRIPTION
## Summary
- Make `discover_grok_cli_models` treat the CLI catalog as available only when grok.com OAuth is verified (same predicate as plane ready).
- Add focused regression coverage; keep separate from Ready pack #252–#285.

@grok APPROVE / YES-DRAFT-PR

## Test plan
- [x] `uv run pytest -q tests/test_cli_catalog_oauth_ready.py`
- [ ] @grok APPROVE / YES-DRAFT-PR on this exact HEAD

Made with [Cursor](https://cursor.com)