### PR TITLE
security: isolate credentials from subprocesses

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,13 @@ services:
         -u GROK_API_KEY
         -u OPENAI_API_KEY -u ANTHROPIC_API_KEY -u CLAUDE_API_KEY
         -u GEMINI_API_KEY -u GOOGLE_API_KEY
+        -u CLAUDE_CODE_OAUTH_TOKEN -u GH_TOKEN -u GITHUB_TOKEN
+        -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY -u AWS_SESSION_TOKEN
+        -u AZURE_CLIENT_SECRET -u AZURE_OPENAI_API_KEY
+        -u NPM_TOKEN -u PYPI_API_TOKEN
         -u GOOGLE_APPLICATION_CREDENTIALS -u UNIGROK_API_KEYS
+        -u UNIGROK_MCP_TOKEN_SECRET -u UNIGROK_CLIENT_TOKEN
+        -u MCP_TOKEN_SECRET -u SSH_AUTH_SOCK -u DOCKER_AUTH_CONFIG
         grok login --device-auth
     volumes:
       - grok-mcp-cli-auth:/home/appuser/.grok

--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -165,6 +165,31 @@ mandatory wherever semantic completion matters.
 
 ## credentials.py {#credentials}
 
+### Function: `is_secret_environment_name` {#credentials-is_secret_environment_name}
+
+```python
+def is_secret_environment_name(name: str) -> bool
+```
+
+**Keywords:** is, secret, environment, name
+
+Return whether an environment name denotes credential-bearing data.
+
+Exact canonical names cover current integrations. Conservative structural
+matching keeps unknown future provider/client secrets out of subprocesses
+by default without treating ordinary names such as TOKENIZERS_PARALLELISM
+as credentials.
+
+### Function: `secret_environment_names` {#credentials-secret_environment_names}
+
+```python
+def secret_environment_names(environ: Mapping[str, str] | None=None) -> tuple[str, ...]
+```
+
+**Keywords:** secret, environment, names
+
+Return every canonical or secret-shaped name present in an env map.
+
 ### Function: `credential_plane_policy` {#credentials-credential_plane_policy}
 
 ```python
@@ -2196,7 +2221,7 @@ backend-specific (the SQLite file path; tests use per-test temp paths).
 ### Function: `scrubbed_subprocess_env` {#subprocess_security-scrubbed_subprocess_env}
 
 ```python
-def scrubbed_subprocess_env(base: Optional[Mapping[str, str]]=None) -> dict[str, str]
+def scrubbed_subprocess_env(base: Optional[Mapping[str, str]]=None, *, allow_secret_names: Collection[str]=()) -> dict[str, str]
 ```
 
 **Keywords:** scrubbed, subprocess, env
@@ -2206,7 +2231,7 @@ Return a child environment without UniGrok server-owned secrets.
 ### Function: `create_scrubbed_subprocess_exec` {#subprocess_security-create_scrubbed_subprocess_exec}
 
 ```python
-async def create_scrubbed_subprocess_exec(*program_and_args: str, env: Optional[Mapping[str, str]]=None, **kwargs: Any) -> asyncio.subprocess.Process
+async def create_scrubbed_subprocess_exec(*program_and_args: str, env: Optional[Mapping[str, str]]=None, allow_secret_names: Collection[str]=(), **kwargs: Any) -> asyncio.subprocess.Process
 ```
 
 **Keywords:** create, scrubbed, subprocess, exec
@@ -2216,7 +2241,7 @@ Launch an async child without inheriting server-owned secrets.
 ### Function: `scrubbed_subprocess_run` {#subprocess_security-scrubbed_subprocess_run}
 
 ```python
-def scrubbed_subprocess_run(*popenargs: Any, env: Optional[Mapping[str, str]]=None, **kwargs: Any) -> subprocess.CompletedProcess[Any]
+def scrubbed_subprocess_run(*popenargs: Any, env: Optional[Mapping[str, str]]=None, allow_secret_names: Collection[str]=(), **kwargs: Any) -> subprocess.CompletedProcess[Any]
 ```
 
 **Keywords:** scrubbed, subprocess, run

--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -4000,8 +4000,9 @@ entry (unset env returns before any parsing — zero hot-path cost by
 default). Spend is today's telemetry cost across every caller matching
 the entry's substring (the entry IS the shared pot), read via one
 created_at-indexed query and cached ~60s per entry. At/over budget raises
-CallerBudgetExceeded. A failing store read degrades open by default, or
-fails closed when ``UNIGROK_BUDGET_FAIL_CLOSED=1``.
+CallerBudgetExceeded. Once a caller matches a configured budget, a failing
+spend-ledger read rejects the request so accounting loss cannot re-arm the
+cap.
 
 ### Function: `new_request_id` {#utils-new_request_id}
 

--- a/docs/okf/api-reference.md
+++ b/docs/okf/api-reference.md
@@ -2191,6 +2191,38 @@ as sqlite). Unknown values fail fast with NotImplementedError naming the
 supported set — a typo must not silently fall back to SQLite. db_path is
 backend-specific (the SQLite file path; tests use per-test temp paths).
 
+## subprocess_security.py {#subprocess_security}
+
+### Function: `scrubbed_subprocess_env` {#subprocess_security-scrubbed_subprocess_env}
+
+```python
+def scrubbed_subprocess_env(base: Optional[Mapping[str, str]]=None) -> dict[str, str]
+```
+
+**Keywords:** scrubbed, subprocess, env
+
+Return a child environment without UniGrok server-owned secrets.
+
+### Function: `create_scrubbed_subprocess_exec` {#subprocess_security-create_scrubbed_subprocess_exec}
+
+```python
+async def create_scrubbed_subprocess_exec(*program_and_args: str, env: Optional[Mapping[str, str]]=None, **kwargs: Any) -> asyncio.subprocess.Process
+```
+
+**Keywords:** create, scrubbed, subprocess, exec
+
+Launch an async child without inheriting server-owned secrets.
+
+### Function: `scrubbed_subprocess_run` {#subprocess_security-scrubbed_subprocess_run}
+
+```python
+def scrubbed_subprocess_run(*popenargs: Any, env: Optional[Mapping[str, str]]=None, **kwargs: Any) -> subprocess.CompletedProcess[Any]
+```
+
+**Keywords:** scrubbed, subprocess, run
+
+Run a synchronous child without inheriting server-owned secrets.
+
 ## swarm/analytics.py {#swarm-analytics}
 
 ### Function: `analyze_python_source` {#swarm-analytics-analyze_python_source}
@@ -3834,11 +3866,9 @@ def grok_cli_oauth_env(base: Optional[Dict[str, str]]=None) -> Dict[str, str]
 
 Return an OAuth-only environment for a Grok CLI child.
 
-The UniGrok process owns API, management, gateway, and subordinate-provider
-credentials. Removing that exact set from every CLI child keeps the xAI
-credential planes independent and prevents Grok-launched tools from seeing
-unrelated provider secrets. The persisted grok.com OAuth path remains
-available, so the CLI must use that subscription identity or fail closed.
+The persisted grok.com OAuth path remains available, while API, management,
+gateway, and subordinate-provider credentials are removed. The CLI must use
+its subscription identity or fail closed.
 
 ### Function: `grok_cli_plane_status` {#utils-grok_cli_plane_status}
 
@@ -3945,8 +3975,8 @@ entry (unset env returns before any parsing — zero hot-path cost by
 default). Spend is today's telemetry cost across every caller matching
 the entry's substring (the entry IS the shared pot), read via one
 created_at-indexed query and cached ~60s per entry. At/over budget raises
-CallerBudgetExceeded; a failing store read degrades OPEN — a broken
-telemetry table must not block traffic.
+CallerBudgetExceeded. A failing store read degrades open by default, or
+fails closed when ``UNIGROK_BUDGET_FAIL_CLOSED=1``.
 
 ### Function: `new_request_id` {#utils-new_request_id}
 

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -57,7 +57,7 @@ individual revocation, membership, scopes, or per-user isolation matters.
 | --- | --- | --- |
 | Provider credential theft | Server-only credentials, CLI environment scrubbing, secret redaction | Host/container compromise can still expose process credentials |
 | Cross-user session access | OAuth subject or key alias in every HTTP session namespace | Parties sharing one static key share one principal by definition |
-| Budget evasion by spoofed headers | HTTP budget owner comes from authenticated principal | Budget storage failure currently degrades open and is logged |
+| Budget evasion by spoofed headers or ledger failure | HTTP budget owner comes from authenticated principal; configured caller caps fail closed when spend cannot be read | Durable atomic multi-instance reservations remain required for hosted hard caps |
 | Unauthorized remote invocation | Fail-closed non-loopback configuration, OAuth introspection/scopes or gateway keys, TLS proxy | Proxy or introspection misconfiguration can weaken deployment |
 | DNS rebinding/browser abuse | Host/origin validation, exact allowed origins, CSP | Operators can deliberately broaden origin policy |
 | SSRF through public resources | Destination validation rejects private, loopback, and unsafe targets | Provider-side fetch behavior remains outside local enforcement |

--- a/example.env
+++ b/example.env
@@ -45,6 +45,8 @@ UNIGROK_TRUSTED_LOOPBACK_PROXY=
 # {"oauth-subject-123": 5.0}. Blank or malformed disables caps (warns, never
 # fails). Useful on a shared/hosted deployment.
 UNIGROK_CALLER_BUDGETS=
+# Set to 1 to reject budgeted calls when spend telemetry cannot be read.
+UNIGROK_BUDGET_FAIL_CLOSED=
 
 # Optional state root. Cloud Run defaults to /tmp/uni-grok.
 UNIGROK_STATE_DIR=

--- a/example.env
+++ b/example.env
@@ -45,8 +45,6 @@ UNIGROK_TRUSTED_LOOPBACK_PROXY=
 # {"oauth-subject-123": 5.0}. Blank or malformed disables caps (warns, never
 # fails). Useful on a shared/hosted deployment.
 UNIGROK_CALLER_BUDGETS=
-# Set to 1 to reject budgeted calls when spend telemetry cannot be read.
-UNIGROK_BUDGET_FAIL_CLOSED=
 
 # Optional state root. Cloud Run defaults to /tmp/uni-grok.
 UNIGROK_STATE_DIR=

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -165,6 +165,31 @@ mandatory wherever semantic completion matters.
 
 ## credentials.py {#credentials}
 
+### Function: `is_secret_environment_name` {#credentials-is_secret_environment_name}
+
+```python
+def is_secret_environment_name(name: str) -> bool
+```
+
+**Keywords:** is, secret, environment, name
+
+Return whether an environment name denotes credential-bearing data.
+
+Exact canonical names cover current integrations. Conservative structural
+matching keeps unknown future provider/client secrets out of subprocesses
+by default without treating ordinary names such as TOKENIZERS_PARALLELISM
+as credentials.
+
+### Function: `secret_environment_names` {#credentials-secret_environment_names}
+
+```python
+def secret_environment_names(environ: Mapping[str, str] | None=None) -> tuple[str, ...]
+```
+
+**Keywords:** secret, environment, names
+
+Return every canonical or secret-shaped name present in an env map.
+
 ### Function: `credential_plane_policy` {#credentials-credential_plane_policy}
 
 ```python
