### PR TITLE
docs: public vs insider agent law (stable MCP audience split)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -1,5 +1,16 @@
 # Workspace Rules
 
+## Audience first (stable MCP client vs this repository)
+
+**Stable MCP / vibe coder (foreign apps + `http://localhost:4765/mcp` only):**
+
+- Do **not** invent **4766**, Forge, Swarm, land, or dual-runtime for ordinary installs.
+- Prefer `using-unigrok`. Honor `discover_self` gates (`can_mutate_workspace`, `can_use_swarm`).
+- Do **not** run product **session-rehydrate** outside a UniGrok product checkout.
+- Status language for their apps: Done / Blocked / plain English — **not** the multi-agent "Ready for supervisor" land pipeline unless they are shipping *this* product.
+
+**This repository / write+ insiders:** full multi-agent law in this file applies (worktrees, draft PRs, land gates, rehydrate).
+
 ## Talk to humans first (mandatory — all brands)
 
 New users and sponsors are **not** git operators. Many readers (including people
@@ -58,6 +69,8 @@ and blocking questions are explicit exceptions.
   pack/skill? Never auto-sync private intelligence or raw memory to public.
 
 ## Human language (user-facing — mandatory)
+
+The sponsor is **not** a git operator. **Ready for supervisor** maps multi-agent UniGrok product shipping — not a vibe user's unrelated app (use Done/Blocked/plain English there).
 
 The sponsor is **not** a git operator. Match **intent**, not literal VCS vocabulary.
 Dyslexia-hostile jargon in answers is a product failure.

--- a/.agents/skills/session-rehydrate/SKILL.md
+++ b/.agents/skills/session-rehydrate/SKILL.md
@@ -1,15 +1,25 @@
 ---
 name: session-rehydrate
 description: >-
-  Boot a new IDE/agent session into full UniGrok product context. Activate on
-  "rehydrate", "boot", "where were we", "session start", first message after
-  IDE reset, or when the agent was started outside the product checkout.
+  Boot a new IDE/agent session into full UniGrok *product* context. Activate only
+  when cwd is a UniGrok product checkout (or agent worktree), or the user
+  explicitly asks for product rehydrate. Triggers: "rehydrate", "boot",
+  "where were we", "session start", first message after IDE reset *inside*
+  product. Do not run full product rehydrate for foreign apps on stable MCP.
 ---
 
 # Session rehydrate (persist intelligence across chats)
 
 New Grok/Claude/Codex sessions do **not** inherit prior chat transcripts.
 Intelligence is rehydrated from **git + disk**, not model memory.
+
+**Product-cwd gate (mandatory):** This skill is for **developing UniGrok itself**.
+If the open project is a foreign app using only stable MCP (`:4765`), do **not**
+run this full product boot (no land-status pipeline, no worktree hygiene lecture,
+no "Ready for supervisor" multi-agent radio). Use `using-unigrok` +
+`grok_mcp_discover_self` instead. Only continue if cwd is `…/grok-mcp-server`
+(or a named agent worktree under it / provider worktree home), or the user
+explicitly said **product rehydrate**.
 
 > [!IMPORTANT]
 > **Glossary: Do not conflate "Hydrate" concepts**
@@ -48,11 +58,15 @@ so these rules load.
 
 ## Boot sequence (run once at session start)
 
-### 0. Workspace
+### 0. Workspace (product-cwd gate)
 
 - Prefer cwd: product checkout `…/grok-mcp-server` or a named agent worktree.
-- If cwd is `$HOME` or unrelated, **say so once**, then rehydrate from absolute
-  product paths anyway (or ask to reopen the project folder).
+- **Foreign app / stable MCP only:** stop product rehydrate. Tell the user once
+  that product boot is for UniGrok development; offer `discover_self` +
+  `using-unigrok` for their app. Do not invent land/Forge/worktree workflows.
+- If cwd is `$HOME` or unclear and the user asked for product rehydrate, **say
+  so once** and either open the product folder or rehydrate from absolute
+  product paths only when they confirm.
 
 ### 1. Product law
 

--- a/.agents/skills/using-unigrok/SKILL.md
+++ b/.agents/skills/using-unigrok/SKILL.md
@@ -117,10 +117,20 @@ credential or billing plane; `cross_plane` allows bounded failover. CLI
 provider cost remains unavailable, so report local counts and estimated tokens,
 not invented subscription cost or remaining provider quota.
 
+## Status language (vibe apps vs UniGrok product)
+
+- **Foreign apps / stable MCP only:** report status as **Done**, **Blocked**,
+  or plain English. Do **not** force multi-agent **Ready for supervisor** /
+  land-pipeline radio — that language is for shipping *this* UniGrok product.
+- **Developing UniGrok itself** (product checkout / write+ insider): full
+  human-radio map in `.agents/AGENTS.md` applies (Ready / Live / Blocked / Who).
+
 ## Safe onboarding behavior
 
 - On first connect in a session, call `grok_mcp_discover_self` and read
   `data.bootstrap` + `data.request_context` before inventing setup steps.
+- When `can_mutate_workspace` and `can_use_swarm` are false, treat contributor
+  workflows as **disabled** (no land, Forge, Swarm, or product rehydrate).
 - Treat `credential_planes` notices from status or an agent result as the
   source of truth. Ask before device authentication, installation, or secret
   configuration.

--- a/.claude/skills/session-rehydrate/SKILL.md
+++ b/.claude/skills/session-rehydrate/SKILL.md
@@ -1,15 +1,25 @@
 ---
 name: session-rehydrate
 description: >-
-  Boot a new IDE/agent session into full UniGrok product context. Activate on
-  "rehydrate", "boot", "where were we", "session start", first message after
-  IDE reset, or when the agent was started outside the product checkout.
+  Boot a new IDE/agent session into full UniGrok *product* context. Activate only
+  when cwd is a UniGrok product checkout (or agent worktree), or the user
+  explicitly asks for product rehydrate. Triggers: "rehydrate", "boot",
+  "where were we", "session start", first message after IDE reset *inside*
+  product. Do not run full product rehydrate for foreign apps on stable MCP.
 ---
 
 # Session rehydrate (persist intelligence across chats)
 
 New Grok/Claude/Codex sessions do **not** inherit prior chat transcripts.
 Intelligence is rehydrated from **git + disk**, not model memory.
+
+**Product-cwd gate (mandatory):** This skill is for **developing UniGrok itself**.
+If the open project is a foreign app using only stable MCP (`:4765`), do **not**
+run this full product boot (no land-status pipeline, no worktree hygiene lecture,
+no "Ready for supervisor" multi-agent radio). Use `using-unigrok` +
+`grok_mcp_discover_self` instead. Only continue if cwd is `…/grok-mcp-server`
+(or a named agent worktree under it / provider worktree home), or the user
+explicitly said **product rehydrate**.
 
 ## Communication discipline (same experience every session)
 
@@ -41,11 +51,15 @@ so these rules load.
 
 ## Boot sequence (run once at session start)
 
-### 0. Workspace
+### 0. Workspace (product-cwd gate)
 
 - Prefer cwd: product checkout `…/grok-mcp-server` or a named agent worktree.
-- If cwd is `$HOME` or unrelated, **say so once**, then rehydrate from absolute
-  product paths anyway (or ask to reopen the project folder).
+- **Foreign app / stable MCP only:** stop product rehydrate. Tell the user once
+  that product boot is for UniGrok development; offer `discover_self` +
+  `using-unigrok` for their app. Do not invent land/Forge/worktree workflows.
+- If cwd is `$HOME` or unclear and the user asked for product rehydrate, **say
+  so once** and either open the product folder or rehydrate from absolute
+  product paths only when they confirm.
 
 ### 1. Product law
 

--- a/.claude/skills/using-unigrok/SKILL.md
+++ b/.claude/skills/using-unigrok/SKILL.md
@@ -120,6 +120,13 @@ secret values):
 
 Then one cheap verification: `agent` with `mode=fast` or `grok_mcp_status`.
 
