### PR TITLE
feat(cloud): owner-default plus optional teammate xAI keys

### DIFF
--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -1137,15 +1137,18 @@ Principal overrides apply only for authenticated OAuth principals. Anonymous
 loopback and static API-key principals keep the owner default (static keys
 already *are* a principal form of auth for the gateway, not per-human BYOK).
 
-### Function: `xai_api_key_fingerprint` {#principal_xai-xai_api_key_fingerprint}
+### Function: `inference_client_cache_id` {#principal_xai-inference_client_cache_id}
 
 ```python
-def xai_api_key_fingerprint(key: str) -> str
+def inference_client_cache_id(*, principal: Optional[str]=None, environ: Mapping[str, str] | None=None) -> str
 ```
 
-**Keywords:** xai, api, key, fingerprint
+**Keywords:** inference, client, cache, id
 
-Stable non-secret cache id for a resolved key.
+Non-secret cache id for the active inference credential path.
+
+Uses principal identity + resolution source only — never hashes key material
+(keys are not passwords; we do not treat them as hashable secrets here).
 
 ### Function: `principal_xai_status` {#principal_xai-principal_xai_status}
 

--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -1101,6 +1101,62 @@ async def fetch_provider_api_usage() -> Dict[str, Any]
 
 Optionally fetch today's team-wide API spend from xAI Management API.
 
+## principal_xai.py {#principal_xai}
+
+### Function: `default_xai_api_key` {#principal_xai-default_xai_api_key}
+
+```python
+def default_xai_api_key(environ: Mapping[str, str] | None=None) -> str
+```
+
+**Keywords:** default, xai, api, key
+
+Owner / service default key (Live cloud twin path).
+
+### Function: `load_principal_xai_key_table` {#principal_xai-load_principal_xai_key_table}
+
+```python
+def load_principal_xai_key_table(environ: Mapping[str, str] | None=None) -> Dict[str, str]
+```
+
+**Keywords:** load, principal, xai, key, table
+
+Load optional principal → key map (never log values).
+
+### Function: `resolve_xai_api_key` {#principal_xai-resolve_xai_api_key}
+
+```python
+def resolve_xai_api_key(*, principal: Optional[str]=None, environ: Mapping[str, str] | None=None) -> Tuple[str, str]
+```
+
+**Keywords:** resolve, xai, api, key
+
+Return ``(key, source)`` where source is ``owner_default`` or ``principal``.
+
+Principal overrides apply only for authenticated OAuth principals. Anonymous
+loopback and static API-key principals keep the owner default (static keys
+already *are* a principal form of auth for the gateway, not per-human BYOK).
+
+### Function: `xai_api_key_fingerprint` {#principal_xai-xai_api_key_fingerprint}
+
+```python
+def xai_api_key_fingerprint(key: str) -> str
+```
+
+**Keywords:** xai, api, key, fingerprint
+
+Stable non-secret cache id for a resolved key.
+
+### Function: `principal_xai_status` {#principal_xai-principal_xai_status}
+
+```python
+def principal_xai_status(*, principal: Optional[str]=None, environ: Mapping[str, str] | None=None) -> Dict[str, Any]
+```
+
+**Keywords:** principal, xai, status
+
+Secret-safe status for diagnostics (never includes key material).
+
 ## provider_harvest.py {#provider_harvest}
 
 ### Function: `worker_episode_collection_name` {#provider_harvest-worker_episode_collection_name}
@@ -3995,6 +4051,16 @@ Respects an inherited id (gateway traceparent, an outer agent call);
 otherwise generates a fresh one and RESETS it on exit so two sequential
 calls in the same task never share a correlation id.
 