@@ -2196,7 +2221,7 @@ backend-specific (the SQLite file path; tests use per-test temp paths).
 ### Function: `scrubbed_subprocess_env` {#subprocess_security-scrubbed_subprocess_env}
 
 ```python
-def scrubbed_subprocess_env(base: Optional[Mapping[str, str]]=None) -> dict[str, str]
+def scrubbed_subprocess_env(base: Optional[Mapping[str, str]]=None, *, allow_secret_names: Collection[str]=()) -> dict[str, str]
 ```
 
 **Keywords:** scrubbed, subprocess, env
@@ -2206,7 +2231,7 @@ Return a child environment without UniGrok server-owned secrets.
 ### Function: `create_scrubbed_subprocess_exec` {#subprocess_security-create_scrubbed_subprocess_exec}
 
 ```python
-async def create_scrubbed_subprocess_exec(*program_and_args: str, env: Optional[Mapping[str, str]]=None, **kwargs: Any) -> asyncio.subprocess.Process
+async def create_scrubbed_subprocess_exec(*program_and_args: str, env: Optional[Mapping[str, str]]=None, allow_secret_names: Collection[str]=(), **kwargs: Any) -> asyncio.subprocess.Process
 ```
 
 **Keywords:** create, scrubbed, subprocess, exec
@@ -2216,7 +2241,7 @@ Launch an async child without inheriting server-owned secrets.
 ### Function: `scrubbed_subprocess_run` {#subprocess_security-scrubbed_subprocess_run}
 
 ```python
-def scrubbed_subprocess_run(*popenargs: Any, env: Optional[Mapping[str, str]]=None, **kwargs: Any) -> subprocess.CompletedProcess[Any]
+def scrubbed_subprocess_run(*popenargs: Any, env: Optional[Mapping[str, str]]=None, allow_secret_names: Collection[str]=(), **kwargs: Any) -> subprocess.CompletedProcess[Any]
 ```
 
 **Keywords:** scrubbed, subprocess, run

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -4000,8 +4000,9 @@ entry (unset env returns before any parsing — zero hot-path cost by
 default). Spend is today's telemetry cost across every caller matching
 the entry's substring (the entry IS the shared pot), read via one
 created_at-indexed query and cached ~60s per entry. At/over budget raises
-CallerBudgetExceeded. A failing store read degrades open by default, or
-fails closed when ``UNIGROK_BUDGET_FAIL_CLOSED=1``.
+CallerBudgetExceeded. Once a caller matches a configured budget, a failing
+spend-ledger read rejects the request so accounting loss cannot re-arm the
+cap.
 
 ### Function: `new_request_id` {#utils-new_request_id}
 

--- a/sites/unigrok-control-center/public/docs/okf/api-reference.md
+++ b/sites/unigrok-control-center/public/docs/okf/api-reference.md
@@ -2191,6 +2191,38 @@ as sqlite). Unknown values fail fast with NotImplementedError naming the
 supported set — a typo must not silently fall back to SQLite. db_path is
 backend-specific (the SQLite file path; tests use per-test temp paths).
 
+## subprocess_security.py {#subprocess_security}
+
+### Function: `scrubbed_subprocess_env` {#subprocess_security-scrubbed_subprocess_env}
+
+```python
+def scrubbed_subprocess_env(base: Optional[Mapping[str, str]]=None) -> dict[str, str]
+```
+
+**Keywords:** scrubbed, subprocess, env
+
+Return a child environment without UniGrok server-owned secrets.
+
+### Function: `create_scrubbed_subprocess_exec` {#subprocess_security-create_scrubbed_subprocess_exec}
+
+```python
+async def create_scrubbed_subprocess_exec(*program_and_args: str, env: Optional[Mapping[str, str]]=None, **kwargs: Any) -> asyncio.subprocess.Process
+```
+
+**Keywords:** create, scrubbed, subprocess, exec
+
+Launch an async child without inheriting server-owned secrets.
+
+### Function: `scrubbed_subprocess_run` {#subprocess_security-scrubbed_subprocess_run}
+
+```python
+def scrubbed_subprocess_run(*popenargs: Any, env: Optional[Mapping[str, str]]=None, **kwargs: Any) -> subprocess.CompletedProcess[Any]
+```
+
+**Keywords:** scrubbed, subprocess, run
+
+Run a synchronous child without inheriting server-owned secrets.
+
 ## swarm/analytics.py {#swarm-analytics}
 
 ### Function: `analyze_python_source` {#swarm-analytics-analyze_python_source}
@@ -3834,11 +3866,9 @@ def grok_cli_oauth_env(base: Optional[Dict[str, str]]=None) -> Dict[str, str]
 
 Return an OAuth-only environment for a Grok CLI child.
 
-The UniGrok process owns API, management, gateway, and subordinate-provider
-credentials. Removing that exact set from every CLI child keeps the xAI
-credential planes independent and prevents Grok-launched tools from seeing
-unrelated provider secrets. The persisted grok.com OAuth path remains
-available, so the CLI must use that subscription identity or fail closed.
+The persisted grok.com OAuth path remains available, while API, management,
+gateway, and subordinate-provider credentials are removed. The CLI must use
+its subscription identity or fail closed.
 
 ### Function: `grok_cli_plane_status` {#utils-grok_cli_plane_status}
 
@@ -3945,8 +3975,8 @@ entry (unset env returns before any parsing — zero hot-path cost by
 default). Spend is today's telemetry cost across every caller matching
 the entry's substring (the entry IS the shared pot), read via one
 created_at-indexed query and cached ~60s per entry. At/over budget raises