+## Status language (vibe apps vs UniGrok product)
+
+- **Foreign apps / stable MCP only:** Done / Blocked / plain English — not
+  multi-agent **Ready for supervisor** land radio unless shipping UniGrok itself.
+- When `can_mutate_workspace` / `can_use_swarm` are false, contributor workflows
+  are disabled (no land, Forge, Swarm, or product rehydrate).
+
 ## Safety
 
 - Never request `XAI_API_KEY` in chat or write it into any IDE config; the

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -1,6 +1,12 @@
 # Grok-MCP Project-Specific Guidelines
 
-Welcome, Gemini Agent! You are operating inside the local environment of the **Grok-MCP** codebase. Follow these project-specific directives on every execution:
+Gemini agent in the **Grok-MCP** codebase. Follow these directives every run:
+
+## 0a. Audience first (stable MCP client vs this repository)
+
+**Stable MCP client only** (`http://localhost:4765/mcp` in *their* apps): port **4765** only — no 4766/Forge/Swarm/land; prefer `using-unigrok` + `grok_mcp_discover_self`; no product rehydrate; status Done/Blocked/plain English (not "Ready for supervisor" unless shipping *this* product).
+
+**Developing UniGrok itself:** sections below apply.
 
 ## 0. Talk to humans first
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,15 @@
 # GitHub Copilot instructions for UniGrok
 
