### PR TITLE
security: distrust installed cwd configuration

### DIFF
--- a/.github/workflows/grok-review.yml
+++ b/.github/workflows/grok-review.yml
@@ -43,13 +43,13 @@ jobs:
     steps:
       # Run only trusted default-branch code. Never check out, execute, install,
       # or import code from the reviewed PR.
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           enable-cache: true
 

--- a/.github/workflows/supervisor-approval.yml
+++ b/.github/workflows/supervisor-approval.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the default-branch evaluator
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false

--- a/src/cli.py
+++ b/src/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import stat
 import sys
 from pathlib import Path
 from typing import Iterable, TextIO
@@ -33,6 +34,87 @@ def _project_root() -> Path:
     # belong in the directory where the command is invoked, not in the
     # interpreter environment.
     return Path.cwd().resolve()
+
+
+def _trusted_runtime_env_path() -> Path | None:
+    """Return a trusted service dotenv path, never an installed caller cwd.
+
+    Source checkouts own their repository-level ``.env``. Installed wheels do
+    not own the directory from which an IDE or user happens to launch the
+    command, so that directory must remain data-only unless ``init`` is
+    explicitly requested. An operator-provided project root is process-level
+    configuration and remains an explicit trusted override.
+    """
+    explicit = os.environ.get("UNIGROK_PROJECT_ROOT", "").strip()
+    if explicit:
+        return Path(explicit).expanduser().resolve() / ".env"
+
+    source_root = Path(__file__).resolve().parents[1]
+    if (source_root / "pyproject.toml").is_file():
+        return source_root / ".env"
+    return None
+
+
+def _validate_secret_env_stat(path: Path, file_stat: os.stat_result) -> None:
+    if not stat.S_ISREG(file_stat.st_mode):
+        raise RuntimeError(f"Refusing unsafe environment file (not regular): {path}")
+    getuid = getattr(os, "getuid", None)
+    if getuid is not None and file_stat.st_uid != getuid():
+        raise RuntimeError(f"Refusing unsafe environment file (wrong owner): {path}")
+    if stat.S_IMODE(file_stat.st_mode) & 0o077:
+        raise RuntimeError(f"Refusing unsafe environment file (must be mode 0600): {path}")
+
+
+def _open_secret_env(path: Path, flags: int) -> int:
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    cloexec = getattr(os, "O_CLOEXEC", 0)
+    fd = os.open(path, flags | nofollow | cloexec)
+    try:
+        opened = os.fstat(fd)
+        _validate_secret_env_stat(path, opened)
+        # O_NOFOLLOW is not portable. Bind the path check to the opened inode
+        # as a fallback and as defense in depth on platforms that expose it.
+        linked = path.lstat()
+        if stat.S_ISLNK(linked.st_mode) or (linked.st_dev, linked.st_ino) != (
+            opened.st_dev,
+            opened.st_ino,
+        ):
+            raise RuntimeError(f"Refusing unsafe environment file (link or race): {path}")
+        return fd
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def _load_trusted_env(path: Path) -> None:
+    """Load a validated owner-only dotenv through its already-bound fd."""
+    fd = _open_secret_env(path, os.O_RDONLY)
+    with os.fdopen(fd, "r", encoding="utf-8") as stream:
+        load_dotenv(stream=stream)
+
+
+def _create_secret_env(path: Path, contents: str) -> None:
+    """Atomically create a new owner-only dotenv independent of process umask."""
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    cloexec = getattr(os, "O_CLOEXEC", 0)
+    fd = os.open(path, flags | nofollow | cloexec, 0o600)
+    try:
+        os.fchmod(fd, 0o600)
+        _validate_secret_env_stat(path, os.fstat(fd))
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            fd = -1
+            stream.write(contents)
+            stream.flush()
+            os.fsync(stream.fileno())
+    except BaseException:
+        if fd >= 0:
+            os.close(fd)
+        try:
+            path.unlink()
+        except OSError:
+            pass
+        raise
 
 
 def _http_requested(argv: Iterable[str]) -> bool:
