### PR TITLE
fix(media): enforce caller budget and record Imagine spend

### DIFF
--- a/src/tools/media.py
+++ b/src/tools/media.py
@@ -5,6 +5,7 @@ import logging
 from typing import Optional, List
 from mcp.server.fastmcp import FastMCP
 from ..models.results import MediaResult
+from ..identity import get_active_principal, resolve_request_caller
 
 from ..utils import (
     get_xai_client,
@@ -16,9 +17,44 @@ from ..utils import (
     run_blocking,
     input_limit,
     validate_local_input,
+    enforce_caller_budget,
+    store,
 )
 
 logger = logging.getLogger("GrokMCP")
+
+
+async def _enforce_media_budget() -> Optional[str]:
+    """Gate Imagine spend on UNIGROK_CALLER_BUDGETS before any xAI call."""
+    caller = resolve_request_caller(None)
+    budget_principal = get_active_principal() or caller
+    await enforce_caller_budget(store, budget_principal)
+    return caller
+
+
+async def _record_media_telemetry(
+    *,
+    intent: str,
+    route: str,
+    cost_usd: float,
+    model: str,
+    latency_sec: float,
+    caller: Optional[str],
+) -> None:
+    """Persist Imagine spend so caller budgets and rolls see direct media tools."""
+    await store.save_telemetry(
+        (intent or route)[:100],
+        "API",
+        1,
+        float(latency_sec or 0.0),
+        float(cost_usd or 0.0),
+        caller=caller,
+        model=model,
+        tokens=0,
+        token_kind="provider_exact",
+        billing_source="xai_response_exact",
+        routing={"route": route, "plane": "API"},
+    )
 
 
 async def generate_image(
@@ -46,6 +82,7 @@ async def generate_image(
     Returns:
         MediaResult containing image metadata and URLs.
     """
+    caller = await _enforce_media_budget()
     async with GrokInvocationContext(model, logger, append_signature=True) as ctx:
         if not 1 <= int(n) <= 10:
             raise ValueError("n must be between 1 and 10")
@@ -93,7 +130,15 @@ async def generate_image(
 
         cost_usd = sum(float(getattr(img, "cost_usd", 0.0) or 0.0) for img in images)
         summary_text = ctx.format_output("".join(result), images)
-        
+        await _record_media_telemetry(
+            intent=prompt,
+            route="imagine",
+            cost_usd=cost_usd,
+            model=model,
+            latency_sec=ctx.elapsed,
+            caller=caller,
+        )
+
         return MediaResult(
             response=",".join([img.url for img in images]),
             text=summary_text,
@@ -138,6 +183,7 @@ async def generate_video(
         aspect_ratio: Aspect ratio like `"16:9"` or `"9:16"`.
         resolution: `"480p"` or `"720p"`.
     """
+    caller = await _enforce_media_budget()
     async with GrokInvocationContext(model, logger, append_signature=True) as ctx:
         if duration is not None and not 1 <= int(duration) <= 15:
             raise ValueError("duration must be between 1 and 15 seconds")
@@ -208,7 +254,15 @@ async def generate_video(
         output_text = f"## Generated Video\n\n\n**URL:** {response.url}\n\n\n**Duration:** {response.duration}s\n\n"
         cost_usd = float(getattr(response, "cost_usd", 0.0) or 0.0)
         summary_text = ctx.format_output(output_text, [response])
-        
+        await _record_media_telemetry(
+            intent=prompt,
+            route="imagine_video",
+            cost_usd=cost_usd,
+            model=model,
+            latency_sec=ctx.elapsed,
+            caller=caller,
+        )
+
         return MediaResult(
             response=output_text,
             text=summary_text,
@@ -247,6 +301,7 @@ async def extend_video(
         model: Video model (default `grok-imagine-video`).
         duration: Length of the extension in seconds (2–10, default 6).
     """
+    caller = await _enforce_media_budget()
     async with GrokInvocationContext(model, logger, append_signature=True) as ctx:
         if duration is not None and not 2 <= int(duration) <= 10:
             raise ValueError("duration must be between 2 and 10 seconds")
@@ -263,7 +318,15 @@ async def extend_video(
         output_text = f"## Extended Video\n\n\n**URL:** {response.url}\n\n\n**Duration:** {response.duration}s\n\n"
         cost_usd = float(getattr(response, "cost_usd", 0.0) or 0.0)
         summary_text = ctx.format_output(output_text, [response])
-        
+        await _record_media_telemetry(
+            intent=prompt,
+            route="extend_video",
+            cost_usd=cost_usd,
+            model=model,
+            latency_sec=ctx.elapsed,
+            caller=caller,
+        )
+
         return MediaResult(
             response=output_text,
             text=summary_text,
@@ -288,3 +351,4 @@ def register_media_tools(mcp: FastMCP):
     mcp.add_tool(extend_video)
 
 register_internal_tool("generate_image", generate_image)
+register_internal_tool("generate_video", generate_video)

--- a/tests/test_media_caller_budget.py
+++ b/tests/test_media_caller_budget.py
@@ -1,0 +1,66 @@
+"""Public media tools must honor caller budgets and record Imagine spend."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.identity import reset_active_principal, set_active_principal
+from src.tools import media as media_tools
+from src.utils import CallerBudgetExceeded, GrokSessionStore
+
+
+class _FakeCtx:
+    elapsed = 0.5
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def format_output(self, text, _objs=None):
+        return text
+
+
+@pytest.mark.asyncio
+async def test_generate_image_enforces_caller_budget(monkeypatch, tmp_path):
+    store = GrokSessionStore(db_path=tmp_path / "media-budget.db")
+    monkeypatch.setattr(media_tools, "store", store)
+    monkeypatch.setenv("UNIGROK_CALLER_BUDGETS", json.dumps({"http:key-test": 0.0}))
+    token = set_active_principal("http:key-test")
+    try:
+        with pytest.raises(CallerBudgetExceeded):
+            await media_tools.generate_image(prompt="a cat")
+    finally:
+        reset_active_principal(token)
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_generate_image_records_telemetry(monkeypatch, tmp_path):
+    store = GrokSessionStore(db_path=tmp_path / "media-telemetry.db")
+    monkeypatch.setattr(media_tools, "store", store)
+    monkeypatch.delenv("UNIGROK_CALLER_BUDGETS", raising=False)
+
+    class _Img:
+        url = "https://example.test/img.png"
+        prompt = "a cat"
+        cost_usd = 0.12
+
+    async def _fake_run_blocking(fn, timeout=120.0):
+        return [_Img()]
+
+    monkeypatch.setattr(media_tools, "run_blocking", _fake_run_blocking)
+    monkeypatch.setattr(media_tools, "GrokInvocationContext", lambda *a, **k: _FakeCtx())
+
+    token = set_active_principal("http:key-media")
+    try:
+        result = await media_tools.generate_image(prompt="a cat")
+        assert result.cost_usd == 0.12
+        spent = await store.get_caller_cost_today("http:key-media")
+        assert spent == pytest.approx(0.12)
+    finally:
+        reset_active_principal(token)
+        await store.close()


### PR DESCRIPTION
## Summary
- Gate public Imagine tools with `enforce_caller_budget` before spend.
- Persist `save_telemetry` for direct media tool costs.
- Focused regression coverage.

@grok APPROVE / YES-DRAFT-PR

## Test plan
- [x] `uv run pytest -q tests/test_media_caller_budget.py`
- [ ] @grok APPROVE / YES-DRAFT-PR on this exact HEAD

Made with [Cursor](https://cursor.com)