### PR TITLE
fix(security): bound get_dynamic_context against symlink escape

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -8178,6 +8178,32 @@ def _rank_candidate_files(
     return best
 
 
+def _bound_dynamic_context_path(path_str: str, project_root: Path) -> Optional[Path]:
+    """Return a workspace-bound file path for auto-context injection, or None.
+
+    Soft-fail: absolute/`..` escapes, symlink leaves, and anything
+    PathResolver.validate_path rejects are omitted rather than injected.
+    """
+    raw = (path_str or "").strip().strip('"')
+    if not raw:
+        return None
+    # Git porcelain can emit odd shapes; never join absolute host paths.
+    candidate = Path(raw)
+    if candidate.is_absolute():
+        return None
+    if ".." in candidate.parts:
+        return None
+    joined = project_root / candidate
+    try:
+        if joined.is_symlink():
+            # Auto-context must not follow workspace symlinks (e.g. *.json →
+            # host auth.json) into the system prompt.
+            return None
+        return PathResolver.validate_path(raw)
+    except (PermissionError, OSError, ValueError):
+        return None
+
+
 async def get_dynamic_context(
     mcp_instance: Any = None, prompt: Optional[str] = None
 ) -> tuple[str, bool, str]:
@@ -8211,7 +8237,8 @@ async def get_dynamic_context(
     workspace = PathResolver.get_workspace_root()
     if workspace is None:  # defensive: local_context_enabled already checks
         raise RuntimeError("local context enabled without an attached workspace")
-    project_root = str(workspace)
+    project_root_path = workspace.resolve()
+    project_root = str(project_root_path)
     recent_file = None
     recent_code = ""
     context_injected = False
@@ -8276,10 +8303,10 @@ async def get_dynamic_context(
 
         # ALL matching modified files become ranking candidates (the old
         # code injected modified_files[0] unconditionally — the known
-        # weakness this ranking fixes).
+        # weakness this ranking fixes). Bound every path before ranking.
         for rel_path in modified_files:
-            target_path = Path(project_root) / rel_path
-            if target_path.exists():
+            target_path = _bound_dynamic_context_path(rel_path, project_root_path)
+            if target_path is not None and target_path.is_file():
                 candidate_paths.append(target_path)
         if not candidate_paths:
             # Fallback: files from the last commit in the branch
@@ -8296,8 +8323,10 @@ async def get_dynamic_context(
                     for line in lines[1:]:
                         line = line.strip()
                         if line.endswith(('.py', '.js', '.ts', '.tsx', '.json', '.html', '.css', '.md', '.sh')):
-                            target_path = Path(project_root) / line
-                            if target_path.exists():
+                            target_path = _bound_dynamic_context_path(
+                                line, project_root_path
+                            )
+                            if target_path is not None and target_path.is_file():
                                 candidate_paths.append(target_path)
     except Exception as e:
         logging.getLogger("GrokMCP").warning(f"Git dynamic context resolution unavailable: {e}")
@@ -8325,10 +8354,16 @@ async def get_dynamic_context(
                 except Exception:
                     return 0.0
 
-            candidate_paths = [
-                p.resolve()
-                for p in sorted(candidate_files[:20], key=_mtime, reverse=True)
-            ]
+            bound: List[Path] = []
+            for p in sorted(candidate_files[:20], key=_mtime, reverse=True):
+                try:
+                    rel = p.resolve().relative_to(project_root_path)
+                except (ValueError, OSError):
+                    continue
+                target = _bound_dynamic_context_path(str(rel), project_root_path)
+                if target is not None and target.is_file():
+                    bound.append(target)
+            candidate_paths = bound
         except Exception as e:
             logging.getLogger("GrokMCP").error(f"Fallback context resolution failed: {e}", exc_info=True)
 
@@ -8339,16 +8374,27 @@ async def get_dynamic_context(
         recent_file = candidate_paths[0]
         if prompt_terms and len(candidate_paths) > 1:
             recent_file = _rank_candidate_files(
-                prompt_terms, candidate_paths, Path(project_root)
+                prompt_terms, candidate_paths, project_root_path
             )
         context_injected = True
 
-    if recent_file and recent_file.exists():
+    if recent_file is not None:
+        # Re-bound immediately before open (defense in depth vs. ranking quirks).
+        try:
+            rel = recent_file.resolve().relative_to(project_root_path)
+            recent_file = _bound_dynamic_context_path(str(rel), project_root_path)
+        except (ValueError, OSError):
+            recent_file = None
+            context_injected = False
+    if recent_file and recent_file.is_file():
         try:
             with open(recent_file, 'r', errors='ignore') as f:
                 recent_code = "".join(f.readlines()[:100])
         except Exception as e:
             logging.getLogger("GrokMCP").error(f"Failed to read file context: {e}", exc_info=True)
+            recent_file = None
+            recent_code = ""
+            context_injected = False
 
     context = (
         "# UniGrok Workspace Context\n"

--- a/tests/test_knowledge.py
+++ b/tests/test_knowledge.py
@@ -591,6 +591,33 @@ class TestRankedContextFile:
 
         assert "alpha.py" in context
 
+    @pytest.mark.asyncio
+    async def test_symlink_escape_is_not_injected(self, tmp_path, monkeypatch):
+        """Workspace symlinks that resolve outside the tree must never enter
+        auto-context (e.g. leak.json → host auth.json)."""
+        from src.utils import get_dynamic_context
+
+        monkeypatch.setattr(PathResolver, "get_workspace_root", staticmethod(lambda: tmp_path))
+        secret = tmp_path.parent / "outside-secret.json"
+        secret.write_text('{"token":"super-secret-token-xyz"}\n', encoding="utf-8")
+        leak = tmp_path / "leak.json"
+        leak.symlink_to(secret)
+        (tmp_path / "safe.py").write_text("safe workspace file\n", encoding="utf-8")
+        _fake_git(monkeypatch, b"M  leak.json\nM  safe.py\n")
+
+        try:
+            git_cache.clear()
+            context, injected, _ = await get_dynamic_context(prompt="read leak.json token")
+        finally:
+            git_cache.clear()
+
+        assert "super-secret-token-xyz" not in context
+        assert "outside-secret" not in context
+        assert "leak.json" not in context
+        assert injected is True
+        assert "safe.py" in context
+        assert "safe workspace file" in context
+
 
 class TestKnowledgeContextInjection:
     @pytest.fixture


### PR DESCRIPTION
## Summary
- `get_dynamic_context` now bounds every auto-context candidate with `PathResolver.validate_path` and refuses symlink leaves before open.
- Absolute/`..` git porcelain paths are skipped instead of being joined blindly.
- Soft-fail: rejected candidates are omitted; the turn continues with remaining safe files.

## Test plan
- [x] `uv run pytest -q tests/test_knowledge.py::TestRankedContextFile`
- [x] `uv run pytest -q tests/test_knowledge.py::TestKnowledgeContextInjection`
- [x] Attribution check vs `origin/main`
- [ ] CI green on draft PR


Made with [Cursor](https://cursor.com)