### PR TITLE
fix(http): omit static API fallbacks from /v1/models without key

### DIFF
--- a/src/http_server.py
+++ b/src/http_server.py
@@ -65,6 +65,7 @@ from .utils import (
     run_agent_turn,
     set_request_id,
     store,
+    xai_api_key_configured,
 )
 
 
@@ -1645,6 +1646,11 @@ async def metrics(request: Request) -> Response:
 
 
 async def get_xai_model_ids() -> List[str]:
+    # OpenAI-compat /v1/models feeds raw-proxy allowlisting. Without a usable
+    # XAI_API_KEY, discovery falls back to static API slugs that cannot be
+    # proxied — advertise only the dual-plane agent virtual model instead.
+    if not xai_api_key_configured():
+        return [UNIGROK_AGENT_MODEL]
     discovery = await discover_xai_api_models()
     names = [item["id"] for item in discovery["models"] if item.get("id")]
     return sorted({UNIGROK_AGENT_MODEL, *names})

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -867,6 +867,55 @@ def test_models_lists_unigrok_agent(monkeypatch):
     assert {"unigrok-agent", "grok-4.3"}.issubset(ids)
 
 
+def test_models_omits_fallback_api_slugs_when_api_key_missing(monkeypatch):
+    """Without XAI_API_KEY, do not advertise static API fallbacks as callable."""
+    monkeypatch.delenv("UNIGROK_RUNTIME", raising=False)
+    monkeypatch.delenv("UNIGROK_API_KEYS", raising=False)
+    monkeypatch.delenv("XAI_API_KEY", raising=False)
+    monkeypatch.setattr("src.http_server.xai_api_key_configured", lambda: False)
+    discover = AsyncMock(
+        return_value={
+            "models": [{"id": "grok-4.3"}, {"id": "grok-4"}],
+            "available": False,
+            "source": "xai_api_fallback",
+            "warnings": ["xAI API model discovery failed"],
+        }
+    )
+    monkeypatch.setattr("src.http_server.discover_xai_api_models", discover)
+
+    with TestClient(create_app()) as client:
+        res = client.get("/v1/models")
+
+    assert res.status_code == 200
+    ids = [item["id"] for item in res.json()["data"]]
+    assert ids == ["unigrok-agent"]
+    discover.assert_not_awaited()
+
+
+def test_models_includes_discovered_api_slugs_when_api_key_present(monkeypatch):
+    monkeypatch.delenv("UNIGROK_RUNTIME", raising=False)
+    monkeypatch.delenv("UNIGROK_API_KEYS", raising=False)
+    monkeypatch.setattr("src.http_server.xai_api_key_configured", lambda: True)
+    monkeypatch.setattr(
+        "src.http_server.discover_xai_api_models",
+        AsyncMock(
+            return_value={
+                "models": [{"id": "grok-4.3"}],
+                "available": True,
+                "source": "xai_api",
+                "warnings": [],
+            }
+        ),
+    )
+
+    with TestClient(create_app()) as client:
+        res = client.get("/v1/models")
+
+    assert res.status_code == 200
+    ids = {item["id"] for item in res.json()["data"]}
+    assert ids == {"unigrok-agent", "grok-4.3"}
+
+
 def test_agent_chat_completion_uses_shared_harness(monkeypatch):
     monkeypatch.delenv("UNIGROK_RUNTIME", raising=False)
     monkeypatch.delenv("UNIGROK_API_KEYS", raising=False)

--- a/tests/test_intelligence_upgrade.py
+++ b/tests/test_intelligence_upgrade.py
@@ -512,6 +512,7 @@ async def test_list_models_renders_api_cli_and_profile_sections(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_http_model_ids_exclude_cli_and_profiles(monkeypatch):
+    monkeypatch.setattr("src.http_server.xai_api_key_configured", lambda: True)
     monkeypatch.setattr(
         "src.http_server.discover_xai_api_models",
         AsyncMock(


### PR DESCRIPTION
## Summary
- When `XAI_API_KEY` is missing, OpenAI-compat `GET /v1/models` now lists only `unigrok-agent` instead of static API fallback slugs that cannot be raw-proxied.
- With a configured API key, discovery still populates the callable catalog as before.
- Unit coverage for both key-missing and key-present paths.

## Test plan
- [x] `uv run pytest -q tests/test_http_server.py::test_models_omits_fallback_api_slugs_when_api_key_missing tests/test_http_server.py::test_models_includes_discovered_api_slugs_when_api_key_present tests/test_intelligence_upgrade.py::test_http_model_ids_exclude_cli_and_profiles`
- [ ] CI green on draft PR


Made with [Cursor](https://cursor.com)