+## Audience first (stable MCP client vs this repository)
+
+**If you only help a user run UniGrok as a stable MCP client** (`http://localhost:4765/mcp` in *their* apps):
+
+- Use **4765 only**. No **4766**, Forge, Swarm, or land workflows for ordinary use.
+- Prefer `.github/skills/using-unigrok/SKILL.md`. Call `grok_mcp_discover_self`.
+- Do **not** product-rehydrate foreign apps. Status language is Done/Blocked/plain English, not "Ready for supervisor" unless shipping UniGrok itself.
+
+**If you are developing this repository**, full multi-agent rules below apply.
+
 ## Talk to humans first
 
 **Short plain answers** in chat. Brand + Ready/Live/Blocked + plain task title.

--- a/.github/skills/using-unigrok/SKILL.md
+++ b/.github/skills/using-unigrok/SKILL.md
@@ -102,6 +102,13 @@ secret values):
 
 Then one cheap verification: `agent` with `mode=fast` or `grok_mcp_status`.
 
+## Status language (vibe apps vs UniGrok product)
+
+- **Foreign apps / stable MCP only:** Done / Blocked / plain English — not
+  multi-agent **Ready for supervisor** land radio unless shipping UniGrok itself.
+- When `can_mutate_workspace` / `can_use_swarm` are false, contributor workflows
+  are disabled (no land, Forge, Swarm, or product rehydrate).
+
 ## Safety and credential boundary
 
 - Never ask users to paste `XAI_API_KEY` into IDE MCP config; credentials live

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,19 @@
 # AGENTS.md
 
+## Audience first (stable MCP client vs this repository)
+
+**If you only help a user run UniGrok as a stable MCP client**
+(`http://localhost:4765/mcp` in *their* apps — not developing this repo):
+
+- Use **port 4765 only**. Do **not** invent **4766**, Forge, Swarm, land, or dual-runtime.
+- Prefer the **`using-unigrok`** skill. Call `grok_mcp_discover_self` first.
+- Do **not** run product **session-rehydrate** or multi-agent land pipelines.
+- User status language: Done / Blocked / plain English — **not** "Ready for
+  supervisor" unless they are shipping *this* product as a collaborator.
+
+**If you are developing UniGrok itself** (this checkout / write+ insider work):
+full multi-agent law below applies.
+
 ## Talk to humans first
 
 Before anything else: **short plain answers**. Brand + status + what it is.
@@ -7,6 +21,8 @@ No diffs, logs, or git lectures unless the human asked. Full law:
 [.agents/AGENTS.md](.agents/AGENTS.md) → **Talk to humans first** / **Human language**.
 
 ---
+
+## Insider / this repository only
 
 Guidance for Codex working in **uni-grok-mcp**. Shared multi-agent rules
 (git coordination, endpoint, credentials boundary) live in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,19 @@
 # CLAUDE.md
 
+## Audience first (stable MCP client vs this repository)
+
+**If you only help a user run UniGrok as a stable MCP client**
+(`http://localhost:4765/mcp` in *their* apps — not developing this repo):
+
+- Use **port 4765 only**. Do **not** invent **4766**, Forge, Swarm, land, or dual-runtime.
+- Prefer the **`using-unigrok`** skill. Call `grok_mcp_discover_self` first.
+- Do **not** run product **session-rehydrate** or multi-agent land pipelines.
+- User status language: Done / Blocked / plain English — **not** "Ready for
+  supervisor" unless they are shipping *this* product as a collaborator.
+
+**If you are developing UniGrok itself** (this checkout / write+ insider work):
+full multi-agent law below applies.
+
 ## Talk to humans first
 
 **Short plain answers only** unless the human asked for technical detail.
