### PR TITLE
fix(security): rate-limit hosted review POSTs

### DIFF
--- a/sites/unigrok-control-center/app/api/control/reviews/route.ts
+++ b/sites/unigrok-control-center/app/api/control/reviews/route.ts
@@ -2,6 +2,7 @@ import { authorizeGitHubCollaborator, createInstallationCredential } from "../..
 import { loadGitHubAuthConfig, requestHostMatchesApplication } from "../../../lib/github-auth-config";
 import { readGitHubSession } from "../../../lib/github-oauth";
 import { callHostedReviewBroker, fetchImmutableReviewEvidence } from "../../../lib/github-review-broker";
+import { tryAcquireHostedReviewBudget } from "../../../lib/hosted-review-budget";
 import { loadMcpOAuthConfig } from "../../../lib/mcp-oauth";
 
 export const dynamic = "force-dynamic";
@@ -15,14 +16,31 @@ export async function POST(request: Request): Promise<Response> {
     const credential = await createInstallationCredential(github);
     const authorization = await authorizeGitHubCollaborator(github, session, credential.token);
     if (!authorization) return response(403);
-    const body = await request.json() as Record<string, unknown>;
-    const pullNumber = body.pull_number;
-    const expectedHeadSha = body.expected_head_sha;
-    if (!Number.isSafeInteger(pullNumber) || typeof expectedHeadSha !== "string") return response(400);
-    const evidence = await fetchImmutableReviewEvidence(github, credential.token, pullNumber as number, expectedHeadSha);
-    const review = await callHostedReviewBroker(loadMcpOAuthConfig(), evidence);
-    console.info(JSON.stringify({ event: "hosted_review_completed", actor: session.login, pull_number: pullNumber, head_sha: evidence.headSha, base_sha: evidence.baseSha }));
-    return Response.json({ schema_version: "unigrok-hosted-review-v1", repository: evidence.repository, pull_number: pullNumber, head_sha: evidence.headSha, base_sha: evidence.baseSha, ...review }, { headers: { "cache-control": "no-store" } });
+    const budget = tryAcquireHostedReviewBudget(session.login);
+    if (!budget.ok) {
+      return Response.json(
+        { error: "rate_limited" },
+        {
+          status: 429,
+          headers: {
+            "cache-control": "no-store",
+            "retry-after": String(budget.retryAfterSec),
+          },
+        },
+      );
+    }
+    try {
+      const body = await request.json() as Record<string, unknown>;
+      const pullNumber = body.pull_number;
+      const expectedHeadSha = body.expected_head_sha;
+      if (!Number.isSafeInteger(pullNumber) || typeof expectedHeadSha !== "string") return response(400);
+      const evidence = await fetchImmutableReviewEvidence(github, credential.token, pullNumber as number, expectedHeadSha);
+      const review = await callHostedReviewBroker(loadMcpOAuthConfig(), evidence);
+      console.info(JSON.stringify({ event: "hosted_review_completed", actor: session.login, pull_number: pullNumber, head_sha: evidence.headSha, base_sha: evidence.baseSha }));
+      return Response.json({ schema_version: "unigrok-hosted-review-v1", repository: evidence.repository, pull_number: pullNumber, head_sha: evidence.headSha, base_sha: evidence.baseSha, ...review }, { headers: { "cache-control": "no-store" } });
+    } finally {
+      budget.release();
+    }
   } catch {
     return response(503);
   }

