### PR TITLE
feat(http): serve public static UI shell in cloudrun

### DIFF
--- a/src/http_server.py
+++ b/src/http_server.py
@@ -5,12 +5,13 @@ import ipaddress
 import json
 import logging
 import os
+import posixpath
 import re
 import time
 import uuid
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Dict, List, Literal, Optional
-from urllib.parse import quote, urlsplit
+from urllib.parse import quote, unquote, urlsplit
 from .models.results import AgentResult
 from .metrics import build_metrics_snapshot, fetch_provider_api_usage
 from .semantic_evals import get_semantic_eval_stats
@@ -504,6 +505,36 @@ def _path_matches_prefix(path: str, prefix: str) -> bool:
     return path == prefix or path.startswith(f"{prefix}/")
 
 
+def _normalized_subtree_path(raw_path: str) -> Optional[str]:
+    """Collapse a request path for static-subtree prefix matching, or reject.
+
+    uvicorn/httptools and Starlette route on the RAW request path and do NOT
+    collapse dot-segments before dispatch. A raw ``/docs/okf/../threat-model.md``
+    therefore still satisfies a naive ``/docs/okf`` prefix test, and the
+    downstream ``Mount('/docs')`` ``StaticFiles`` app then resolves the ``..``
+    back into the gated ``docs/`` tree — serving any gated doc with no bearer
+    credentials in Cloud Run. Refuse to admit any path that carries a ``..`` or
+    ``.`` segment, or an interior ``//`` empty segment (percent-encoded forms
+    decoded first so ``..%2f`` cannot slip past when the stack forwards it raw),
+    and hand back the ``posixpath.normpath`` form so callers only ever match a
+    genuinely in-subtree path. A single canonical trailing slash (``/ui/``,
+    ``/docs/okf/``) is legitimate and preserved as normalization. Returns
+    ``None`` when the path must fall through to normal bearer auth.
+    """
+    if not raw_path.startswith("/"):
+        return None
+    decoded = unquote(raw_path)
+    segments = decoded.split("/")
+    interior = segments[1:]
+    if interior and interior[-1] == "":
+        # Drop the canonical trailing-slash empty segment before inspection;
+        # every other empty segment is a "//" collapse we refuse to admit.
+        interior = interior[:-1]
+    if any(segment in ("", ".", "..") for segment in interior):
+        return None
+    return posixpath.normpath(decoded)
+
+
 def _is_public_auth_exempt_path(path: str) -> bool:
     return path in _PUBLIC_AUTH_EXEMPT_PATHS
 
@@ -511,6 +542,12 @@ def _is_public_auth_exempt_path(path: str) -> bool:
 def _is_local_operator_request(scope: Dict[str, Any]) -> bool:
     if not _is_verified_local_request(scope):
         return False