+### Function: `xai_api_key_configured` {#utils-xai_api_key_configured}
+
+```python
+def xai_api_key_configured() -> bool
+```
+
+**Keywords:** xai, api, key, configured
+
+True when the active principal has a usable xAI key (owner or override).
+
 ### Function: `prefer_cli_for_route` {#utils-prefer_cli_for_route}
 
 ```python
@@ -4127,7 +4193,10 @@ def get_xai_inference_client()
 
 **Keywords:** get, xai, inference, client
 
-Return the cached inference-only xAI SDK client.
+Return a cached inference-only xAI SDK client for the active key.
+
+Owner default is ``XAI_API_KEY``. Optional OAuth principal overrides come
+from ``UNIGROK_PRINCIPAL_XAI_KEYS_JSON`` (see ``src.principal_xai``).
 
 The installed SDK reads ``XAI_MANAGEMENT_KEY`` whenever its management
 argument is falsey.  Pass a fixed, non-provider isolation canary instead of

--- a/docs/remote-mcp-deployment.md
+++ b/docs/remote-mcp-deployment.md
@@ -62,11 +62,31 @@ on the production OAuth service; a static bearer must not become a hidden
 bypass around membership revocation. The service account needs only access to
 that xAI secret and the normal logging/metrics permissions.
 
-Optional **per-insider** cloud credentials (write+ principal binds their own
-Grok key or CLI material) are a **TARGET** design: they must not replace the
-owner default, must bind to OAuth `sub` (never `X-Client-ID`), and must use
-Secret Manager / KMS-class storage — never plaintext browser forms for public
-or unauthenticated callers.
+Optional **per-insider** cloud credentials (write+ OAuth principal) may bind
+their own xAI API key without replacing the owner default:
+
+| Variable | Purpose |
+| --- | --- |
+| `XAI_API_KEY` | **Owner default** (Secret Manager) — always the fallback |
+| `UNIGROK_PRINCIPAL_XAI_KEYS_JSON` | JSON map of OAuth principal → xAI API key |
+
+Example map (store the whole JSON as one Secret Manager secret; never commit):
+
+```json
+{
+  "oauth:github|user:123456": "xai-teammate-key",
+  "github|user:123456": "xai-teammate-key"
+}
+```
+
+Rules:
+
+- Only principals with kind `oauth:` use the map; `http:anon` and labels never do.
+- Lookup accepts full `oauth:…` keys or the bare subject after `oauth:`.
+- Missing map entry → **owner default**.
+- Never put raw keys in IDE MCP JSON or public clone workflows.
+- Prefer Secret Manager / KMS-class injection of the JSON blob; never browser
+  paste for unauthenticated callers.
 
 The gateway publishes RFC 9728 metadata without authentication. Every other
 remote route is denied unless control-origin introspection returns an active

--- a/docs/remote-mcp-deployment.md
+++ b/docs/remote-mcp-deployment.md
@@ -1,14 +1,45 @@
 # Private remote MCP deployment
 
-`https://mcp.grokmcp.org/mcp` is the private, API-plane-only UniGrok resource.
-It is not an anonymous inference endpoint and it never receives the local Grok
-CLI OAuth volume. The Python gateway runs with `UNIGROK_RUNTIME=cloudrun`, which
-disables the CLI plane and all local agent-tool execution.
+`https://mcp.grokmcp.org/mcp` is the **owner-operated insider** UniGrok Cloud Run
+resource for **team members and cloud agents** (GitHub write+ / scoped tokens).
+It is **not** a public multi-tenant SaaS for anonymous vibe users, and it is
+**not** an anonymous inference endpoint.
+
+## Same Docker, cloud mode
+
+Cloud Run deploys the **same repository `Dockerfile` image** used for local
+product builds (digest-pinned). Behavior is **not** a 1:1 laptop Compose clone:
+
+| | Local Docker / Compose | Cloud Run (`UNIGROK_RUNTIME=cloudrun`) |
+| --- | --- | --- |
+| Image | Product `Dockerfile` | Same image family, digest-pinned |
+| CLI OAuth volume | May attach for SuperGrok CLI plane | **Never** mounted |
+| Default Grok spend | Machine `.env` / local CLI | **Owner** `XAI_API_KEY` from Secret Manager (**Live default**) |
+| Optional teammate own keys | Each engineer’s local keys | **TARGET** (bind to OAuth principal later; does not remove owner default) |
+| Forge / git-write tools | Contributor laptop only | **Off** |
+
+The gateway runs with `UNIGROK_RUNTIME=cloudrun`, which disables the CLI plane
+and all local agent-tool execution. Hosted PR review wiring is
+[design/hosted-review-p0.md](design/hosted-review-p0.md).
 
 **Live probes (re-verify):** `GET /healthz` and `GET /readyz` on the same host
 are public process gates. Authenticated MCP and status routes return `401`
-without a bearer. Hosted PR review wiring is
-[design/hosted-review-p0.md](design/hosted-review-p0.md).
+without a bearer.
+
+## Operator checklist (cloud agents)
+
+1. Build the product image; record the Artifact Registry **digest**.
+2. Deploy that digest with `UNIGROK_RUNTIME=cloudrun` and OAuth introspection
+   pointing at Control (`control.grokmcp.org`).
+3. Inject **owner** `XAI_API_KEY` only from Secret Manager (default spend path).
+4. Do **not** put raw `XAI_API_KEY` in IDE MCP JSON, Cursor Cloud agent secrets,
+   or GitHub as a substitute for owner SM injection.
+5. Cloud agents authenticate with **scoped short-lived tokens** (or the approved
+   Control mint path) — not the xAI provider key.
+6. Confirm: health/ready `200`; `POST /mcp` without token → `401`.
+7. Confirm cloud surface has **no** git-write / Forge mutation tools.
+8. Optional later: per write+ principal own Grok credentials (SM/KMS, bind to
+   OAuth `sub`, cut off when write+ is lost). Owner default remains.
 
 ## Runtime contract
 
@@ -25,10 +56,17 @@ Deploy the repository `Dockerfile` to a dedicated Cloud Run service and set:
 | `UNIGROK_CALLER_BUDGETS` | JSON daily cost caps keyed by authenticated OAuth subject |
 | `UNIGROK_STATE_DIR` | `/tmp/uni-grok` unless a durable store is deliberately attached |
 
-Inject `XAI_API_KEY` from a version-pinned Secret Manager resource. Do not set
-`UNIGROK_API_KEYS` on the production OAuth service; a static bearer must not
-become a hidden bypass around membership revocation. The service account needs
-only access to that xAI secret and the normal logging/metrics permissions.
+Inject the **owner** `XAI_API_KEY` from a version-pinned Secret Manager resource
+— this is the cloud twin **default** spend path. Do not set `UNIGROK_API_KEYS`
+on the production OAuth service; a static bearer must not become a hidden
+bypass around membership revocation. The service account needs only access to
+that xAI secret and the normal logging/metrics permissions.
+
+Optional **per-insider** cloud credentials (write+ principal binds their own
+Grok key or CLI material) are a **TARGET** design: they must not replace the
+owner default, must bind to OAuth `sub` (never `X-Client-ID`), and must use
+Secret Manager / KMS-class storage — never plaintext browser forms for public
+or unauthenticated callers.
 
 The gateway publishes RFC 9728 metadata without authentication. Every other
 remote route is denied unless control-origin introspection returns an active

