### PR TITLE
fix(security): rate-limit public OAuth client registration

### DIFF
--- a/sites/unigrok-control-center/app/lib/oauth-register-budget.ts
+++ b/sites/unigrok-control-center/app/lib/oauth-register-budget.ts
@@ -1,0 +1,48 @@
+/** Process-local abuse budget for public OAuth dynamic client registration. */
+
+const WINDOW_MS = 10 * 60 * 1000;
+const MAX_PER_WINDOW = 20;
+
+const buckets = new Map<string, number[]>();
+
+export type OAuthRegisterBudgetDecision =
+  | { ok: true }
+  | { ok: false; retryAfterSec: number };
+
+/**
+ * Acquire a registration slot for a coarse client key (usually remote IP).
+ *
+ * Public `/oauth/register` is unauthenticated and CORS-open; this bound
+ * blunts signing spam on a single isolate (20 starts / 10 minutes).
+ */
+export function tryAcquireOAuthRegisterBudget(
+  clientKey: string,
+  now = Date.now(),
+): OAuthRegisterBudgetDecision {
+  const key = clientKey.trim().toLowerCase().slice(0, 128) || "anon";
+  const prior = buckets.get(key) ?? [];
+  const timestamps = prior.filter((stamp) => now - stamp < WINDOW_MS);
+  if (timestamps.length >= MAX_PER_WINDOW) {
+    const oldest = timestamps[0] ?? now;
+    const retryAfterSec = Math.max(1, Math.ceil((WINDOW_MS - (now - oldest)) / 1000));
+    buckets.set(key, timestamps);
+    return { ok: false, retryAfterSec };
+  }
+  timestamps.push(now);
+  buckets.set(key, timestamps);
+  return { ok: true };
+}
+
+/** Best-effort client key for registration budgets (not an auth principal). */
+export function registrationClientKey(request: Request): string {
+  const cf = request.headers.get("cf-connecting-ip")?.trim();
+  if (cf && cf.length <= 64 && !/[\s,]/.test(cf)) return cf;
+  const forwarded = request.headers.get("x-forwarded-for")?.split(",", 1)[0]?.trim();
+  if (forwarded && forwarded.length <= 64 && !/\s/.test(forwarded)) return forwarded;
+  return "anon";
+}
+
+/** Test-only reset of process-local buckets. */
+export function resetOAuthRegisterBudgetForTests(): void {
+  buckets.clear();
+}

--- a/sites/unigrok-control-center/app/oauth/register/route.ts
+++ b/sites/unigrok-control-center/app/oauth/register/route.ts
@@ -1,10 +1,29 @@
 import { McpOAuthError, loadMcpOAuthConfig, registerOAuthClient } from "../../lib/mcp-oauth";
+import {
+  registrationClientKey,
+  tryAcquireOAuthRegisterBudget,
+} from "../../lib/oauth-register-budget";
 
 export const dynamic = "force-dynamic";
 
 export async function POST(request: Request): Promise<Response> {
   try {
-    if ((request.headers.get("content-type") ?? "").split(";", 1)[0] !== "application/json") throw new McpOAuthError("invalid_client_metadata");
+    const budget = tryAcquireOAuthRegisterBudget(registrationClientKey(request));
+    if (!budget.ok) {
+      return Response.json(
+        { error: "temporarily_unavailable" },
+        {
+          status: 429,
+          headers: {
+            "cache-control": "no-store",
+            "retry-after": String(budget.retryAfterSec),
+          },
+        },
+      );
+    }
+    if ((request.headers.get("content-type") ?? "").split(";", 1)[0] !== "application/json") {
+      throw new McpOAuthError("invalid_client_metadata");
+    }
     const body = await request.json();
     return Response.json(await registerOAuthClient(loadMcpOAuthConfig(), body), {
       status: 201,
@@ -12,6 +31,9 @@ export async function POST(request: Request): Promise<Response> {
     });
   } catch (error) {
     const code = error instanceof McpOAuthError ? error.oauthCode : "invalid_client_metadata";
-    return Response.json({ error: code }, { status: code === "temporarily_unavailable" ? 503 : 400, headers: { "cache-control": "no-store" } });
+    return Response.json({ error: code }, {
+      status: code === "temporarily_unavailable" ? 503 : 400,
+      headers: { "cache-control": "no-store" },
+    });
   }
 }

--- a/sites/unigrok-control-center/tests/oauth-register-budget.test.ts
+++ b/sites/unigrok-control-center/tests/oauth-register-budget.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  registrationClientKey,
+  resetOAuthRegisterBudgetForTests,
+  tryAcquireOAuthRegisterBudget,
+} from "../app/lib/oauth-register-budget";
+
+test("oauth register budget limits rolling starts per client key", () => {
+  resetOAuthRegisterBudgetForTests();
+  const t0 = 1_800_000_000_000;
+  for (let index = 0; index < 20; index += 1) {
+    assert.equal(tryAcquireOAuthRegisterBudget("203.0.113.9", t0 + index).ok, true);
+  }
+  const blocked = tryAcquireOAuthRegisterBudget("203.0.113.9", t0 + 21);
+  assert.equal(blocked.ok, false);
+  if (!blocked.ok) assert.ok(blocked.retryAfterSec >= 1);
+
+  assert.equal(tryAcquireOAuthRegisterBudget("198.51.100.2", t0 + 21).ok, true);
+  assert.equal(
+    tryAcquireOAuthRegisterBudget("203.0.113.9", t0 + 10 * 60 * 1000 + 1).ok,
+    true,
+  );
+});
+
+test("registrationClientKey prefers CF-Connecting-IP", () => {
+  const request = new Request("https://control.example/oauth/register", {
+    headers: {
+      "cf-connecting-ip": "203.0.113.9",
+      "x-forwarded-for": "198.51.100.2, 203.0.113.9",
+    },
+  });
+  assert.equal(registrationClientKey(request), "203.0.113.9");
+  assert.equal(
+    registrationClientKey(new Request("https://control.example/oauth/register")),
+    "anon",
+  );
+});


### PR DESCRIPTION
## Summary
- Public `/oauth/register` now enforces a process-local budget (20 starts / 10 minutes) keyed by `CF-Connecting-IP` (else first `X-Forwarded-For` hop, else `anon`).
- Exhaustion returns `429` with `Retry-After` and `temporarily_unavailable`.
- Blunts unauthenticated CORS-open registration spam without changing happy-path client metadata rules.

## Test plan
- [x] `npx tsx --test tests/oauth-register-budget.test.ts`
- [x] Attribution check vs `origin/main`
- [ ] CI green on draft PR


Made with [Cursor](https://cursor.com)