+    # The dot-segment discipline in _normalized_subtree_path is deliberately NOT
+    # applied here: this branch is loopback-gated, and _LOCAL_OPERATOR_PREFIXES
+    # already exposes the whole "/docs" tree locally, so a "../" within it leaks
+    # nothing an operator could not GET directly (escape past docs/ is still
+    # blocked by StaticFiles commonpath). Hardening lives centrally in the
+    # Cloud Run static-shell path, which admits only the "/docs/okf" subtree.
     path = scope.get("path", "")
     return path in _LOCAL_OPERATOR_PATHS or any(
         _path_matches_prefix(path, prefix) for prefix in _LOCAL_OPERATOR_PREFIXES
@@ -542,9 +579,14 @@ def _is_public_static_shell_request(scope: Dict[str, Any]) -> bool:
         return False
     if scope.get("method") not in ("GET", "HEAD"):
         return False
-    path = scope.get("path", "")
+    # Normalize (and reject dot-/empty-segment) the RAW path BEFORE the prefix
+    # check: a raw "/docs/okf/../threat-model.md" must not ride this exemption
+    # and then let StaticFiles resolve the ".." back into the gated docs/ tree.
+    normalized = _normalized_subtree_path(scope.get("path", ""))
+    if normalized is None:
+        return False
     return any(
-        _path_matches_prefix(path, prefix)
+        _path_matches_prefix(normalized, prefix)
         for prefix in _PUBLIC_STATIC_SHELL_PREFIXES
     )
 

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -451,8 +451,10 @@ _PUBLIC_AUTH_EXEMPT_PATHS = (
 
 # The bundled Control Center, runtime diagnostics, and source documentation
 # are local operator surfaces. They stay convenient at localhost, including
-# when client bearer keys are configured, but are never exempt in Cloud Run or
-# when reached through a non-loopback Host.
+# when client bearer keys are configured, but this exemption never applies in
+# Cloud Run or through a non-loopback Host. (Cloud Run separately publishes
+# only the read-only static shell via _is_public_static_shell_request below;
+# /runtimez and /metrics data stay gated everywhere remote.)
 _LOCAL_OPERATOR_PATHS = ("/runtimez", "/metrics")
 _LOCAL_OPERATOR_PREFIXES = ("/ui", "/docs")
 
@@ -515,6 +517,38 @@ def _is_local_operator_request(scope: Dict[str, Any]) -> bool:
     )
 
 
+# Cloud Run serves the static Control Center shell publicly: these files ship
+# on GitHub and PyPI already, so gating them buys no secrecy while breaking the
+# one-console architecture (the hosted shell must load before any sign-in can
+# happen). Scope is deliberately exact:
+#
+# * ``/docs/okf`` rather than ``/docs`` broadly — the Docker image only bakes
+#   ``docs/okf/``, but a source-checkout Cloud Run deployment would have
+#   ``create_docs_app`` serving the entire ``docs/`` tree, which is not a
+#   published surface.
+# * GET/HEAD only — the shell is read-only; state-changing verbs keep normal
+#   bearer auth so no write path ever rides this exemption.
+#
+# Everything the shell talks to (/mcp, /v1, /metrics, /runtimez) stays behind
+# bearer auth. Deployment note: browser POSTs from the hosted shell to /mcp
+# additionally require UNIGROK_ALLOWED_ORIGINS to list the exact hosted origin
+# (e.g. https://mcp.grokmcp.org) — MCPOriginMiddleware rejects other browser
+# origins regardless of this static exemption.
+_PUBLIC_STATIC_SHELL_PREFIXES = ("/ui", "/docs/okf")
+
+
+def _is_public_static_shell_request(scope: Dict[str, Any]) -> bool:
+    if not is_cloudrun_runtime():
+        return False
+    if scope.get("method") not in ("GET", "HEAD"):
+        return False
+    path = scope.get("path", "")
+    return any(
+        _path_matches_prefix(path, prefix)
+        for prefix in _PUBLIC_STATIC_SHELL_PREFIXES
+    )
+
+
 def _request_may_bypass_auth(scope: Dict[str, Any]) -> bool:
     # The broad development bypass is stricter than the operator-static
     # exemption: an asserted Docker proxy boundary may expose /ui, /runtimez,
@@ -540,7 +574,11 @@ class GatewayAuthMiddleware:
             return
         scope["unigrok.bound_host"] = self.bound_host
         path = scope.get("path", "")
-        if _is_public_auth_exempt_path(path) or _is_local_operator_request(scope):
+        if (
+            _is_public_auth_exempt_path(path)
+            or _is_local_operator_request(scope)
+            or _is_public_static_shell_request(scope)
+        ):
             await self.app(scope, receive, send)
             return
         if not _auth_is_active() or _request_may_bypass_auth(scope):

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -502,7 +502,7 @@ def test_local_okf_manifest_and_generated_api_reference_are_served(monkeypatch):
 
 
 def test_cloudrun_protects_mcp_inference_and_operator_surfaces(monkeypatch):
-    """Remote clients never inherit the localhost UI/runtime exemptions."""
+    """Remote clients never inherit the localhost data-endpoint exemptions."""
     monkeypatch.setenv("UNIGROK_RUNTIME", "cloudrun")
     monkeypatch.setenv("UNIGROK_API_KEYS", "client-secret")
     monkeypatch.delenv("UNIGROK_ALLOW_UNAUTHENTICATED", raising=False)
@@ -513,12 +513,85 @@ def test_cloudrun_protects_mcp_inference_and_operator_surfaces(monkeypatch):
             "/v1/models": client.get("/v1/models"),
             "/runtimez": client.get("/runtimez"),
             "/metrics": client.get("/metrics"),
-            "/ui/": client.get("/ui/"),
-            "/docs/okf/manifest.json": client.get("/docs/okf/manifest.json"),
         }
 
     assert all(response.status_code == 401 for response in responses.values()), responses
     assert all(response.headers["WWW-Authenticate"] == "Bearer" for response in responses.values())
