### PR TITLE
fix(routing): scope circuit breakers by credential plane

### DIFF
--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -4216,36 +4216,36 @@ burn retries — retrying an auth failure only delays the real error.
 ### Function: `check_circuit_breaker` {#utils-check_circuit_breaker}
 
 ```python
-def check_circuit_breaker(model: str)
+def check_circuit_breaker(model: str, *, plane: str='API')
 ```
 
 **Keywords:** check, circuit, breaker
 
-Fail fast with CircuitBreakerOpenError while a model's breaker is open.
+Fail fast with CircuitBreakerOpenError while a plane+model breaker is open.
 
 After the cool-down elapses the breaker half-opens: the next call is
 allowed through as a probe; its success closes the breaker, its failure
-re-opens it via record_xai_failure.
+re-opens it via record_xai_failure. CLI and API breakers are independent.
 
 ### Function: `record_xai_failure` {#utils-record_xai_failure}
 
 ```python
-def record_xai_failure(model: str)
+def record_xai_failure(model: str, *, plane: str='API')
 ```
 
 **Keywords:** record, xai, failure
 
-Count a failed xAI call; open the breaker at the consecutive threshold.
+Count a failed xAI call; open the plane+model breaker at threshold.
 
 ### Function: `record_xai_success` {#utils-record_xai_success}
 
 ```python
-def record_xai_success(model: str)
+def record_xai_success(model: str, *, plane: str='API')
 ```
 
 **Keywords:** record, xai, success
 
-Reset a model's breaker after any successful xAI call.
+Reset a plane+model breaker after any successful xAI call.
 
 ### Function: `get_circuit_breaker_state` {#utils-get_circuit_breaker_state}
 
@@ -4255,7 +4255,9 @@ def get_circuit_breaker_state() -> Dict[str, Any]
 
 **Keywords:** get, circuit, breaker, state
 
-Snapshot of per-model breaker state (consumed by grok_mcp_status).
+Snapshot of plane-scoped breaker state (consumed by grok_mcp_status).
+
+Keys are ``API:<model>`` / ``CLI:<model>``.
 
 ### Class: `RequestContextLogFilter` {#utils-requestcontextlogfilter}
 

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -4216,36 +4216,36 @@ burn retries — retrying an auth failure only delays the real error.
 ### Function: `check_circuit_breaker` {#utils-check_circuit_breaker}
 
 ```python
-def check_circuit_breaker(model: str)
+def check_circuit_breaker(model: str, *, plane: str='API')
 ```
 
 **Keywords:** check, circuit, breaker
 
-Fail fast with CircuitBreakerOpenError while a model's breaker is open.
+Fail fast with CircuitBreakerOpenError while a plane+model breaker is open.
 
 After the cool-down elapses the breaker half-opens: the next call is
 allowed through as a probe; its success closes the breaker, its failure
-re-opens it via record_xai_failure.
+re-opens it via record_xai_failure. CLI and API breakers are independent.
 
 ### Function: `record_xai_failure` {#utils-record_xai_failure}
 
 ```python
-def record_xai_failure(model: str)
+def record_xai_failure(model: str, *, plane: str='API')
 ```
 
 **Keywords:** record, xai, failure
 
-Count a failed xAI call; open the breaker at the consecutive threshold.
+Count a failed xAI call; open the plane+model breaker at threshold.
 
 ### Function: `record_xai_success` {#utils-record_xai_success}
 
 ```python
-def record_xai_success(model: str)
+def record_xai_success(model: str, *, plane: str='API')
 ```
 
 **Keywords:** record, xai, success
 
-Reset a model's breaker after any successful xAI call.
+Reset a plane+model breaker after any successful xAI call.
 
 ### Function: `get_circuit_breaker_state` {#utils-get_circuit_breaker_state}
 
@@ -4255,7 +4255,9 @@ def get_circuit_breaker_state() -> Dict[str, Any]
 
 **Keywords:** get, circuit, breaker, state
 
-Snapshot of per-model breaker state (consumed by grok_mcp_status).
+Snapshot of plane-scoped breaker state (consumed by grok_mcp_status).
+
+Keys are ``API:<model>`` / ``CLI:<model>``.
 
 ### Class: `RequestContextLogFilter` {#utils-requestcontextlogfilter}
 