@@ -113,16 +195,20 @@ def init_project(root: Path | None = None, stream: TextIO | None = None) -> int:
     env_path = root / ".env"
     example_path = root / "example.env"
     packaged_example_path = Path(__file__).resolve().parents[1] / "example.env"
-    if env_path.exists():
+    if env_path.exists() or env_path.is_symlink():
+        fd = _open_secret_env(env_path, os.O_RDONLY)
+        os.close(fd)
         print(f".env already exists at {env_path}; leaving it unchanged.", file=stream)
     elif example_path.exists():
-        shutil.copyfile(example_path, env_path)
+        _create_secret_env(env_path, example_path.read_text(encoding="utf-8"))
         print(f"Created {env_path} from {example_path}.", file=stream)
     elif packaged_example_path.exists():
-        shutil.copyfile(packaged_example_path, env_path)
+        _create_secret_env(
+            env_path, packaged_example_path.read_text(encoding="utf-8")
+        )
         print(f"Created {env_path} from the packaged environment template.", file=stream)
     else:
-        env_path.write_text(DEFAULT_ENV_TEMPLATE, encoding="utf-8")
+        _create_secret_env(env_path, DEFAULT_ENV_TEMPLATE)
         print(f"Created {env_path} from the built-in template.", file=stream)
 
     print("Edit .env and set XAI_API_KEY before making real xAI API calls.", file=stream)
@@ -133,9 +219,9 @@ def init_project(root: Path | None = None, stream: TextIO | None = None) -> int:
 def main(argv: list[str] | None = None) -> int | None:
     argv = list(sys.argv[1:] if argv is None else argv)
     root = _project_root()
-    env_path = root / ".env"
-    if env_path.exists():
-        load_dotenv(env_path)
+    env_path = _trusted_runtime_env_path()
+    if env_path is not None and (env_path.exists() or env_path.is_symlink()):
+        _load_trusted_env(env_path)
 
     if argv and argv[0] == "init":
         return init_project(root)

--- a/src/cli.py
+++ b/src/cli.py
@@ -62,7 +62,10 @@ def _validate_secret_env_stat(path: Path, file_stat: os.stat_result) -> None:
     if getuid is not None and file_stat.st_uid != getuid():
         raise RuntimeError(f"Refusing unsafe environment file (wrong owner): {path}")
     if stat.S_IMODE(file_stat.st_mode) & 0o077:
-        raise RuntimeError(f"Refusing unsafe environment file (must be mode 0600): {path}")
+        raise RuntimeError(
+            "Refusing unsafe environment file (must be mode 0600): "
+            f"{path}. Verify its ownership and contents, then run chmod 600 on it."
+        )
 
 
 def _open_secret_env(path: Path, flags: int) -> int:

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -1871,7 +1871,11 @@ def _xai_chat_completions_url() -> Optional[str]:
     if base is None:
         return None
     parsed = urlsplit(base)
-    origin = f"{parsed.scheme.lower()}://{parsed.netloc.lower()}"
+    host = str(parsed.hostname or "").lower().rstrip(".")
+    authority = f"[{host}]" if ":" in host else host
+    if parsed.port not in (None, 443):
+        authority = f"{authority}:{parsed.port}"
+    origin = f"https://{authority}"
     allowed_origins = {"https://api.x.ai"}
     for item in os.environ.get("UNIGROK_ALLOWED_XAI_API_ORIGINS", "").split(","):
         validated = _validated_https_url(item.strip())
@@ -1880,9 +1884,13 @@ def _xai_chat_completions_url() -> Optional[str]:
         candidate = urlsplit(validated)
         if candidate.path not in ("", "/"):
             continue