+
+
+def test_cloudrun_serves_public_static_ui_shell_without_credentials(monkeypatch):
+    """Cloud Run publishes the read-only static shell; data endpoints stay gated.
+
+    The shell files are already public on GitHub/PyPI, so serving them
+    anonymously leaks nothing while letting the hosted console load before
+    sign-in.
+    """
+    monkeypatch.setenv("UNIGROK_RUNTIME", "cloudrun")
+    monkeypatch.setenv("UNIGROK_API_KEYS", "client-secret")
+    monkeypatch.delenv("UNIGROK_ALLOW_UNAUTHENTICATED", raising=False)
+
+    with TestClient(create_app(), base_url="https://mcp.grokmcp.org") as client:
+        index = client.get("/ui/")
+        script = client.get("/ui/app.js")
+        okf = client.get("/docs/okf/okf-manifest.json")
+        mcp_denied = client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+            headers={"Accept": "application/json, text/event-stream"},
+        )
+        metrics_denied = client.get("/metrics")
+        runtimez_denied = client.get("/runtimez")
+
+    assert index.status_code == 200
+    assert "UniGrok" in index.text
+    assert script.status_code == 200
+    assert okf.status_code == 200
+    assert "api-reference.md" in okf.json()["files"]
+    assert mcp_denied.status_code == 401
+    assert metrics_denied.status_code == 401
+    assert runtimez_denied.status_code == 401
+
+
+def test_cloudrun_static_shell_exemption_is_get_head_only(monkeypatch):
+    """POST under /ui is not a side door: only safe read verbs are exempt."""
+    monkeypatch.setenv("UNIGROK_RUNTIME", "cloudrun")
+    monkeypatch.setenv("UNIGROK_API_KEYS", "client-secret")
+    monkeypatch.delenv("UNIGROK_ALLOW_UNAUTHENTICATED", raising=False)
+
+    with TestClient(create_app(), base_url="https://mcp.grokmcp.org") as client:
+        ui_post = client.post("/ui/", json={"probe": True})
+        okf_post = client.post("/docs/okf/okf-manifest.json", json={"probe": True})
+        docs_root = client.get("/docs/architecture.md")
+        prefix_sibling = client.get("/uix")
+
+    # Auth denies the non-exempt verb before StaticFiles can even answer 405.
+    assert ui_post.status_code == 401
+    assert okf_post.status_code == 401
+    # The exemption is /docs/okf exactly, never the broader /docs tree a
+    # source-checkout deployment would expose.
+    assert docs_root.status_code == 401
+    # Boundary-correct prefix: "/uix" must not inherit the shell exemption.
+    assert prefix_sibling.status_code == 401
+
+
+def test_local_runtime_never_inherits_cloudrun_static_shell_exemption(monkeypatch):
+    """Regression pin: non-loopback GET /ui with auth active stays denied in
+    local runtime exactly as before the Cloud Run shell exemption existed."""
+    monkeypatch.setenv("UNIGROK_RUNTIME", "local")
+    monkeypatch.setenv("UNIGROK_API_KEYS", "client-secret")
+    monkeypatch.delenv("UNIGROK_ALLOW_UNAUTHENTICATED", raising=False)
+    monkeypatch.delenv("UNIGROK_TRUSTED_LOOPBACK_PROXY", raising=False)
+
+    with TestClient(
+        create_app(),
+        base_url="https://gateway.example.com",
+        client=("203.0.113.20", 50000),
+    ) as client:
+        ui = client.get("/ui/")
+        okf = client.get("/docs/okf/okf-manifest.json")
+
+    assert ui.status_code == 401
+    assert okf.status_code == 401
 
 
 def test_cloudrun_well_known_allowlist_is_exact(monkeypatch):

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -594,6 +594,83 @@ def test_local_runtime_never_inherits_cloudrun_static_shell_exemption(monkeypatc
     assert okf.status_code == 401
 
 
+@pytest.mark.asyncio
+async def test_cloudrun_static_shell_exemption_rejects_raw_dot_segment_traversal(monkeypatch):
+    """Raw dot-segment paths must not ride the Cloud Run static-shell exemption.
+
+    uvicorn/httptools and Starlette route on the un-normalized request path, so
+    a raw ``/docs/okf/../threat-model.md`` satisfies a naive ``/docs/okf``
+    prefix test and the downstream ``/docs`` StaticFiles Mount then resolves the
+    ``..`` back into the gated docs/ tree — serving any gated doc with no
+    credentials in Cloud Run. TestClient/httpx collapse ``..`` client-side and
+    hide the bypass, so this drives the ASGI middleware directly with a
+    hand-built raw scope (path/raw_path set to the un-normalized string),
+    mirroring how the bypass was reproduced.
+    """
+    monkeypatch.setenv("UNIGROK_RUNTIME", "cloudrun")
+    monkeypatch.setenv("UNIGROK_API_KEYS", "client-secret")
+    monkeypatch.delenv("UNIGROK_ALLOW_UNAUTHENTICATED", raising=False)
+    monkeypatch.delenv("UNIGROK_OAUTH_INTROSPECTION_URL", raising=False)
+
+    async def drive(method: str, raw_path: str):
+        """Return (served_downstream, response_status) for one raw scope."""
+        served = False
+
+        async def downstream(scope, receive, send):
+            nonlocal served
+            served = True
+            await JSONResponse({"ok": True})(scope, receive, send)
+
+        status = {"code": None}
+
+        async def send(message):
+            if message["type"] == "http.response.start":
+                status["code"] = message["status"]
+
+        async def receive():
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        middleware = GatewayAuthMiddleware(downstream, bound_host="0.0.0.0")
+        scope = {
+            "type": "http",
+            "method": method,
+            "path": raw_path,
+            "raw_path": raw_path.encode(),
+            "query_string": b"",
+            "scheme": "https",
+            "client": ("203.0.113.10", 50000),
+            "server": ("mcp.grokmcp.org", 443),
+            "headers": [(b"host", b"mcp.grokmcp.org")],
+        }
+        await middleware(scope, receive, send)
+        return served, status["code"]
+
+    # The traversal escapes the /docs/okf subtree back into gated docs/. It must
+    # NOT be exempt: the downstream app is never reached and normal bearer auth
+    # returns 401 for both GET and HEAD.
+    for method in ("GET", "HEAD"):
+        served, code = await drive(method, "/docs/okf/../threat-model.md")
+        assert served is False, method
+        assert code == 401, method
+
+    # Percent-encoded slash forwarded raw ("..%2f") is decoded and rejected too.
+    served, code = await drive("GET", "/docs/okf/..%2fthreat-model.md")
+    assert served is False
+    assert code == 401
+
+    # An interior "//" empty-segment collapse is likewise never admitted.
+    served, code = await drive("GET", "/docs/okf/..//threat-model.md")
+    assert served is False
+    assert code == 401
+
+    # Positive control: the genuinely in-subtree published shell still serves
+    # anonymously in Cloud Run (a real file under docs/okf, plus /ui assets).
+    for good in ("/docs/okf/", "/docs/okf/okf-manifest.json", "/ui/", "/ui/app.js"):
+        served, code = await drive("GET", good)
+        assert served is True, good
+        assert code == 200, good
+
+
 def test_cloudrun_well_known_allowlist_is_exact(monkeypatch):
     monkeypatch.setenv("UNIGROK_RUNTIME", "cloudrun")
     monkeypatch.setenv("UNIGROK_API_KEYS", "client-secret")


### PR DESCRIPTION
## What

Phase 1 of the single-origin console (design: #323). Makes the Cloud Run gateway serve the **public static UI shell** (`GET`/`HEAD` under `/ui` and `/docs/okf`) without a bearer, while **every data endpoint stays OAuth-gated**. This is the mechanical fix for why the hosted UI can't work today: browsers can't attach `Authorization` headers to static page loads, so the shell must be public and the data must be gated — no tunnel, no cross-origin.

Only affects `UNIGROK_RUNTIME=cloudrun`. Local runtime behavior (verified-loopback operator exemption) is byte-identical.

## Security — path-traversal bypass caught in review and fixed

The first cut prefix-matched the **raw** request path, so `GET /docs/okf/../threat-model.md` was auth-exempted and then StaticFiles resolved the `..` back into the gated `docs/` tree — leaking it anonymously. Fixed before push:

- New `_normalized_subtree_path()` helper: `unquote`-decodes first (so `..%2f` can't slip through), rejects any interior `''` / `.` / `..` segment, then `posixpath.normpath` — matched against the normalized path, admitting only `/ui` and `/docs/okf` subtrees. Never broadened to `/docs`.
- Scoped to `/docs/okf` (not `/docs`) on purpose: a source-checkout cloudrun deploy would otherwise serve the whole `docs/` tree — noted in-code.
- **Raw-ASGI regression test** (TestClient normalizes `..` client-side and hides the bug, so it drives the middleware directly): `GET`/`HEAD` `/docs/okf/../threat-model.md`, the `..%2f` variant, and interior `//` all assert **401, downstream never reached**; positive controls `/ui/`, `/ui/app.js`, `/docs/okf/`, `/docs/okf/okf-manifest.json` still serve 200 anonymously; `/mcp`, `/v1`, `/metrics`, `/runtimez` still 401.
- An independent adversarial re-probe (encoded, double-slash, `/ui/../docs`, `..;`) found **zero surviving vectors**.

## Not in this PR

- Sign-in / PKCE / token broker = Phase 2.
- `MCPOriginMiddleware` untouched. **Deployment note:** hosted browser POSTs to `/mcp` require the exact hosted origin (e.g. `https://mcp.grokmcp.org`) in `UNIGROK_ALLOWED_ORIGINS` — kept out of `docs/remote-mcp-deployment.md` (conflicted by #298/#299); it's in the code comment and here.

## Changed paths

- `src/http_server.py`, `tests/test_http_server.py`

## Tests

- Full suite: **2160 passed**; focused `tests/test_http_server.py`: 130 passed; regression test verified to **fail when the fix is reverted**. Attribution check: passed.

## Risks / handoff

- Security-relevant middleware change on the auth boundary — **Codex/human landing gate only**, do not autoland.
- Sponsor: David Johnston (@djtelicloud). Draft — awaiting Codex landing.

Agent-Assisted-By: Anthropic Claude | model=Fable 5 | model-source=user-reported | surface=Claude Code | role=implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the gateway auth boundary and fixes a path-traversal class of bypass on static doc serving; incorrect matching could expose gated `/docs` or block the hosted shell.
> 
> **Overview**
> **Cloud Run** can now serve the hosted Control Center **without a bearer** for read-only static assets, while **API and operator data paths stay gated**.
> 
> `GatewayAuthMiddleware` gains a **Cloud Run–only** bypass for **`GET`/`HEAD`** under **`/ui`** and **`/docs/okf`** (not all of `/docs`), so browsers can load the shell before sign-in. **`/mcp`**, **`/v1`**, **`/metrics`**, and **`/runtimez`** still require auth on remote hosts.
> 
> A new **`_normalized_subtree_path`** decodes the path, rejects `.`, `..`, empty segments, and encoded `..%2f`, then normalizes before prefix matching—closing a bypass where a raw **`/docs/okf/../…`** could match the exemption and **`StaticFiles`** could serve gated docs anonymously.
> 
> Local verified-loopback operator behavior is unchanged; non-loopback **`local`** runtime does not get the Cloud Run shell exemption. Tests cover anonymous shell access, verb/prefix boundaries, and raw-ASGI traversal cases that **`TestClient`** would collapse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31448e1ab2dd8b0b1d007ad43ab08f6d6a3c5eaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->