### PR TITLE
fix(security): gate search/code tools on caller budgets

### DIFF
--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -41,6 +41,7 @@ from ..utils import (
     credential_plane_contract,
     input_limit,
     validate_local_input,
+    enforce_caller_budget,
 )
 from xai_sdk.chat import user
 from xai_sdk.tools import code_execution, web_search as xai_web_search, x_search as xai_x_search
@@ -49,6 +50,7 @@ from ..identity import (
     get_active_client_id,
     get_active_principal,
     principal_kind,
+    resolve_request_caller,
     scoped_session,
 )
 
@@ -96,6 +98,40 @@ def _build_tool_result(
         plane="API",
         citations=citations,
         data=data,
+    )
+
+
+async def _enforce_metered_tool_budget() -> Optional[str]:
+    """Gate direct API-metered system tools on UNIGROK_CALLER_BUDGETS."""
+    caller = resolve_request_caller(None)
+    budget_principal = get_active_principal() or caller
+    await enforce_caller_budget(store, budget_principal)
+    return caller
+
+
+async def _record_metered_tool_telemetry(
+    *,
+    intent: str,
+    route: str,
+    cost_usd: float,
+    model: str,
+    latency_sec: float,
+    tokens: int,
+    caller: Optional[str],
+) -> None:
+    """Persist direct tool spend so caller budgets see non-orchestrate paths."""
+    await store.save_telemetry(
+        (intent or route)[:100],
+        "API",
+        1,
+        float(latency_sec or 0.0),
+        float(cost_usd or 0.0),
+        caller=caller,
+        model=model,
+        tokens=int(tokens or 0),
+        token_kind="provider_exact",
+        billing_source="xai_response_exact",
+        routing={"route": route, "plane": "API"},
     )
 
 
@@ -694,6 +730,7 @@ async def remote_code_execution(prompt: str, max_turns: Optional[int] = None) ->
     Renamed from `code_executor` — it invokes xAI's remote `code_execution`
     tool; no code runs on this machine.
     """
+    caller = await _enforce_metered_tool_budget()
     async with GrokInvocationContext("grok-4.3", logger, append_signature=True) as ctx:
         chat_params = {"model": "grok-4.3", "tools": [code_execution()], "include": ["code_execution_call_output"]}
         if max_turns:
@@ -717,7 +754,7 @@ async def remote_code_execution(prompt: str, max_turns: Optional[int] = None) ->
                 code_outputs.append(output.message.content)
 
         formatted = ctx.format_output("\n".join(result), [response])
-        return _build_tool_result(
+        built = _build_tool_result(
             ctx,
             response=response,
             route="code_execution",
@@ -725,6 +762,16 @@ async def remote_code_execution(prompt: str, max_turns: Optional[int] = None) ->
             formatted_text=formatted,
             data={"code_outputs": code_outputs} if code_outputs else None,
         )
+        await _record_metered_tool_telemetry(
+            intent=(prompt or "code_execution")[:100],
+            route="code_execution",
+            cost_usd=built.cost_usd,
+            model=built.model,
+            latency_sec=built.latency_sec,
+            tokens=built.tokens,
+            caller=caller,
+        )
+        return built
 
 
 def _validate_test_target(target: str) -> str:
@@ -825,6 +872,7 @@ async def web_search(
         allowed_domains: Restrict search to these domains (e.g. `["arxiv.org"]`).
         excluded_domains: Domains to exclude from search results.
     """
+    caller = await _enforce_metered_tool_budget()
     async with GrokInvocationContext("grok-4.3", logger, append_signature=True) as ctx:
         def _call_web():
             client = get_xai_client()
