### PR TITLE
fix(http): attach UniGrok identity on OpenAI agent stream finish

### DIFF
--- a/src/http_server.py
+++ b/src/http_server.py
@@ -1715,6 +1715,21 @@ def _agent_turn_kwargs(payload: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _layer_unigrok_identity(layer: MetaLayer) -> Dict[str, Any]:
+    """Plane/route/cost identity shared by JSON and SSE agent responses."""
+    return {
+        "plane": layer.plane,
+        "route": layer.route,
+        "profile": layer.profile,
+        "policy_mode": layer.policy_mode,
+        "finish_reason": layer.finish_reason,
+        "cost_usd": layer.cost_usd,
+        "latency": layer.latency,
+        "context_id": layer.context_id,
+        "request_id": layer.request_id,
+    }
+
+
 def _layer_to_chat_completion(layer: MetaLayer, model: str) -> Dict[str, Any]:
     created = int(time.time())
     content = layer.generation or ""
@@ -1736,17 +1751,7 @@ def _layer_to_chat_completion(layer: MetaLayer, model: str) -> Dict[str, Any]:
             "completion_tokens": 0,
             "total_tokens": total_tokens,
         },
-        "unigrok": {
-            "plane": layer.plane,
-            "route": layer.route,
-            "profile": layer.profile,
-            "policy_mode": layer.policy_mode,
-            "finish_reason": layer.finish_reason,
-            "cost_usd": layer.cost_usd,
-            "latency": layer.latency,
-            "context_id": layer.context_id,
-            "request_id": layer.request_id,
-        },
+        "unigrok": _layer_unigrok_identity(layer),
     }
 
 
@@ -1775,7 +1780,12 @@ async def _stream_agent(payload: Dict[str, Any], model: str) -> AsyncIterator[by
     response_id = f"chatcmpl-{uuid.uuid4().hex}"
     created = int(time.time())
 
-    def _chunk(delta: Dict[str, Any], finish_reason: Optional[str] = None, event: Optional[Dict[str, Any]] = None) -> bytes:
+    def _chunk(
+        delta: Dict[str, Any],
+        finish_reason: Optional[str] = None,
+        event: Optional[Dict[str, Any]] = None,
+        identity: Optional[Dict[str, Any]] = None,
+    ) -> bytes:
         chunk: Dict[str, Any] = {
             "id": response_id,
             "object": "chat.completion.chunk",
@@ -1785,6 +1795,9 @@ async def _stream_agent(payload: Dict[str, Any], model: str) -> AsyncIterator[by
         }
         if event is not None:
             chunk["unigrok"] = {"event": event}
+        elif identity is not None:
+            # Final finish chunk: same identity envelope as non-stream JSON.
+            chunk["unigrok"] = identity
         return _sse(chunk)
 
     yield _chunk({"role": "assistant"})
@@ -1838,7 +1851,11 @@ async def _stream_agent(payload: Dict[str, Any], model: str) -> AsyncIterator[by
                 remainder = content
             for idx in range(0, len(remainder), 1200):
                 yield _chunk({"content": remainder[idx : idx + 1200]})
-        yield _chunk({}, finish_reason=_openai_finish_reason(layer))
+        yield _chunk(
+            {},
+            finish_reason=_openai_finish_reason(layer),
+            identity=_layer_unigrok_identity(layer),
+        )
         yield b"data: [DONE]\n\n"
     except Exception:
         yield _sse({"error": {"message": _request_error_message("Agent request failed."), "type": "server_error"}})

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -1730,16 +1730,26 @@ def test_agent_stream_emits_progress_event_chunks(monkeypatch):
     assert all(chunk["object"] == "chat.completion.chunk" for chunk in chunks)
     assert all(len(chunk["choices"]) == 1 and "delta" in chunk["choices"][0] for chunk in chunks)
 
-    events = [chunk["unigrok"]["event"] for chunk in chunks if "unigrok" in chunk]
+    events = [
+        chunk["unigrok"]["event"]
+        for chunk in chunks
+        if "unigrok" in chunk and "event" in chunk["unigrok"]
+    ]
     assert [event["type"] for event in events] == ["depth", "tool_start", "tool_end"]
     # Progress chunks carry an empty delta so standard OpenAI clients skip them.
     for chunk in chunks:
-        if "unigrok" in chunk:
+        if "unigrok" in chunk and "event" in chunk["unigrok"]:
             assert chunk["choices"][0]["delta"] == {}
 
     contents = [chunk["choices"][0]["delta"].get("content") for chunk in chunks]
     assert "agentic answer" in "".join(text for text in contents if text)
-    assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
+    finish = chunks[-1]
+    assert finish["choices"][0]["finish_reason"] == "stop"
+    assert finish["unigrok"]["plane"] == "API"
+    assert "route" in finish["unigrok"]
+    assert "cost_usd" in finish["unigrok"]
+    assert "request_id" in finish["unigrok"]
+    assert "event" not in finish["unigrok"]
 
 
 def test_agent_stream_real_deltas_replace_final_block(monkeypatch):
@@ -1772,6 +1782,51 @@ def test_agent_stream_real_deltas_replace_final_block(monkeypatch):
     ]
     assert contents == ["Hello ", "world"]
     assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
+    assert chunks[-1]["unigrok"]["finish_reason"] == "final_answer"
+
+
+def test_agent_stream_finish_chunk_carries_unigrok_identity(monkeypatch):
+    """Final SSE chunk mirrors the non-stream unigrok identity envelope."""
+    monkeypatch.delenv("UNIGROK_RUNTIME", raising=False)
+    monkeypatch.delenv("UNIGROK_API_KEYS", raising=False)
+
+    async def fake_run_agent_turn(**kwargs):
+        return MetaLayer(
+            generation="done",
+            finish_reason="final_answer",
+            plane="CLI",
+            route="fast",
+            profile="p",
+            policy_mode="cli_first",
+            cost_usd=0.42,
+            latency=1.5,
+            context_id="ctx-1",
+            request_id="rid-stream-1",
+        )
+
+    monkeypatch.setattr("src.http_server.run_agent_turn", fake_run_agent_turn)
+
+    with TestClient(create_app()) as client:
+        with client.stream(
+            "POST",
+            "/v1/chat/completions",
+            json={"model": "unigrok-agent", "stream": True, "messages": [{"role": "user", "content": "hi"}]},
+        ) as res:
+            body = "".join(res.iter_text())
+
+    finish = _sse_chunks(body)[-1]
+    assert finish["choices"][0]["finish_reason"] == "stop"
+    assert finish["unigrok"] == {
+        "plane": "CLI",
+        "route": "fast",
+        "profile": "p",
+        "policy_mode": "cli_first",
+        "finish_reason": "final_answer",
+        "cost_usd": 0.42,
+        "latency": 1.5,
+        "context_id": "ctx-1",
+        "request_id": "rid-stream-1",
+    }
 
 
 def test_agent_stream_fallback_recovery_replaces_partial_deltas(monkeypatch):


### PR DESCRIPTION
## Summary
- OpenAI-compat `/v1` agent SSE finish chunks now carry the same `unigrok` identity envelope as non-stream JSON (plane, route, cost, request_id, …).
- Progress chunks keep `unigrok.event` only; no change to the raw xAI proxy stream path.
- Shared `_layer_unigrok_identity` helper avoids drift between JSON and SSE.

## Test plan
- [x] `uv run pytest -q tests/test_http_server.py -k agent_stream`
- [x] Attribution check vs `origin/main`
- [ ] CI green on draft PR


Made with [Cursor](https://cursor.com)