### PR TITLE
docs: vibe-first README + restore demo image

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,19 +3,29 @@
 Thanks for helping improve UniGrok. Prefer small, verified changes that keep the
 shared Grok MCP gateway reliable.
 
-**Public users** should follow the root [README.md](README.md) only. This file is
-for **insiders**: people developing UniGrok itself (admins and GitHub write+
-collaborators such as Curtis). Product language freeze:
+## Who this file is for
+
+| You are… | Read |
+|---|---|
+| **Vibe coder** (install Grok in your IDE) | **[README.md](README.md) only** — stop here |
+| **Insider** (write+ collaborator building UniGrok) | **This file** |
+
+Insiders develop the product (admins and GitHub write+ collaborators). Product
+language freeze:
 [docs/design/public-vs-insider-surfaces.md](docs/design/public-vs-insider-surfaces.md).
+
+Public README stays vibe-first: install, paste-to-agent, prove it. **Do not**
+push dual-runtime / land / Swarm detail into the public README.
 
 ## Surfaces you must not confuse
 
 | Surface | Port / URL | Who | Purpose |
 |---|---|---|---|
-| **Stable Core** | `http://localhost:4765/mcp` · `/ui/` | Everyone | Public product MCP + machine-owner status UI |
-| **Contributor Forge** | `http://localhost:4766/mcp` (dev compose) | Insiders | UniGrok checkout attach, Swarm, workspace memory |
-| **Cloud control** | `https://control.grokmcp.org` / site `/control` | Insiders (GitHub OAuth) | Repo-facing control; **no** secret proxy, **no** local MCP tunnel |
-| **IDE chat** | Core MCP `agent` | Everyone | **Primary** `@grok` path for public and insiders |
+| **Stable Core** | `http://localhost:4765/mcp` · `/ui/` | Everyone (public product) | Daily MCP + machine-owner status UI |
+| **Contributor Forge** | `http://localhost:4766/mcp` (dev compose) | Insiders only | UniGrok checkout, Swarm, workspace memory |
+| **Cloud control** | `https://control.grokmcp.org` | Insiders (GitHub OAuth) | Repo control; **no** secret proxy; **no** laptop tunnel |
+| **Cloud MCP** | `https://mcp.grokmcp.org/mcp` | Team / cloud agents | Same Docker image, `cloudrun` mode; owner keys default |
+| **IDE chat** | Core MCP `agent` | Everyone | **Primary** `@grok` path |
 
 ### LIVE vs TARGET (do not over-claim)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="assets/hero.svg" alt="UniGrok · Grok MCP Server & Gateway — one Grok server, every IDE, zero pasted API keys" width="100%"/>