-CallerBudgetExceeded; a failing store read degrades OPEN — a broken
-telemetry table must not block traffic.
+CallerBudgetExceeded. A failing store read degrades open by default, or
+fails closed when ``UNIGROK_BUDGET_FAIL_CLOSED=1``.
 
 ### Function: `new_request_id` {#utils-new_request_id}
 

--- a/src/credentials.py
+++ b/src/credentials.py
@@ -72,6 +72,7 @@ _SECRET_ENV_SUFFIXES = (
     "_API_KEY",
     "_PRIVATE_KEY",
     "_ACCESS_KEY",
+    "_ACCESS_KEY_ID",
     "_AUTH_SOCK",
     "_DSN",
 )

--- a/src/credentials.py
+++ b/src/credentials.py
@@ -8,6 +8,7 @@ same contract safe to expose through MCP discovery, status, and ``/runtimez``.
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 from typing import Any, Dict, Optional
 
 
@@ -22,6 +23,23 @@ UPSTREAM_PROVIDER_SECRET_ENV_NAMES = (
     "GEMINI_API_KEY",
     "GOOGLE_API_KEY",
 )
+AMBIENT_SERVER_SECRET_ENV_NAMES = (
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "AZURE_CLIENT_SECRET",
+    "AZURE_OPENAI_API_KEY",
+    "NPM_TOKEN",
+    "PYPI_API_TOKEN",
+    "UNIGROK_MCP_TOKEN_SECRET",
+    "UNIGROK_CLIENT_TOKEN",
+    "MCP_TOKEN_SECRET",
+    "SSH_AUTH_SOCK",
+    "DOCKER_AUTH_CONFIG",
+)
 # These server-owned values must be scrubbed from Grok CLI subprocesses, but
 # they are not upstream provider bearer secrets: one is a credential-file path
 # and the other is the gateway's own client-token allowlist.
@@ -31,8 +49,60 @@ NON_BEARER_SERVER_OWNED_ENV_NAMES = (
 )
 SERVER_OWNED_SECRET_ENV_NAMES = (
     *UPSTREAM_PROVIDER_SECRET_ENV_NAMES,
+    *AMBIENT_SERVER_SECRET_ENV_NAMES,
     *NON_BEARER_SERVER_OWNED_ENV_NAMES,
 )
+
+_SECRET_ENV_EXACT_NAMES = frozenset(
+    {
+        *SERVER_OWNED_SECRET_ENV_NAMES,
+        "DATABASE_URL",
+        "DB_URL",
+        "POSTGRES_URL",
+        "MYSQL_URL",
+        "MONGODB_URI",
+        "REDIS_URL",
+        "SENTRY_DSN",
+    }
+)
+_SECRET_ENV_SEGMENTS = frozenset(
+    {"TOKEN", "SECRET", "PASSWORD", "PASSWD", "COOKIE", "CREDENTIAL"}
+)
+_SECRET_ENV_SUFFIXES = (
+    "_API_KEY",
+    "_PRIVATE_KEY",
+    "_ACCESS_KEY",
+    "_AUTH_SOCK",
+    "_DSN",
+)
+
+
+def is_secret_environment_name(name: str) -> bool:
+    """Return whether an environment name denotes credential-bearing data.
+
+    Exact canonical names cover current integrations. Conservative structural
+    matching keeps unknown future provider/client secrets out of subprocesses
+    by default without treating ordinary names such as TOKENIZERS_PARALLELISM
+    as credentials.
+    """
+
+    normalized = str(name or "").strip().upper()
+    if not normalized:
+        return False
+    if normalized in _SECRET_ENV_EXACT_NAMES or normalized.endswith(
+        _SECRET_ENV_SUFFIXES
+    ):
+        return True
+    return bool(_SECRET_ENV_SEGMENTS.intersection(normalized.split("_")))
+
+
+def secret_environment_names(
+    environ: Mapping[str, str] | None = None,
+) -> tuple[str, ...]:
+    """Return every canonical or secret-shaped name present in an env map."""
+
+    source = os.environ if environ is None else environ
+    return tuple(name for name in source if is_secret_environment_name(name))
 _CLI_AUTH_ENV_UNSETS = " ".join(
     f"-u {name}" for name in SERVER_OWNED_SECRET_ENV_NAMES
 )

