### PR TITLE
fix(security): scrub server secrets from pytest children

### DIFF
--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -38,6 +38,7 @@ from ..utils import (
     get_circuit_breaker_state,
     get_routing_advisor,
     grok_cli_plane_status,
+    grok_cli_oauth_env,
     credential_plane_contract,
     input_limit,
     validate_local_input,
@@ -777,11 +778,14 @@ async def run_local_tests(
         else:
             cmd = [sys.executable, "-m", "pytest", "-q", safe_target]
 
+        # Scrub server-owned secrets (XAI_API_KEY, etc.) so pytest children
+        # cannot echo them back through the MCP tool result.
         proc = await asyncio.create_subprocess_exec(
             *cmd,
             cwd=str(project_root),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            env=grok_cli_oauth_env(),
         )
         try:
             stdout, stderr = await communicate_with_timeout(proc, timeout)

--- a/tests/test_pytest_env_scrub.py
+++ b/tests/test_pytest_env_scrub.py
@@ -1,0 +1,57 @@
+"""run_local_tests must not inherit server-owned secrets into pytest children."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.credentials import SERVER_OWNED_SECRET_ENV_NAMES
+from src.tools import system as system_tools
+
+
+@pytest.mark.asyncio
+async def test_run_local_tests_passes_scrubbed_env(monkeypatch, tmp_path):
+    root = tmp_path / "proj"
+    root.mkdir()
+    (root / "tests").mkdir()
+    (root / "tests" / "test_ok.py").write_text(
+        "def test_ok():\n    assert True\n", encoding="utf-8"
+    )
+    monkeypatch.setattr(
+        system_tools.PathResolver,
+        "get_workspace_root",
+        staticmethod(lambda: root),
+    )
+    monkeypatch.setattr(system_tools, "is_cloudrun_runtime", lambda: False)
+    monkeypatch.setattr(system_tools.shutil, "which", lambda _name: None)
+    monkeypatch.setenv("XAI_API_KEY", "xai-should-not-reach-pytest")
+
+    captured: dict = {}
+
+    async def _fake_exec(*cmd, **kwargs):
+        captured["env"] = kwargs.get("env")
+        captured["cmd"] = cmd
+
+        class _Proc:
+            returncode = 0
+
+            async def wait(self):
+                return 0
+
+            def kill(self):
+                return None
+
+        return _Proc()
+
+    async def _fake_communicate(proc, timeout):
+        return (b"1 passed\n", b"")
+
+    monkeypatch.setattr(system_tools.asyncio, "create_subprocess_exec", _fake_exec)
+    monkeypatch.setattr(system_tools, "communicate_with_timeout", _fake_communicate)
+
+    out = await system_tools.run_local_tests(target="tests")
+    assert "passed" in out
+    env = captured["env"]
+    assert isinstance(env, dict)
+    for name in SERVER_OWNED_SECRET_ENV_NAMES:
+        assert name not in env
+    assert "XAI_API_KEY" not in env

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1017,9 +1017,10 @@ class TestTier2ToolsRegistered:
             async def wait(self):
                 return 0
 
-        async def fake_create_subprocess_exec(*cmd, cwd, stdout, stderr):
+        async def fake_create_subprocess_exec(*cmd, cwd, stdout, stderr, **kwargs):
             captured["cmd"] = cmd
             captured["cwd"] = cwd
+            captured["kwargs"] = kwargs
             return FakeProc()
 
         monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)


### PR DESCRIPTION
## Summary
- Pass `env=grok_cli_oauth_env()` into `run_local_tests` pytest children.
- Prevent `XAI_API_KEY` (and peers) from inheriting into MCP-returned stdout.
- Focused regression coverage. Distinct from Ready #290 (process-group budget).

@grok APPROVE / YES-DRAFT-PR

## Test plan
- [x] `uv run pytest -q tests/test_pytest_env_scrub.py`
- [ ] @grok APPROVE / YES-DRAFT-PR on this exact HEAD

Made with [Cursor](https://cursor.com)