### PR TITLE
fix(http): extend Origin guard to operator surfaces

### DIFF
--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -310,10 +310,11 @@ class MCPOriginMiddleware
 
 **Keywords:** mcp, origin, middleware
 
-Origin validation on /mcp and /v1 (MCP-spec DNS-rebinding protection).
+Origin validation on agent + operator surfaces (DNS-rebinding protection).
 
 /v1/chat/completions reaches the same agent backend as /mcp, so a rebound
-browser page must not be able to drive it either.
+browser page must not be able to drive it. /runtimez, /ui, /docs, and
+/metrics expose operator recon/UI and are guarded the same way.
 
 Pure ASGI for the same SSE-disconnect reason as GatewayAuthMiddleware.
 Loopback origins and the UNIGROK_ALLOWED_ORIGINS allowlist pass; any other

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -310,10 +310,11 @@ class MCPOriginMiddleware
 
 **Keywords:** mcp, origin, middleware
 
-Origin validation on /mcp and /v1 (MCP-spec DNS-rebinding protection).
+Origin validation on agent + operator surfaces (DNS-rebinding protection).
 
 /v1/chat/completions reaches the same agent backend as /mcp, so a rebound
-browser page must not be able to drive it either.
+browser page must not be able to drive it. /runtimez, /ui, /docs, and
+/metrics expose operator recon/UI and are guarded the same way.
 
 Pure ASGI for the same SSE-disconnect reason as GatewayAuthMiddleware.
 Loopback origins and the UNIGROK_ALLOWED_ORIGINS allowlist pass; any other

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -630,16 +630,36 @@ def _origin_is_allowed(origin: Optional[str]) -> bool:
     return host in _LOOPBACK_HOSTS
 
 
-# Every surface that can reach the agent backend is origin-guarded; health
-# probes stay open (probes send no Origin, so they pass regardless).
-_ORIGIN_GUARDED_PREFIXES = ("/mcp", "/v1")
+# Agent backend plus local operator recon/UI surfaces are origin-guarded.
+# Health/readiness and well-known probes stay open (probes send no Origin).
+_ORIGIN_GUARDED_PREFIXES = (
+    "/mcp",
+    "/v1",
+    "/runtimez",
+    "/ui",
+    "/docs",
+    "/metrics",
+)
+
+
+def _path_is_origin_guarded(path: str) -> bool:
+    """True when path is exactly a guarded prefix or a nested path under one.
+
+    Boundary-aware so ``/ui`` does not match ``/uix`` and ``/docs`` does not
+    match ``/docsish``.
+    """
+    for prefix in _ORIGIN_GUARDED_PREFIXES:
+        if path == prefix or path.startswith(prefix + "/"):
+            return True
+    return False
 
 
 class MCPOriginMiddleware:
-    """Origin validation on /mcp and /v1 (MCP-spec DNS-rebinding protection).
+    """Origin validation on agent + operator surfaces (DNS-rebinding protection).
 
     /v1/chat/completions reaches the same agent backend as /mcp, so a rebound
-    browser page must not be able to drive it either.
+    browser page must not be able to drive it. /runtimez, /ui, /docs, and
+    /metrics expose operator recon/UI and are guarded the same way.
 
     Pure ASGI for the same SSE-disconnect reason as GatewayAuthMiddleware.
     Loopback origins and the UNIGROK_ALLOWED_ORIGINS allowlist pass; any other
@@ -650,7 +670,7 @@ class MCPOriginMiddleware:
         self.app = app
 
     async def __call__(self, scope, receive, send):
-        if scope["type"] == "http" and scope.get("path", "").startswith(_ORIGIN_GUARDED_PREFIXES):
+        if scope["type"] == "http" and _path_is_origin_guarded(scope.get("path", "")):
             if not _origin_is_allowed(_scope_header(scope, b"origin")):
                 response = _json_error("Origin not allowed.", status_code=403, code="forbidden")
                 await response(scope, receive, send)

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -1323,6 +1323,38 @@ def test_origin_check_covers_v1_surface(monkeypatch):
     assert health.status_code == 200
 
 
+def test_origin_check_covers_operator_surfaces(monkeypatch):
+    """Local operator recon/UI must not answer a rebound browser Origin either."""
+    from src.http_server import _path_is_origin_guarded
+
+    monkeypatch.delenv("UNIGROK_RUNTIME", raising=False)
+    monkeypatch.delenv("UNIGROK_API_KEYS", raising=False)
+    monkeypatch.delenv("UNIGROK_ALLOWED_ORIGINS", raising=False)
+
+    assert _path_is_origin_guarded("/runtimez")
+    assert _path_is_origin_guarded("/ui/")
+    assert _path_is_origin_guarded("/docs/okf/faq.md")
+    assert _path_is_origin_guarded("/metrics")
+    assert not _path_is_origin_guarded("/uix")
+    assert not _path_is_origin_guarded("/docsish/thing")
+    assert not _path_is_origin_guarded("/healthz")
+    assert not _path_is_origin_guarded("/readyz")
+
+    with TestClient(create_app()) as client:
+        runtimez = client.get("/runtimez", headers={"Origin": "http://evil.example"})
+        ui = client.get("/ui/", headers={"Origin": "http://evil.example"})
+        metrics = client.get("/metrics", headers={"Origin": "http://evil.example"})
+        health = client.get("/healthz", headers={"Origin": "http://evil.example"})
+        # Non-browser clients (no Origin) still reach operator surfaces.
+        runtimez_ok = client.get("/runtimez")
+
+    assert runtimez.status_code == 403
+    assert ui.status_code == 403
+    assert metrics.status_code == 403
+    assert health.status_code == 200
+    assert runtimez_ok.status_code == 200
+
+
 def test_resolve_bind_host_defaults_to_loopback(monkeypatch, caplog):
     """Local/unset runtime binds 127.0.0.1 so `python main.py --http` does not
     expose an unauthenticated agent to the whole LAN."""


### PR DESCRIPTION
## Summary
- Extend MCP DNS-rebinding Origin validation beyond `/mcp` and `/v1` to `/runtimez`, `/ui`, `/docs`, and `/metrics`.
- Use boundary-aware prefix matching so `/ui` does not match `/uix` (and `/docs` does not match `/docsish`).
- Keep `/healthz` / `/readyz` open for probes; missing Origin still allowed for non-browser clients.

## Test plan
- [x] `uv run pytest -q tests/test_http_server.py -k origin`
- [x] Attribution check vs `origin/main`
- [ ] CI green on draft PR


Made with [Cursor](https://cursor.com)