--- a/src/http_server.py
+++ b/src/http_server.py
@@ -455,6 +455,7 @@ _PUBLIC_AUTH_EXEMPT_PATHS = (
 # when reached through a non-loopback Host.
 _LOCAL_OPERATOR_PATHS = ("/runtimez", "/metrics")
 _LOCAL_OPERATOR_PREFIXES = ("/ui", "/docs")
+_AUTH_REQUIRED_LOCAL_OPERATOR_PATHS = frozenset({"/runtimez", "/metrics"})
 
 
 def _scope_host_is_loopback(scope: Dict[str, Any]) -> bool:
@@ -510,8 +511,11 @@ def _is_local_operator_request(scope: Dict[str, Any]) -> bool:
     if not _is_verified_local_request(scope):
         return False
     path = scope.get("path", "")
-    return path in _LOCAL_OPERATOR_PATHS or any(
+    is_operator = path in _LOCAL_OPERATOR_PATHS or any(
         _path_matches_prefix(path, prefix) for prefix in _LOCAL_OPERATOR_PREFIXES
+    )
+    return is_operator and not (
+        _auth_is_active() and path in _AUTH_REQUIRED_LOCAL_OPERATOR_PATHS
     )
 
 
@@ -519,6 +523,11 @@ def _request_may_bypass_auth(scope: Dict[str, Any]) -> bool:
     # The broad development bypass is stricter than the operator-static
     # exemption: an asserted Docker proxy boundary may expose /ui, /runtimez,
     # and local-only /metrics, but it never disables auth for /mcp or /v1.
+    if (
+        _auth_is_active()
+        and scope.get("path", "") in _AUTH_REQUIRED_LOCAL_OPERATOR_PATHS
+    ):
+        return False
     return _allow_unauthenticated() and _is_direct_loopback_request(scope)
 
 

--- a/src/providers/subscription.py
+++ b/src/providers/subscription.py
@@ -288,6 +288,7 @@ async def _run_bounded_process(
             stderr=asyncio.subprocess.PIPE,
             cwd=cwd,
             env=dict(env),
+            allow_secret_names={"CLAUDE_CODE_OAUTH_TOKEN"},
             start_new_session=True,
         )
     except Exception:

--- a/src/providers/subscription.py
+++ b/src/providers/subscription.py
@@ -46,6 +46,7 @@ from .contracts import (
     is_safe_model_id,
     transport_resource_identity,
 )
+from ..subprocess_security import create_scrubbed_subprocess_exec
 from .errors import (
     ProviderAuthorizationInvariantError,
     ProviderConfigurationError,
@@ -280,7 +281,7 @@ async def _run_bounded_process(
 
     started = time.monotonic()
     try:
-        process = await asyncio.create_subprocess_exec(
+        process = await create_scrubbed_subprocess_exec(
             *argv,
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,

--- a/src/subprocess_security.py
+++ b/src/subprocess_security.py
@@ -11,33 +11,40 @@ from __future__ import annotations
 import asyncio
 import os
 import subprocess
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping
 from typing import Any, Optional
 
-from .credentials import SERVER_OWNED_SECRET_ENV_NAMES
+from .credentials import secret_environment_names
 
 
 def scrubbed_subprocess_env(
     base: Optional[Mapping[str, str]] = None,
+    *,
+    allow_secret_names: Collection[str] = (),
 ) -> dict[str, str]:
     """Return a child environment without UniGrok server-owned secrets."""
 
     env = dict(os.environ if base is None else base)
-    for name in SERVER_OWNED_SECRET_ENV_NAMES:
-        env.pop(name, None)
+    allowed = {str(name).upper() for name in allow_secret_names}
+    for name in secret_environment_names(env):
+        if name.upper() not in allowed:
+            env.pop(name, None)
     return env
 
 
 async def create_scrubbed_subprocess_exec(
     *program_and_args: str,
     env: Optional[Mapping[str, str]] = None,
+    allow_secret_names: Collection[str] = (),
     **kwargs: Any,
 ) -> asyncio.subprocess.Process:
     """Launch an async child without inheriting server-owned secrets."""
 
     return await asyncio.create_subprocess_exec(
         *program_and_args,
-        env=scrubbed_subprocess_env(env),
+        env=scrubbed_subprocess_env(
+            env, allow_secret_names=allow_secret_names
+        ),
         **kwargs,
     )
 
@@ -45,12 +52,15 @@ async def create_scrubbed_subprocess_exec(
 def scrubbed_subprocess_run(
     *popenargs: Any,
     env: Optional[Mapping[str, str]] = None,
+    allow_secret_names: Collection[str] = (),
     **kwargs: Any,
 ) -> subprocess.CompletedProcess[Any]:
     """Run a synchronous child without inheriting server-owned secrets."""
 
     return subprocess.run(
         *popenargs,
-        env=scrubbed_subprocess_env(env),
+        env=scrubbed_subprocess_env(
+            env, allow_secret_names=allow_secret_names
+        ),
         **kwargs,
     )

--- a/src/subprocess_security.py
+++ b/src/subprocess_security.py
@@ -1,0 +1,56 @@
+"""Credential-safe subprocess helpers.
+
+UniGrok owns provider, management, and gateway credentials in its server
+process. Child processes receive the caller-supplied environment after those
+server-owned values are removed, or a scrubbed copy of the process environment
+when no explicit environment is supplied.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+from collections.abc import Mapping
+from typing import Any, Optional
+
+from .credentials import SERVER_OWNED_SECRET_ENV_NAMES
+
+
+def scrubbed_subprocess_env(
+    base: Optional[Mapping[str, str]] = None,
+) -> dict[str, str]:
+    """Return a child environment without UniGrok server-owned secrets."""
+
+    env = dict(os.environ if base is None else base)
+    for name in SERVER_OWNED_SECRET_ENV_NAMES:
+        env.pop(name, None)
+    return env
+
+
+async def create_scrubbed_subprocess_exec(
+    *program_and_args: str,
+    env: Optional[Mapping[str, str]] = None,
+    **kwargs: Any,
+) -> asyncio.subprocess.Process:
+    """Launch an async child without inheriting server-owned secrets."""
+
+    return await asyncio.create_subprocess_exec(
+        *program_and_args,
+        env=scrubbed_subprocess_env(env),
+        **kwargs,
+    )
+
+
+def scrubbed_subprocess_run(
+    *popenargs: Any,
+    env: Optional[Mapping[str, str]] = None,
+    **kwargs: Any,
+) -> subprocess.CompletedProcess[Any]:
+    """Run a synchronous child without inheriting server-owned secrets."""
+
+    return subprocess.run(
+        *popenargs,
+        env=scrubbed_subprocess_env(env),
+        **kwargs,
+    )

--- a/src/swarm/analytics.py
+++ b/src/swarm/analytics.py
@@ -18,6 +18,7 @@ import sys
 import tokenize
 from typing import Any, Dict, Iterable, List, Optional
 
+from ..subprocess_security import create_scrubbed_subprocess_exec
 from ..utils import redact_secrets
 
 MAX_SOURCE_BYTES = 256 * 1024
@@ -267,7 +268,7 @@ async def add_ruff_summary(source: str, analytics: Dict[str, Any]) -> Dict[str, 
         analytics["ruff"] = {"available": False, "counts_by_code": {}}
         return analytics
     try:
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_scrubbed_subprocess_exec(
             binary,
             "check",
             "--isolated",

--- a/src/swarm/sandbox.py
+++ b/src/swarm/sandbox.py
@@ -28,6 +28,11 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from ..subprocess_security import (
+    create_scrubbed_subprocess_exec,
+    scrubbed_subprocess_run,
+)
+
 _EXCLUDED_DIRS = {
     ".git", ".venv", "chats", "node_modules", "__pycache__",
     ".pytest_cache", ".mypy_cache", ".ruff_cache", ".idea", ".vscode",
@@ -177,7 +182,7 @@ class SwarmSandbox:
         venv_python = self.work / ".venv" / "bin" / "python"
         if venv_python.is_file():
             try:
-                probe = subprocess.run(
+                probe = scrubbed_subprocess_run(
                     [str(venv_python), "-c", "import sys; raise SystemExit(0)"],
                     stdin=subprocess.DEVNULL,
                     stdout=subprocess.DEVNULL,
@@ -229,7 +234,7 @@ class SwarmSandbox:
     ) -> Tuple[int, str, str]:
         """Run one untrusted child: own session, RLIMITs, allowlisted env,
         process-group SIGKILL on timeout (rc -9)."""
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_scrubbed_subprocess_exec(
             *argv,
             cwd=str(self.work),
             env=self.child_env(),

--- a/src/swarm/static_gate.py
+++ b/src/swarm/static_gate.py
@@ -25,6 +25,8 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+from ..subprocess_security import create_scrubbed_subprocess_exec
+
 # Correctness-only pyflakes rules: undefined name / local used before binding.
 _RUFF_RULES = "F821,F823"
 
@@ -50,7 +52,7 @@ async def violation_counts(
     if not binary:
         return None
     try:
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_scrubbed_subprocess_exec(
             binary, "check",
             "--select", _RUFF_RULES,
             "--isolated",

--- a/src/tools/git.py
+++ b/src/tools/git.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
+from ..subprocess_security import create_scrubbed_subprocess_exec
 from ..utils import (
     PathResolver,
     communicate_with_timeout,
@@ -140,7 +141,7 @@ def _validate_patch_targets(patch: str, repo: Path):
 
 async def _run_git(args: List[str], repo_path: Optional[str] = None, stdin: Optional[bytes] = None) -> str:
     repo = _repo_root(repo_path)
-    proc = await asyncio.create_subprocess_exec(
+    proc = await create_scrubbed_subprocess_exec(
         "git",
         *args,
         cwd=str(repo),

--- a/src/tools/swarm.py
+++ b/src/tools/swarm.py
@@ -22,6 +22,8 @@ import shlex
 import signal
 import tempfile
 import textwrap
+
+from ..subprocess_security import create_scrubbed_subprocess_exec
 import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional
@@ -893,7 +895,7 @@ async def _reverify(task: Dict[str, Any], target: Path, original: bytes) -> tupl
     env["PYTHONPATH"] = str(workspace)
     env["PYTHONHASHSEED"] = "0"
     try:
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_scrubbed_subprocess_exec(
             python, "-m", "pytest", "-q", "-p", "no:cacheprovider", task["test_target"],
             cwd=str(workspace),
             env=env,

--- a/src/tools/system.py
+++ b/src/tools/system.py
@@ -16,6 +16,7 @@ from mcp.types import ToolAnnotations
 from ..models.results import SystemResult
 from ..metrics import build_metrics_snapshot, fetch_provider_api_usage
 from ..semantic_evals import get_semantic_eval_stats
+from ..subprocess_security import create_scrubbed_subprocess_exec
 from ..version import __version__
 
 from ..utils import (
@@ -141,7 +142,7 @@ async def grok_mcp_status(view: Literal["text", "json"] = "text") -> str:
 
         git_sha = "Unknown"
         try:
-            proc_git = await asyncio.create_subprocess_exec(
+            proc_git = await create_scrubbed_subprocess_exec(
                 "git", "rev-parse", "HEAD",
                 cwd=str(proj_root), stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
@@ -777,7 +778,7 @@ async def run_local_tests(
         else:
             cmd = [sys.executable, "-m", "pytest", "-q", safe_target]
 
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_scrubbed_subprocess_exec(
             *cmd,
             cwd=str(project_root),
             stdout=asyncio.subprocess.PIPE,
@@ -1449,7 +1450,7 @@ async def grok_mcp_restart_container() -> SystemResult:
             )
 
         try:
-            proc = await asyncio.create_subprocess_exec(
+            proc = await create_scrubbed_subprocess_exec(
                 "docker", "compose", "up", "--build", "-d",
                 cwd=str(proj_root),
                 stdout=subprocess.PIPE,

--- a/src/utils.py
+++ b/src/utils.py
@@ -45,6 +45,7 @@ from .subprocess_security import (
 from .credentials import (
     CLI_AUTH_SETUP_COMMAND,
     SERVER_OWNED_SECRET_ENV_NAMES,
+    secret_environment_names,
     build_credential_plane_contract,
     credential_plane_policy,
 )
@@ -1292,7 +1293,7 @@ def redact_secrets(text: str) -> str:
     # the pattern guard below. Ignore short values to avoid destructive false
     # positives in ordinary output.
     exact_values: set[str] = set()
-    for name in SERVER_OWNED_SECRET_ENV_NAMES:
+    for name in secret_environment_names(os.environ):
         raw_value = os.environ.get(name, "")
         values = [raw_value.strip()]
         if name == "UNIGROK_API_KEYS":

--- a/src/utils.py
+++ b/src/utils.py
@@ -37,6 +37,11 @@ from .routing import (
     extract_routing_features,
     make_routing_receipt,
 )
+from .subprocess_security import (
+    create_scrubbed_subprocess_exec,
+    scrubbed_subprocess_env,
+    scrubbed_subprocess_run,
+)
 from .credentials import (
     CLI_AUTH_SETUP_COMMAND,
     SERVER_OWNED_SECRET_ENV_NAMES,
@@ -230,16 +235,12 @@ _CLI_PLANE_STATUS_LOCK = threading.Lock()
 def grok_cli_oauth_env(base: Optional[Dict[str, str]] = None) -> Dict[str, str]:
     """Return an OAuth-only environment for a Grok CLI child.
 
-    The UniGrok process owns API, management, gateway, and subordinate-provider
-    credentials. Removing that exact set from every CLI child keeps the xAI
-    credential planes independent and prevents Grok-launched tools from seeing
-    unrelated provider secrets. The persisted grok.com OAuth path remains
-    available, so the CLI must use that subscription identity or fail closed.
+    The persisted grok.com OAuth path remains available, while API, management,
+    gateway, and subordinate-provider credentials are removed. The CLI must use
+    its subscription identity or fail closed.
     """
-    env = dict(os.environ if base is None else base)
-    for name in SERVER_OWNED_SECRET_ENV_NAMES:
-        env.pop(name, None)
-    return env
+
+    return scrubbed_subprocess_env(base)
 
 
 @contextlib.contextmanager
@@ -394,7 +395,7 @@ def grok_cli_plane_status(
 
     parsed_models: Dict[str, Any] = {"models": [], "default_model": None}
     try:
-        completed = subprocess.run(
+        completed = scrubbed_subprocess_run(
             [PathResolver.get_grok_cli_path(), "models"],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -599,7 +600,7 @@ def _owned_descendant_pids(root_pid: int) -> List[int]:
     """Snapshot descendants without exposing their command lines."""
 
     try:
-        result = subprocess.run(
+        result = scrubbed_subprocess_run(
             ["ps", "-axo", "pid=,ppid="],
             capture_output=True,
             text=True,
@@ -775,8 +776,8 @@ async def enforce_caller_budget(store_param: Any, caller: Optional[str]) -> None
     default). Spend is today's telemetry cost across every caller matching
     the entry's substring (the entry IS the shared pot), read via one
     created_at-indexed query and cached ~60s per entry. At/over budget raises
-    CallerBudgetExceeded; a failing store read degrades OPEN — a broken
-    telemetry table must not block traffic.
+    CallerBudgetExceeded. A failing store read degrades open by default, or
+    fails closed when ``UNIGROK_BUDGET_FAIL_CLOSED=1``.
     """
     if not caller or not os.environ.get("UNIGROK_CALLER_BUDGETS", "").strip():
         return
@@ -803,6 +804,10 @@ async def enforce_caller_budget(store_param: Any, caller: Optional[str]) -> None
         try:
             spent = float(await active_store.get_caller_cost_today(entry))
         except Exception as exc:
+            if os.environ.get("UNIGROK_BUDGET_FAIL_CLOSED", "").strip() == "1":
+                raise CallerBudgetExceeded(
+                    f"daily budget check failed and UNIGROK_BUDGET_FAIL_CLOSED is set: {exc}"
+                )
             logging.getLogger("GrokMCP").warning(
                 f"Caller budget check unavailable (degrading open): {exc}"
             )
@@ -1277,6 +1282,15 @@ def load_grok_prompt(prompt_ref: str) -> str:
 
 def redact_secrets(text: str) -> str:
     redacted = str(text or "")
+
+    # Exact-value redaction catches credentials whose format is not covered by
+    # the pattern guard below. Ignore short values to avoid destructive false
+    # positives in ordinary output.
+    for name in SERVER_OWNED_SECRET_ENV_NAMES:
+        value = os.environ.get(name)
+        if value and len(value) >= 8:
+            redacted = redacted.replace(value, "[REDACTED]")
+
     if "xai-" not in redacted and "sk-" not in redacted:
         # This guard must remain a conservative superset of the two
         # case-insensitive regexes below. False positives only cost a regex
@@ -1831,7 +1845,7 @@ async def discover_grok_cli_models(timeout_sec: float = 5.0) -> Dict[str, Any]:
 
     grok_path = PathResolver.get_grok_cli_path()
     try:
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_scrubbed_subprocess_exec(
             grok_path,
             "models",
             stdout=asyncio.subprocess.PIPE,
@@ -8220,7 +8234,7 @@ async def get_dynamic_context(
     candidate_paths: List[Path] = []
 
     try:
-        proc_sha = await asyncio.create_subprocess_exec(
+        proc_sha = await create_scrubbed_subprocess_exec(
             "git", "rev-parse", "--short=12", "HEAD",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
@@ -8233,7 +8247,7 @@ async def get_dynamic_context(
         pass
 
     try:
-        proc_branch = await asyncio.create_subprocess_exec(
+        proc_branch = await create_scrubbed_subprocess_exec(
             "git", "rev-parse", "--abbrev-ref", "HEAD",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
@@ -8249,7 +8263,7 @@ async def get_dynamic_context(
 
     # 1. Try Git mode first (extremely fast and high signal)
     try:
-        proc = await asyncio.create_subprocess_exec(
+        proc = await create_scrubbed_subprocess_exec(
             "git", "status", "--porcelain",
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
@@ -8283,7 +8297,7 @@ async def get_dynamic_context(
                 candidate_paths.append(target_path)
         if not candidate_paths:
             # Fallback: files from the last commit in the branch
-            proc_log = await asyncio.create_subprocess_exec(
+            proc_log = await create_scrubbed_subprocess_exec(
                 "git", "log", "-n", "1", "--name-only", "--oneline",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
@@ -10902,7 +10916,7 @@ async def _call_plane(
                     )
 
             with _runtime() as (cli_cwd, cli_env):
-                proc = await asyncio.create_subprocess_exec(
+                proc = await create_scrubbed_subprocess_exec(
                     grok_path, *args,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,

--- a/src/utils.py
+++ b/src/utils.py
@@ -1291,6 +1291,7 @@ def redact_secrets(text: str) -> str:
     # Exact-value redaction catches credentials whose format is not covered by
     # the pattern guard below. Ignore short values to avoid destructive false
     # positives in ordinary output.
+    exact_values: set[str] = set()
     for name in SERVER_OWNED_SECRET_ENV_NAMES:
         raw_value = os.environ.get(name, "")
         values = [raw_value.strip()]
@@ -1298,7 +1299,9 @@ def redact_secrets(text: str) -> str:
             values.extend(part.strip() for part in raw_value.split(","))
         for value in values:
             if len(value) >= 8:
-                redacted = redacted.replace(value, "[REDACTED]")
+                exact_values.add(value)
+    for value in sorted(exact_values, key=len, reverse=True):
+        redacted = redacted.replace(value, "[REDACTED]")
 
     if "xai-" not in redacted and "sk-" not in redacted:
         # This guard must remain a conservative superset of the two

--- a/src/utils.py
+++ b/src/utils.py
@@ -1291,7 +1291,7 @@ def redact_secrets(text: str) -> str:
     for name in secret_environment_names(os.environ):
         raw_value = os.environ.get(name, "")
         values = [raw_value.strip()]
-        if name == "UNIGROK_API_KEYS":
+        if name.upper() == "UNIGROK_API_KEYS":
             values.extend(part.strip() for part in raw_value.split(","))
         for value in values:
             if len(value) >= 8:

--- a/src/utils.py
+++ b/src/utils.py
@@ -777,8 +777,9 @@ async def enforce_caller_budget(store_param: Any, caller: Optional[str]) -> None
     default). Spend is today's telemetry cost across every caller matching
     the entry's substring (the entry IS the shared pot), read via one
     created_at-indexed query and cached ~60s per entry. At/over budget raises
-    CallerBudgetExceeded. A failing store read degrades open by default, or
-    fails closed when ``UNIGROK_BUDGET_FAIL_CLOSED=1``.
+    CallerBudgetExceeded. Once a caller matches a configured budget, a failing
+    spend-ledger read rejects the request so accounting loss cannot re-arm the
+    cap.
     """
     if not caller or not os.environ.get("UNIGROK_CALLER_BUDGETS", "").strip():
         return
@@ -805,19 +806,13 @@ async def enforce_caller_budget(store_param: Any, caller: Optional[str]) -> None
         try:
             spent = float(await active_store.get_caller_cost_today(entry))
         except Exception as exc:
-            if os.environ.get("UNIGROK_BUDGET_FAIL_CLOSED", "").strip() == "1":
-                logging.getLogger("GrokMCP").warning(
-                    "Caller budget check unavailable; rejecting the request because "
-                    "UNIGROK_BUDGET_FAIL_CLOSED is enabled: %s",
-                    exc,
-                )
-                raise CallerBudgetExceeded(
-                    "daily budget check unavailable; fail-closed policy is enabled"
-                ) from None
             logging.getLogger("GrokMCP").warning(
-                f"Caller budget check unavailable (degrading open): {exc}"
+                "Caller budget check unavailable; rejecting the budgeted request: %s",
+                exc,
             )
-            return
+            raise CallerBudgetExceeded(
+                "daily budget check unavailable; configured cap is fail-closed"
+            ) from None
         _CALLER_SPEND_CACHE[entry] = (spent, now)
     if spent >= limit_usd:
         raise CallerBudgetExceeded(

--- a/src/utils.py
+++ b/src/utils.py
@@ -805,9 +805,14 @@ async def enforce_caller_budget(store_param: Any, caller: Optional[str]) -> None
             spent = float(await active_store.get_caller_cost_today(entry))
         except Exception as exc:
             if os.environ.get("UNIGROK_BUDGET_FAIL_CLOSED", "").strip() == "1":
-                raise CallerBudgetExceeded(
-                    f"daily budget check failed and UNIGROK_BUDGET_FAIL_CLOSED is set: {exc}"
+                logging.getLogger("GrokMCP").warning(
+                    "Caller budget check unavailable; rejecting the request because "
+                    "UNIGROK_BUDGET_FAIL_CLOSED is enabled: %s",
+                    exc,
                 )
+                raise CallerBudgetExceeded(
+                    "daily budget check unavailable; fail-closed policy is enabled"
+                ) from None
             logging.getLogger("GrokMCP").warning(
                 f"Caller budget check unavailable (degrading open): {exc}"
             )
@@ -1287,9 +1292,13 @@ def redact_secrets(text: str) -> str:
     # the pattern guard below. Ignore short values to avoid destructive false
     # positives in ordinary output.
     for name in SERVER_OWNED_SECRET_ENV_NAMES:
-        value = os.environ.get(name)
-        if value and len(value) >= 8:
-            redacted = redacted.replace(value, "[REDACTED]")
+        raw_value = os.environ.get(name, "")
+        values = [raw_value.strip()]
+        if name == "UNIGROK_API_KEYS":
+            values.extend(part.strip() for part in raw_value.split(","))
+        for value in values:
+            if len(value) >= 8:
+                redacted = redacted.replace(value, "[REDACTED]")
 
     if "xai-" not in redacted and "sk-" not in redacted:
         # This guard must remain a conservative superset of the two

--- a/src/workspace_memory.py
+++ b/src/workspace_memory.py
@@ -15,13 +15,13 @@ import json
 import logging
 import os
 import re
-import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path, PurePosixPath
 from typing import Any, Dict, List, Optional, TextIO
 
 from .identity import get_active_caller
+from .subprocess_security import scrubbed_subprocess_run
 from .utils import (
     PathResolver,
     _bounded_redacted,
@@ -51,7 +51,7 @@ def workspace_memory_mode() -> str:
 
 
 def _git(repo: Path, *args: str, check: bool = True) -> str:
-    result = subprocess.run(
+    result = scrubbed_subprocess_run(
         ["git", *args],
         cwd=repo,
         check=False,
@@ -94,7 +94,7 @@ def _validate_sha(repo: Path, value: str, *, require_landed: bool = False) -> st
         raise WorkspaceMemoryError("commit SHA must be a full 40-character lowercase hex id")
     _git(repo, "cat-file", "-e", f"{sha}^{{commit}}")
     if require_landed:
-        result = subprocess.run(
+        result = scrubbed_subprocess_run(
             ["git", "merge-base", "--is-ancestor", sha, "refs/heads/main"],
             cwd=repo,
             check=False,
@@ -215,7 +215,7 @@ def _write_git_note(repo: Path, row: Dict[str, Any]) -> None:
                 "GIT_COMMITTER_EMAIL": "unigrok@local.invalid",
             }
         )
-        result = subprocess.run(
+        result = scrubbed_subprocess_run(
             [
                 "git", "notes", f"--ref={NOTE_REF}", "add", "-f", "-m", payload,
                 row["landed_sha"],
@@ -436,7 +436,7 @@ def _freshness(kind: str, created_at: Any) -> float:
 
 def _git_applicability(repo: Path, row: Dict[str, Any], head: str) -> Optional[Dict[str, Any]]:
     landed = row["landed_sha"]
-    ancestor = subprocess.run(
+    ancestor = scrubbed_subprocess_run(
         ["git", "merge-base", "--is-ancestor", landed, head],
         cwd=repo,
         check=False,
@@ -455,7 +455,7 @@ def _git_applicability(repo: Path, row: Dict[str, Any], head: str) -> Optional[D
             if line
         ]
         for path in paths:
-            probe = subprocess.run(
+            probe = scrubbed_subprocess_run(
                 ["git", "cat-file", "-e", f"{head}:{path}"],
                 cwd=repo,
                 check=False,
@@ -479,7 +479,7 @@ def _git_applicability(repo: Path, row: Dict[str, Any], head: str) -> Optional[D
 
 
 def _is_ancestor(repo: Path, candidate: str, head: str) -> bool:
-    result = subprocess.run(
+    result = scrubbed_subprocess_run(
         ["git", "merge-base", "--is-ancestor", candidate, head],
         cwd=repo,
         check=False,

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -599,7 +599,7 @@ def test_runtimez_reports_the_current_phoneword_dial(monkeypatch):
     }
 
 
-def test_runtimez_stays_open_on_localhost_with_gateway_auth(monkeypatch):
+def test_runtimez_requires_auth_on_localhost_when_keys_set(monkeypatch):
     monkeypatch.delenv("UNIGROK_RUNTIME", raising=False)
     monkeypatch.setenv("UNIGROK_API_KEYS", "client-secret")
 
@@ -608,12 +608,16 @@ def test_runtimez_stays_open_on_localhost_with_gateway_auth(monkeypatch):
         base_url="http://localhost:8080",
         client=("127.0.0.1", 50000),
     ) as client:
-        res = client.get("/runtimez")
+        denied = client.get("/runtimez")
+        allowed = client.get(
+            "/runtimez", headers={"Authorization": "Bearer client-secret"}
+        )
 
-    assert res.status_code == 200
+    assert denied.status_code == 401
+    assert allowed.status_code == 200
 
 
-def test_local_unauthenticated_override_is_loopback_only(monkeypatch):
+def test_local_unauthenticated_override_does_not_open_sensitive_status(monkeypatch):
     monkeypatch.setenv("UNIGROK_RUNTIME", "local")
     monkeypatch.setenv("UNIGROK_API_KEYS", "client-secret")
     monkeypatch.setenv("UNIGROK_ALLOW_UNAUTHENTICATED", "1")
@@ -623,7 +627,8 @@ def test_local_unauthenticated_override_is_loopback_only(monkeypatch):
         base_url="http://localhost:8080",
         client=("127.0.0.1", 50000),
     ) as client:
-        loopback = client.get("/metrics")
+        loopback_metrics = client.get("/metrics")
+        loopback_ui = client.get("/ui/")
     with TestClient(
         create_app(),
         base_url="https://gateway.example.com",
@@ -631,7 +636,8 @@ def test_local_unauthenticated_override_is_loopback_only(monkeypatch):
     ) as client:
         remote = client.get("/metrics")
 
-    assert loopback.status_code == 200
+    assert loopback_metrics.status_code == 401
+    assert loopback_ui.status_code == 200
     assert remote.status_code == 401
 
 
@@ -690,9 +696,9 @@ def test_trusted_compose_proxy_never_bypasses_inference_auth(monkeypatch):
         metrics = client.get("/metrics")
 
     assert ui.status_code == 200
-    assert runtime.status_code == 200
+    assert runtime.status_code == 401
     assert inference.status_code == 401
-    assert metrics.status_code == 200
+    assert metrics.status_code == 401
 
 
 def test_readyz_accepts_cli_auth_without_xai_api_key(monkeypatch, tmp_path):
@@ -1875,13 +1881,17 @@ def test_metrics_is_verified_local_operator_only(monkeypatch):
         base_url="http://localhost:8080",
         client=("127.0.0.1", 50000),
     ) as client:
-        local = client.get("/metrics")
+        local_denied = client.get("/metrics")
+        local_allowed = client.get(
+            "/metrics", headers={"Authorization": "Bearer metrics-secret"}
+        )
 
     assert denied.status_code == 401
     assert allowed.status_code == 403
     assert allowed.json()["error"]["code"] == "forbidden"
-    assert local.status_code == 200
-    assert local.json()["format"] == "unigrok-json-v1"
+    assert local_denied.status_code == 401
+    assert local_allowed.status_code == 200
+    assert local_allowed.json()["format"] == "unigrok-json-v1"
 
 
 def test_metrics_aggregates_planes_and_runtime(monkeypatch):

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -7,6 +7,7 @@ from starlette.responses import JSONResponse
 from starlette.testclient import TestClient
 
 from src.credentials import (
+    AMBIENT_SERVER_SECRET_ENV_NAMES,
     NON_BEARER_SERVER_OWNED_ENV_NAMES,
     SERVER_OWNED_SECRET_ENV_NAMES,
     UPSTREAM_PROVIDER_SECRET_ENV_NAMES,
@@ -783,8 +784,13 @@ def test_upstream_provider_secret_registry_completely_classifies_server_envs():
         set(UPSTREAM_PROVIDER_SECRET_ENV_NAMES)
         & set(NON_BEARER_SERVER_OWNED_ENV_NAMES)
     )
+    assert not (
+        set(AMBIENT_SERVER_SECRET_ENV_NAMES)
+        & set(UPSTREAM_PROVIDER_SECRET_ENV_NAMES)
+    )
     assert set(SERVER_OWNED_SECRET_ENV_NAMES) == (
         set(UPSTREAM_PROVIDER_SECRET_ENV_NAMES)
+        | set(AMBIENT_SERVER_SECRET_ENV_NAMES)
         | set(NON_BEARER_SERVER_OWNED_ENV_NAMES)
     )
 

--- a/tests/test_multiagent.py
+++ b/tests/test_multiagent.py
@@ -496,8 +496,13 @@ class TestBudgetEnforcement:
         broken_store = MagicMock()
         broken_store.get_caller_cost_today = AsyncMock(side_effect=RuntimeError("db gone"))
 
-        with pytest.raises(CallerBudgetExceeded, match="budget check failed"):
+        with pytest.raises(CallerBudgetExceeded) as raised:
             await enforce_caller_budget(broken_store, "codex-cli")
+
+        assert str(raised.value) == (
+            "daily budget check unavailable; fail-closed policy is enabled"
+        )
+        assert "db gone" not in str(raised.value)
 
     @pytest.mark.asyncio
     async def test_malformed_budgets_env_ignored(self, cstore, monkeypatch):

--- a/tests/test_multiagent.py
+++ b/tests/test_multiagent.py
@@ -481,18 +481,8 @@ class TestBudgetEnforcement:
         assert counting_store.get_caller_cost_today.await_count == 2
 
     @pytest.mark.asyncio
-    async def test_store_failure_degrades_open(self, monkeypatch):
+    async def test_store_failure_fails_closed_for_budgeted_caller(self, monkeypatch):
         monkeypatch.setenv("UNIGROK_CALLER_BUDGETS", json.dumps({"codex-cli": 1.0}))
-        monkeypatch.delenv("UNIGROK_BUDGET_FAIL_CLOSED", raising=False)
-        broken_store = MagicMock()
-        broken_store.get_caller_cost_today = AsyncMock(side_effect=RuntimeError("db gone"))
-
-        await enforce_caller_budget(broken_store, "codex-cli")  # no raise
-
-    @pytest.mark.asyncio
-    async def test_store_failure_can_fail_closed(self, monkeypatch):
-        monkeypatch.setenv("UNIGROK_CALLER_BUDGETS", json.dumps({"codex-cli": 1.0}))
-        monkeypatch.setenv("UNIGROK_BUDGET_FAIL_CLOSED", "1")
         broken_store = MagicMock()
         broken_store.get_caller_cost_today = AsyncMock(side_effect=RuntimeError("db gone"))
 
@@ -500,7 +490,7 @@ class TestBudgetEnforcement:
             await enforce_caller_budget(broken_store, "codex-cli")
 
         assert str(raised.value) == (
-            "daily budget check unavailable; fail-closed policy is enabled"
+            "daily budget check unavailable; configured cap is fail-closed"
         )
         assert "db gone" not in str(raised.value)
 

--- a/tests/test_multiagent.py
+++ b/tests/test_multiagent.py
@@ -483,10 +483,21 @@ class TestBudgetEnforcement:
     @pytest.mark.asyncio
     async def test_store_failure_degrades_open(self, monkeypatch):
         monkeypatch.setenv("UNIGROK_CALLER_BUDGETS", json.dumps({"codex-cli": 1.0}))
+        monkeypatch.delenv("UNIGROK_BUDGET_FAIL_CLOSED", raising=False)
         broken_store = MagicMock()
         broken_store.get_caller_cost_today = AsyncMock(side_effect=RuntimeError("db gone"))
 
         await enforce_caller_budget(broken_store, "codex-cli")  # no raise
+
+    @pytest.mark.asyncio
+    async def test_store_failure_can_fail_closed(self, monkeypatch):
+        monkeypatch.setenv("UNIGROK_CALLER_BUDGETS", json.dumps({"codex-cli": 1.0}))
+        monkeypatch.setenv("UNIGROK_BUDGET_FAIL_CLOSED", "1")
+        broken_store = MagicMock()
+        broken_store.get_caller_cost_today = AsyncMock(side_effect=RuntimeError("db gone"))
+
+        with pytest.raises(CallerBudgetExceeded, match="budget check failed"):
+            await enforce_caller_budget(broken_store, "codex-cli")
 
     @pytest.mark.asyncio
     async def test_malformed_budgets_env_ignored(self, cstore, monkeypatch):

--- a/tests/test_subprocess_security.py
+++ b/tests/test_subprocess_security.py
@@ -1,0 +1,72 @@
+import asyncio
+import subprocess
+
+import pytest
+
+from src.credentials import SERVER_OWNED_SECRET_ENV_NAMES
+from src.subprocess_security import (
+    create_scrubbed_subprocess_exec,
+    scrubbed_subprocess_env,
+    scrubbed_subprocess_run,
+)
+from src.utils import redact_secrets
+
+
+def test_scrubbed_subprocess_env_preserves_explicit_safe_values(monkeypatch):
+    for index, name in enumerate(SERVER_OWNED_SECRET_ENV_NAMES):
+        monkeypatch.setenv(name, f"server-secret-{index}")
+
+    child = scrubbed_subprocess_env(
+        {
+            "PATH": "/safe/bin",
+            "SAFE_CHILD_SETTING": "kept",
+            "XAI_API_KEY": "explicit-secret",
+        }
+    )
+
+    assert child == {"PATH": "/safe/bin", "SAFE_CHILD_SETTING": "kept"}
+
+
+@pytest.mark.asyncio
+async def test_async_subprocess_wrapper_scrubs_environment(monkeypatch):
+    captured = {}
+    sentinel = object()
+
+    async def fake_exec(*args, **kwargs):
+        captured["args"] = args
+        captured["env"] = kwargs["env"]
+        return sentinel
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+    result = await create_scrubbed_subprocess_exec(
+        "tool",
+        "arg",
+        env={"SAFE": "yes", "XAI_API_KEY": "do-not-inherit"},
+    )
+
+    assert result is sentinel
+    assert captured == {"args": ("tool", "arg"), "env": {"SAFE": "yes"}}
+
+
+def test_sync_subprocess_wrapper_scrubs_environment(monkeypatch):
+    captured = {}
+    sentinel = subprocess.CompletedProcess(["tool"], 0)
+
+    def fake_run(*args, **kwargs):
+        captured["args"] = args
+        captured["env"] = kwargs["env"]
+        return sentinel
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = scrubbed_subprocess_run(
+        ["tool"], env={"SAFE": "yes", "UNIGROK_API_KEYS": "do-not-inherit"}
+    )
+
+    assert result is sentinel
+    assert captured == {"args": (["tool"],), "env": {"SAFE": "yes"}}
+
+
+def test_redact_secrets_removes_unstructured_exact_value(monkeypatch):
+    monkeypatch.setenv("GOOGLE_API_KEY", "plain-provider-secret")
+
+    assert redact_secrets("failure: plain-provider-secret") == "failure: [REDACTED]"

--- a/tests/test_subprocess_security.py
+++ b/tests/test_subprocess_security.py
@@ -34,6 +34,7 @@ def test_scrubbed_subprocess_env_rejects_named_and_unknown_secret_families():
             "LANG": "C.UTF-8",
             "GH_TOKEN": "github-secret",
             "AWS_SECRET_ACCESS_KEY": "aws-secret",
+            "FUTURE_CLOUD_ACCESS_KEY_ID": "future-access-key-id",
             "DATABASE_URL": "postgres://user:pass@example/db",
             "SSH_AUTH_SOCK": "/tmp/agent.sock",
             "FUTURE_PROVIDER_API_KEY": "future-secret",
@@ -116,6 +117,14 @@ def test_redact_secrets_removes_individual_gateway_keys(monkeypatch):
     )
 
     assert redact_secrets("failure: second-gateway-secret") == "failure: [REDACTED]"
+
+
+def test_redact_secrets_splits_gateway_keys_case_insensitively(monkeypatch):
+    monkeypatch.setenv(
+        "Unigrok_Api_Keys", "first-mixed-gateway, second-mixed-gateway"
+    )
+
+    assert redact_secrets("failure: second-mixed-gateway") == "failure: [REDACTED]"
 
 
 def test_redact_secrets_replaces_longer_prefix_keys_first(monkeypatch):

--- a/tests/test_subprocess_security.py
+++ b/tests/test_subprocess_security.py
@@ -27,6 +27,44 @@ def test_scrubbed_subprocess_env_preserves_explicit_safe_values(monkeypatch):
     assert child == {"PATH": "/safe/bin", "SAFE_CHILD_SETTING": "kept"}
 
 
+def test_scrubbed_subprocess_env_rejects_named_and_unknown_secret_families():
+    child = scrubbed_subprocess_env(
+        {
+            "PATH": "/safe/bin",
+            "LANG": "C.UTF-8",
+            "GH_TOKEN": "github-secret",
+            "AWS_SECRET_ACCESS_KEY": "aws-secret",
+            "DATABASE_URL": "postgres://user:pass@example/db",
+            "SSH_AUTH_SOCK": "/tmp/agent.sock",
+            "FUTURE_PROVIDER_API_KEY": "future-secret",
+            "SOME_CLIENT_SECRET": "client-secret",
+            "TOKENIZERS_PARALLELISM": "false",
+        }
+    )
+
+    assert child == {
+        "PATH": "/safe/bin",
+        "LANG": "C.UTF-8",
+        "TOKENIZERS_PARALLELISM": "false",
+    }
+
+
+def test_scrubbed_subprocess_env_allows_only_explicit_reviewed_secret():
+    child = scrubbed_subprocess_env(
+        {
+            "PATH": "/safe/bin",
+            "CLAUDE_CODE_OAUTH_TOKEN": "subscription-oauth",
+            "XAI_API_KEY": "server-api-secret",
+        },
+        allow_secret_names={"CLAUDE_CODE_OAUTH_TOKEN"},
+    )
+
+    assert child == {
+        "PATH": "/safe/bin",
+        "CLAUDE_CODE_OAUTH_TOKEN": "subscription-oauth",
+    }
+
+
 @pytest.mark.asyncio
 async def test_async_subprocess_wrapper_scrubs_environment(monkeypatch):
     captured = {}
@@ -86,5 +124,13 @@ def test_redact_secrets_replaces_longer_prefix_keys_first(monkeypatch):
     )
 
     assert redact_secrets("failure: shared-prefix-key-with-suffix") == (
+        "failure: [REDACTED]"
+    )
+
+
+def test_redact_secrets_removes_unknown_secret_shaped_env_value(monkeypatch):
+    monkeypatch.setenv("FUTURE_PROVIDER_API_KEY", "future-provider-secret")
+
+    assert redact_secrets("failure: future-provider-secret") == (
         "failure: [REDACTED]"
     )

--- a/tests/test_subprocess_security.py
+++ b/tests/test_subprocess_security.py
@@ -78,3 +78,13 @@ def test_redact_secrets_removes_individual_gateway_keys(monkeypatch):
     )
 
     assert redact_secrets("failure: second-gateway-secret") == "failure: [REDACTED]"
+
+
+def test_redact_secrets_replaces_longer_prefix_keys_first(monkeypatch):
+    monkeypatch.setenv(
+        "UNIGROK_API_KEYS", "shared-prefix-key,shared-prefix-key-with-suffix"
+    )
+
+    assert redact_secrets("failure: shared-prefix-key-with-suffix") == (
+        "failure: [REDACTED]"
+    )

--- a/tests/test_subprocess_security.py
+++ b/tests/test_subprocess_security.py
@@ -70,3 +70,11 @@ def test_redact_secrets_removes_unstructured_exact_value(monkeypatch):
     monkeypatch.setenv("GOOGLE_API_KEY", "plain-provider-secret")
 
     assert redact_secrets("failure: plain-provider-secret") == "failure: [REDACTED]"
+
+
+def test_redact_secrets_removes_individual_gateway_keys(monkeypatch):
+    monkeypatch.setenv(
+        "UNIGROK_API_KEYS", "first-gateway-secret, second-gateway-secret"
+    )
+
+    assert redact_secrets("failure: second-gateway-secret") == "failure: [REDACTED]"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1017,9 +1017,10 @@ class TestTier2ToolsRegistered:
             async def wait(self):
                 return 0
 
-        async def fake_create_subprocess_exec(*cmd, cwd, stdout, stderr):
+        async def fake_create_subprocess_exec(*cmd, cwd, stdout, stderr, env=None, **kwargs):
             captured["cmd"] = cmd
             captured["cwd"] = cwd
+            captured["env"] = env
             return FakeProc()
 
         monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)


### PR DESCRIPTION
## Summary
- rebase the approved security-only packet from #306 onto current protected main
- require auth for sensitive runtime/metrics surfaces whenever gateway auth is configured
- route all Python subprocess creation through credential-scrubbing wrappers
- remove canonical and unknown secret-shaped ambient credentials by default, with only the reviewed Claude OAuth exception
- redact exact configured secrets and fail closed for budgeted callers when spend accounting is unavailable

## Verification
- `uv run python -m compileall -q src evals main.py`
- `uv run python scripts/generate_okf.py --check`
- `uv run pytest -q` — 2173 passed
- focused Ruff checks passed
- `git diff --check`

## Risk
High security sensitivity. This supersedes #306 after exact-head review. The repair removes environment credentials from child processes; separate filesystem, network, HOME, and process-tree isolation gates remain fail-closed work. Durable atomic multi-instance budget reservations remain separate work.

Human sponsor: djtelicloud

Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=user-reported | surface=Codex Desktop | role=implementation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication surfaces, secret handling in subprocesses, and budget enforcement—security-critical paths where misconfiguration could block operators or leak credentials if scrubbing is incomplete.
> 
> **Overview**
> **Centralizes credential isolation for child processes** via a new `subprocess_security` module and expanded secret detection in `credentials` (canonical names plus conservative `*_API_KEY` / `TOKEN` / `SECRET` heuristics). Git, Grok CLI, swarm/sandbox, ruff, pytest, and related paths now launch through scrubbed wrappers; `grok_cli_oauth_env` delegates to the same scrubber. The only explicit allowlisted secret in a child is `CLAUDE_CODE_OAUTH_TOKEN` for the Anthropic subscription CLI path.
> 
> **Hardens exposure and abuse controls:** `/runtimez` and `/metrics` require gateway auth when keys are configured, even on loopback or with unauthenticated overrides; `/ui` stays locally convenient. `redact_secrets` also strips exact configured env values (including comma-split gateway keys). Configured caller daily budgets **fail closed** if spend ledger reads fail. Docker CLI auth bootstrap unsets the expanded secret set to match server scrubbing.
> 
> Docs and OKF reference the new APIs; threat model notes the budget ledger behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79f048a1bb5dc462f6f866b32084cbb783b8691b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