--- a/example.env
+++ b/example.env
@@ -2,6 +2,8 @@
 # This file is never loaded by the server; the placeholder key below is
 # rejected at startup.
 XAI_API_KEY=your_xai_api_key_here
+# Optional Cloud Run: JSON map of OAuth principal -> xAI key (owner XAI_API_KEY remains default)
+# UNIGROK_PRINCIPAL_XAI_KEYS_JSON={"oauth:github|user:123":"xai-..."}
 
 # Gateway runtime: local, http, or cloudrun
 UNIGROK_RUNTIME=local

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -1137,15 +1137,18 @@ Principal overrides apply only for authenticated OAuth principals. Anonymous
 loopback and static API-key principals keep the owner default (static keys
 already *are* a principal form of auth for the gateway, not per-human BYOK).
 
-### Function: `xai_api_key_fingerprint` {#principal_xai-xai_api_key_fingerprint}
+### Function: `inference_client_cache_id` {#principal_xai-inference_client_cache_id}
 
 ```python
-def xai_api_key_fingerprint(key: str) -> str
+def inference_client_cache_id(*, principal: Optional[str]=None, environ: Mapping[str, str] | None=None) -> str
 ```
 
-**Keywords:** xai, api, key, fingerprint
+**Keywords:** inference, client, cache, id
 
-Stable non-secret cache id for a resolved key.
+Non-secret cache id for the active inference credential path.
+
+Uses principal identity + resolution source only — never hashes key material
+(keys are not passwords; we do not treat them as hashable secrets here).
 
 ### Function: `principal_xai_status` {#principal_xai-principal_xai_status}
 

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -1101,6 +1101,62 @@ async def fetch_provider_api_usage() -> Dict[str, Any]
 
 Optionally fetch today's team-wide API spend from xAI Management API.
 
+## principal_xai.py {#principal_xai}
+
+### Function: `default_xai_api_key` {#principal_xai-default_xai_api_key}
+
+```python
+def default_xai_api_key(environ: Mapping[str, str] | None=None) -> str
+```
+
+**Keywords:** default, xai, api, key
+
+Owner / service default key (Live cloud twin path).
+
+### Function: `load_principal_xai_key_table` {#principal_xai-load_principal_xai_key_table}
+
+```python
+def load_principal_xai_key_table(environ: Mapping[str, str] | None=None) -> Dict[str, str]
+```
+
+**Keywords:** load, principal, xai, key, table
+
+Load optional principal → key map (never log values).
+
+### Function: `resolve_xai_api_key` {#principal_xai-resolve_xai_api_key}
+
+```python
+def resolve_xai_api_key(*, principal: Optional[str]=None, environ: Mapping[str, str] | None=None) -> Tuple[str, str]
+```
+
+**Keywords:** resolve, xai, api, key
+
+Return ``(key, source)`` where source is ``owner_default`` or ``principal``.
+
+Principal overrides apply only for authenticated OAuth principals. Anonymous
+loopback and static API-key principals keep the owner default (static keys
+already *are* a principal form of auth for the gateway, not per-human BYOK).
+
+### Function: `xai_api_key_fingerprint` {#principal_xai-xai_api_key_fingerprint}
+
+```python
+def xai_api_key_fingerprint(key: str) -> str
+```
+
+**Keywords:** xai, api, key, fingerprint
+
+Stable non-secret cache id for a resolved key.
+
+### Function: `principal_xai_status` {#principal_xai-principal_xai_status}
+
+```python
+def principal_xai_status(*, principal: Optional[str]=None, environ: Mapping[str, str] | None=None) -> Dict[str, Any]
+```
+
+**Keywords:** principal, xai, status
+
+Secret-safe status for diagnostics (never includes key material).
+
 ## provider_harvest.py {#provider_harvest}
 
 ### Function: `worker_episode_collection_name` {#provider_harvest-worker_episode_collection_name}
@@ -3995,6 +4051,16 @@ Respects an inherited id (gateway traceparent, an outer agent call);
 otherwise generates a fresh one and RESETS it on exit so two sequential
 calls in the same task never share a correlation id.
 