@@ -8,6 +22,8 @@ lectures in chat. Full law: [.agents/AGENTS.md](.agents/AGENTS.md) →
 **Talk to humans first** / **Human language**.
 
 ---
+
+## Insider / this repository only
 
 Guidance for Claude Code working in **uni-grok-mcp**. Shared multi-agent rules
 (git coordination, endpoint, credentials boundary) live in

--- a/docs/public-intelligence/packs/manifest.json
+++ b/docs/public-intelligence/packs/manifest.json
@@ -105,6 +105,33 @@
         "Session or task-RAG database dumps",
         "Contributor workspace memory rows"
       ]
+    },
+    {
+      "pack_id": "public-vs-insider-agent-law",
+      "version": "v0",
+      "title": "Public vs insider agent law",
+      "summary": "Stable MCP clients stay on 4765 + using-unigrok; product rehydrate and Ready-for-supervisor land radio are insider-only.",
+      "audience": "public",
+      "body_path": "docs/public-intelligence/packs/v0-public-vs-insider-agent-law.md",
+      "source_gym": "Audience-split deep dive: vibe users on stable Docker MCP loading full AGENTS land culture.",
+      "promoted_from": [
+        "AGENTS.md",
+        ".agents/AGENTS.md",
+        "skills/using-unigrok/SKILL.md",
+        ".agents/skills/session-rehydrate/SKILL.md"
+      ],
+      "scrub": {
+        "secrets": true,
+        "private_paths": true,
+        "raw_memory": true,
+        "unreviewed_logs": true
+      },
+      "never_includes": [
+        "API keys or OAuth secrets",
+        "Private unigrok-intelligence playbooks",
+        "Session or task-RAG database dumps",
+        "Contributor workspace memory rows"
+      ]
     }
   ]
 }

--- a/docs/public-intelligence/packs/v0-public-vs-insider-agent-law.md
+++ b/docs/public-intelligence/packs/v0-public-vs-insider-agent-law.md
@@ -1,0 +1,63 @@
+# Public pack — Public vs insider agent law
+
+**Audience:** public installers and any agent connected only to stable MCP  
+**Pack id:** `public-vs-insider-agent-law` · **version:** `v0`
+
+Distilled from multi-brand gym work on audience split. Safe to ship: no secrets,
+no private memory, no competitive process IP.
+
+## Problem this pack solves
+
+Users who only want Grok chat in **their** apps sometimes open the UniGrok
+clone (or trigger **rehydrate**) and the agent starts acting like a UniGrok
+**contributor** — land, worktrees, Forge, dual ports, multi-agent radio.
+
+**Runtime tools on stable MCP are mostly fine.** The leak is **instruction
+files and skills** when the agent’s cwd is the product repo or product boot runs
+in a foreign app.
+
+## Two audiences
+
+| Audience | Should load |
+|----------|-------------|
+| **Vibe / stable MCP client** | README paste + optional `using-unigrok` + `grok_mcp_discover_self` |
+| **Insider (building UniGrok)** | Full `AGENTS.md` / `.agents/*`, product rehydrate, land, worktrees |
+
+## Rules for stable clients (`:4765` only)
+
+1. Use **port 4765 only**. Do **not** invent **4766**, Forge, Swarm, land, or
+   dual-runtime for ordinary installs.
+2. Prefer **`using-unigrok`**. Call **`grok_mcp_discover_self`** first.
+3. Honor gates: when `can_mutate_workspace` and `can_use_swarm` are **false**,
+   **contributor workflows are disabled**.
+4. Do **not** run product **session-rehydrate** outside a UniGrok product
+   checkout (or an explicit “product rehydrate” request).
+5. Status language for **their** apps: **Done / Blocked / plain English** — not
+   multi-agent **Ready for supervisor** land radio unless they ship UniGrok.
+
+## Task titles, not numbers
+
+Lead updates with brand + status + plain task title. Ticket numbers are
+optional footnotes, never the lead.
+
+## What stays insider-only
+
+- Full multi-agent land / worktree / draft-PR pipeline
+- Product session-rehydrate brand next-steps map
+- Private intelligence playbooks and hive process
+- Forge / Swarm tooling on contributor surfaces
+
+## Success check
+
+| Situation | Pass |
+|-----------|------|
+| Foreign app + stable MCP | agent / discover only; no land or Forge story |
+| UniGrok product checkout | full insider law available |
+| Rehydrate in foreign app | no product land pipeline invented |
+| Vibe status language | not forced “Ready for supervisor” |
+
+## Related packs
+
+- `install-and-any-project` — close the clone after install
+- `human-radio-and-cloud-boundary` — Ready / Live / Blocked map for product work
+- `rehydrate-brand-next-steps` — **product** rehydrate only (cwd-gated)

