### PR TITLE
fix(http): forward plane and fallback_policy on /v1 agent

### DIFF
--- a/src/http_server.py
+++ b/src/http_server.py
@@ -1671,6 +1671,8 @@ def _openai_finish_reason(layer: MetaLayer) -> str:
 
 
 _AGENT_MODES = ("auto", "fast", "reasoning", "thinking")
+_AGENT_PLANES = ("auto", "cli", "api")
+_AGENT_FALLBACK_POLICIES = ("same_plane", "cross_plane")
 
 
 def _resolve_agent_model(payload: Dict[str, Any]) -> Optional[str]:
@@ -1690,14 +1692,26 @@ def _resolve_agent_model(payload: Dict[str, Any]) -> Optional[str]:
 def _agent_turn_kwargs(payload: Dict[str, Any]) -> Dict[str, Any]:
     """Shared run_agent_turn kwargs for the OpenAI-compatible agent branch.
 
-    Accepts the extension fields `xai_model`, `mode`, and `thinking_mode` so
-    remote clients keep the full routing surface (same mode mapping as the
-    stdio `agent` tool).
+    Accepts the extension fields `xai_model`, `mode`, `thinking_mode`, `plane`,
+    and `fallback_policy` so remote clients keep the full routing surface
+    (same mode/plane mapping as the public MCP `agent` tool).
     """
     mode = payload.get("mode")
     mode = mode.strip().lower() if isinstance(mode, str) else ""
     if mode not in _AGENT_MODES:
         mode = "auto"
+    plane = payload.get("plane")
+    plane = plane.strip().lower() if isinstance(plane, str) else "auto"
+    if plane not in _AGENT_PLANES:
+        plane = "auto"
+    fallback_policy = payload.get("fallback_policy")
+    fallback_policy = (
+        fallback_policy.strip().lower()
+        if isinstance(fallback_policy, str)
+        else "cross_plane"
+    )
+    if fallback_policy not in _AGENT_FALLBACK_POLICIES:
+        fallback_policy = "cross_plane"
     return {
         "session": _scoped_session(_session_from_payload(payload)),
         "messages": payload.get("messages") or [],
@@ -1705,6 +1719,8 @@ def _agent_turn_kwargs(payload: Dict[str, Any]) -> Dict[str, Any]:
         "mode": "reasoning" if mode == "reasoning" else "auto",
         "thinking_mode": mode == "thinking" or bool(payload.get("thinking_mode")),
         "enable_agentic": mode != "fast",
+        "plane": plane,
+        "fallback_policy": fallback_policy,
         # The HTTP compatibility surface is an untrusted principal boundary.
         # Subscription CLI execution must never inherit the service checkout,
         # durable CLI home, native session memory, or built-in tools.

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -1657,6 +1657,41 @@ def test_agent_chat_completion_passes_mode_extensions(monkeypatch):
         assert mock_run.await_args.kwargs["mode"] == "reasoning"
 
 
+def test_agent_chat_completion_passes_plane_and_fallback_policy(monkeypatch):
+    """Facade forwards allowlisted plane/fallback_policy like the MCP agent."""
+    monkeypatch.delenv("UNIGROK_RUNTIME", raising=False)
+    monkeypatch.delenv("UNIGROK_API_KEYS", raising=False)
+    mock_run = AsyncMock(return_value=MetaLayer(generation="ok"))
+    monkeypatch.setattr("src.http_server.run_agent_turn", mock_run)
+
+    with TestClient(create_app()) as client:
+        client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "unigrok-agent",
+                "plane": "cli",
+                "fallback_policy": "same_plane",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+        kwargs = mock_run.await_args.kwargs
+        assert kwargs["plane"] == "cli"
+        assert kwargs["fallback_policy"] == "same_plane"
+
+        client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "unigrok-agent",
+                "plane": "evil",
+                "fallback_policy": "also-evil",
+                "messages": [{"role": "user", "content": "hi"}],
+            },
+        )
+        kwargs = mock_run.await_args.kwargs
+        assert kwargs["plane"] == "auto"
+        assert kwargs["fallback_policy"] == "cross_plane"
+
+
 def test_agent_chat_completion_maps_finish_reason(monkeypatch):
     """Budget/depth exhaustion reads as OpenAI's 'length'; the raw
     finish_reason and usage come through in the response."""


### PR DESCRIPTION
## Summary
- `/v1/chat/completions` `unigrok-agent` path now forwards allowlisted `plane` (`auto`/`cli`/`api`) and `fallback_policy` (`same_plane`/`cross_plane`) into `run_agent_turn`.
- Invalid values fall back to `auto` / `cross_plane` (same defaults as MCP `agent`).
- Closes the dual-plane honesty gap where OpenAI-compat clients could not force `same_plane`.

## Test plan
- [x] `uv run pytest -q tests/test_http_server.py::test_agent_chat_completion_passes_plane_and_fallback_policy`
- [x] Attribution check vs `origin/main`
- [ ] CI green on draft PR


Made with [Cursor](https://cursor.com)