--- a/sites/unigrok-control-center/app/lib/hosted-review-budget.ts
+++ b/sites/unigrok-control-center/app/lib/hosted-review-budget.ts
@@ -1,0 +1,67 @@
+/** Per-principal abuse budget for hosted review POSTs. */
+
+const WINDOW_MS = 10 * 60 * 1000;
+const MAX_PER_WINDOW = 5;
+const MAX_IN_FLIGHT = 1;
+
+type Bucket = {
+  timestamps: number[];
+  inFlight: number;
+};
+
+const buckets = new Map<string, Bucket>();
+
+export type HostedReviewBudgetDecision =
+  | { ok: true; release: () => void }
+  | { ok: false; retryAfterSec: number };
+
+/**
+ * Acquire a short-lived review slot for `principal` (GitHub login).
+ *
+ * Limits: one in-flight review and five starts per rolling 10 minutes.
+ * Process-local only — enough to blunt cookie-session abuse on a single
+ * control-center isolate.
+ */
+export function tryAcquireHostedReviewBudget(
+  principal: string,
+  now = Date.now(),
+): HostedReviewBudgetDecision {
+  const key = principal.trim().toLowerCase();
+  if (!key) return { ok: false, retryAfterSec: 60 };
+
+  let bucket = buckets.get(key);
+  if (!bucket) {
+    bucket = { timestamps: [], inFlight: 0 };
+    buckets.set(key, bucket);
+  }
+
+  bucket.timestamps = bucket.timestamps.filter((stamp) => now - stamp < WINDOW_MS);
+
+  if (bucket.inFlight >= MAX_IN_FLIGHT) {
+    return { ok: false, retryAfterSec: 30 };
+  }
+  if (bucket.timestamps.length >= MAX_PER_WINDOW) {
+    const oldest = bucket.timestamps[0] ?? now;
+    const retryAfterSec = Math.max(1, Math.ceil((WINDOW_MS - (now - oldest)) / 1000));
+    return { ok: false, retryAfterSec };
+  }
+
+  bucket.inFlight += 1;
+  bucket.timestamps.push(now);
+  let released = false;
+  return {
+    ok: true,
+    release: () => {
+      if (released) return;
+      released = true;
+      const current = buckets.get(key);
+      if (!current) return;
+      current.inFlight = Math.max(0, current.inFlight - 1);
+    },
+  };
+}
+
+/** Test-only reset of process-local buckets. */
+export function resetHostedReviewBudgetForTests(): void {
+  buckets.clear();
+}

--- a/sites/unigrok-control-center/tests/hosted-review-budget.test.ts
+++ b/sites/unigrok-control-center/tests/hosted-review-budget.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  resetHostedReviewBudgetForTests,
+  tryAcquireHostedReviewBudget,
+} from "../app/lib/hosted-review-budget";
+
+test("hosted review budget limits in-flight and rolling starts", () => {
+  resetHostedReviewBudgetForTests();
+  const t0 = 1_800_000_000_000;
+
+  const first = tryAcquireHostedReviewBudget("alice", t0);
+  assert.equal(first.ok, true);
+  const blockedInFlight = tryAcquireHostedReviewBudget("alice", t0 + 1);
+  assert.equal(blockedInFlight.ok, false);
+  if (first.ok) first.release();
+
+  for (let index = 0; index < 4; index += 1) {
+    const grant = tryAcquireHostedReviewBudget("alice", t0 + 1_000 + index);
+    assert.equal(grant.ok, true);
+    if (grant.ok) grant.release();
+  }
+
+  const sixth = tryAcquireHostedReviewBudget("alice", t0 + 2_000);
+  assert.equal(sixth.ok, false);
+  if (!sixth.ok) assert.ok(sixth.retryAfterSec >= 1);
+
+  const other = tryAcquireHostedReviewBudget("bob", t0 + 2_000);
+  assert.equal(other.ok, true);
+  if (other.ok) other.release();
+
+  const afterWindow = tryAcquireHostedReviewBudget("alice", t0 + 10 * 60 * 1000 + 1);
+  assert.equal(afterWindow.ok, true);
+  if (afterWindow.ok) afterWindow.release();
+});


### PR DESCRIPTION
## Summary
- Per-GitHub-login hosted review budget: 1 in-flight and 5 starts per rolling 10 minutes (process-local).
- `/api/control/reviews` returns `429` with `Retry-After` when the budget is exhausted.
- Blunts compromised-session / malicious-collaborator abuse of GitHub + metered Grok review work.

## Test plan
- [x] `npx tsx --test tests/hosted-review-budget.test.ts`
- [x] Attribution check vs `origin/main`
- [ ] CI green on draft PR


Made with [Cursor](https://cursor.com)