### PR TITLE
docs: refresh Codex integration handoff

### DIFF
--- a/.codex/memory/active-work.md
+++ b/.codex/memory/active-work.md
@@ -2,59 +2,59 @@
 
 Last updated: 2026-07-16
 Owner: Codex integration coordinator
-Status: GitHub, security, local runtimes, and the hosted product are clean.
-The contributor queue is empty. Stage 1 live generation and training remain
-blocked behind their existing exact-head authorization gates.
+Status: Current critical repairs are merged and Live; the security queue remains active.
 
 This is the project-scoped handoff for new Codex chats. Verify drift-prone Git,
-CI, runtime, DNS, cloud, and benchmark state live before acting. Never record
+CI, runtime, DNS, cloud, and pull-request state live before acting. Never record
 credentials, OAuth codes, tokens, or private keys here.
 
 ## Current integration state
 
-- Protected `origin/main` and the protected local `main` checkout agree at
-  `142e62c7bbf2aa261dd701892bdf1081e39ab591`.
-- The open pull-request queue is empty. The latest Live task is the Cursor MCP
-  attribution smoke checklist; exact-main CI and the three CodeQL analyzers
-  passed.
-- Open Dependabot, code-scanning, secret-scanning, and draft security-advisory
-  counts are zero. Release and source version remain 0.6.0.
-- Stable `:4765` and contributor `:4766` are ready with usable model auth.
-  Their source marker is the prior runtime-bearing main revision; the two
-  later main commits are documentation-only, so no runtime restart is needed.
-- Remote MCP is Live at 100% on ready `us-central1` revision
-  `unigrok-remote-mcp-519bbdd`, image digest
-  `sha256:36ff1e1d81b4454ddaf421ff99e84a1b343ba9e54c1709b30ce12bd22a9aa396`.
-  Public health, readiness, OAuth protected-resource metadata, and protected
-  MCP rejection probes pass.
-- Control Center is Live at 100% on ready `us-central1` revision
-  `unigrok-control-center-617e8cf`, image digest
-  `sha256:93b0191372cf45e104a08d3294735a9c240d3ed02a73bd8c64c9bda8598cd011`.
-  The homepage and `GET /api/public/v1/project` pass.
-- East-region rollback services remain healthy and are not the active global
-  route.
+- Protected `origin/main` and the locked local `main` checkout agree at
+  `d87bd1473246893eae8e5960a4862e366619b59a`.
+- PR #316 is merged. Installed CLI startup no longer imports caller-cwd dotenv
+  policy, credential dotenv files are owner-only and validated before loading,
+  credential-bearing xAI proxy origins are allowlisted, and write-token
+  workflows pin third-party actions to immutable commits.
+- Exact-head CI, CodeQL, Codex Approval, Supervisor Approval, Security Reviewer,
+  and Bugbot passed for PR #316. The exact local suite passed 2,163 tests.
+- Stable `:4765` and contributor `:4766` are healthy and ready on the current
+  image with read-only root filesystems.
+- Remote MCP is Live at 100% in both regions on image digest
+  `sha256:3cbde9349bead22c133bd2a12a2ca59dfd372f4ce9b632aee322ffe6d6667f7e`:
+  `us-central1` revision `unigrok-remote-mcp-00013-qfz` and `us-east1`
+  revision `unigrok-remote-mcp-00017-5bp`.
+- Public health, readiness, OAuth protected-resource metadata, and protected
+  `/metrics` and `/mcp` rejection probes pass. No error logs were found on the
+  new Cloud Run revisions after rollout.
+
+## Active queue and safety posture
+
+- Stable explicit bearer IDs, issuer-bound OAuth principals, and audience
+  binding remain blockers before principal-storage publication.
+- Caller-scoped research jobs and other ready security packets remain queued;
+  rebase and integrate only after exact-head review and conflict checks.
+- Provider-broker, stateful MCP sampling, Swarm, and shared multi-principal
+  surfaces remain fail-closed until their recorded activation gates are met.
+- Do not promote ready feature/product PRs merely because checks are green;
+  coordinator authority covers system health and already-authorized work only.
 
 ## Scratchpad safety
 
-- Codex removed detached worktree `7812` only after proving it unloaded,
-  process-free, clean, and zero commits ahead of main.
-- Preserve the current detached coordinator worktree and the locked protected
-  `main` checkout.
-- Preserve the sponsor's primary Documents checkout of this repo: it has
-  active processes and uncommitted contributor work.
-- Provider IDEs may automatically rehydrate clean scratchpads. Before removing
-  any candidate, re-check task state, process ownership, dirty state, unique
-  commits, and open task packets. Never rely on this handoff as a live lock.
+- Codex removed the finished land-gate, distill-scope, and compaction-fence
+  worktrees only after proving each clean and merged into `main`.
+- Codex removed the mount-free `grok-mcp-ci-local` verification container after
+  the production local runtimes were healthy.
+- Preserve the locked protected `main`, active Codex/Cursor/Claude/Grok
+  worktrees, and the sponsor's primary Documents checkout.
+- Before removing any future candidate, re-check task state, processes, dirty
+  state, unique commits, and open task packets. Never rely on this handoff as a
+  live lock.
 
 ## Product boundary
 
 - Coordinator work is limited to integration health, safe repairs, deployment
   verification, and proven-orphan cleanup. Do not invent product priorities.
-- Stage 2 remains fail-closed. A new bounded live Stage 1 manifest must specify
-  provider, call, cost, time, privacy, retry, and artifact limits and receive
-  Codex approval at its exact head before live generation.
-- Any generated dataset needs mechanical gates and another exact-head Codex
-  review before training. Training and sealed evaluation require separate
-  authorization.
-- Publishing a new release, accepting the `google-genai` 2.x migration, or
-  changing the enabled empty GitHub Wiki remains a maintainer decision.
+- Stage 2 remains fail-closed. Live generation, training, sealed evaluation,
+  release publication, and material provider-policy changes require their
+  existing explicit authorization gates.


### PR DESCRIPTION
## Summary
- refresh the project-local Codex handoff to current protected main
- record the verified local and two-region Cloud Run rollout
- preserve the active security queue and scratchpad safety boundaries

## Verification
- `git diff --check`
- documentation-only; no runtime code changed

Risk: low documentation-only handoff refresh.

Human sponsor: djtelicloud

Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=user-reported | surface=Codex Desktop | role=implementation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only update to a Codex handoff file; no runtime or application code changes.
> 
> **Overview**
> Updates **`.codex/memory/active-work.md`**, the required Codex cross-chat handoff, so new sessions start from verified reality instead of the prior snapshot.
> 
> The **integration state** block now pins protected `main` to **`d87bd147…`**, documents **merged PR #316** (dotenv/credential hardening, xAI proxy allowlisting, pinned GitHub Actions), and records **exact-head CI/local test** outcomes. Local **`:4765`/`:4766`** and **two-region Remote MCP** (shared image digest, revision IDs, health/readiness/OAuth/metrics probes) replace the older single-region MCP/Control Center narrative and the “empty PR queue” posture.
> 
> A new **Active queue and safety posture** section states what still blocks principal-storage publication, how queued security packets may be integrated, and that green checks alone do not authorize feature promotion. **Scratchpad safety** and **product boundary** text are tightened to match recent cleanup (merged worktrees, verification container) and consolidated Stage 2 fail-closed gates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0cad30a6b17a95566418219a1699c07396c1c17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->