### PR TITLE
fix(security): gate chat vision/files tools on caller budgets

### DIFF
--- a/src/tools/chats.py
+++ b/src/tools/chats.py
@@ -8,7 +8,12 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field
 from ..models.results import ChatResult, AgentResult, ReflectionResult
-from ..identity import caller_from_mcp_context, scoped_session
+from ..identity import (
+    caller_from_mcp_context,
+    get_active_principal,
+    resolve_request_caller,
+    scoped_session,
+)
 
 from ..utils import (
     store,
@@ -27,6 +32,7 @@ from ..utils import (
     input_limit,
     validate_local_input,
     DEFAULT_PLANNING_MODEL,
+    enforce_caller_budget,
 )
 from xai_sdk.chat import system, user, assistant, image, file as xai_file
 
@@ -61,6 +67,41 @@ def _research_agent_count() -> int:
     except ValueError:
         return 4
     return value if value in (4, 16) else 4
+
+
+async def _enforce_chat_tool_budget() -> Optional[str]:
+    """Gate direct API-metered chat tools on UNIGROK_CALLER_BUDGETS."""
+    caller = resolve_request_caller(None)
+    budget_principal = get_active_principal() or caller
+    await enforce_caller_budget(store, budget_principal)
+    return caller
+
+
+async def _record_chat_tool_telemetry(
+    *,
+    intent: str,
+    route: str,
+    cost_usd: float,
+    model: str,
+    latency_sec: float,
+    tokens: int,
+    caller: Optional[str],
+) -> None:
+    """Persist vision/files spend so caller budgets see non-orchestrate paths."""
+    await store.save_telemetry(
+        (intent or route)[:100],
+        "API",
+        1,
+        float(latency_sec or 0.0),
+        float(cost_usd or 0.0),
+        caller=caller,
+        model=model,
+        tokens=int(tokens or 0),
+        token_kind="provider_exact",
+        billing_source="xai_response_exact",
+        routing={"route": route, "plane": "API"},
+    )
+
 
 # Pydantic Schemas for RPC Boundary Validation
 class GrokAgentInput(BaseModel):
@@ -602,6 +643,7 @@ async def chat_with_vision(
         image_urls: Public image URLs to analyze.
         detail: Image detail level. One of `"auto"`, `"low"`, or `"high"`.
     """
+    caller = await _enforce_chat_tool_budget()
     session = scoped_session(session)
     async with GrokInvocationContext(model, logger, append_signature=True) as ctx:
         history = (await load_history(session, store)) if session else []
@@ -661,6 +703,15 @@ async def chat_with_vision(
 
         citations_mapped = [{"url": url} for url in response.citations] if hasattr(response, 'citations') and response.citations else None
 
+        await _record_chat_tool_telemetry(
+            intent=(prompt or "vision")[:100],
+            route="vision",
+            cost_usd=cost_usd,
+            model=model,
+            latency_sec=ctx.elapsed,
+            tokens=tokens_val,
+            caller=caller,
+        )
         return ChatResult(
             response=response.content,
             text=formatted_text,
@@ -704,6 +755,7 @@ async def chat_with_files(
             plane="API",
         )
 
+    caller = await _enforce_chat_tool_budget()
     dynamic_sys_prompt, ctx_injected, context_id = await get_dynamic_context(prompt=prompt)
     if system_prompt:
         dynamic_sys_prompt += f"\nAdditional Instructions:\n{system_prompt}"
@@ -759,6 +811,15 @@ async def chat_with_files(
 
         citations_mapped = [{"url": url} for url in response.citations] if hasattr(response, 'citations') and response.citations else None
 
+        await _record_chat_tool_telemetry(
+            intent=(prompt or "files")[:100],
+            route="files",
+            cost_usd=cost_usd,
+            model=model,
+            latency_sec=ctx.elapsed,
+            tokens=tokens_val,
+            caller=caller,
+        )
         return ChatResult(
             response=response.content,
             text=formatted_text,

--- a/tests/test_chat_tools_caller_budget.py
+++ b/tests/test_chat_tools_caller_budget.py
@@ -1,0 +1,91 @@
+"""chat_with_vision / chat_with_files must honor caller budgets and record spend."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from src.identity import reset_active_principal, set_active_principal
+from src.tools import chats as chat_tools
+from src.utils import CallerBudgetExceeded, GrokSessionStore
+
+
+class _FakeCtx:
+    elapsed = 0.4
+    context_injected = False
+    finish_reason = "final_answer"
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def format_output(self, text, _objs=None):
+        return text
+
+
+class _FakeResponse:
+    content = "ok"
+    citations = None
+    cost_usd = 0.09
+    finish_reason = "final_answer"
+    usage = type("U", (), {"prompt_tokens": 2, "completion_tokens": 3})()
+
+
+@pytest.mark.asyncio
+async def test_chat_with_vision_enforces_caller_budget(monkeypatch, tmp_path):
+    store = GrokSessionStore(db_path=tmp_path / "vision-budget.db")
+    monkeypatch.setattr(chat_tools, "store", store)
+    monkeypatch.setenv("UNIGROK_CALLER_BUDGETS", json.dumps({"http:key-test": 0.0}))
+    token = set_active_principal("http:key-test")
+    try:
+        with pytest.raises(CallerBudgetExceeded):
+            await chat_tools.chat_with_vision(
+                prompt="what is this?",
+                image_urls=["https://example.test/a.png"],
+            )
+    finally:
+        reset_active_principal(token)
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_chat_with_files_enforces_caller_budget(monkeypatch, tmp_path):
+    store = GrokSessionStore(db_path=tmp_path / "files-budget.db")
+    monkeypatch.setattr(chat_tools, "store", store)
+    monkeypatch.setenv("UNIGROK_CALLER_BUDGETS", json.dumps({"http:key-test": 0.0}))
+    token = set_active_principal("http:key-test")
+    try:
+        with pytest.raises(CallerBudgetExceeded):
+            await chat_tools.chat_with_files(prompt="summarize", file_ids=["file-1"])
+    finally:
+        reset_active_principal(token)
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_chat_with_vision_records_telemetry(monkeypatch, tmp_path):
+    store = GrokSessionStore(db_path=tmp_path / "vision-telemetry.db")
+    monkeypatch.setattr(chat_tools, "store", store)
+    monkeypatch.delenv("UNIGROK_CALLER_BUDGETS", raising=False)
+
+    async def _fake_run_blocking(fn, timeout=60.0):
+        return _FakeResponse()
+
+    monkeypatch.setattr(chat_tools, "run_blocking", _fake_run_blocking)
+    monkeypatch.setattr(chat_tools, "GrokInvocationContext", lambda *a, **k: _FakeCtx())
+
+    token = set_active_principal("http:key-vision")
+    try:
+        result = await chat_tools.chat_with_vision(
+            prompt="what is this?",
+            image_urls=["https://example.test/a.png"],
+        )
+        assert result.cost_usd == 0.09
+        spent = await store.get_caller_cost_today("http:key-vision")
+        assert spent == pytest.approx(0.09)
+    finally:
+        reset_active_principal(token)
+        await store.close()


### PR DESCRIPTION
## Summary
- `chat_with_vision` and `chat_with_files` now enforce `UNIGROK_CALLER_BUDGETS` before any xAI call (same principal resolution as #301/#310).
- Successful calls record spend via `save_telemetry` so later budget checks see direct vision/files usage.
- Unset budgets / unmatched principals remain a no-op.

## Test plan
- [x] `uv run pytest -q tests/test_chat_tools_caller_budget.py`
- [x] Attribution check vs `origin/main`
- [ ] CI green on draft PR


Made with [Cursor](https://cursor.com)