--- a/docs/public-intelligence/packs/v0-rehydrate-brand-next-steps.md
+++ b/docs/public-intelligence/packs/v0-rehydrate-brand-next-steps.md
@@ -1,10 +1,15 @@
 # Public pack v0 — Rehydrate with brand next steps
 
-**Audience:** public installers and contributor agents  
+**Audience:** contributor agents developing UniGrok (product checkout)  
 **Pack id:** `rehydrate-brand-next-steps` · **version:** `v0`
 
 Distilled from multi-brand UniGrok gym work. Safe to ship: no secrets, no private
 memory, no competitive process IP.
+
+**Product-cwd gate:** full product rehydrate is for a UniGrok checkout (or
+explicit “product rehydrate”). Foreign apps on stable MCP should use
+`using-unigrok` + `discover_self` instead — see pack
+`public-vs-insider-agent-law`.
 
 ## Problem this pack solves
 

--- a/skills/using-unigrok/SKILL.md
+++ b/skills/using-unigrok/SKILL.md
@@ -117,10 +117,20 @@ credential or billing plane; `cross_plane` allows bounded failover. CLI
 provider cost remains unavailable, so report local counts and estimated tokens,
 not invented subscription cost or remaining provider quota.
 
+## Status language (vibe apps vs UniGrok product)
+
+- **Foreign apps / stable MCP only:** report status as **Done**, **Blocked**,
+  or plain English. Do **not** force multi-agent **Ready for supervisor** /
+  land-pipeline radio — that language is for shipping *this* UniGrok product.
+- **Developing UniGrok itself** (product checkout / write+ insider): full
+  human-radio map in `.agents/AGENTS.md` applies (Ready / Live / Blocked / Who).
+
 ## Safe onboarding behavior
 
 - On first connect in a session, call `grok_mcp_discover_self` and read
   `data.bootstrap` + `data.request_context` before inventing setup steps.
+- When `can_mutate_workspace` and `can_use_swarm` are false, treat contributor
+  workflows as **disabled** (no land, Forge, Swarm, or product rehydrate).
 - Treat `credential_planes` notices from status or an agent result as the
   source of truth. Ask before device authentication, installation, or secret
   configuration.

--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -1311,6 +1311,57 @@ async def grok_mcp_discover_self(include_models: bool = False) -> SystemResult:
         surface = _markdown_inline_label(request_context.get("surface") or "stable_core")
         bootstrap_status = _markdown_inline_label(bootstrap.get("status") or "WARN")
 