+<img src="assets/hero.svg" alt="UniGrok · one Grok server, every IDE, zero pasted API keys" width="100%"/>
 
 [![CI](https://img.shields.io/github/actions/workflow/status/djtelicloud/grok-mcp-server/ci.yml?branch=main&style=flat-square&label=CI)](https://github.com/djtelicloud/grok-mcp-server/actions)
 [![Release](https://img.shields.io/github/v/release/djtelicloud/grok-mcp-server?style=flat-square&label=release)](https://github.com/djtelicloud/grok-mcp-server/releases)
@@ -9,171 +9,150 @@
 [![MCP](https://img.shields.io/badge/MCP-Streamable%20HTTP-black?style=flat-square)](https://modelcontextprotocol.io)
 [![xAI Grok](https://img.shields.io/badge/xAI-Grok-000000?style=flat-square)](https://docs.x.ai/?utm_source=github&utm_medium=readme&utm_campaign=unigrok&utm_content=badge-docs)
 
+<br/>
+
+<img src="assets/control-center-demo.gif" alt="UniGrok Console — agent run with live tokens, cost, latency, route, and plane metadata" width="100%"/>
+
 </div>
 
-# UniGrok · one Grok gateway for every coding agent
+# UniGrok — Grok for every coding agent
 
-> Run Grok once on your machine. Point every IDE agent at it. Keep the xAI
-> credential on the server — never in each editor.
-
-UniGrok is a local-first [MCP](https://modelcontextprotocol.io) gateway for
-[xAI Grok](https://docs.x.ai/). Cursor, Claude, VS Code, Codex, Antigravity, and
-other MCP clients share **one** Streamable HTTP endpoint:
+**For vibe coders first.** One Grok gateway on your laptop. Point Cursor, Claude,
+VS Code, Codex, or any MCP agent at it. Your xAI key stays on the server — never
+in the IDE.
 
 ```text
 http://localhost:4765/mcp
 ```
 
-It routes across the **xAI developer API** (metered) and the **SuperGrok CLI
-subscription** (when authenticated), and returns the answer under `response`
-with route / plane / cost metadata.
-
 Current release: **v0.6.0**.
 
 ---
 
-## 1. What you get
+## You are a vibe coder (start here)
 
-- Shared `@grok` / `agent` tool for every IDE on your laptop
-- Server-side credentials (API key and/or CLI OAuth)
-- Optional local Core UI for status: `http://localhost:4765/ui/`
-- A habit you can opt into: critique Implementation Plans with Grok before the
-  user sees them
+You want Grok inside your IDE. You do **not** need to contribute to this repo
+or learn “planes” and “Forge.”
 
-Your other projects do **not** need UniGrok repo folders, contributor trees, or
-special mounts.
+### Step 1 — Run UniGrok once on this machine
 
-## 2. Prerequisites
-
-- Git
-- [`uv`](https://docs.astral.sh/uv/getting-started/installation/)
-- An MCP-capable IDE
-- At least one Grok credential path:
-  - **xAI API key** from [console.x.ai](https://console.x.ai/), **or**
-  - **SuperGrok / Grok CLI** device login (subscription)
-
-Docker Desktop is the current packaging path for the shared service. Treat it as
-how UniGrok runs on your machine — not as “you are a Docker developer.”
-
-## 3. Run the gateway (one path)
+You need: **Git**, **[uv](https://docs.astral.sh/uv/getting-started/installation/)**,
+**Docker Desktop**, and either an **[xAI API key](https://console.x.ai/)** or a
+**SuperGrok / Grok CLI** login.
 
 > [!WARNING]
-> UniGrok is not published on PyPI.
-> `pip install mcp-grok` installs an unrelated project; use this GitHub checkout.
+> UniGrok is **not published on PyPI**.
+> `pip install mcp-grok` installs an **unrelated project**; use this GitHub checkout.
 > There is no real `npx unigrok` server yet — Docker (or `uv` + compose) **is** the install.
 
-**Fast path (copy/paste):**
-
 ```bash
-git clone https://github.com/djtelicloud/grok-mcp-server.git && cd grok-mcp-server
+git clone https://github.com/djtelicloud/grok-mcp-server.git
+cd grok-mcp-server
 uv run python main.py init
 docker compose up --build -d
 ```
 
-`init` creates `.env` if missing and prints IDE MCP snippets for
-`http://localhost:4765/mcp`. After the service is healthy, you can **close this
-repo** and work in any project with `@grok`.
+**Pick one credential path:**
 
-Before checking readiness, complete **one** credential path:
+| Path | What to do |
+|------|------------|
+| **xAI API key** | Put the key in server `.env` as `XAI_API_KEY=…`, then `docker compose up -d` again if needed |
+| **SuperGrok subscription** | After the image is up: `docker compose run --rm grok-cli-auth` |
 
-- **xAI API:** set the developer key in server `.env` before starting Compose
-  (or rerun `docker compose up -d` after editing it).
-- **CLI subscription:** after the image is up, run:
-
-```bash
-docker compose run --rm grok-cli-auth
-```
-
-Then verify the usable plane:
+Check ready:
 
 ```bash
 curl --fail -s http://localhost:4765/readyz
 ```
 
-You are ready when `/readyz` reports `"status":"ready"`. `/healthz` only proves
-the process is up; CLI-only installs must authenticate before this readiness
-check.
+You want `"status":"ready"`.  
+(`/healthz` only means the process started — not that Grok can answer yet.)
 
-## 4. Connect your IDE (paste this to your agent)
+When it’s ready, you can **close this folder** and work in your own apps with
+`@grok`.
 
-Copy the block for your IDE from the `init` output, or paste this prompt to your
-local coding agent:
+### Step 2 — Paste this to your coding agent
+
+Copy the whole block into Cursor / Claude / VS Code / Codex and send it:
 
 ```text
 Configure UniGrok MCP for this machine:
+
 - Streamable HTTP URL: http://localhost:4765/mcp
 - Send a stable X-Client-ID header for this IDE (e.g. cursor, claude-code, vscode, codex)
-- Never put XAI_API_KEY in IDE MCP settings; credentials stay in UniGrok's server .env
+- Never put XAI_API_KEY in IDE MCP settings — credentials stay in UniGrok's server .env
 - After connecting, call tools/list and grok_mcp_discover_self
 - Prefer the UniGrok agent tool when I say @grok or want a second opinion
 - When I ask for a multi-step Implementation Plan, get a UniGrok second opinion
   (agent mode thinking or reasoning) and improve the plan before showing it —
   only if I want that habit; do not silently spend metered API credits
-- Do not invent a second MCP port, Forge, or land workflow for ordinary use
+- Do not invent a second MCP port, Forge, Swarm, or land workflow for ordinary use
 ```
 
-Detailed multi-IDE notes: [docs/ide-setup.md](docs/ide-setup.md) (public path
-only; contributor dual-runtime detail lives in CONTRIBUTING).
+`init` also prints ready-made IDE snippets if you prefer those.
 
-## 5. Prove it in 60 seconds
+### Step 3 — Prove it (60 seconds)
 
-1. Restart the IDE MCP client.
-2. Ask: “Call UniGrok discover_self and tell me which credential planes are ready.”
-3. Ask for a small plan, then: “Get a UniGrok second opinion on that plan before
-   you show me the Implementation Plan.”
+1. Restart the IDE’s MCP connection.
+2. Ask: *Call UniGrok discover_self and tell me which credential planes are ready.*
+3. Optional: open the local status UI → [http://localhost:4765/ui/](http://localhost:4765/ui/)
 
-Optional status UI (this machine only): open
-[http://localhost:4765/ui/](http://localhost:4765/ui/).
+---
 
-## 6. Security (short)
+## What you get
 
-1. Keep `XAI_API_KEY` and CLI OAuth on the UniGrok service — never in IDE configs.
-2. API plane is metered; CLI subscription cost is not exposed by the provider —
-   UniGrok only tracks local CLI activity.
-3. Stable UniGrok does not browse your project unless you pass
-   `workspace_context`.
-4. Loopback Core UI is for the machine owner; it is not a public multi-user
-   console.
-5. Do not paste secrets into chat.
+- One shared Grok connection for every IDE on this machine  
+- Keys stay server-side (API and/or CLI OAuth)  
+- Optional status UI on this machine only  
+- Opt-in: Grok can critique big plans before you see them  
 
-## 7. Project site (optional)
+Your app repos do **not** need UniGrok folders, contributor trees, or special
+mounts.
 
-The public site at [https://grokmcp.org](https://grokmcp.org) is **bound to the
-existing project** repository. It is not an idless installer template. For the
-optional contributor control surface, **GitHub App OAuth establishes identity**
-and each privileged request performs a **fresh installation-token lookup** of
-repo role; a **Sites rollback fallback** remains only for the legacy identity
-binding path. That control plane does not replace local UniGrok MCP on
-`localhost:4765`, and it never holds your xAI key.
+---
 
-## 8. Where docs live
+## Safety (short)
+
+1. Never put `XAI_API_KEY` in IDE MCP JSON.  
+2. API calls can cost money; CLI subscription cost is not exposed the same way.  
+3. UniGrok does not browse your project unless you pass `workspace_context`.  
+4. Local UI is for **this machine’s owner** — not a public multi-user site.  
+5. Never paste secrets into chat.
+
+---
+
+## More help (still public)
+
+| I want… | Go here |
+|---------|---------|
+| More IDE setups | [docs/ide-setup.md](docs/ide-setup.md) |
+| Agent knowledge (OKF) | [OKF on the site](https://grokmcp.org/docs/okf/index.md) |
+| Smarter default recipes | [docs/public-intelligence/](docs/public-intelligence/) |
+| Project site | [https://grokmcp.org](https://grokmcp.org) |
+| Architecture deep dive | [architecture.md](architecture.md) |
+| Security reporting | [SECURITY.md](SECURITY.md) |
+
+### Where docs live
 
 | You are… | Use |
 |---|---|
 | Installing / connecting an IDE | This README |
-| An agent needing schemas and operations | [OKF knowledge bundle](https://grokmcp.org/docs/okf/index.md) (also via `discover_self` and local `/docs/okf/`) |
-| Public “smarter defaults” recipes | [docs/public-intelligence/](docs/public-intelligence/) |
+| An agent needing schemas | [OKF knowledge bundle](https://grokmcp.org/docs/okf/index.md) (also local `/docs/okf/`) |
+| Public recipes | [docs/public-intelligence/](docs/public-intelligence/) |
 | Changing UniGrok itself | [CONTRIBUTING.md](CONTRIBUTING.md) |
 
 **Source of truth:** this repo’s `docs/okf/` + the site OKF.  
 **GitHub Wiki (optional):** human-friendly **mirror only**, generated from OKF
 (see [docs/wiki-okf-mirror.md](docs/wiki-okf-mirror.md)). Do not hand-edit the
-wiki as product docs. Empty or stale wiki is not an outage — use OKF.
+wiki as product docs.
 
-## 9. Next steps
+---
 
-| I want… | Go here |
-|---|---|
-| More IDE examples | [docs/ide-setup.md](docs/ide-setup.md) |
-| Agent knowledge (OKF) | [https://grokmcp.org/docs/okf/index.md](https://grokmcp.org/docs/okf/index.md) |
-| Architecture | [architecture.md](architecture.md) |
-| Security reporting | [SECURITY.md](SECURITY.md) |
-| **Contribute to UniGrok itself** | [CONTRIBUTING.md](CONTRIBUTING.md) |
-| Project site | [https://grokmcp.org](https://grokmcp.org) |
+## Building UniGrok itself?
 
-Contributors and admins: dual-runtime Forge, landing, Swarm, and insider Console
-behavior are documented only in [CONTRIBUTING.md](CONTRIBUTING.md) — not required
-for ordinary use.
+If you are an **insider** (write+ collaborator) working on the product —
+Core vs Forge, dual ports, landing, Swarm, cloud control — use
+**[CONTRIBUTING.md](CONTRIBUTING.md)**. That is not required for vibe-coder use.
 
 ## License
 

--- a/tests/test_release_hygiene.py
+++ b/tests/test_release_hygiene.py
@@ -332,7 +332,8 @@ def test_public_docs_surfaces_wiki_is_okf_mirror_only():
     contributing = (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
     wiki_policy = (ROOT / "docs" / "wiki-okf-mirror.md").read_text(encoding="utf-8")
 
-    assert "## 8. Where docs live" in readme
+    # Public README is vibe-first; section title may change, content must not.
+    assert "Where docs live" in readme
     assert "https://grokmcp.org/docs/okf/index.md" in readme
     assert "mirror only" in readme.lower()
     assert "mirror only" in contributing.lower()


### PR DESCRIPTION
## Summary
Public **README** is rewritten for **vibe coders first**: hero + restored Control Center demo image, install → **paste-to-agent** → prove it. **CONTRIBUTING** leads with who should read which file and keeps insider surface map.

## Why
- Demo GIF had been removed from README (still in `assets/`)
- Agent paste block felt buried vs contributor-ish framing
- Clear split: public install vs insider build

## Tests
- `test_public_install_warns_about_unrelated_pypi_distribution`
- `test_public_docs_surfaces_wiki_is_okf_mirror_only` (relaxed section title match)

## Human sponsor
djtelicloud

## Ready for supervisor?
Yes — docs only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test assertion tweaks only; no runtime, auth, or API behavior changes.
> 
> **Overview**
> **Public README** is reframed for **vibe coders**: restored `assets/control-center-demo.gif`, a three-step path (run once → **paste-to-agent** → prove in 60s), and less contributor jargon up front. The agent paste block now explicitly warns against inventing Forge/Swarm/land workflows; insider topics are pushed to **CONTRIBUTING**.
> 
> **CONTRIBUTING** opens with a **who reads what** table (README vs this file), states that the public README must stay install-focused, and extends the surface map with **Cloud MCP** (`mcp.grokmcp.org`) plus clearer “public product vs insider” wording on Core/Forge/control.
> 
> **Tests:** `test_public_docs_surfaces_wiki_is_okf_mirror_only` no longer requires the exact `## 8. Where docs live` heading—only that “Where docs live” and OKF/wiki-mirror policy strings remain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8874620dbc72f715ef628c660afd9b628453c138. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->