### PR TITLE
fix(security): require owner-only CLI auth.json

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -10,6 +10,7 @@ import hashlib
 import hmac
 import re
 import secrets
+import stat
 import uuid
 import subprocess
 import signal
@@ -244,6 +245,33 @@ def grok_cli_oauth_env(base: Optional[Dict[str, str]] = None) -> Dict[str, str]:
     return scrubbed_subprocess_env(base)
 
 
+def _persisted_grok_auth_path() -> Path:
+    return Path.home() / ".grok" / "auth.json"
+
+
+def _grok_auth_permission_failure(path: Path) -> Optional[str]:
+    """Return a non-secret auth failure token when ``auth.json`` is unsafe.
+
+    Matches the owner-only secret-file contract used for dotenv: refuse
+    group/other permission bits so a world-writable OAuth document cannot
+    satisfy CLI-plane readiness or be copied into an isolated runtime.
+    """
+    try:
+        if path.is_symlink():
+            return "symlink_refused"
+        file_stat = path.stat()
+    except OSError:
+        return "missing"
+    if not stat.S_ISREG(file_stat.st_mode):
+        return "missing"
+    getuid = getattr(os, "getuid", None)
+    if getuid is not None and file_stat.st_uid != getuid():
+        return "wrong_owner"
+    if stat.S_IMODE(file_stat.st_mode) & 0o077:
+        return "insecure_permissions"
+    return None
+
+
 @contextlib.contextmanager
 def _isolated_grok_cli_runtime():
     """Yield an empty CLI workspace and minimal OAuth-only environment.
@@ -255,11 +283,17 @@ def _isolated_grok_cli_runtime():
     never receives a path to the durable auth volume; refresh cannot mutate
     shared credentials. ``GROK_HOME`` stays temporary and config-free.
     """
-    source_auth = Path.home() / ".grok" / "auth.json"
+    source_auth = _persisted_grok_auth_path()
     if not source_auth.is_file():
         raise RuntimeError(
             "Isolated Grok CLI execution requires the persisted OAuth file "
             "at ~/.grok/auth.json."
+        )
+    permission_failure = _grok_auth_permission_failure(source_auth)
+    if permission_failure is not None:
+        raise RuntimeError(
+            "Isolated Grok CLI execution requires an owner-only OAuth file "
+            f"at ~/.grok/auth.json ({permission_failure})."
         )
 
     with tempfile.TemporaryDirectory(prefix="unigrok-cli-isolated-") as raw_root:
@@ -357,13 +391,22 @@ def grok_cli_plane_status(
             "setup_command": setup,
         }
 
-    auth_state = Path.home() / ".grok" / "auth.json"
-    if not auth_state.is_file():
+    auth_state = _persisted_grok_auth_path()
+    if not auth_state.is_file() and not auth_state.is_symlink():
         return {
             "state": "needs_auth",
             "ready": False,
             "binary": True,
             "auth": "missing",
+            "setup_command": setup,
+        }
+    permission_failure = _grok_auth_permission_failure(auth_state)
+    if permission_failure is not None:
+        return {
+            "state": "needs_auth",
+            "ready": False,
+            "binary": True,
+            "auth": permission_failure,
             "setup_command": setup,
         }
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5626,7 +5626,9 @@ class TestCliPlaneV2:
         monkeypatch.setenv("GROK_AUTH_PATH", "/oauth/auth.json")
         monkeypatch.setenv("UNIGROK_RUNTIME", "local")
         (tmp_path / ".grok").mkdir()
-        (tmp_path / ".grok" / "auth.json").write_text("{}", encoding="utf-8")
+        auth_path = tmp_path / ".grok" / "auth.json"
+        auth_path.write_text("{}", encoding="utf-8")
+        auth_path.chmod(0o600)
         monkeypatch.setattr(utils, "grok_cli_available", lambda: True)
         monkeypatch.setattr(
             PathResolver, "get_grok_cli_path", staticmethod(lambda: "/tmp/grok")
@@ -5716,6 +5718,7 @@ class TestCliPlaneV2:
             '{"account":{"access_token":"test-only","expires_at":1}}',
             encoding="utf-8",
         )
+        source_auth.chmod(0o600)
         (source_home / ".grok" / "settings.json").write_text(
             '{"mcpServers":{"unsafe":{}}}', encoding="utf-8"
         )
@@ -5754,6 +5757,27 @@ class TestCliPlaneV2:
             assert "UNRELATED_SECRET" not in env
 
         assert not isolated_root.exists()
+
+    def test_cli_auth_insecure_permissions_are_refused(self, tmp_path, monkeypatch):
+        from src import utils
+
+        source_home = tmp_path / "source-home"
+        auth_path = source_home / ".grok" / "auth.json"
+        auth_path.parent.mkdir(parents=True)
+        auth_path.write_text('{"account":{"access_token":"test-only"}}', encoding="utf-8")
+        auth_path.chmod(0o666)
+        monkeypatch.setenv("HOME", str(source_home))
+        monkeypatch.setenv("UNIGROK_RUNTIME", "local")
+        monkeypatch.delenv("UNI_GROK_TESTING", raising=False)
+        monkeypatch.setattr(utils, "grok_cli_available", lambda: True)
+
+        status = utils.grok_cli_plane_status(timeout_sec=1.0, force=True)
+        assert status["ready"] is False
+        assert status["auth"] == "insecure_permissions"
+
+        with pytest.raises(RuntimeError, match="owner-only"):
+            with utils._isolated_grok_cli_runtime():
+                pass
 
     @pytest.mark.asyncio
     async def test_isolated_agent_turn_skips_inherited_dynamic_context(self, monkeypatch):


### PR DESCRIPTION
## Summary
- CLI-plane readiness refuses `~/.grok/auth.json` with group/other permission bits (`auth: insecure_permissions`), wrong owner, or symlink.
- Isolated CLI OAuth copy requires the same owner-only regular file before reading.
- Matches the existing dotenv secret-file mode contract (`0o077` refuse).

## Test plan
- [x] `uv run pytest -q -k "cli_auth_insecure_permissions or isolated_cli_runtime_has_empty or cli_check_uses_oauth_only"`
- [x] Attribution check vs `origin/main`
- [ ] CI green on draft PR


Made with [Cursor](https://cursor.com)