@@ -846,7 +894,7 @@ async def web_search(
         formatted = ctx.format_output("\n".join(result), [response])
         citations_mapped = [{"url": url} for url in response.citations] if response.citations else None
 
-        return _build_tool_result(
+        built = _build_tool_result(
             ctx,
             response=response,
             route="web_search",
@@ -855,6 +903,16 @@ async def web_search(
             citations=citations_mapped,
             data={"query": prompt, "citations": list(response.citations)} if response.citations else {"query": prompt},
         )
+        await _record_metered_tool_telemetry(
+            intent=(prompt or "web_search")[:100],
+            route="web_search",
+            cost_usd=built.cost_usd,
+            model=built.model,
+            latency_sec=built.latency_sec,
+            tokens=built.tokens,
+            caller=caller,
+        )
+        return built
 
 
 def _parse_search_date(value: str, param_name: str) -> datetime:
@@ -895,6 +953,7 @@ async def x_search(
             plane="API",
         )
 
+    caller = await _enforce_metered_tool_budget()
     async with GrokInvocationContext("grok-4.3", logger, append_signature=True) as ctx:
         def _call_x():
             client = get_xai_client()
@@ -917,7 +976,7 @@ async def x_search(
         formatted = ctx.format_output("\n".join(result), [response])
         citations_mapped = [{"url": url} for url in response.citations] if response.citations else None
 
-        return _build_tool_result(
+        built = _build_tool_result(
             ctx,
             response=response,
             route="x_search",
@@ -926,6 +985,16 @@ async def x_search(
             citations=citations_mapped,
             data={"query": prompt, "citations": list(response.citations)} if response.citations else {"query": prompt},
         )
+        await _record_metered_tool_telemetry(
+            intent=(prompt or "x_search")[:100],
+            route="x_search",
+            cost_usd=built.cost_usd,
+            model=built.model,
+            latency_sec=built.latency_sec,
+            tokens=built.tokens,
+            caller=caller,
+        )
+        return built
 
 
 async def db_vacuum() -> str:

--- a/tests/test_search_tools_caller_budget.py
+++ b/tests/test_search_tools_caller_budget.py
@@ -1,0 +1,86 @@
+"""Direct metered search/code tools must honor caller budgets and record spend."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.identity import reset_active_principal, set_active_principal
+from src.tools import system as system_tools
+from src.utils import CallerBudgetExceeded, GrokSessionStore
+
+
+class _FakeCtx:
+    elapsed = 0.5
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def format_output(self, text, _objs=None):
+        return text
+
+
+class _FakeResponse:
+    content = "ok"
+    citations = ["https://example.test"]
+    tool_outputs = None
+    cost_usd = 0.07
+    finish_reason = "final_answer"
+    usage = type("U", (), {"prompt_tokens": 3, "completion_tokens": 4})()
+
+
+@pytest.mark.asyncio
+async def test_web_search_enforces_caller_budget(monkeypatch, tmp_path):
+    store = GrokSessionStore(db_path=tmp_path / "search-budget.db")
+    monkeypatch.setattr(system_tools, "store", store)
+    monkeypatch.setenv("UNIGROK_CALLER_BUDGETS", json.dumps({"http:key-test": 0.0}))
+    token = set_active_principal("http:key-test")
+    try:
+        with pytest.raises(CallerBudgetExceeded):
+            await system_tools.web_search(prompt="latest news")
+    finally:
+        reset_active_principal(token)
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_web_search_records_telemetry(monkeypatch, tmp_path):
+    store = GrokSessionStore(db_path=tmp_path / "search-telemetry.db")
+    monkeypatch.setattr(system_tools, "store", store)
+    monkeypatch.delenv("UNIGROK_CALLER_BUDGETS", raising=False)
+
+    async def _fake_run_blocking(fn, timeout=60.0):
+        return _FakeResponse()
+
+    monkeypatch.setattr(system_tools, "run_blocking", _fake_run_blocking)
+    monkeypatch.setattr(system_tools, "GrokInvocationContext", lambda *a, **k: _FakeCtx())
+
+    token = set_active_principal("http:key-search")
+    try:
+        result = await system_tools.web_search(prompt="latest news")
+        assert result.cost_usd == 0.07
+        spent = await store.get_caller_cost_today("http:key-search")
+        assert spent == pytest.approx(0.07)
+    finally:
+        reset_active_principal(token)
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_x_search_and_remote_code_enforce_budget(monkeypatch, tmp_path):
+    store = GrokSessionStore(db_path=tmp_path / "search-budget-more.db")
+    monkeypatch.setattr(system_tools, "store", store)
+    monkeypatch.setenv("UNIGROK_CALLER_BUDGETS", json.dumps({"http:key-test": 0.0}))
+    token = set_active_principal("http:key-test")
+    try:
+        with pytest.raises(CallerBudgetExceeded):
+            await system_tools.x_search(prompt="posts about grok")
+        with pytest.raises(CallerBudgetExceeded):
+            await system_tools.remote_code_execution(prompt="print(1)")
+    finally:
+        reset_active_principal(token)
+        await store.close()


### PR DESCRIPTION
## Summary
- `web_search`, `x_search`, and `remote_code_execution` now enforce `UNIGROK_CALLER_BUDGETS` before any xAI call (same principal resolution as #301 media).
- Successful calls record spend via `save_telemetry` so later budget checks see direct-tool usage.
- Unset budgets / unmatched principals remain a no-op.

## Test plan
- [x] `uv run pytest -q tests/test_search_tools_caller_budget.py`
- [x] Attribution check vs `origin/main`
- [ ] CI green on draft PR


Made with [Cursor](https://cursor.com)