-        allowed_origins.add(
-            f"{candidate.scheme.lower()}://{candidate.netloc.lower()}"
+        candidate_host = str(candidate.hostname or "").lower().rstrip(".")
+        candidate_authority = (
+            f"[{candidate_host}]" if ":" in candidate_host else candidate_host
         )
+        if candidate.port not in (None, 443):
+            candidate_authority = f"{candidate_authority}:{candidate.port}"
+        allowed_origins.add(f"https://{candidate_authority}")
     if origin not in allowed_origins:
         return None
     return f"{base.rstrip('/')}/chat/completions"

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -1859,14 +1859,31 @@ def _xai_chat_completions_url() -> Optional[str]:
 
     ``XAI_API_BASE_URL`` is operator-controlled but credential-bearing: the
     gateway attaches ``XAI_API_KEY``. Unset keeps the built-in xAI default.
-    A set-but-unsafe override fails closed (no silent fallback that would hide
-    a misconfiguration while still shipping the bearer token elsewhere).
+    A set-but-unsafe or unapproved override fails closed (no silent fallback
+    that would hide a misconfiguration while still shipping the bearer token
+    elsewhere). Additional origins require an explicit trusted process-level
+    allowlist; installed launches never import that authority from caller cwd.
     """
     raw = os.environ.get("XAI_API_BASE_URL", "").strip()
     if not raw:
         return f"{XAI_BASE_URL.rstrip('/')}/chat/completions"
     base = _validated_https_url(raw)
     if base is None:
+        return None
+    parsed = urlsplit(base)
+    origin = f"{parsed.scheme.lower()}://{parsed.netloc.lower()}"
+    allowed_origins = {"https://api.x.ai"}
+    for item in os.environ.get("UNIGROK_ALLOWED_XAI_API_ORIGINS", "").split(","):
+        validated = _validated_https_url(item.strip())
+        if validated is None:
+            continue
+        candidate = urlsplit(validated)
+        if candidate.path not in ("", "/"):
+            continue
+        allowed_origins.add(
+            f"{candidate.scheme.lower()}://{candidate.netloc.lower()}"
+        )
+    if origin not in allowed_origins:
         return None
     return f"{base.rstrip('/')}/chat/completions"
 
@@ -1957,7 +1974,7 @@ async def post_xai_chat(payload: Dict[str, Any]) -> Response:
     url = _xai_chat_completions_url()
     if url is None:
         return _json_error(
-            "XAI_API_BASE_URL is not a public HTTPS endpoint.",
+            "XAI_API_BASE_URL is not an approved public HTTPS endpoint.",
             status_code=503,
             code="service_unavailable",
         )
@@ -2003,7 +2020,7 @@ async def stream_xai_chat(payload: Dict[str, Any]) -> AsyncIterator[bytes]:
     url = _xai_chat_completions_url()
     if url is None:
         yield _sse_error(
-            "XAI_API_BASE_URL is not a public HTTPS endpoint.",
+            "XAI_API_BASE_URL is not an approved public HTTPS endpoint.",
             "service_unavailable",
         )
         yield b"data: [DONE]\n\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,11 @@
 import io
+import os
+import sys
+import types
+import stat
 from pathlib import Path
+
+import pytest
 
 import src.cli as cli
 from src.cli import init_project
@@ -13,6 +19,7 @@ def test_init_project_copies_example_env_and_prints_ide_configs(tmp_path: Path):
 
     assert code == 0
     assert (tmp_path / ".env").read_text(encoding="utf-8") == "XAI_API_KEY=your_xai_api_key_here\n"
+    assert stat.S_IMODE((tmp_path / ".env").stat().st_mode) == 0o600
     out = stream.getvalue()
     assert "Created" in out
     assert "VS Code" in out
@@ -27,6 +34,7 @@ def test_init_project_copies_example_env_and_prints_ide_configs(tmp_path: Path):
 def test_init_project_leaves_existing_env_unchanged(tmp_path: Path):
     (tmp_path / "example.env").write_text("XAI_API_KEY=template\n", encoding="utf-8")
     (tmp_path / ".env").write_text("XAI_API_KEY=real\n", encoding="utf-8")
+    (tmp_path / ".env").chmod(0o600)
     stream = io.StringIO()
 
     code = init_project(tmp_path, stream)
@@ -50,6 +58,79 @@ def test_installed_cli_uses_current_directory_as_project_root(monkeypatch, tmp_p
     assert cli._project_root() == workdir
 
 
+def test_installed_cli_never_trusts_cwd_dotenv_for_runtime(monkeypatch, tmp_path: Path):
+    package_root = tmp_path / "venv" / "site-packages"
+    fake_cli = package_root / "src" / "cli.py"
+    fake_cli.parent.mkdir(parents=True)
+    workdir = tmp_path / "untrusted-project"
+    workdir.mkdir()
+    (workdir / ".env").write_text(
+        "\n".join(
+            (
+                "UNIGROK_RUNTIME=http",
+                "UNIGROK_HOST=0.0.0.0",
+                "UNIGROK_TRUSTED_LOOPBACK_PROXY=1",
+                "UNIGROK_SERVICE_MODE=contributor",
+                "UNIGROK_CONTRIBUTOR_MODE=1",
+                "WORKSPACE_ROOT=/tmp/attacker-workspace",
+                "ENABLE_GIT_WRITE=1",
+                "XAI_API_BASE_URL=https://attacker.example/v1",
+            )
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    sensitive_names = (
+        "UNIGROK_RUNTIME",
+        "UNIGROK_HOST",
+        "UNIGROK_TRUSTED_LOOPBACK_PROXY",
+        "UNIGROK_SERVICE_MODE",
+        "UNIGROK_CONTRIBUTOR_MODE",
+        "WORKSPACE_ROOT",
+        "ENABLE_GIT_WRITE",
+        "XAI_API_BASE_URL",
+    )
+    for name in sensitive_names:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.delenv("UNIGROK_PROJECT_ROOT", raising=False)
+    monkeypatch.setenv("XAI_API_KEY", "trusted-parent-key")
+    monkeypatch.setattr(cli, "__file__", str(fake_cli))
+    monkeypatch.chdir(workdir)
+
+    called = {}
+    fake_server = types.ModuleType("src.server")
+    fake_server.main = lambda argv: called.setdefault("argv", list(argv))
+    monkeypatch.setitem(sys.modules, "src.server", fake_server)
+    import src
+
+    monkeypatch.setattr(src, "server", fake_server, raising=False)
+
+    assert cli._trusted_runtime_env_path() is None
+    assert cli.main([]) is None
+    assert called["argv"] == []
+    assert os.environ["XAI_API_KEY"] == "trusted-parent-key"
+    for name in sensitive_names:
+        assert name not in os.environ
+
+
+def test_source_cli_loads_only_its_repository_dotenv(monkeypatch, tmp_path: Path):
+    source_root = tmp_path / "trusted-source"
+    fake_cli = source_root / "src" / "cli.py"
+    fake_cli.parent.mkdir(parents=True)
+    (source_root / "pyproject.toml").write_text("[project]\nname='test'\n", encoding="utf-8")
+    (source_root / ".env").write_text("XAI_API_KEY=trusted-source-key\n", encoding="utf-8")
+    untrusted_cwd = tmp_path / "untrusted"
+    untrusted_cwd.mkdir()
+    (untrusted_cwd / ".env").write_text("XAI_API_KEY=attacker-key\n", encoding="utf-8")
+
+    monkeypatch.delenv("UNIGROK_PROJECT_ROOT", raising=False)
+    monkeypatch.setattr(cli, "__file__", str(fake_cli))
+    monkeypatch.chdir(untrusted_cwd)
+
+    assert cli._trusted_runtime_env_path() == source_root / ".env"
+
+
 def test_init_project_uses_packaged_template_for_installed_cli(monkeypatch, tmp_path: Path):
     package_root = tmp_path / "venv" / "site-packages"
     fake_cli = package_root / "src" / "cli.py"
@@ -63,7 +144,54 @@ def test_init_project_uses_packaged_template_for_installed_cli(monkeypatch, tmp_
 
     assert code == 0
     assert (target / ".env").read_text(encoding="utf-8") == "XAI_API_KEY=packaged-template\n"
+    assert stat.S_IMODE((target / ".env").stat().st_mode) == 0o600
     assert "packaged environment template" in stream.getvalue()
+
+
+def test_init_project_secret_env_mode_ignores_permissive_umask(tmp_path: Path):
+    stream = io.StringIO()
+    previous = os.umask(0)
+    try:
+        assert init_project(tmp_path, stream) == 0
+    finally:
+        os.umask(previous)
+    assert stat.S_IMODE((tmp_path / ".env").stat().st_mode) == 0o600
+
+
+def test_trusted_env_rejects_unsafe_modes_links_and_non_files(monkeypatch, tmp_path: Path):
+    for mode in (0o644, 0o660):
+        path = tmp_path / f"mode-{mode:o}.env"
+        path.write_text("XAI_API_KEY=not-loaded\n", encoding="utf-8")
+        path.chmod(mode)
+        with pytest.raises(RuntimeError, match="mode 0600"):
+            cli._load_trusted_env(path)
+
+    safe = tmp_path / "safe.env"
+    safe.write_text("UNIGROK_TEST_SAFE_ENV=loaded\n", encoding="utf-8")
+    safe.chmod(0o600)
+    monkeypatch.delenv("UNIGROK_TEST_SAFE_ENV", raising=False)
+    cli._load_trusted_env(safe)
+    assert os.environ["UNIGROK_TEST_SAFE_ENV"] == "loaded"
+
+    link = tmp_path / "linked.env"
+    link.symlink_to(safe)
+    with pytest.raises((OSError, RuntimeError)):
+        cli._load_trusted_env(link)
+
+    directory = tmp_path / "directory.env"
+    directory.mkdir()
+    with pytest.raises((OSError, RuntimeError)):
+        cli._load_trusted_env(directory)
+
+
+def test_trusted_env_rejects_wrong_owner(monkeypatch, tmp_path: Path):
+    path = tmp_path / "owned.env"
+    path.write_text("XAI_API_KEY=not-loaded\n", encoding="utf-8")
+    path.chmod(0o600)
+    real_uid = path.stat().st_uid
+    monkeypatch.setattr(os, "getuid", lambda: real_uid + 1)
+    with pytest.raises(RuntimeError, match="wrong owner"):
+        cli._load_trusted_env(path)
 
 
 def test_main_dispatches_rag_subcommand_without_starting_server(monkeypatch):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -163,7 +163,7 @@ def test_trusted_env_rejects_unsafe_modes_links_and_non_files(monkeypatch, tmp_p
         path = tmp_path / f"mode-{mode:o}.env"
         path.write_text("XAI_API_KEY=not-loaded\n", encoding="utf-8")
         path.chmod(mode)
-        with pytest.raises(RuntimeError, match="mode 0600"):
+        with pytest.raises(RuntimeError, match="mode 0600.*chmod 600"):
             cli._load_trusted_env(path)
 
     safe = tmp_path / "safe.env"

--- a/tests/test_github_review_integration.py
+++ b/tests/test_github_review_integration.py
@@ -1,6 +1,7 @@
 import asyncio
 import importlib.util
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -417,6 +418,20 @@ def test_codex_approval_workflow_is_owner_only_and_exact_head_bound():
     assert "actions/checkout" not in workflow
     assert "XAI_API_KEY" not in workflow
     assert "UNIGROK_MCP_URL" not in workflow
+
+
+def test_write_token_workflows_pin_every_action_to_an_immutable_sha():
+    workflows = ROOT / ".github" / "workflows"
+    for path in sorted(workflows.glob("*.yml")):
+        text = path.read_text(encoding="utf-8")
+        if not re.search(r"^\s+(?:statuses|pull-requests): write\s*$", text, re.MULTILINE):
+            continue
+        for line in text.splitlines():
+            match = re.search(r"\buses:\s*[^\s@]+@([^\s#]+)", line)
+            if match:
+                assert re.fullmatch(r"[0-9a-f]{40}", match.group(1)), (
+                    f"{path.name} has mutable action ref: {line.strip()}"
+                )
 
 
 def test_cloud_governance_contract_marks_target_features_not_live():

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -2051,6 +2051,7 @@ def test_xai_chat_completions_url_defaults_and_rejects_unsafe_overrides(monkeypa
     from src.http_server import XAI_BASE_URL, _xai_chat_completions_url
 
     monkeypatch.delenv("XAI_API_BASE_URL", raising=False)
+    monkeypatch.delenv("UNIGROK_ALLOWED_XAI_API_ORIGINS", raising=False)
     assert _xai_chat_completions_url() == f"{XAI_BASE_URL.rstrip('/')}/chat/completions"
 
     monkeypatch.setenv("XAI_API_BASE_URL", "https://api.x.ai/v1")
@@ -2061,9 +2062,44 @@ def test_xai_chat_completions_url_defaults_and_rejects_unsafe_overrides(monkeypa
         "https://169.254.169.254/v1",
         "https://evil.internal/v1",
         "https://localhost/v1",
+        "https://attacker.example/v1",
     ):
         monkeypatch.setenv("XAI_API_BASE_URL", unsafe)
         assert _xai_chat_completions_url() is None, unsafe
+
+    monkeypatch.setenv(
+        "UNIGROK_ALLOWED_XAI_API_ORIGINS", "https://trusted-proxy.example"
+    )
+    monkeypatch.setenv("XAI_API_BASE_URL", "https://trusted-proxy.example/v1")
+    assert (
+        _xai_chat_completions_url()
+        == "https://trusted-proxy.example/v1/chat/completions"
+    )
+
+
+@pytest.mark.asyncio
+async def test_post_xai_chat_rejects_unapproved_https_origin_before_auth(monkeypatch):
+    from src.http_server import post_xai_chat
+    import json
+
+    captured = {"constructed": False}
+
+    class ForbiddenClient:
+        def __init__(self, **kwargs):
+            captured["constructed"] = True
+            raise AssertionError("unapproved origin must fail before client construction")
+
+    monkeypatch.setenv("XAI_API_KEY", "trusted-parent-key")
+    monkeypatch.setenv("XAI_API_BASE_URL", "https://attacker.example/v1")
+    monkeypatch.delenv("UNIGROK_ALLOWED_XAI_API_ORIGINS", raising=False)
+    monkeypatch.setattr("src.http_server.httpx.AsyncClient", ForbiddenClient)
+
+    res = await post_xai_chat({"model": "grok-4.3", "messages": []})
+    assert res.status_code == 503
+    body = json.loads(res.body.decode())
+    assert body["error"]["code"] == "service_unavailable"
+    assert "approved public HTTPS" in body["error"]["message"]
+    assert captured["constructed"] is False
 
 
 @pytest.mark.asyncio
@@ -2120,6 +2156,6 @@ async def test_stream_xai_chat_rejects_unsafe_base_url_without_calling_out(monke
         async for chunk in stream_xai_chat({"model": "grok-4.3", "messages": []})
     ]
     body = b"".join(chunks).decode("utf-8")
-    assert "XAI_API_BASE_URL is not a public HTTPS endpoint." in body
+    assert "XAI_API_BASE_URL is not an approved public HTTPS endpoint." in body
     assert body.endswith("data: [DONE]\n\n")
     assert called["stream"] is False

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -2056,6 +2056,8 @@ def test_xai_chat_completions_url_defaults_and_rejects_unsafe_overrides(monkeypa
 
     monkeypatch.setenv("XAI_API_BASE_URL", "https://api.x.ai/v1")
     assert _xai_chat_completions_url() == "https://api.x.ai/v1/chat/completions"
+    monkeypatch.setenv("XAI_API_BASE_URL", "https://api.x.ai:443/v1")
+    assert _xai_chat_completions_url() == "https://api.x.ai:443/v1/chat/completions"
 
     for unsafe in (
         "http://api.x.ai/v1",
@@ -2069,6 +2071,14 @@ def test_xai_chat_completions_url_defaults_and_rejects_unsafe_overrides(monkeypa
 
     monkeypatch.setenv(
         "UNIGROK_ALLOWED_XAI_API_ORIGINS", "https://trusted-proxy.example"
+    )
+    monkeypatch.setenv("XAI_API_BASE_URL", "https://trusted-proxy.example/v1")
+    assert (
+        _xai_chat_completions_url()
+        == "https://trusted-proxy.example/v1/chat/completions"
+    )
+    monkeypatch.setenv(
+        "UNIGROK_ALLOWED_XAI_API_ORIGINS", "https://trusted-proxy.example:443"
     )
     monkeypatch.setenv("XAI_API_BASE_URL", "https://trusted-proxy.example/v1")
     assert (

--- a/tests/test_supervisor_approval.py
+++ b/tests/test_supervisor_approval.py
@@ -159,6 +159,8 @@ def test_supervisor_status_event_does_not_retrigger_its_own_workflow():
     assert "github.event.context != 'Supervisor Approval'" in workflow
     assert "github.event.check_run.name != 'evaluate'" in workflow
     assert "CHECK_RUN_HEAD_SHA" in workflow
+    assert "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" in workflow
+    assert "actions/checkout@v" not in workflow
 
 
 def test_collect_check_states_prefers_newer_finished_success_over_older_in_progress():


### PR DESCRIPTION
## Summary
- prevent installed `unigrok-mcp` launches from importing runtime/security policy from caller cwd `.env`
- create and load credential dotenv files as owner-only regular files with fd-bound validation
- restrict credential-bearing xAI proxy overrides to the xAI origin or an explicit trusted origin allowlist

## Verification
- `uv run python -m compileall -q src tests main.py`
- `uv run pytest -q` — 2162 passed
- `uv run ruff check src/cli.py src/http_server.py tests/test_cli.py tests/test_http_server.py`
- `git diff --check`

## Risk
High-risk startup, authentication, credential, and network-boundary repair. Exact-head Codex and Supervisor approval required before merge.

Human sponsor: djtelicloud

Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=user-reported | surface=Codex Desktop | role=implementation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication, credential loading, and where API keys are sent at startup and in the xAI proxy—security-critical paths with meaningful behavior change for installed CLI users.
> 
> **Overview**
> **Hardens startup and proxy configuration** so a malicious or untrusted working directory cannot steer an installed `unigrok-mcp` process.
> 
> The CLI **stops auto-loading `.env` from the caller’s cwd** when running from a wheel; only a source checkout’s repo `.env` or an explicit `UNIGROK_PROJECT_ROOT` is trusted at runtime. **`init` still writes project files under cwd**, but new `.env` files are created as **owner-only (0600)** and loaded only after **fd-bound checks** (regular file, correct owner, no symlinks/races).
> 
> The HTTP xAI chat proxy now **fails closed** unless `XAI_API_BASE_URL` resolves to **`https://api.x.ai`** or an origin listed in **`UNIGROK_ALLOWED_XAI_API_ORIGINS`** (process env, not cwd dotenv), with updated client error text.
> 
> GitHub workflows that can write statuses or PRs **pin `actions/checkout` and `setup-uv` to full commit SHAs**, with a test enforcing immutable refs on all write-capable workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31a0cbf3deae2e94aaee912e3dda173ba0707564. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->