+### Function: `xai_api_key_configured` {#utils-xai_api_key_configured}
+
+```python
+def xai_api_key_configured() -> bool
+```
+
+**Keywords:** xai, api, key, configured
+
+True when the active principal has a usable xAI key (owner or override).
+
 ### Function: `prefer_cli_for_route` {#utils-prefer_cli_for_route}
 
 ```python
@@ -4127,7 +4193,10 @@ def get_xai_inference_client()
 
 **Keywords:** get, xai, inference, client
 
-Return the cached inference-only xAI SDK client.
+Return a cached inference-only xAI SDK client for the active key.
+
+Owner default is ``XAI_API_KEY``. Optional OAuth principal overrides come
+from ``UNIGROK_PRINCIPAL_XAI_KEYS_JSON`` (see ``src.principal_xai``).
 
 The installed SDK reads ``XAI_MANAGEMENT_KEY`` whenever its management
 argument is falsey.  Pass a fixed, non-provider isolation canary instead of

--- a/src/principal_xai.py
+++ b/src/principal_xai.py
@@ -1,0 +1,141 @@
+"""Owner-default and optional principal-bound xAI API keys.
+
+Cloud twin law (sponsor Approved):
+- Default spend path is the service ``XAI_API_KEY`` (owner Secret Manager).
+- Write+ insiders may optionally bind their own key for their OAuth principal.
+- Labels like ``X-Client-ID`` never select a key.
+- Never log key material.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from typing import Any, Dict, Mapping, Optional, Tuple
+
+from src.identity import get_active_principal, principal_kind
+
+_PLACEHOLDER = "your_xai_api_key_here"
+_PRINCIPAL_KEYS_ENV = "UNIGROK_PRINCIPAL_XAI_KEYS_JSON"
+
+
+def normalize_xai_api_key(value: Optional[str]) -> str:
+    key = str(value or "").strip()
+    return "" if not key or key == _PLACEHOLDER else key
+
+
+def default_xai_api_key(environ: Mapping[str, str] | None = None) -> str:
+    """Owner / service default key (Live cloud twin path)."""
+    source = os.environ if environ is None else environ
+    return normalize_xai_api_key(source.get("XAI_API_KEY"))
+
+
+def _parse_principal_key_table(raw: str) -> Dict[str, str]:
+    text = str(raw or "").strip()
+    if not text:
+        return {}
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    out: Dict[str, str] = {}
+    for key, value in data.items():
+        if not isinstance(key, str):
+            continue
+        norm_key = re.sub(r"[\x00-\x1f\x7f]", "", key).strip()
+        if not norm_key or len(norm_key) > 240:
+            continue
+        secret = normalize_xai_api_key(value if isinstance(value, str) else None)
+        if secret:
+            out[norm_key] = secret
+    return out
+
+
+def load_principal_xai_key_table(
+    environ: Mapping[str, str] | None = None,
+) -> Dict[str, str]:
+    """Load optional principal → key map (never log values)."""
+    source = os.environ if environ is None else environ
+    return _parse_principal_key_table(source.get(_PRINCIPAL_KEYS_ENV, ""))
+
+
+def _lookup_principal_key(
+    principal: str, table: Mapping[str, str]
+) -> Optional[str]:
+    if principal in table:
+        return table[principal]
+    # Allow map keys without the ``oauth:`` prefix when principal is OAuth.
+    if principal.startswith("oauth:"):
+        bare = principal[len("oauth:") :]
+        if bare in table:
+            return table[bare]
+    return None
+
+
+def resolve_xai_api_key(
+    *,
+    principal: Optional[str] = None,
+    environ: Mapping[str, str] | None = None,
+) -> Tuple[str, str]:
+    """Return ``(key, source)`` where source is ``owner_default`` or ``principal``.
+
+    Principal overrides apply only for authenticated OAuth principals. Anonymous
+    loopback and static API-key principals keep the owner default (static keys
+    already *are* a principal form of auth for the gateway, not per-human BYOK).
+    """
+    source = os.environ if environ is None else environ
+    owner = default_xai_api_key(source)
+    active = principal if principal is not None else get_active_principal()
+    if not active or principal_kind(active) != "oauth":
+        return owner, "owner_default"
+    table = load_principal_xai_key_table(source)
+    if not table:
+        return owner, "owner_default"
+    personal = _lookup_principal_key(active, table)
+    if personal:
+        return personal, "principal"
+    return owner, "owner_default"
+
+
+def effective_xai_api_key(
+    *,
+    principal: Optional[str] = None,
+    environ: Mapping[str, str] | None = None,
+) -> str:
+    key, _src = resolve_xai_api_key(principal=principal, environ=environ)
+    return key
+
+
+def xai_api_key_fingerprint(key: str) -> str:
+    """Stable non-secret cache id for a resolved key."""
+    material = normalize_xai_api_key(key)
+    if not material:
+        return "missing"
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+def principal_xai_status(
+    *,
+    principal: Optional[str] = None,
+    environ: Mapping[str, str] | None = None,
+) -> Dict[str, Any]:
+    """Secret-safe status for diagnostics (never includes key material)."""
+    key, source = resolve_xai_api_key(principal=principal, environ=environ)
+    active = principal if principal is not None else get_active_principal()
+    table = load_principal_xai_key_table(environ)
+    return {
+        "configured": bool(key),
+        "source": source,
+        "principal_kind": principal_kind(active),
+        "principal_override_available": bool(
+            active
+            and principal_kind(active) == "oauth"
+            and _lookup_principal_key(active, table)
+        ),
+        "owner_default_configured": bool(default_xai_api_key(environ)),
+        "principal_map_entries": len(table),
+    }

--- a/src/principal_xai.py
+++ b/src/principal_xai.py
@@ -9,7 +9,6 @@ Cloud twin law (sponsor Approved):
 
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 import re
@@ -110,12 +109,24 @@ def effective_xai_api_key(
     return key
 
 
-def xai_api_key_fingerprint(key: str) -> str:
-    """Stable non-secret cache id for a resolved key."""
-    material = normalize_xai_api_key(key)
-    if not material:
+def inference_client_cache_id(
+    *,
+    principal: Optional[str] = None,
+    environ: Mapping[str, str] | None = None,
+) -> str:
+    """Non-secret cache id for the active inference credential path.
+
+    Uses principal identity + resolution source only — never hashes key material
+    (keys are not passwords; we do not treat them as hashable secrets here).
+    """
+    active = principal if principal is not None else get_active_principal()
+    key, source = resolve_xai_api_key(principal=active, environ=environ)
+    if not key:
         return "missing"
-    return hashlib.sha256(material.encode("utf-8")).hexdigest()
+    if source == "owner_default":
+        return "owner_default"
+    # Principal-bound path: one cache entry per OAuth principal id.
+    return f"principal:{active or 'unknown'}"
 
 
 def principal_xai_status(

--- a/src/utils.py
+++ b/src/utils.py
@@ -2060,12 +2060,12 @@ def get_xai_inference_client():
     client's channel or inference call paths.
     """
 
-    from src.principal_xai import effective_xai_api_key, xai_api_key_fingerprint
+    from src.principal_xai import effective_xai_api_key, inference_client_cache_id
 
     api_key = effective_xai_api_key()
     if not api_key:
         raise ValueError("XAI_API_KEY is not configured in the environment.")
-    cache_id = xai_api_key_fingerprint(api_key)
+    cache_id = inference_client_cache_id()
 
     client = _clients.get(cache_id)
     if client is None:

--- a/src/utils.py
+++ b/src/utils.py
@@ -909,7 +909,12 @@ CLI_MODEL_IDS = tuple(FALLBACK_GROK_CLI_MODELS)
 
 
 def xai_api_key_configured() -> bool:
-    return bool(_normalize_xai_api_key(os.environ.get("XAI_API_KEY") or XAI_API_KEY))
+    """True when the active principal has a usable xAI key (owner or override)."""
+    try:
+        from src.principal_xai import effective_xai_api_key
+    except Exception:
+        return bool(_normalize_xai_api_key(os.environ.get("XAI_API_KEY") or XAI_API_KEY))
+    return bool(effective_xai_api_key())
 
 
 def cli_plane_ready_for_local_runtime() -> bool:
@@ -1953,7 +1958,9 @@ async def build_model_catalog(include_cli: bool = True) -> Dict[str, Any]:
 # Global xAI client connection pools.  The inference client is intentionally
 # incapable of carrying management authority; Collections call sites receive
 # the operation-scoped management facade below.
-_client = None
+# Inference clients keyed by non-secret key fingerprint so optional principal
+# overrides (UNIGROK_PRINCIPAL_XAI_KEYS_JSON) do not share the owner client.
+_clients: dict[str, Any] = {}
 _management_client = None
 # Both factories are called from executor threads — guard each check-then-set
 # so concurrent first calls cannot leak duplicate Client instances or cross
@@ -2041,7 +2048,10 @@ def xai_management_key_state() -> XAIManagementKeyState:
 
 
 def get_xai_inference_client():
-    """Return the cached inference-only xAI SDK client.
+    """Return a cached inference-only xAI SDK client for the active key.
+
+    Owner default is ``XAI_API_KEY``. Optional OAuth principal overrides come
+    from ``UNIGROK_PRINCIPAL_XAI_KEYS_JSON`` (see ``src.principal_xai``).
 
     The installed SDK reads ``XAI_MANAGEMENT_KEY`` whenever its management
     argument is falsey.  Pass a fixed, non-provider isolation canary instead of
@@ -2050,25 +2060,32 @@ def get_xai_inference_client():
     client's channel or inference call paths.
     """
 
-    global _client
-    if _client is None:
+    from src.principal_xai import effective_xai_api_key, xai_api_key_fingerprint
+
+    api_key = effective_xai_api_key()
+    if not api_key:
+        raise ValueError("XAI_API_KEY is not configured in the environment.")
+    cache_id = xai_api_key_fingerprint(api_key)
+
+    client = _clients.get(cache_id)
+    if client is None:
         with _client_lock:
-            if _client is None:
-                if not XAI_API_KEY:
-                    raise ValueError("XAI_API_KEY is not configured in the environment.")
+            client = _clients.get(cache_id)
+            if client is None:
                 from xai_sdk import Client
 
                 raw_client = Client(
-                    api_key=XAI_API_KEY,
+                    api_key=api_key,
                     management_api_key=_XAI_INFERENCE_MANAGEMENT_ISOLATION_KEY,
                 )
-                _client = _InferenceOnlyXAIClient(raw_client)
+                client = _InferenceOnlyXAIClient(raw_client)
+                _clients[cache_id] = client
     if _eval_record_enabled():
         # Opt-in eval recording tap (UNIGROK_EVAL_RECORD=1): a thin per-call
         # proxy that appends completed responses to a cassette event log.
         # OFF by default — this branch never runs without the env flag.
-        return _EvalRecordingClient(_client)
-    return _client
+        return _EvalRecordingClient(client)
+    return client
 
 
 def get_xai_client():
@@ -2110,14 +2127,13 @@ def get_xai_management_client():
 def close_xai_inference_client():
     """Close only the inference client cache."""
 
-    global _client
     with _client_lock:
-        if _client is not None:
+        for client in list(_clients.values()):
             try:
-                _client.close()
+                client.close()
             except Exception:
                 pass
-            _client = None
+        _clients.clear()
 
 
 def close_xai_management_client():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,14 +20,20 @@ def setup_test_env(tmp_path_factory):
 
 @pytest.fixture(autouse=True)
 def reset_global_client():
-    src.utils._client = None
+    if hasattr(src.utils, "_clients"):
+        src.utils._clients.clear()
+    else:
+        src.utils._client = None  # legacy attribute name
     src.utils._management_client = None
     src.utils._MODEL_MAX_TOKENS_CACHE.clear()
     src.utils._BREAKER_STATE.clear()
     src.utils._ROUTING_ADVISOR.invalidate()
     src.utils._CALLER_SPEND_CACHE.clear()
     yield
-    src.utils._client = None
+    if hasattr(src.utils, "_clients"):
+        src.utils._clients.clear()
+    else:
+        src.utils._client = None  # legacy attribute name
     src.utils._management_client = None
     src.utils._MODEL_MAX_TOKENS_CACHE.clear()
     src.utils._BREAKER_STATE.clear()

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -134,9 +134,10 @@ def test_management_key_alone_never_satisfies_inference_readiness(monkeypatch):
     from src import utils
 
     monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.delenv("UNIGROK_PRINCIPAL_XAI_KEYS_JSON", raising=False)
     monkeypatch.setenv("XAI_MANAGEMENT_API_KEY", "xai-management-only")
     monkeypatch.setattr(utils, "XAI_API_KEY", "")
-    monkeypatch.setattr(utils, "_client", None)
+    utils._clients.clear()
 
     assert utils.xai_api_key_configured() is False
     contract = build_credential_plane_contract(
@@ -163,10 +164,11 @@ def test_inference_key_alone_never_satisfies_management_readiness(monkeypatch):
             created.update(kwargs)
 
     monkeypatch.setenv("XAI_API_KEY", "xai-inference-only")
+    monkeypatch.delenv("UNIGROK_PRINCIPAL_XAI_KEYS_JSON", raising=False)
     monkeypatch.delenv("XAI_MANAGEMENT_API_KEY", raising=False)
     monkeypatch.delenv("XAI_MANAGEMENT_KEY", raising=False)
     monkeypatch.setattr(utils, "XAI_API_KEY", "xai-inference-only")
-    monkeypatch.setattr(utils, "_client", None)
+    utils._clients.clear()
     monkeypatch.setattr("xai_sdk.Client", FakeClient)
 
     assert utils.xai_api_key_configured() is True

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -613,14 +613,14 @@ class TestRoutingAdvisorCalibration:
 # ─────────────────────────────────────────────────────────────────────────────
 
 def _seed_inference_client(utils, monkeypatch, raw, *, api_key: str = "eval-test-key") -> None:
-    """Put a fake client in the fingerprint cache for the active key."""
-    from src.principal_xai import xai_api_key_fingerprint
+    """Put a fake client in the principal/owner cache for the active key path."""
+    from src.principal_xai import inference_client_cache_id
 
     monkeypatch.setenv("XAI_API_KEY", api_key)
     monkeypatch.delenv("UNIGROK_PRINCIPAL_XAI_KEYS_JSON", raising=False)
     monkeypatch.setattr(utils, "XAI_API_KEY", api_key)
     utils._clients.clear()
-    utils._clients[xai_api_key_fingerprint(api_key)] = raw
+    utils._clients[inference_client_cache_id()] = raw
 
 
 class TestEvalRecordingTap:

--- a/tests/test_evals.py
+++ b/tests/test_evals.py
@@ -612,13 +612,24 @@ class TestRoutingAdvisorCalibration:
 # UNIGROK_EVAL_RECORD tap
 # ─────────────────────────────────────────────────────────────────────────────
 
+def _seed_inference_client(utils, monkeypatch, raw, *, api_key: str = "eval-test-key") -> None:
+    """Put a fake client in the fingerprint cache for the active key."""
+    from src.principal_xai import xai_api_key_fingerprint
+
+    monkeypatch.setenv("XAI_API_KEY", api_key)
+    monkeypatch.delenv("UNIGROK_PRINCIPAL_XAI_KEYS_JSON", raising=False)
+    monkeypatch.setattr(utils, "XAI_API_KEY", api_key)
+    utils._clients.clear()
+    utils._clients[xai_api_key_fingerprint(api_key)] = raw
+
+
 class TestEvalRecordingTap:
     def test_off_by_default_returns_raw_client(self, monkeypatch):
         import src.utils as utils
 
         monkeypatch.delenv("UNIGROK_EVAL_RECORD", raising=False)
         raw = FakeClient(responses=[make_response(content="hi")])
-        monkeypatch.setattr(utils, "_client", raw)
+        _seed_inference_client(utils, monkeypatch, raw)
         assert get_xai_client() is raw
 
     def test_on_records_sample_events(self, tmp_path, monkeypatch):
@@ -628,7 +639,7 @@ class TestEvalRecordingTap:
         monkeypatch.setenv("UNIGROK_EVAL_RECORD", "1")
         monkeypatch.setenv("UNIGROK_EVAL_RECORD_FILE", str(record_file))
         raw = FakeClient(responses=[make_response(content="recorded answer", cost_usd=0.007)])
-        monkeypatch.setattr(utils, "_client", raw)
+        _seed_inference_client(utils, monkeypatch, raw)
 
         client = get_xai_client()
         assert isinstance(client, _EvalRecordingClient)
@@ -659,7 +670,7 @@ class TestEvalRecordingTap:
         monkeypatch.setenv("UNIGROK_EVAL_RECORD_FILE", str(record_file))
         leaked = "the key is XAI_API_KEY=xai-recordedsecret1234 as configured"
         raw = FakeClient(responses=[make_response(content=leaked)])
-        monkeypatch.setattr(utils, "_client", raw)
+        _seed_inference_client(utils, monkeypatch, raw)
 
         client = get_xai_client()
         chat = client.chat.create(model="grok-4.3")
@@ -687,7 +698,7 @@ class TestEvalRecordingTap:
                 return make_response(content="x")
 
         raw = SimpleNamespace(chat=SimpleNamespace(create=lambda **kw: _ParselessChat()))
-        monkeypatch.setattr(utils, "_client", raw)
+        _seed_inference_client(utils, monkeypatch, raw)
         chat = get_xai_client().chat.create(model="m")
         assert not hasattr(chat, "parse")
         assert hasattr(FakeChat(responses=[]), "parse")

--- a/tests/test_principal_xai.py
+++ b/tests/test_principal_xai.py
@@ -1,0 +1,107 @@
+"""Owner-default and principal-bound xAI API key resolution."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.identity import reset_active_principal, set_active_principal
+from src.principal_xai import (
+    default_xai_api_key,
+    effective_xai_api_key,
+    principal_xai_status,
+    resolve_xai_api_key,
+)
+
+
+def test_owner_default_when_no_principal(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XAI_API_KEY", "xai-owner-default")
+    monkeypatch.delenv("UNIGROK_PRINCIPAL_XAI_KEYS_JSON", raising=False)
+    token = set_active_principal(None)
+    try:
+        key, source = resolve_xai_api_key(environ=dict(**__import__("os").environ))
+        assert key == "xai-owner-default"
+        assert source == "owner_default"
+    finally:
+        reset_active_principal(token)
+
+
+def test_oauth_principal_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XAI_API_KEY", "xai-owner-default")
+    monkeypatch.setenv(
+        "UNIGROK_PRINCIPAL_XAI_KEYS_JSON",
+        json.dumps({"oauth:github|user:42": "xai-teammate"}),
+    )
+    token = set_active_principal("oauth:github|user:42")
+    try:
+        key, source = resolve_xai_api_key()
+        assert key == "xai-teammate"
+        assert source == "principal"
+        status = principal_xai_status()
+        assert status["source"] == "principal"
+        assert status["principal_override_available"] is True
+        assert "xai-" not in json.dumps(status) or status["configured"] is True
+        # Status must not embed the secret value.
+        assert "xai-teammate" not in json.dumps(status)
+    finally:
+        reset_active_principal(token)
+
+
+def test_oauth_principal_bare_map_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XAI_API_KEY", "xai-owner-default")
+    monkeypatch.setenv(
+        "UNIGROK_PRINCIPAL_XAI_KEYS_JSON",
+        json.dumps({"github|user:99": "xai-bare"}),
+    )
+    token = set_active_principal("oauth:github|user:99")
+    try:
+        assert effective_xai_api_key() == "xai-bare"
+    finally:
+        reset_active_principal(token)
+
+
+def test_unknown_oauth_falls_back_to_owner(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XAI_API_KEY", "xai-owner-default")
+    monkeypatch.setenv(
+        "UNIGROK_PRINCIPAL_XAI_KEYS_JSON",
+        json.dumps({"oauth:other": "xai-other"}),
+    )
+    token = set_active_principal("oauth:github|user:nope")
+    try:
+        key, source = resolve_xai_api_key()
+        assert key == "xai-owner-default"
+        assert source == "owner_default"
+    finally:
+        reset_active_principal(token)
+
+
+def test_anon_ignores_principal_map(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("XAI_API_KEY", "xai-owner-default")
+    monkeypatch.setenv(
+        "UNIGROK_PRINCIPAL_XAI_KEYS_JSON",
+        json.dumps({"http:anon": "xai-should-not-use", "oauth:x": "xai-x"}),
+    )
+    token = set_active_principal("http:anon")
+    try:
+        key, source = resolve_xai_api_key()
+        assert key == "xai-owner-default"
+        assert source == "owner_default"
+    finally:
+        reset_active_principal(token)
+
+
+def test_client_id_cannot_select_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """X-Client-ID is not consulted; only OAuth principal map entries apply."""
+    monkeypatch.setenv("XAI_API_KEY", "xai-owner-default")
+    monkeypatch.setenv(
+        "UNIGROK_PRINCIPAL_XAI_KEYS_JSON",
+        json.dumps({"cursor": "xai-spoof", "oauth:real": "xai-real"}),
+    )
+    token = set_active_principal("oauth:real")
+    try:
+        assert effective_xai_api_key() == "xai-real"
+    finally:
+        reset_active_principal(token)
+    # Without principal, spoof label in map is irrelevant.
+    assert default_xai_api_key() == "xai-owner-default"

--- a/tests/test_xai_client_authority.py
+++ b/tests/test_xai_client_authority.py
@@ -26,9 +26,11 @@ def test_inference_factory_constructs_with_only_inference_authority(monkeypatch)
 
     monkeypatch.setattr("xai_sdk.Client", FakeClient)
     monkeypatch.setattr(utils, "XAI_API_KEY", "inference-test-key")
+    monkeypatch.setenv("XAI_API_KEY", "inference-test-key")
+    monkeypatch.delenv("UNIGROK_PRINCIPAL_XAI_KEYS_JSON", raising=False)
     monkeypatch.setenv("XAI_MANAGEMENT_API_KEY", "management-test-key")
     monkeypatch.setenv("XAI_MANAGEMENT_KEY", "sdk-management-test-key")
-    monkeypatch.setattr(utils, "_client", None)
+    utils._clients.clear()
 
     inference = utils.get_xai_inference_client()
 
@@ -53,9 +55,11 @@ def test_real_sdk_inference_constructor_never_uses_management_environment(
 
     monkeypatch.setattr(SDKClient, "_make_grpc_channel", capture_channel)
     monkeypatch.setattr(utils, "XAI_API_KEY", "inference-test-key")
+    monkeypatch.setenv("XAI_API_KEY", "inference-test-key")
+    monkeypatch.delenv("UNIGROK_PRINCIPAL_XAI_KEYS_JSON", raising=False)
     monkeypatch.setenv("XAI_MANAGEMENT_API_KEY", "canonical-management-test-key")
     monkeypatch.setenv("XAI_MANAGEMENT_KEY", "sdk-management-test-key")
-    monkeypatch.setattr(utils, "_client", None)
+    utils._clients.clear()
 
     inference = utils.get_xai_inference_client()
 
@@ -226,7 +230,9 @@ def test_eval_recording_wraps_inference_but_never_management(monkeypatch):
     monkeypatch.setenv("XAI_MANAGEMENT_API_KEY", "management-test-key")
     monkeypatch.delenv("XAI_MANAGEMENT_KEY", raising=False)
     monkeypatch.setenv("UNIGROK_EVAL_RECORD", "1")
-    monkeypatch.setattr(utils, "_client", None)
+    monkeypatch.setenv("XAI_API_KEY", "inference-test-key")
+    monkeypatch.delenv("UNIGROK_PRINCIPAL_XAI_KEYS_JSON", raising=False)
+    utils._clients.clear()
     monkeypatch.setattr(utils, "_management_client", None)
 
     inference = utils.get_xai_inference_client()
@@ -248,14 +254,15 @@ def test_eval_recording_wraps_inference_but_never_management(monkeypatch):
 def test_role_specific_close_functions_do_not_cross_caches(monkeypatch):
     inference = SimpleNamespace(close=MagicMock())
     management = SimpleNamespace(close=MagicMock())
-    monkeypatch.setattr(utils, "_client", inference)
+    utils._clients.clear()
+    utils._clients["fp-test"] = inference
     monkeypatch.setattr(utils, "_management_client", management)
 
     utils.close_xai_inference_client()
 
     inference.close.assert_called_once_with()
     management.close.assert_not_called()
-    assert utils._client is None
+    assert utils._clients == {}
     assert utils._management_client is management
 
     utils.close_xai_management_client()
@@ -267,14 +274,15 @@ def test_role_specific_close_functions_do_not_cross_caches(monkeypatch):
 def test_compatibility_close_hook_closes_both_role_caches(monkeypatch):
     inference = SimpleNamespace(close=MagicMock())
     management = SimpleNamespace(close=MagicMock())
-    monkeypatch.setattr(utils, "_client", inference)
+    utils._clients.clear()
+    utils._clients["fp-test"] = inference
     monkeypatch.setattr(utils, "_management_client", management)
 
     utils.close_xai_client()
 
     inference.close.assert_called_once_with()
     management.close.assert_called_once_with()
-    assert utils._client is None
+    assert utils._clients == {}
     assert utils._management_client is None
 
 
@@ -291,9 +299,11 @@ def test_management_factory_is_thread_safe_and_separate_from_inference(monkeypat
 
     monkeypatch.setattr("xai_sdk.Client", SlowClient)
     monkeypatch.setattr(utils, "XAI_API_KEY", "inference-test-key")
+    monkeypatch.setenv("XAI_API_KEY", "inference-test-key")
+    monkeypatch.delenv("UNIGROK_PRINCIPAL_XAI_KEYS_JSON", raising=False)
     monkeypatch.setenv("XAI_MANAGEMENT_API_KEY", "management-test-key")
     monkeypatch.delenv("XAI_MANAGEMENT_KEY", raising=False)
-    monkeypatch.setattr(utils, "_client", None)
+    utils._clients.clear()
     monkeypatch.setattr(utils, "_management_client", None)
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:


### PR DESCRIPTION
## Summary
Stage **1c** after sponsor **Approved**: Cloud Run keeps **owner** `XAI_API_KEY` as default, and optional OAuth principals may use their own keys via `UNIGROK_PRINCIPAL_XAI_KEYS_JSON`. Includes Stage 1a docs (same Docker / cloud mode checklist).

## Why
Team hive KEEP + sponsor Approved. Laptop already uses each engineer’s keys; cloud now supports the same fairness for write+ principals without removing owner default.

## Changes
- `src/principal_xai.py` resolution (oauth only; never X-Client-ID)
- Inference client cache per key fingerprint
- Docs + `example.env` comment
- Tests for override, fallback, anon ignore, spoof resistance

## Tests
`uv run pytest -q tests/test_principal_xai.py tests/test_xai_client_authority.py` → 22 passed

## Human sponsor
djtelicloud

## Ready for supervisor?
Yes — low/medium: credentials plane; needs security review on land.

Head: `fc05d6d775d0929f9bc89572e24de1b876191101`

Supersedes docs-only #298 when this lands (includes those docs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which xAI credential is used for inference per authenticated OAuth principal; misconfigured JSON maps or principal binding could bill the wrong key or leak spend attribution, though overrides are restricted to oauth principals and keys are never logged.
> 
> **Overview**
> Adds **per-OAuth-principal xAI API key resolution** for Cloud Run while keeping **`XAI_API_KEY` as the owner default** for everyone else.
> 
> New **`src/principal_xai`** loads optional **`UNIGROK_PRINCIPAL_XAI_KEYS_JSON`** (OAuth principal → key), resolves **`(key, source)`** with overrides only for **`oauth:`** principals (anonymous/static principals stay on owner default; **`X-Client-ID` is not used**), and exposes secret-safe **`principal_xai_status`**.
> 
> **`get_xai_inference_client`** and **`xai_api_key_configured`** now use the active principal’s resolved key; inference clients are cached in a **multi-entry map** (`owner_default` vs `principal:<id>`) so teammate keys do not share the owner SDK client. **`close_xai_inference_client`** clears all cached inference clients.
> 
> Docs (**`remote-mcp-deployment`**, OKF api-reference, **`example.env`**) describe the cloud operator checklist and principal key map. Tests cover override, fallback, anon ignore, and client-id non-selection; existing client/credential tests were updated for **`_clients`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e7055325d55a056b1b9909f32adf828045d828e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->