### PR TITLE
fix(security): require Origin on control cookie POSTs

### DIFF
--- a/sites/unigrok-control-center/app/api/control/receipts/route.ts
+++ b/sites/unigrok-control-center/app/api/control/receipts/route.ts
@@ -1,5 +1,9 @@
 import { authorizeGitHubCollaborator, createInstallationCredential } from "../../../lib/github-app";
-import { loadGitHubAuthConfig, requestHostMatchesApplication } from "../../../lib/github-auth-config";
+import {
+  loadGitHubAuthConfig,
+  requestHostMatchesApplication,
+  requestOriginMatchesApplication,
+} from "../../../lib/github-auth-config";
 import { readGitHubSession } from "../../../lib/github-oauth";
 import { buildLandingReceiptPayload, loadReceiptSigningConfig, signLandingReceipt } from "../../../lib/landing-receipt";
 
@@ -8,7 +12,12 @@ export const dynamic = "force-dynamic";
 export async function POST(request: Request): Promise<Response> {
   try {
     const github = loadGitHubAuthConfig();
-    if (!requestHostMatchesApplication(github, request.headers.get("host"))) return failure(400);
+    if (
+      !requestHostMatchesApplication(github, request.headers.get("host")) ||
+      !requestOriginMatchesApplication(github, request.headers.get("origin"))
+    ) {
+      return failure(400);
+    }
     const session = await readGitHubSession(github, request.headers.get("cookie"));
     if (!session) return failure(401);
     const credential = await createInstallationCredential(github);

--- a/sites/unigrok-control-center/app/api/control/reviews/route.ts
+++ b/sites/unigrok-control-center/app/api/control/reviews/route.ts
@@ -1,5 +1,9 @@
 import { authorizeGitHubCollaborator, createInstallationCredential } from "../../../lib/github-app";
-import { loadGitHubAuthConfig, requestHostMatchesApplication } from "../../../lib/github-auth-config";
+import {
+  loadGitHubAuthConfig,
+  requestHostMatchesApplication,
+  requestOriginMatchesApplication,
+} from "../../../lib/github-auth-config";
 import { readGitHubSession } from "../../../lib/github-oauth";
 import { callHostedReviewBroker, fetchImmutableReviewEvidence } from "../../../lib/github-review-broker";
 import { loadMcpOAuthConfig } from "../../../lib/mcp-oauth";
@@ -9,7 +13,12 @@ export const dynamic = "force-dynamic";
 export async function POST(request: Request): Promise<Response> {
   try {
     const github = loadGitHubAuthConfig();
-    if (!requestHostMatchesApplication(github, request.headers.get("host"))) return response(400);
+    if (
+      !requestHostMatchesApplication(github, request.headers.get("host")) ||
+      !requestOriginMatchesApplication(github, request.headers.get("origin"))
+    ) {
+      return response(400);
+    }
     const session = await readGitHubSession(github, request.headers.get("cookie"));
     if (!session) return response(401);
     const credential = await createInstallationCredential(github);

--- a/sites/unigrok-control-center/app/auth/github/logout/route.ts
+++ b/sites/unigrok-control-center/app/auth/github/logout/route.ts
@@ -3,6 +3,7 @@ import {
   getGitHubControlMode,
   loadGitHubAuthConfig,
   requestHostMatchesApplication,
+  requestOriginMatchesApplication,
 } from "../../../lib/github-auth-config";
 import { clearGitHubSessionCookie } from "../../../lib/github-oauth";
 
@@ -14,7 +15,7 @@ export async function POST(request: Request): Promise<Response> {
     const config = loadGitHubAuthConfig();
     if (
       !requestHostMatchesApplication(config, request.headers.get("host")) ||
-      request.headers.get("origin") !== config.appBaseUrl.origin
+      !requestOriginMatchesApplication(config, request.headers.get("origin"))
     ) {
       return new Response("Sign-out is unavailable.", { status: 400 });
     }

--- a/sites/unigrok-control-center/app/lib/github-auth-config.ts
+++ b/sites/unigrok-control-center/app/lib/github-auth-config.ts
@@ -105,6 +105,23 @@ export function requestHostMatchesApplication(
   return hostHeader.toLowerCase() === config.appBaseUrl.host.toLowerCase();
 }
 
+/** True when a browser Origin matches the control app origin exactly.
+ *
+ * Cookie-authenticated control POSTs must require this: session cookies are
+ * SameSite=Lax, which still sends them on same-site sibling-subdomain forms.
+ */
+export function requestOriginMatchesApplication(
+  config: Pick<GitHubAuthConfig, "appBaseUrl">,
+  originHeader: string | null | undefined,
+): boolean {
+  if (!originHeader || originHeader.length > 512) return false;
+  try {
+    return new URL(originHeader).origin === config.appBaseUrl.origin;
+  } catch {
+    return false;
+  }
+}
+
 function readEnvironmentText(
   environment: NodeJS.ProcessEnv,
   key: string,

--- a/sites/unigrok-control-center/tests/github-auth.test.ts
+++ b/sites/unigrok-control-center/tests/github-auth.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { authorizeGitHubCollaborator, githubRequest } from "../app/lib/github-app";
-import { loadGitHubAuthConfig, type GitHubAuthConfig } from "../app/lib/github-auth-config";
+import {
+  loadGitHubAuthConfig,
+  requestOriginMatchesApplication,
+  type GitHubAuthConfig,
+} from "../app/lib/github-auth-config";
 import { createGitHubSessionCookie, readGitHubSession } from "../app/lib/github-oauth";
 
 const privateKey = ["-----BEGIN", "PRIVATE KEY-----\n", "A".repeat(256), "\n-----END", "PRIVATE KEY-----"].join(" ").replaceAll("  ", " ");
@@ -78,4 +82,23 @@ test("GitHub requests cannot escape the constant repository API origin", async (
     await assert.rejects(() => githubRequest(path, "t".repeat(40), request as typeof fetch));
   }
   assert.equal(called, false);
+});
+
+test("cookie control POSTs require exact application Origin", () => {
+  const config = loadGitHubAuthConfig(environment);
+  assert.equal(
+    requestOriginMatchesApplication(config, "https://control.grokmcp.org"),
+    true,
+  );
+  assert.equal(
+    requestOriginMatchesApplication(config, "https://evil.example"),
+    false,
+  );
+  assert.equal(
+    requestOriginMatchesApplication(config, "https://docs.grokmcp.org"),
+    false,
+  );
+  assert.equal(requestOriginMatchesApplication(config, null), false);
+  assert.equal(requestOriginMatchesApplication(config, ""), false);
+  assert.equal(requestOriginMatchesApplication(config, "not-a-url"), false);
 });


### PR DESCRIPTION
## Summary
- Cookie-authenticated Control Center POSTs (`/api/control/reviews`, `/api/control/receipts`) now require `Origin` to match `appBaseUrl.origin`.
- Shared `requestOriginMatchesApplication` helper; logout uses the same check.
- Closes same-site sibling-subdomain CSRF under `SameSite=Lax` session cookies.

## Test plan
- [x] `npx tsx --test tests/github-auth.test.ts` (Origin exact vs evil/sibling/null)
- [x] Attribution check vs `origin/main`
- [ ] CI green on draft PR


Made with [Cursor](https://cursor.com)