### PR TITLE
fix(auth): advertise compose-run CLI device-auth path

### DIFF
--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -165,6 +165,16 @@ mandatory wherever semantic completion matters.
 
 ## credentials.py {#credentials}
 
+### Function: `default_cli_auth_setup_command` {#credentials-default_cli_auth_setup_command}
+
+```python
+def default_cli_auth_setup_command(*, containerized: bool=True) -> str
+```
+
+**Keywords:** default, cli, auth, setup, command
+
+Return the operator-facing device-auth command for this runtime.
+
 ### Function: `credential_plane_policy` {#credentials-credential_plane_policy}
 
 ```python

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -165,6 +165,16 @@ mandatory wherever semantic completion matters.
 
 ## credentials.py {#credentials}
 
+### Function: `default_cli_auth_setup_command` {#credentials-default_cli_auth_setup_command}
+
+```python
+def default_cli_auth_setup_command(*, containerized: bool=True) -> str
+```
+
+**Keywords:** default, cli, auth, setup, command
+
+Return the operator-facing device-auth command for this runtime.
+
 ### Function: `credential_plane_policy` {#credentials-credential_plane_policy}
 
 ```python

--- a/src/credentials.py
+++ b/src/credentials.py
@@ -36,15 +36,23 @@ SERVER_OWNED_SECRET_ENV_NAMES = (
 _CLI_AUTH_ENV_UNSETS = " ".join(
     f"-u {name}" for name in SERVER_OWNED_SECRET_ENV_NAMES
 )
-CLI_AUTH_SETUP_COMMAND = (
-    "docker exec -u 0 -it grok-mcp-server sh -lc "
-    "'chown -R 1000:1000 /home/appuser/.grok && exec setpriv "
-    "--reuid=1000 --regid=1000 --clear-groups env "
-    f"{_CLI_AUTH_ENV_UNSETS} grok login --device-auth'"
+# Documented operator path: one-shot auth profile (volume + privilege drop live
+# in docker-compose.yml). Prefer this over `docker exec -u 0` into the live
+# service container.
+CLI_AUTH_SETUP_COMMAND = "docker compose run --rm grok-cli-auth"
+# Host-native HTTP/dev path: scrub server-owned secrets, then device-auth.
+CLI_AUTH_NATIVE_SETUP_COMMAND = (
+    f"env {_CLI_AUTH_ENV_UNSETS} grok login --device-auth"
 )
 CLI_DOCKER_REBUILD_COMMAND = "docker compose up --build -d grok-mcp"
 CLI_NATIVE_INSTALL_COMMAND = "curl -fsSL https://x.ai/cli/install.sh | bash"
 SERVICE_RECREATE_COMMAND = "docker compose up -d --force-recreate grok-mcp"
+
+
+def default_cli_auth_setup_command(*, containerized: bool = True) -> str:
+    """Return the operator-facing device-auth command for this runtime."""
+
+    return CLI_AUTH_SETUP_COMMAND if containerized else CLI_AUTH_NATIVE_SETUP_COMMAND
 
 
 def credential_plane_policy(*, cloudrun: bool = False) -> str:
@@ -108,7 +116,10 @@ def _cli_action(cli: Dict[str, Any], *, containerized: bool) -> Dict[str, Any]:
             "requires_user_approval": True,
             "requires_user_secret": False,
             "interactive": True,
-            "command": str(cli.get("setup_command") or CLI_AUTH_SETUP_COMMAND),
+            "command": str(
+                cli.get("setup_command")
+                or default_cli_auth_setup_command(containerized=containerized)
+            ),
             "instructions": (
                 "Ask permission to run the device-auth command, then let the user "
                 "complete the browser/device confirmation. Recheck plane health afterward."

--- a/src/utils.py
+++ b/src/utils.py
@@ -42,6 +42,7 @@ from .credentials import (
     SERVER_OWNED_SECRET_ENV_NAMES,
     build_credential_plane_contract,
     credential_plane_policy,
+    default_cli_auth_setup_command,
 )
 from .xai_credentials import (
     XAIManagementKeyState,
@@ -337,7 +338,9 @@ def grok_cli_plane_status(
     turn.  The probe always strips API-key variables so an API-backed CLI can
     never masquerade as the independent subscription plane.
     """
-    setup = CLI_AUTH_SETUP_COMMAND
+    setup = default_cli_auth_setup_command(
+        containerized=Path("/.dockerenv").exists()
+    )
     if is_cloudrun_runtime():
         return {
             "state": "disabled",

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -5,18 +5,30 @@ from unittest.mock import AsyncMock
 import pytest
 
 from src.credentials import (
+    CLI_AUTH_NATIVE_SETUP_COMMAND,
     CLI_AUTH_SETUP_COMMAND,
     SERVER_OWNED_SECRET_ENV_NAMES,
     build_credential_plane_contract,
     credential_plane_policy,
+    default_cli_auth_setup_command,
 )
+
+
+def test_cli_auth_setup_prefers_compose_auth_profile():
+    assert CLI_AUTH_SETUP_COMMAND == "docker compose run --rm grok-cli-auth"
+    assert default_cli_auth_setup_command(containerized=True) == CLI_AUTH_SETUP_COMMAND
+    assert (
+        default_cli_auth_setup_command(containerized=False)
+        == CLI_AUTH_NATIVE_SETUP_COMMAND
+    )
 
 
 def test_cli_auth_setup_scrubs_server_credentials_but_keeps_oauth_path():
     for name in SERVER_OWNED_SECRET_ENV_NAMES:
-        assert f"-u {name}" in CLI_AUTH_SETUP_COMMAND
-    assert "-u GROK_AUTH_PATH" not in CLI_AUTH_SETUP_COMMAND
-    assert "-u GOOGLE_CLOUD_PROJECT" not in CLI_AUTH_SETUP_COMMAND
+        assert f"-u {name}" in CLI_AUTH_NATIVE_SETUP_COMMAND
+    assert "-u GROK_AUTH_PATH" not in CLI_AUTH_NATIVE_SETUP_COMMAND
+    assert "-u GOOGLE_CLOUD_PROJECT" not in CLI_AUTH_NATIVE_SETUP_COMMAND
+    assert "grok login --device-auth" in CLI_AUTH_NATIVE_SETUP_COMMAND
 
 
 def test_compose_cli_auth_scrubs_every_canonical_server_credential():
@@ -89,19 +101,35 @@ def test_missing_cli_auth_prompts_for_device_flow(monkeypatch):
     assert action["command"] == "docker exec auth"
 
 
-def test_default_cli_auth_action_repairs_volume_then_drops_privileges():
+def test_default_cli_auth_action_uses_compose_auth_profile():
     contract = build_credential_plane_contract(
         api_configured=True,
         cli_status={
             "state": "needs_auth", "ready": False, "binary": True,
             "auth": "missing",
         },
+        containerized=True,
     )
     command = contract["cli"]["action"]["command"]
     assert command == CLI_AUTH_SETUP_COMMAND
-    assert "docker exec -u 0 -it grok-mcp-server" in command
-    assert "chown -R 1000:1000 /home/appuser/.grok" in command
-    assert "setpriv --reuid=1000 --regid=1000 --clear-groups" in command
+    assert command == "docker compose run --rm grok-cli-auth"
+    assert "docker exec" not in command
+
+
+def test_host_native_cli_auth_action_scrubs_server_secrets():
+    contract = build_credential_plane_contract(
+        api_configured=True,
+        cli_status={
+            "state": "needs_auth", "ready": False, "binary": True,
+            "auth": "missing",
+        },
+        containerized=False,
+    )
+    command = contract["cli"]["action"]["command"]
+    assert command == CLI_AUTH_NATIVE_SETUP_COMMAND
+    assert "docker" not in command
+    for name in SERVER_OWNED_SECRET_ENV_NAMES:
+        assert f"-u {name}" in command
 
 
 def test_missing_api_prompts_once_but_does_not_block_when_cli_can_serve(monkeypatch):


### PR DESCRIPTION
## Summary
- Replace the default CLI device-auth hint (`docker exec -u 0` into the live service) with the documented `docker compose run --rm grok-cli-auth` profile.
- Host-native runtimes advertise an `env -u … grok login --device-auth` command that scrubs server-owned secrets.
- Leaves `docs/ide-setup.md` and repo-root `.mcp.json` untouched.

## Test plan
- [x] `uv run pytest -q tests/test_credentials.py`
- [x] Attribution check vs `origin/main`
- [ ] CI green on draft PR


Made with [Cursor](https://cursor.com)