### PR TITLE
fix(http): optional per-principal rate limit on /mcp and /v1

### DIFF
--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -319,6 +319,20 @@ Pure ASGI for the same SSE-disconnect reason as GatewayAuthMiddleware.
 Loopback origins and the UNIGROK_ALLOWED_ORIGINS allowlist pass; any other
 browser origin is rejected with 403.
 
+### Class: `HttpRateLimitMiddleware` {#http_server-httpratelimitmiddleware}
+
+```python
+class HttpRateLimitMiddleware
+```
+
+**Keywords:** http, rate, limit, middleware
+
+In-process per-principal QPS throttle for /mcp and /v1.
+
+Fail-open when UNIGROK_HTTP_RATE_LIMIT is unset. Distinct from
+UNIGROK_CALLER_BUDGETS (spend) and circuit breakers (provider errors).
+Pure ASGI — same SSE-disconnect tombstone as GatewayAuthMiddleware.
+
 ### Class: `CallerContextMiddleware` {#http_server-callercontextmiddleware}
 
 ```python

--- a/example.env
+++ b/example.env
@@ -44,6 +44,11 @@ UNIGROK_TRUSTED_LOOPBACK_PROXY=
 # Per-caller daily spend caps as JSON {principal: daily_usd}, e.g.
 # {"oauth-subject-123": 5.0}. Blank or malformed disables caps (warns, never
 # fails). Useful on a shared/hosted deployment.
+# Optional HTTP abuse throttle: max requests per minute per authenticated
+# principal (or http:anon) on /mcp and /v1. Unset = fail-open (no limit).
+# Spend budgets remain UNIGROK_CALLER_BUDGETS — this is QPS only.
+# UNIGROK_HTTP_RATE_LIMIT=120
+
 UNIGROK_CALLER_BUDGETS=
 
 # Optional state root. Cloud Run defaults to /tmp/uni-grok.

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -319,6 +319,20 @@ Pure ASGI for the same SSE-disconnect reason as GatewayAuthMiddleware.
 Loopback origins and the UNIGROK_ALLOWED_ORIGINS allowlist pass; any other
 browser origin is rejected with 403.
 
+### Class: `HttpRateLimitMiddleware` {#http_server-httpratelimitmiddleware}
+
+```python
+class HttpRateLimitMiddleware
+```
+
+**Keywords:** http, rate, limit, middleware
+
+In-process per-principal QPS throttle for /mcp and /v1.
+
+Fail-open when UNIGROK_HTTP_RATE_LIMIT is unset. Distinct from
+UNIGROK_CALLER_BUDGETS (spend) and circuit breakers (provider errors).
+Pure ASGI — same SSE-disconnect tombstone as GatewayAuthMiddleware.
+
 ### Class: `CallerContextMiddleware` {#http_server-callercontextmiddleware}
 
 ```python

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -1,4 +1,5 @@
 import asyncio
+from collections import defaultdict, deque
 import contextvars
 import hmac
 import ipaddress
@@ -655,6 +656,73 @@ class MCPOriginMiddleware:
                 response = _json_error("Origin not allowed.", status_code=403, code="forbidden")
                 await response(scope, receive, send)
                 return
+        await self.app(scope, receive, send)
+
+
+
+_RATE_LIMITED_PREFIXES = ("/mcp", "/v1")
+
+
+def _http_rate_limit_per_minute() -> Optional[int]:
+    """UNIGROK_HTTP_RATE_LIMIT: max requests/minute/principal. Unset/blank = off."""
+    raw = os.environ.get("UNIGROK_HTTP_RATE_LIMIT", "").strip()
+    if not raw:
+        return None
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logging.getLogger("GrokMCP").warning(
+            "Ignoring malformed UNIGROK_HTTP_RATE_LIMIT=%r", raw
+        )
+        return None
+    if value <= 0:
+        return None
+    return max(1, min(value, 1_000_000))
+
+
+class HttpRateLimitMiddleware:
+    """In-process per-principal QPS throttle for /mcp and /v1.
+
+    Fail-open when UNIGROK_HTTP_RATE_LIMIT is unset. Distinct from
+    UNIGROK_CALLER_BUDGETS (spend) and circuit breakers (provider errors).
+    Pure ASGI — same SSE-disconnect tombstone as GatewayAuthMiddleware.
+    """
+
+    def __init__(self, app):
+        self.app = app
+        self._hits: Dict[str, deque] = defaultdict(deque)
+        self._lock = asyncio.Lock()
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+        path = scope.get("path", "") or ""
+        if not path.startswith(_RATE_LIMITED_PREFIXES):
+            await self.app(scope, receive, send)
+            return
+        limit = _http_rate_limit_per_minute()
+        if limit is None:
+            await self.app(scope, receive, send)
+            return
+        principal = _derive_http_principal(scope)
+        now = time.monotonic()
+        window = 60.0
+        async with self._lock:
+            bucket = self._hits[principal]
+            while bucket and (now - bucket[0]) >= window:
+                bucket.popleft()
+            if len(bucket) >= limit:
+                retry_after = max(1, int(window - (now - bucket[0])) + 1)
+                response = _json_error(
+                    "Rate limit exceeded.",
+                    status_code=429,
+                    code="rate_limit_exceeded",
+                )
+                response.headers["Retry-After"] = str(retry_after)
+                await response(scope, receive, send)
+                return
+            bucket.append(now)
         await self.app(scope, receive, send)
 
 