--- a/src/semantic_evals.py
+++ b/src/semantic_evals.py
@@ -404,9 +404,10 @@ async def _grade_and_record(sample: TrajectorySample, store: Any, reservation: f
     actual_cost = 0.0
     try:
         model = _judge_model_override() or await resolve_model("coding")
-        if get_circuit_breaker_state().get(model, {}).get("open"):
+        # Judge traffic is API-plane; only the API breaker for this model matters.
+        if get_circuit_breaker_state().get(f"API:{model}", {}).get("open"):
             _record_stat("judge_failures")
-            logger.warning(f"Semantic eval skipped (breaker open for {model}).")
+            logger.warning(f"Semantic eval skipped (breaker open for API:{model}).")
             return
 
         # Floor the accumulator at the durable record, then re-check: a

--- a/src/utils.py
+++ b/src/utils.py
@@ -2395,20 +2395,34 @@ def _breaker_cooldown_sec() -> float:
     return _env_timeout("UNIGROK_BREAKER_COOLDOWN_SEC", 60.0)
 
 
-# model → {"consecutive_failures": int, "opened_at": float|None, "trips": int}
+# "plane:model" → {"consecutive_failures": int, "opened_at": float|None, "trips": int}
+# Plane-scoped so a CLI subscription outage cannot fail-fast metered API (or
+# the reverse) for the same model slug.
 _BREAKER_STATE: Dict[str, Dict[str, Any]] = {}
 _BREAKER_LOCK = threading.Lock()
 
 
-def check_circuit_breaker(model: str):
-    """Fail fast with CircuitBreakerOpenError while a model's breaker is open.
+def _normalize_breaker_plane(plane: Optional[str] = None) -> str:
+    raw = str(plane or "API").strip().upper().replace("_", "-")
+    if raw in {"CLI", "COMPOSER", "CLI-FALLBACK"}:
+        return "CLI"
+    return "API"
+
+
+def _breaker_key(model: str, *, plane: Optional[str] = None) -> str:
+    return f"{_normalize_breaker_plane(plane)}:{model}"
+
+
+def check_circuit_breaker(model: str, *, plane: str = "API"):
+    """Fail fast with CircuitBreakerOpenError while a plane+model breaker is open.
 
     After the cool-down elapses the breaker half-opens: the next call is
     allowed through as a probe; its success closes the breaker, its failure
-    re-opens it via record_xai_failure.
+    re-opens it via record_xai_failure. CLI and API breakers are independent.
     """
+    key = _breaker_key(model, plane=plane)
     with _BREAKER_LOCK:
-        state = _BREAKER_STATE.get(model)
+        state = _BREAKER_STATE.get(key)
         if not state or not state.get("opened_at"):
             return
         elapsed = time.time() - state["opened_at"]
@@ -2417,49 +2431,54 @@ def check_circuit_breaker(model: str):
             state["opened_at"] = None  # Half-open: allow a probe call.
             return
         raise CircuitBreakerOpenError(
-            f"Circuit breaker open for model '{model}' after "
+            f"Circuit breaker open for {key} after "
             f"{state['consecutive_failures']} consecutive xAI failures; "
             f"retry in {cooldown - elapsed:.0f}s."
         )
 
 
-def record_xai_failure(model: str):
-    """Count a failed xAI call; open the breaker at the consecutive threshold."""
+def record_xai_failure(model: str, *, plane: str = "API"):
+    """Count a failed xAI call; open the plane+model breaker at threshold."""
+    key = _breaker_key(model, plane=plane)
     threshold = _breaker_threshold()
     with _BREAKER_LOCK:
         state = _BREAKER_STATE.setdefault(
-            model, {"consecutive_failures": 0, "opened_at": None, "trips": 0}
+            key, {"consecutive_failures": 0, "opened_at": None, "trips": 0}
         )
         state["consecutive_failures"] += 1
         if state["consecutive_failures"] >= threshold and not state.get("opened_at"):
             state["opened_at"] = time.time()
             state["trips"] += 1
             logging.getLogger("GrokMCP").warning(
-                f"Circuit breaker OPENED for model '{model}' after "
+                f"Circuit breaker OPENED for {key} after "
                 f"{state['consecutive_failures']} consecutive failures; "
                 f"cooling down for {_breaker_cooldown_sec():.0f}s."
             )
 
 
-def record_xai_success(model: str):
-    """Reset a model's breaker after any successful xAI call."""
+def record_xai_success(model: str, *, plane: str = "API"):
+    """Reset a plane+model breaker after any successful xAI call."""
+    key = _breaker_key(model, plane=plane)
     with _BREAKER_LOCK:
-        state = _BREAKER_STATE.get(model)
+        state = _BREAKER_STATE.get(key)
         if state:
             state["consecutive_failures"] = 0
             state["opened_at"] = None
 
 
 def get_circuit_breaker_state() -> Dict[str, Any]:
-    """Snapshot of per-model breaker state (consumed by grok_mcp_status)."""
+    """Snapshot of plane-scoped breaker state (consumed by grok_mcp_status).
+
+    Keys are ``API:<model>`` / ``CLI:<model>``.
+    """
     now = time.time()
     cooldown = _breaker_cooldown_sec()
     with _BREAKER_LOCK:
         snapshot = {}
-        for model, state in _BREAKER_STATE.items():
+        for key, state in _BREAKER_STATE.items():
             opened_at = state.get("opened_at")
             remaining = max(0.0, cooldown - (now - opened_at)) if opened_at else 0.0
-            snapshot[model] = {
+            snapshot[key] = {
                 "open": bool(opened_at and remaining > 0),
                 "consecutive_failures": int(state.get("consecutive_failures", 0)),
                 "cooldown_remaining_sec": round(remaining, 1),
@@ -10829,7 +10848,7 @@ async def _call_plane(
             raise RuntimeError("Grok CLI execution is disabled in Cloud Run runtime.")
 
         grok_path = PathResolver.get_grok_cli_path()
-        check_circuit_breaker(model_name)
+        check_circuit_breaker(model_name, plane="CLI")
         # Explicit message arrays are authoritative conversation state. They
         # use a self-contained prompt instead of mixing caller history with a
         # possibly unrelated native CLI transcript.
@@ -11092,10 +11111,10 @@ async def _call_plane(
                         )
         except RuntimeError as exc:
             if not _is_cli_session_in_use_error(str(exc)):
-                record_xai_failure(model_name)
+                record_xai_failure(model_name, plane="CLI")
             raise
 
-        record_xai_success(model_name)
+        record_xai_success(model_name, plane="CLI")
         # Subscription plane: the CLI exposes no token usage and has no
         # per-token price, so tokens/cost stay 0 by design.
         return text, 0, 0.0, True
@@ -11166,16 +11185,16 @@ async def _call_plane(
             res = grok.sample()
             return res
 
-        # Per-model circuit breaker: fail fast while open, and report the
+        # Per-plane+model circuit breaker: fail fast while open, and report the
         # outcome of every real upstream attempt.
-        check_circuit_breaker(model_name)
+        check_circuit_breaker(model_name, plane="API")
         try:
             response = await run_blocking(
                 _call_api,
                 timeout=_env_timeout("UNIGROK_API_CALL_TIMEOUT", 180.0),
             )
         except Exception as exc:
-            record_xai_failure(model_name)
+            record_xai_failure(model_name, plane="API")
             await _emit_physical_attempt(
                 attempt_recorder,
                 plane="API",
@@ -11185,7 +11204,7 @@ async def _call_plane(
                 error=exc,
             )
             raise
-        record_xai_success(model_name)
+        record_xai_success(model_name, plane="API")
         observed_tokens, observed_cost, usage_source = _provider_response_usage(
             response
         )

--- a/tests/test_semantic_evals.py
+++ b/tests/test_semantic_evals.py
@@ -307,7 +307,7 @@ class TestGradeAndRecord:
         )
         monkeypatch.setattr(
             "src.semantic_evals.get_circuit_breaker_state",
-            MagicMock(return_value={"grok-test": {"open": True}}),
+            MagicMock(return_value={"API:grok-test": {"open": True}}),
         )
         parse_mock = AsyncMock()
         monkeypatch.setattr("src.semantic_evals._parse_structured", parse_mock)
@@ -329,7 +329,7 @@ class TestGradeAndRecord:
             "prompt", "API", 1, 1.0, 0.0, request_id="rid-semantic-test"
         )
         with U._BREAKER_LOCK:
-            U._BREAKER_STATE["grok-test"] = {
+            U._BREAKER_STATE["API:grok-test"] = {
                 "consecutive_failures": 2, "opened_at": None, "trips": 1,
             }
 
@@ -337,7 +337,7 @@ class TestGradeAndRecord:
 
         assert get_semantic_eval_stats()["graded"] == 1  # the judge did run
         with U._BREAKER_LOCK:
-            assert U._BREAKER_STATE["grok-test"] == {
+            assert U._BREAKER_STATE["API:grok-test"] == {
                 "consecutive_failures": 2, "opened_at": None, "trips": 1,
             }
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4521,7 +4521,7 @@ class TestCircuitBreaker:
         with pytest.raises(CircuitBreakerOpenError, match="model-x"):
             check_circuit_breaker("model-x")
 
-        state = get_circuit_breaker_state()["model-x"]
+        state = get_circuit_breaker_state()["API:model-x"]
         assert state["open"] is True
         assert state["consecutive_failures"] == 3
         assert state["trips"] == 1
@@ -4540,7 +4540,7 @@ class TestCircuitBreaker:
         record_xai_failure("model-y")
         record_xai_success("model-y")
         check_circuit_breaker("model-y")  # must not raise
-        assert get_circuit_breaker_state()["model-y"]["consecutive_failures"] == 0
+        assert get_circuit_breaker_state()["API:model-y"]["consecutive_failures"] == 0
 
     def test_breaker_half_opens_after_cooldown(self, monkeypatch):
         import src.utils as utils_module
@@ -4549,13 +4549,13 @@ class TestCircuitBreaker:
         monkeypatch.setenv("UNIGROK_BREAKER_THRESHOLD", "1")
         record_xai_failure("model-z")
         # Rewind opened_at past the cool-down → next check half-opens (probe allowed)
-        utils_module._BREAKER_STATE["model-z"]["opened_at"] = time.time() - 10_000
+        utils_module._BREAKER_STATE["API:model-z"]["opened_at"] = time.time() - 10_000
         check_circuit_breaker("model-z")  # must not raise
-        assert get_circuit_breaker_state()["model-z"]["open"] is False
+        assert get_circuit_breaker_state()["API:model-z"]["open"] is False
         # A failing probe re-opens the breaker
         record_xai_failure("model-z")
-        assert get_circuit_breaker_state()["model-z"]["open"] is True
-        assert get_circuit_breaker_state()["model-z"]["trips"] == 2
+        assert get_circuit_breaker_state()["API:model-z"]["open"] is True
+        assert get_circuit_breaker_state()["API:model-z"]["trips"] == 2
 
     @pytest.mark.asyncio
     async def test_call_plane_fails_fast_when_breaker_open(self, monkeypatch):
@@ -4573,6 +4573,22 @@ class TestCircuitBreaker:
                 )
 
         mock_get_client.assert_not_called()
+
+    def test_cli_breaker_does_not_poison_api_plane(self, monkeypatch):
+        """CLI failures must not open the API breaker for the same model slug."""
+        from src.utils import (
+            CircuitBreakerOpenError,
+            check_circuit_breaker,
+            get_circuit_breaker_state,
+            record_xai_failure,
+        )
+
+        monkeypatch.setenv("UNIGROK_BREAKER_THRESHOLD", "1")
+        record_xai_failure("grok-4.3", plane="CLI")
+        assert get_circuit_breaker_state()["CLI:grok-4.3"]["open"] is True
+        check_circuit_breaker("grok-4.3", plane="API")  # must not raise
+        with pytest.raises(CircuitBreakerOpenError):
+            check_circuit_breaker("grok-4.3", plane="CLI")
 
     @pytest.mark.asyncio
     async def test_agentloop_fatal_error_raises_without_retries(self):
@@ -4674,7 +4690,7 @@ class TestCircuitBreaker:
                 await loop.run("test prompt")
 
         assert mock_chat.sample.call_count == 2
-        state = get_circuit_breaker_state()["grok-4.3"]
+        state = get_circuit_breaker_state()["API:grok-4.3"]
         assert state["open"] is True
         assert state["trips"] == 1
 
@@ -6494,7 +6510,7 @@ class TestCliPlaneV2:
 
         assert exc_info.value.partial_output == "receipt effect-7: edited file"
         assert "xai-123456789SECRET" not in str(exc_info.value)
-        assert utils._BREAKER_STATE["grok-composer-2.5-fast"]["consecutive_failures"] == 1
+        assert utils._BREAKER_STATE["CLI:grok-composer-2.5-fast"]["consecutive_failures"] == 1
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Circuit breaker state is now keyed as `API:<model>` / `CLI:<model>` so a subscription outage cannot fail-fast metered API traffic for the same slug (and reverse).
- `_call_plane` threads `plane=` into check/record; AgentLoop/jobs/distill keep the API default.
- Semantic-eval judge skip reads the API-plane key only; status snapshots show plane-scoped keys.

## Test plan
- [x] `uv run pytest -q tests/test_utils.py::TestCircuitBreaker`
- [x] `uv run pytest -q tests/test_utils.py -k 'cli_failure_records or cli_breaker_does_not'`
- [x] `uv run pytest -q tests/test_semantic_evals.py -k breaker`
- [x] Attribution check vs `origin/main`
- [ ] CI green on draft PR


Made with [Cursor](https://cursor.com)