+        # Stronger client prose when contributor workflows are gated off.
+        stable_client = (
+            not contributor
+            and not bootstrap.get("can_mutate_workspace")
+            and not bootstrap.get("can_use_swarm")
+        )
+        if stable_client:
+            contributor_gate_extra = (
+                "- **Contributor workflows disabled** on this surface "
+                "(`can_mutate_workspace=false`, `can_use_swarm=false`): do not invent land, "
+                "Forge, Swarm, dual-runtime, or product session-rehydrate for ordinary installs.\n"
+                "- Status language for the user's own apps: Done / Blocked / plain English — not "
+                "multi-agent \"Ready for supervisor\" unless they are shipping UniGrok itself.\n"
+                "- Prefer the `using-unigrok` skill and the connected Core endpoint only.\n"
+            )
+            # Prefer concrete next actions for pure clients.
+            pure_client_actions = [
+                {
+                    "id": "stable_client_use_agent",
+                    "prompt_user": False,
+                    "action": {
+                        "id": "stable_client_use_agent",
+                        "summary": (
+                            "Use the UniGrok `agent` tool on this Core endpoint only; "
+                            "do not invent a second port or land workflow."
+                        ),
+                    },
+                },
+                {
+                    "id": "stable_client_status_language",
+                    "prompt_user": False,
+                    "action": {
+                        "id": "stable_client_status_language",
+                        "summary": (
+                            "For foreign apps, report Done/Blocked/plain English — not "
+                            "Ready-for-supervisor land radio."
+                        ),
+                    },
+                },
+            ]
+            existing_ids = {
+                item.get("id")
+                for item in bootstrap.get("next_actions") or []
+                if isinstance(item, dict)
+            }
+            for item in pure_client_actions:
+                if item["id"] not in existing_ids:
+                    bootstrap.setdefault("next_actions", []).append(item)
+        else:
+            contributor_gate_extra = ""
+
         doc_text = (
             "# UniGrok MCP Discovery & Self-Description\n\n"
             "Zero-configuration onboarding for IDE agents. The primary product chat path is the "
@@ -1323,6 +1374,7 @@ async def grok_mcp_discover_self(include_models: bool = False) -> SystemResult:
             f"can_spend_api=`{bootstrap.get('can_spend_api')}`, "
             f"can_mutate_workspace=`{bootstrap.get('can_mutate_workspace')}`, "
             f"can_use_swarm=`{bootstrap.get('can_use_swarm')}`.\n"
+            f"{contributor_gate_extra}"
             "- Read structured `data.bootstrap` and `data.request_context` for machine-usable gates.\n"
             "- This service does **not** read global IDE settings or the caller's project files. "
             "With user permission, audit those locally (report only; never rewrite without consent; "

--- a/tests/test_agent_law_audience_split.py
+++ b/tests/test_agent_law_audience_split.py
@@ -1,0 +1,116 @@
+"""Audience split: public stable clients must not inherit insider agent law."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+BRAND_ROOTS = (
+    ROOT / "AGENTS.md",
+    ROOT / "CLAUDE.md",
+    ROOT / ".agents" / "AGENTS.md",
+    ROOT / ".gemini" / "GEMINI.md",
+    ROOT / ".github" / "copilot-instructions.md",
+)
+
+
+def test_brand_roots_lead_with_audience_first() -> None:
+    for path in BRAND_ROOTS:
+        text = path.read_text(encoding="utf-8")
+        assert "Audience first" in text, path.relative_to(ROOT)
+        assert text.index("Audience first") < 400, path.relative_to(ROOT)
+        assert "4765" in text
+        assert "using-unigrok" in text or "using-unigrok" in text.lower()
+        # Public path forbids inventing Forge/land for ordinary installs.
+        lowered = " ".join(text.lower().split())
+        assert "forge" in lowered or "4766" in text
+        assert "ready for supervisor" in lowered
+
+
+def test_session_rehydrate_has_product_cwd_gate() -> None:
+    for rel in (
+        ".agents/skills/session-rehydrate/SKILL.md",
+        ".claude/skills/session-rehydrate/SKILL.md",
+    ):
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        assert "product-cwd gate" in text.lower() or "Product-cwd gate" in text
+        assert "foreign app" in text.lower()
+        assert "product rehydrate" in text.lower()
+        assert "do not run full product rehydrate" in text.lower()
+        # Description frontmatter must mention the gate.
+        assert "product checkout" in text
+        assert "stable MCP" in text or "stable MCP" in text.replace("`", "")
+
+
+def test_using_unigrok_status_language_for_vibe_apps() -> None:
+    public = (ROOT / "skills" / "using-unigrok" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    agent = (ROOT / ".agents" / "skills" / "using-unigrok" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    assert public == agent
+    assert "Status language (vibe apps vs UniGrok product)" in public
+    assert "Done" in public and "Blocked" in public
+    assert "Ready for supervisor" in public
+    assert "can_mutate_workspace" in public
+    for rel in (
+        ".claude/skills/using-unigrok/SKILL.md",
+        ".github/skills/using-unigrok/SKILL.md",
+    ):
+        text = (ROOT / rel).read_text(encoding="utf-8")
+        assert "Status language (vibe apps vs UniGrok product)" in text
+        assert "Ready for supervisor" in text
+
+
+def test_public_pack_public_vs_insider_exists() -> None:
+    body = (
+        ROOT
+        / "docs"
+        / "public-intelligence"
+        / "packs"
+        / "v0-public-vs-insider-agent-law.md"
+    )
+    text = body.read_text(encoding="utf-8")
+    assert "Ready for supervisor" in text
+    assert "Task titles, not numbers" in text
+    assert "can_mutate_workspace" in text
+    assert "session-rehydrate" in text
+
+
+@pytest.mark.asyncio
+async def test_stable_discover_self_states_contributor_workflows_disabled(
+    monkeypatch,
+) -> None:
+    from src.tools.system import grok_mcp_discover_self
+
+    monkeypatch.setenv("UNIGROK_SERVICE_MODE", "stable")
+    monkeypatch.delenv("WORKSPACE_ROOT", raising=False)
+    monkeypatch.setattr(
+        "src.tools.system.grok_cli_plane_status",
+        lambda timeout_sec=5.0: {
+            "state": "ready",
+            "ready": True,
+            "binary": True,
+            "auth": "oauth",
+            "setup_command": "unused",
+        },
+    )
+
+    result = await grok_mcp_discover_self()
+    prose = (result.response or "") + "\n" + (result.text or "")
+    assert result.data["bootstrap"]["can_mutate_workspace"] is False
+    assert result.data["bootstrap"]["can_use_swarm"] is False
+    assert "Contributor workflows disabled" in prose
+    assert "Ready for supervisor" in prose or "Ready-for-supervisor" in prose
+    assert "using-unigrok" in prose.lower()
+    action_ids = {
+        item.get("id")
+        for item in result.data["bootstrap"].get("next_actions") or []
+        if isinstance(item, dict)
+    }
+    assert "stable_client_use_agent" in action_ids
+    assert "stable_client_status_language" in action_ids


### PR DESCRIPTION
## Summary

Vibe users on stable Docker MCP (`:4765`) must not inherit full UniGrok contributor culture (land, worktrees, Forge, multi-agent “Ready for supervisor”). This PR is the approved **Phases 1–3** audience split: docs/skills first, stronger `discover_self` prose when mutation/swarm gates are off — **no** stable tool-list surgery.

## What changed

- **Audience first** banners on `AGENTS.md`, `CLAUDE.md`, `.agents/AGENTS.md`, `.gemini/GEMINI.md`, `.github/copilot-instructions.md`
- **session-rehydrate** product-cwd gate (`.agents` + `.claude` copies)
- **using-unigrok** vibe status language (canonical `skills` == `.agents`; brand adapters updated)
- **discover_self** markdown: “Contributor workflows disabled” + pure-client `next_actions` when `can_mutate_workspace` / `can_use_swarm` are false
- Public pack `v0-public-vs-insider-agent-law` + contract tests

## Tests

```bash
uv run pytest -q tests/test_agent_law_audience_split.py tests/test_public_intelligence_packs.py tests/test_namespace_human_radio_roots.py tests/test_service_workspace_boundary.py::test_stable_discover_self_has_no_forge_connect_recipes
```

21 related tests passed in this worktree.

## Risks

- Docs/skills only for most surfaces; small runtime prose/`next_actions` change on stable discover_self
- Agents still open on the UniGrok clone will see insider sections *below* the audience banner — expected

## Human sponsor

djtelicloud — approved all phases in parallel

## Provenance

- Branch: `grok/agent-law-audience-split`
- Head: `400663158ce8bb680c6a3001692939e90dffedea`
- Agent-Assisted-By: xAI Grok | model=grok-4.5 | surface=Grok Build CLI | role=implementation

Ready for supervisor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation and agent instructions; the only runtime change is additive `discover_self` markdown and bootstrap `next_actions`, with no auth, billing, or tool-list changes.
> 
> **Overview**
> Splits **stable MCP / vibe users** from **UniGrok product insiders** so foreign apps on `:4765` are not pushed into land, Forge, Swarm, dual ports, or **Ready for supervisor** radio.
> 
> **Docs & skills:** Adds **Audience first** banners on root and brand agent files (`AGENTS.md`, `CLAUDE.md`, `.agents/AGENTS.md`, `.gemini/GEMINI.md`, Copilot instructions). **session-rehydrate** is cwd-gated to product checkouts only. **using-unigrok** (canonical + Claude/GitHub adapters) documents vibe **Done/Blocked** status and disables contributor flows when `can_mutate_workspace` / `can_use_swarm` are false.
> 
> **Runtime:** `grok_mcp_discover_self` on stable surfaces with those gates off now adds bootstrap markdown (“Contributor workflows disabled”), vibe status guidance, and `next_actions` ids `stable_client_use_agent` and `stable_client_status_language`.
> 
> **Public intelligence:** New pack `public-vs-insider-agent-law` plus manifest entry; **rehydrate-brand-next-steps** audience narrowed to product contributors with a cross-link to the new pack.
> 
> **Tests:** `tests/test_agent_law_audience_split.py` locks banners, rehydrate gate, skill parity, pack content, and stable `discover_self` prose/actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 400663158ce8bb680c6a3001692939e90dffedea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->