### PR TITLE
fix(status): redact operator metrics for bound principals

### DIFF
--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -3453,6 +3453,9 @@ async def grok_mcp_status(view: Literal['text', 'json']='text') -> str
 
 Inspect health and usage; ``view=json`` returns stable structured metrics.
 
+Bound HTTP/MCP principals get a redacted readiness view only — cross-caller
+telemetry, spend, breakers, and operator snapshots stay local/unbound.
+
 ### Function: `list_chat_sessions` {#tools-system-list_chat_sessions}
 
 ```python

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -3453,6 +3453,9 @@ async def grok_mcp_status(view: Literal['text', 'json']='text') -> str
 
 Inspect health and usage; ``view=json`` returns stable structured metrics.
 
+Bound HTTP/MCP principals get a redacted readiness view only — cross-caller
+telemetry, spend, breakers, and operator snapshots stay local/unbound.
+
 ### Function: `list_chat_sessions` {#tools-system-list_chat_sessions}
 
 ```python

--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -116,8 +116,13 @@ def _resolve_workspace_file(
 
 
 async def grok_mcp_status(view: Literal["text", "json"] = "text") -> str:
-    """Inspect health and usage; ``view=json`` returns stable structured metrics."""
+    """Inspect health and usage; ``view=json`` returns stable structured metrics.
+
+    Bound HTTP/MCP principals get a redacted readiness view only — cross-caller
+    telemetry, spend, breakers, and operator snapshots stay local/unbound.
+    """
     async with GrokInvocationContext("utility", logger, append_signature=False) as ctx:
+        bound_principal = get_active_principal() is not None
         server_version = __version__
         proj_root = PathResolver.get_service_root()
         grok_cli = PathResolver.get_grok_cli_path()
@@ -138,6 +143,39 @@ async def grok_mcp_status(view: Literal["text", "json"] = "text") -> str:
             }
         cli_auth = f"{cli_plane['state']} ({cli_plane['auth']})"
         credential_planes = credential_plane_contract(cli_plane)
+
+        if bound_principal:
+            if view == "json":
+                return json.dumps(
+                    {
+                        "server_version": server_version,
+                        "service_mode": (
+                            "contributor" if PathResolver.contributor_mode() else "stable"
+                        ),
+                        "workspace_attached": PathResolver.get_workspace_root() is not None,
+                        "credential_planes": credential_planes,
+                        "metrics_redacted": True,
+                        "reason": "operator_metrics_require_unbound_local_session",
+                    },
+                    separators=(",", ":"),
+                )
+            redacted = (
+                "# UniGrok MCP Server Status\n\n"
+                f"**Server Version:** `{server_version}`\n"
+                f"**Service Mode:** `{'contributor' if PathResolver.contributor_mode() else 'stable'}`\n"
+                f"**Workspace Attached:** "
+                f"`{'yes' if PathResolver.get_workspace_root() is not None else 'no'}`\n"
+                f"**CLI Authentication:** `{cli_auth}`\n"
+                f"**Developer API Key:** `{'Configured' if XAI_API_KEY else 'Missing'}`\n\n"
+                "### Credential Planes\n"
+                f"- **Policy:** `{credential_planes['policy']}`\n"
+                f"- **Preferred Plane:** `{credential_planes['preferred_plane']}`\n"
+                f"- **Effective Plane:** `{credential_planes['effective_plane'] or 'none'}`\n"
+                f"- **Service Usable:** `{'yes' if credential_planes['service_usable'] else 'no'}`\n\n"
+                "Operator telemetry (spend, callers, breakers, metrics snapshot) "
+                "is available only from an unbound local session.\n"
+            )
+            return ctx.format_output(redacted)
 
         git_sha = "Unknown"
         try:

--- a/tests/test_status_metrics_principal_redact.py
+++ b/tests/test_status_metrics_principal_redact.py
@@ -1,0 +1,83 @@
+"""Bound principals must not receive cross-caller operator metrics via status."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.identity import reset_active_principal, set_active_principal
+from src.tools.system import grok_mcp_status
+
+
+@pytest.mark.asyncio
+async def test_bound_principal_status_json_is_redacted(monkeypatch):
+    monkeypatch.setattr(
+        "src.tools.system.run_blocking",
+        lambda *a, **k: {
+            "state": "ready",
+            "auth": "oauth_verified",
+            "setup_command": "x",
+            "ready": True,
+            "binary": True,
+        },
+    )
+    # run_blocking is async in real code — patch with AsyncMock style
+    async def fake_run_blocking(fn, *args, timeout=None, **kwargs):
+        return {
+            "state": "ready",
+            "auth": "oauth_verified",
+            "setup_command": "x",
+            "ready": True,
+            "binary": True,
+        }
+
+    monkeypatch.setattr("src.tools.system.run_blocking", fake_run_blocking)
+    monkeypatch.setattr(
+        "src.tools.system.credential_plane_contract",
+        lambda *_a, **_k: {
+            "policy": "cli_first",
+            "preferred_plane": "CLI",
+            "effective_plane": "CLI",
+            "service_usable": True,
+        },
+    )
+    token = set_active_principal("oauth:service:tenant-a")
+    try:
+        raw = await grok_mcp_status(view="json")
+    finally:
+        reset_active_principal(token)
+    payload = json.loads(raw)
+    assert payload["metrics_redacted"] is True
+    assert "planes" not in payload
+    assert "credential_planes" in payload
+
+
+@pytest.mark.asyncio
+async def test_bound_principal_status_text_omits_top_callers(monkeypatch):
+    async def fake_run_blocking(fn, *args, timeout=None, **kwargs):
+        return {
+            "state": "ready",
+            "auth": "oauth_verified",
+            "setup_command": "x",
+            "ready": True,
+            "binary": True,
+        }
+
+    monkeypatch.setattr("src.tools.system.run_blocking", fake_run_blocking)
+    monkeypatch.setattr(
+        "src.tools.system.credential_plane_contract",
+        lambda *_a, **_k: {
+            "policy": "cli_first",
+            "preferred_plane": "CLI",
+            "effective_plane": "CLI",
+            "service_usable": True,
+        },
+    )
+    token = set_active_principal("http:key-1")
+    try:
+        text = await grok_mcp_status(view="text")
+    finally:
+        reset_active_principal(token)
+    assert "Top Callers Today" not in text
+    assert "unbound local session" in text


### PR DESCRIPTION
## Summary
- Redact operator metrics for bound principals on status surfaces.
- Add focused regression coverage; keep separate from Ready pack #252–#290.

@grok APPROVE / YES-DRAFT-PR

## Test plan
- [x] `uv run pytest -q tests/test_status_metrics_principal_redact.py`
- [ ] @grok APPROVE / YES-DRAFT-PR on this exact HEAD

Made with [Cursor](https://cursor.com)