### PR TITLE
fix(resources): scope job resource by caller

### DIFF
--- a/src/tools/resources.py
+++ b/src/tools/resources.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, Optional
 
 from mcp.server.fastmcp import FastMCP
 
+from ..identity import get_active_caller, normalize_caller
 from ..jobs import get_job_manager
 from ..utils import (
     PathResolver,
@@ -139,7 +140,13 @@ def register_resource_primitives(mcp: FastMCP):
     )
     async def job_resource(job_id: str) -> str:
         view = await get_job_manager().get(job_id)
-        return _to_json(view if view is not None else {"status": "not_found", "job_id": job_id})
+        if view is None:
+            return _to_json({"status": "not_found", "job_id": job_id})
+        # Mirror research-job tool authz (#259): bound callers only see own rows.
+        requester = normalize_caller(get_active_caller())
+        if requester and normalize_caller(view.get("caller")) != requester:
+            return _to_json({"status": "not_found", "job_id": job_id})
+        return _to_json(view)
 
     @mcp.resource(
         "grok://knowledge",

--- a/tests/test_job_resource_caller_scope.py
+++ b/tests/test_job_resource_caller_scope.py
@@ -1,0 +1,46 @@
+"""grok://jobs/{id} must honor bound caller fencing."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from src.identity import reset_active_caller, set_active_caller
+from src.jobs import JobManager
+from src.tools import resources as resources_mod
+from src.utils import GrokSessionStore
+
+
+@pytest.mark.asyncio
+async def test_job_resource_hides_foreign_jobs(tmp_path, monkeypatch):
+    store = GrokSessionStore(db_path=tmp_path / "jobs.db")
+    mgr = JobManager(store)
+    monkeypatch.setattr(resources_mod, "get_job_manager", lambda: mgr)
+    await store.create_job("j-a", prompt="a", model="m", caller="cursor")
+    await store.create_job("j-b", prompt="b", model="m", caller="vscode")
+
+    mcp = FastMCP("probe")
+    resources_mod.register_resource_primitives(mcp)
+
+    token = set_active_caller("cursor")
+    try:
+        own_contents = list(await mcp.read_resource("grok://jobs/j-a"))
+        foreign_contents = list(await mcp.read_resource("grok://jobs/j-b"))
+    finally:
+        reset_active_caller(token)
+
+    def _payload(contents):
+        text = (
+            getattr(contents[0], "text", None)
+            or getattr(contents[0], "content", None)
+            or str(contents[0])
+        )
+        return json.loads(text) if isinstance(text, str) else text
+
+    own_payload = _payload(own_contents)
+    foreign_payload = _payload(foreign_contents)
+    assert own_payload.get("job_id") == "j-a" or own_payload.get("status") != "not_found"
+    assert foreign_payload.get("status") == "not_found"
+    await store.close()


### PR DESCRIPTION
## Summary
- Scope `grok://jobs/{id}` so bound callers only see their own job rows.
- Add focused regression coverage; keep separate from Ready pack #252–#290.

@grok APPROVE / YES-DRAFT-PR

## Test plan
- [x] `uv run pytest -q tests/test_job_resource_caller_scope.py`
- [ ] @grok APPROVE / YES-DRAFT-PR on this exact HEAD

Made with [Cursor](https://cursor.com)