@@ -2564,6 +2632,7 @@ def create_app(*, bound_host: Optional[str] = None) -> Starlette:
             Middleware(StaticAssetCacheMiddleware),
             Middleware(MCPOriginMiddleware),
             Middleware(GatewayAuthMiddleware, bound_host=effective_bound_host),
+            Middleware(HttpRateLimitMiddleware),
             Middleware(ModeDialContextMiddleware),
             Middleware(CallerContextMiddleware),
         ],

--- a/tests/test_http_rate_limit.py
+++ b/tests/test_http_rate_limit.py
@@ -1,0 +1,50 @@
+"""HTTP /mcp and /v1 per-principal rate limiting."""
+
+from __future__ import annotations
+
+import pytest
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.testclient import TestClient
+
+from src.http_server import (
+    HttpRateLimitMiddleware,
+    MCPOriginMiddleware,
+    create_app,
+)
+
+
+def test_rate_limit_middleware_is_pure_asgi():
+    assert not issubclass(HttpRateLimitMiddleware, BaseHTTPMiddleware)
+
+
+def test_rate_limit_fail_open_when_unset(monkeypatch):
+    monkeypatch.delenv("UNIGROK_HTTP_RATE_LIMIT", raising=False)
+    monkeypatch.delenv("UNIGROK_API_KEYS", raising=False)
+    monkeypatch.delenv("UNIGROK_RUNTIME", raising=False)
+    with TestClient(create_app()) as client:
+        for _ in range(5):
+            res = client.get("/v1/models")
+            assert res.status_code != 429
+
+
+def test_rate_limit_returns_429_when_exceeded(monkeypatch):
+    monkeypatch.setenv("UNIGROK_HTTP_RATE_LIMIT", "2")
+    monkeypatch.delenv("UNIGROK_API_KEYS", raising=False)
+    monkeypatch.delenv("UNIGROK_RUNTIME", raising=False)
+    with TestClient(create_app()) as client:
+        assert client.get("/v1/models").status_code != 429
+        assert client.get("/v1/models").status_code != 429
+        limited = client.get("/v1/models")
+        assert limited.status_code == 429
+        assert limited.json()["error"]["code"] == "rate_limit_exceeded"
+        assert "Retry-After" in limited.headers
+
+
+def test_rate_limit_does_not_apply_to_healthz(monkeypatch):
+    monkeypatch.setenv("UNIGROK_HTTP_RATE_LIMIT", "1")
+    monkeypatch.delenv("UNIGROK_API_KEYS", raising=False)
+    monkeypatch.delenv("UNIGROK_RUNTIME", raising=False)
+    with TestClient(create_app()) as client:
+        assert client.get("/healthz").status_code == 200
+        assert client.get("/healthz").status_code == 200
+        assert client.get("/healthz").status_code == 200

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -12,6 +12,7 @@ from src.credentials import (
     UPSTREAM_PROVIDER_SECRET_ENV_NAMES,
 )
 from src.http_server import (
+    HttpRateLimitMiddleware,
     GatewayAuthMiddleware,
     MCPOriginMiddleware,
     ModeDialContextMiddleware,
@@ -1243,6 +1244,7 @@ def test_middleware_is_pure_asgi():
 
     assert not issubclass(GatewayAuthMiddleware, BaseHTTPMiddleware)
     assert not issubclass(MCPOriginMiddleware, BaseHTTPMiddleware)
+    assert not issubclass(HttpRateLimitMiddleware, BaseHTTPMiddleware)
     assert not issubclass(ModeDialContextMiddleware, BaseHTTPMiddleware)
     assert not issubclass(StaticAssetCacheMiddleware, BaseHTTPMiddleware)
 


### PR DESCRIPTION
## Summary
- Add pure-ASGI `HttpRateLimitMiddleware` for `/mcp` and `/v1`.
- `UNIGROK_HTTP_RATE_LIMIT` = requests/minute/principal; unset fails open.
- Returns 429 + `Retry-After`. Distinct from spend budgets.

@grok APPROVE / YES-DRAFT-PR

## Test plan
- [x] `uv run pytest -q tests/test_http_rate_limit.py tests/test_http_server.py::test_middleware_is_pure_asgi`
- [ ] @grok APPROVE / YES-DRAFT-PR on this exact HEAD

Made with [Cursor](https://cursor.com)