### PR TITLE
fix(cli): keep user prompts out of process argv

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -955,8 +955,28 @@ def _json_schema_for_cli(schema: Any) -> Optional[str]:
     return json.dumps(schema, sort_keys=True, separators=(",", ":"))
 
 
+@contextlib.contextmanager
+def _cli_prompt_file(prompt: str):
+    """Write the CLI user prompt to a private temp file for ``--prompt-file``.
+
+    Putting the prompt on ``-p`` exposes customer text (and any pasted secrets)
+    to every local process inspector for the lifetime of the Grok CLI child.
+    """
+    fd, path = tempfile.mkstemp(prefix="unigrok-cli-prompt-", suffix=".txt")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(prompt)
+        os.chmod(path, 0o600)
+        yield path
+    finally:
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+
+
 def _build_grok_cli_args(
-    cli_prompt: str,
+    cli_prompt_file: str,
     model_name: str,
     dynamic_sys_prompt: str,
     output_format: str,
@@ -1012,7 +1032,10 @@ def _build_grok_cli_args(
             ]
         )
 
-    args.extend(["-p", cli_prompt, "-m", model_name, "--output-format", output_format])
+    # Prefer --prompt-file over -p so the user payload is not visible in ps(1).
+    args.extend(
+        ["--prompt-file", cli_prompt_file, "-m", model_name, "--output-format", output_format]
+    )
     return args
 
 
@@ -10896,21 +10919,6 @@ async def _call_plane(
             cli_resume_session_id: Optional[str] = None,
         ) -> tuple[str, Optional[str]]:
             output_format = "streaming-json" if on_event is not None else "json"
-            args = _build_grok_cli_args(
-                cli_prompt=current_prompt,
-                model_name=model_name,
-                dynamic_sys_prompt=dynamic_sys_prompt,
-                output_format=output_format,
-                cli_session_id=cli_session_id,
-                cli_resume_session_id=cli_resume_session_id,
-                profile=profile or load_grok_profile(model_name),
-                max_turns=max_turns,
-                json_schema=json_schema,
-                no_plan=cli_no_plan,
-                verbatim=cli_verbatim,
-                allowed_tools=cli_allowed_tools,
-                isolated=cli_isolated,
-            )
 
             @contextlib.contextmanager
             def _runtime():
@@ -10923,58 +10931,75 @@ async def _call_plane(
                         grok_cli_oauth_env(),
                     )
 
-            with _runtime() as (cli_cwd, cli_env):
-                proc = await create_scrubbed_subprocess_exec(
-                    grok_path, *args,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                    cwd=str(cli_cwd),
-                    env=cli_env,
-                    # Grok may launch long-running tool children (pytest,
-                    # builds, subagents). UniGrok owns this isolated process
-                    # group so timeout/cancellation can reap the whole tree.
-                    start_new_session=True,
+            with _cli_prompt_file(current_prompt) as prompt_path:
+                args = _build_grok_cli_args(
+                    cli_prompt_file=prompt_path,
+                    model_name=model_name,
+                    dynamic_sys_prompt=dynamic_sys_prompt,
+                    output_format=output_format,
+                    cli_session_id=cli_session_id,
+                    cli_resume_session_id=cli_resume_session_id,
+                    profile=profile or load_grok_profile(model_name),
+                    max_turns=max_turns,
+                    json_schema=json_schema,
+                    no_plan=cli_no_plan,
+                    verbatim=cli_verbatim,
+                    allowed_tools=cli_allowed_tools,
+                    isolated=cli_isolated,
                 )
-                proc._unigrok_process_group = True
-                # Native coding work can legitimately run for many minutes.  Do
-                # not turn "slow" into a fabricated failure; deployments that
-                # require a wall-clock deadline can opt in explicitly.
-                cli_timeout = _optional_env_timeout("UNIGROK_CLI_TIMEOUT")
-                try:
-                    if on_event is not None:
-                        consume = _consume_cli_stream(proc, on_event)
-                        if cli_timeout is None:
-                            text, returned_id, stderr = await consume
-                        else:
-                            text, returned_id, stderr = await asyncio.wait_for(
-                                consume, timeout=cli_timeout
-                            )
-                    else:
-                        stdout, stderr = await communicate_with_timeout(proc, cli_timeout)
-                        text, returned_id = _parse_cli_json_output(
-                            stdout.decode("utf-8", errors="ignore")
-                        )
-                except asyncio.CancelledError:
-                    await _terminate_and_reap_subprocess(proc)
-                    raise
-                except asyncio.TimeoutError:
-                    await _terminate_and_reap_subprocess(proc)
-                    raise RuntimeError(
-                        f"Grok CLI execution timed out after {cli_timeout:.1f} seconds"
-                    )
 
-                if proc.returncode != 0:
-                    err_msg = stderr.decode("utf-8", errors="ignore").strip()
-                    safe_error = _bounded_redacted(
-                        err_msg or f"process exited with code {proc.returncode}",
-                        500,
+                with _runtime() as (cli_cwd, cli_env):
+                    proc = await create_scrubbed_subprocess_exec(
+                        grok_path, *args,
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.PIPE,
+                        cwd=str(cli_cwd),
+                        env=cli_env,
+                        # Grok may launch long-running tool children (pytest,
+                        # builds, subagents). UniGrok owns this isolated process
+                        # group so timeout/cancellation can reap the whole tree.
+                        start_new_session=True,
                     )
-                    safe_partial = _bounded_redacted(text, 1200)
-                    raise _GrokCLIExecutionError(
-                        f"Grok CLI error: {safe_error}",
-                        partial_output=safe_partial,
-                    )
-                return text, returned_id
+                    proc._unigrok_process_group = True
+                    # Native coding work can legitimately run for many minutes.  Do
+                    # not turn "slow" into a fabricated failure; deployments that
+                    # require a wall-clock deadline can opt in explicitly.
+                    cli_timeout = _optional_env_timeout("UNIGROK_CLI_TIMEOUT")
+                    try:
+                        if on_event is not None:
+                            consume = _consume_cli_stream(proc, on_event)
+                            if cli_timeout is None:
+                                text, returned_id, stderr = await consume
+                            else:
+                                text, returned_id, stderr = await asyncio.wait_for(
+                                    consume, timeout=cli_timeout
+                                )
+                        else:
+                            stdout, stderr = await communicate_with_timeout(proc, cli_timeout)
+                            text, returned_id = _parse_cli_json_output(
+                                stdout.decode("utf-8", errors="ignore")
+                            )
+                    except asyncio.CancelledError:
+                        await _terminate_and_reap_subprocess(proc)
+                        raise
+                    except asyncio.TimeoutError:
+                        await _terminate_and_reap_subprocess(proc)
+                        raise RuntimeError(
+                            f"Grok CLI execution timed out after {cli_timeout:.1f} seconds"
+                        )
+
+                    if proc.returncode != 0:
+                        err_msg = stderr.decode("utf-8", errors="ignore").strip()
+                        safe_error = _bounded_redacted(
+                            err_msg or f"process exited with code {proc.returncode}",
+                            500,
+                        )
+                        safe_partial = _bounded_redacted(text, 1200)
+                        raise _GrokCLIExecutionError(
+                            f"Grok CLI error: {safe_error}",
+                            partial_output=safe_partial,
+                        )
+                    return text, returned_id
 
         async def _invoke_cli(
             current_prompt: str,

--- a/tests/test_subagent_surface_contract.py
+++ b/tests/test_subagent_surface_contract.py
@@ -79,7 +79,7 @@ async def test_submit_research_job_rejects_illegal_agent_count() -> None:
 
 def test_isolated_cli_args_always_disable_subagents() -> None:
     isolated = _build_grok_cli_args(
-        cli_prompt="p",
+        cli_prompt_file="/tmp/unigrok-cli-prompt-test.txt",
         model_name="grok-4.5",
         dynamic_sys_prompt="sys",
         output_format="json",
@@ -92,7 +92,7 @@ def test_isolated_cli_args_always_disable_subagents() -> None:
     assert isolated[isolated.index("--permission-mode") + 1] == "dontAsk"
 
     normal = _build_grok_cli_args(
-        cli_prompt="p",
+        cli_prompt_file="/tmp/unigrok-cli-prompt-test.txt",
         model_name="grok-4.5",
         dynamic_sys_prompt="sys",
         output_format="json",

--- a/tests/test_swarm_engine.py
+++ b/tests/test_swarm_engine.py
@@ -57,7 +57,7 @@ class TestGenerationPlane:
         from src.utils import _build_grok_cli_args
 
         args = _build_grok_cli_args(
-            "prompt",
+            "/tmp/unigrok-cli-prompt-test.txt",
             "grok-4.5",
             "system",
             "json",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5490,7 +5490,10 @@ class TestCliPlaneV2:
             returncode = 0
 
         async def fake_exec(*cmd, **kwargs):
-            captured["cmd"] = list(cmd)
+            argv = list(cmd)
+            captured["cmd"] = argv
+            pf = argv[argv.index("--prompt-file") + 1]
+            captured["prompt"] = Path(pf).read_text(encoding="utf-8")
             return FakeProc()
 
         async def fake_communicate(proc, timeout_sec, input_data=None):
@@ -5512,23 +5515,19 @@ class TestCliPlaneV2:
         )
 
         assert (content, is_cli) == ("structured", True)
-        assert captured["cmd"] == [
-            "/tmp/grok",
-            "--system-prompt-override",
-            "sys",
-            "--effort",
-            "high",
-            "--max-turns",
-            "5",
-            "--json-schema",
-            json_module.dumps(schema, sort_keys=True, separators=(",", ":")),
-            "-p",
-            "hi",
-            "-m",
-            "grok-composer-2.5-fast",
-            "--output-format",
-            "json",
-        ]
+        cmd = captured["cmd"]
+        assert cmd[0] == "/tmp/grok"
+        assert cmd[cmd.index("--system-prompt-override") + 1] == "sys"
+        assert cmd[cmd.index("--effort") + 1] == "high"
+        assert cmd[cmd.index("--max-turns") + 1] == "5"
+        assert cmd[cmd.index("--json-schema") + 1] == json_module.dumps(
+            schema, sort_keys=True, separators=(",", ":")
+        )
+        assert "-p" not in cmd
+        assert "--prompt-file" in cmd
+        assert captured["prompt"] == "hi"
+        assert cmd[cmd.index("-m") + 1] == "grok-composer-2.5-fast"
+        assert cmd[cmd.index("--output-format") + 1] == "json"
 
     @pytest.mark.asyncio
     async def test_cli_streaming_session_exact_argv_includes_max_turns(self, monkeypatch):
@@ -5565,7 +5564,10 @@ class TestCliPlaneV2:
                 return 0
 
         async def fake_exec(*cmd, **kwargs):
-            captured["cmd"] = list(cmd)
+            argv = list(cmd)
+            captured["cmd"] = argv
+            pf = argv[argv.index("--prompt-file") + 1]
+            captured["prompt"] = Path(pf).read_text(encoding="utf-8")
             return FakeProc()
 
         monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
@@ -5587,22 +5589,61 @@ class TestCliPlaneV2:
         )
 
         assert (content, is_cli) == ("ok", True)
-        assert captured["cmd"] == [
-            "/tmp/grok",
-            "--resume",
-            "sid-existing",
-            "--system-prompt-override",
-            "sys",
-            "--max-turns",
-            "2",
-            "-p",
-            "hi",
-            "-m",
-            "grok-composer-2.5-fast",
-            "--output-format",
-            "streaming-json",
-        ]
+        cmd = captured["cmd"]
+        assert cmd[0] == "/tmp/grok"
+        assert cmd[cmd.index("--resume") + 1] == "sid-existing"
+        assert cmd[cmd.index("--system-prompt-override") + 1] == "sys"
+        assert cmd[cmd.index("--max-turns") + 1] == "2"
+        assert "-p" not in cmd
+        assert "--prompt-file" in cmd
+        assert captured["prompt"] == "hi"
+        assert cmd[cmd.index("-m") + 1] == "grok-composer-2.5-fast"
+        assert cmd[cmd.index("--output-format") + 1] == "streaming-json"
         store.save_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cli_user_prompt_stays_out_of_process_argv(self, monkeypatch):
+        """CLI user text must travel via --prompt-file (0600), never -p argv."""
+        import json as json_module
+        import stat
+
+        from src.utils import _call_plane
+
+        monkeypatch.setenv("UNIGROK_RUNTIME", "local")
+        monkeypatch.setattr(
+            PathResolver, "get_grok_cli_path", staticmethod(lambda: "/tmp/grok")
+        )
+        secret = "SENTINEL-CLI-PROMPT-SECRET-9f3a"
+        captured = {}
+
+        class FakeProc:
+            returncode = 0
+
+        async def fake_exec(*cmd, **kwargs):
+            argv = list(cmd)
+            captured["argv"] = argv
+            pf = argv[argv.index("--prompt-file") + 1]
+            captured["mode"] = stat.S_IMODE(Path(pf).stat().st_mode)
+            captured["prompt"] = Path(pf).read_text(encoding="utf-8")
+            return FakeProc()
+
+        async def fake_communicate(proc, timeout_sec, input_data=None):
+            return json_module.dumps({"text": "ok"}).encode(), b""
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+        monkeypatch.setattr("src.utils.communicate_with_timeout", fake_communicate)
+
+        content, _, _, is_cli = await _call_plane(
+            "cli-fallback", secret, None, None, "sys"
+        )
+
+        assert (content, is_cli) == ("ok", True)
+        assert "-p" not in captured["argv"]
+        assert "--prompt-file" in captured["argv"]
+        assert secret not in captured["argv"]
+        assert secret not in " ".join(captured["argv"])
+        assert captured["prompt"] == secret
+        assert captured["mode"] == 0o600
 
     def test_cli_check_uses_oauth_only_models_probe_for_plane_health(self, monkeypatch, tmp_path):
         from src import utils
@@ -5961,7 +6002,11 @@ class TestCliPlaneV2:
                 self.returncode = returncode
 
         async def fake_exec(*cmd, **kwargs):
-            captured["cmds"].append(list(cmd))
+            argv = list(cmd)
+            captured["cmds"].append(argv)
+            captured.setdefault("prompts", []).append(
+                Path(argv[argv.index("--prompt-file") + 1]).read_text(encoding="utf-8")
+            )
             return FakeProc(1 if len(captured["cmds"]) == 1 else 0)
 
         payload = json_module.dumps({
@@ -6006,7 +6051,7 @@ class TestCliPlaneV2:
         assert "--resume" not in fresh_cmd
         assert "--fork-session" not in fresh_cmd
         uuid_module.UUID(fresh_cmd[fresh_cmd.index("--session-id") + 1])
-        retry_prompt = fresh_cmd[fresh_cmd.index("-p") + 1]
+        retry_prompt = captured["prompts"][1]
         assert "MISSING-SESSION-MARKER" in retry_prompt
         assert retry_prompt.count("What marker did I give you?") == 1
         assert len(attempts) == len(captured["cmds"]) == 2
@@ -6059,7 +6104,11 @@ class TestCliPlaneV2:
                 self.returncode = returncode
 
         async def fake_exec(*cmd, **kwargs):
-            captured["cmds"].append(list(cmd))
+            argv = list(cmd)
+            captured["cmds"].append(argv)
+            captured.setdefault("prompts", []).append(
+                Path(argv[argv.index("--prompt-file") + 1]).read_text(encoding="utf-8")
+            )
             return FakeProc(1 if len(captured["cmds"]) == 1 else 0)
 
         payload = json_module.dumps({
@@ -6112,7 +6161,7 @@ class TestCliPlaneV2:
         assert "--fork-session" not in fresh_cmd
         uuid_module.UUID(fresh_cmd[fresh_cmd.index("--session-id") + 1])
         assert fresh_cmd[fresh_cmd.index("-m") + 1] == "grok-4.5"
-        retry_prompt = fresh_cmd[fresh_cmd.index("-p") + 1]
+        retry_prompt = captured["prompts"][1]
         assert "MODEL-SWITCH-MARKER" in retry_prompt
         assert retry_prompt.count("What marker did I give you?") == 1
         store.load_messages.assert_awaited_once()
@@ -6141,7 +6190,11 @@ class TestCliPlaneV2:
                 self.returncode = returncode
 
         async def fake_exec(*cmd, **kwargs):
-            captured["cmds"].append(list(cmd))
+            argv = list(cmd)
+            captured["cmds"].append(argv)
+            captured.setdefault("prompts", []).append(
+                Path(argv[argv.index("--prompt-file") + 1]).read_text(encoding="utf-8")
+            )
             calls["count"] += 1
             return FakeProc(1 if calls["count"] == 1 else 0)
 
@@ -6167,14 +6220,13 @@ class TestCliPlaneV2:
         assert len(captured["cmds"]) == 2
         assert captured["cmds"][0][captured["cmds"][0].index("--resume") + 1] == "abc-123"
         assert "--session-id" not in captured["cmds"][0]
-        first_prompt = captured["cmds"][0][captured["cmds"][0].index("-p") + 1]
-        assert first_prompt == "What marker did I give you?"
+        assert captured["prompts"][0] == "What marker did I give you?"
         fork_cmd = captured["cmds"][1]
         assert fork_cmd[fork_cmd.index("--resume") + 1] == "abc-123"
         assert "--fork-session" in fork_cmd
         fork_id = fork_cmd[fork_cmd.index("--session-id") + 1]
         uuid_module.UUID(fork_id)
-        assert fork_cmd[fork_cmd.index("-p") + 1] == "What marker did I give you?"
+        assert captured["prompts"][1] == "What marker did I give you?"
         store.load_messages.assert_not_awaited()
         store.save_session.assert_awaited_once_with(
             "sess",
@@ -6200,7 +6252,11 @@ class TestCliPlaneV2:
                 self.returncode = returncode
 
         async def fake_exec(*cmd, **kwargs):
-            captured["cmds"].append(list(cmd))
+            argv = list(cmd)
+            captured["cmds"].append(argv)
+            captured.setdefault("prompts", []).append(
+                Path(argv[argv.index("--prompt-file") + 1]).read_text(encoding="utf-8")
+            )
             return FakeProc(1 if len(captured["cmds"]) < 3 else 0)
 
         payload = json_module.dumps({
@@ -6233,7 +6289,7 @@ class TestCliPlaneV2:
         assert "--resume" not in fresh_cmd
         assert "--fork-session" not in fresh_cmd
         uuid_module.UUID(fresh_cmd[fresh_cmd.index("--session-id") + 1])
-        retry_prompt = fresh_cmd[fresh_cmd.index("-p") + 1]
+        retry_prompt = captured["prompts"][2]
         assert "# Server Conversation History" in retry_prompt
         assert "STALE-SESSION-MARKER" in retry_prompt
         assert "# Current User Request" in retry_prompt
@@ -6261,7 +6317,11 @@ class TestCliPlaneV2:
             returncode = 0
 
         async def fake_exec(*cmd, **kwargs):
-            captured["cmd"] = list(cmd)
+            argv = list(cmd)
+            captured["cmd"] = argv
+            captured["prompt"] = Path(
+                argv[argv.index("--prompt-file") + 1]
+            ).read_text(encoding="utf-8")
             return FakeProc()
 
         payload = json_module.dumps({"text": "MCP-MARKER"}).encode()
@@ -6290,7 +6350,8 @@ class TestCliPlaneV2:
         cmd = captured["cmd"]
         assert "--session-id" not in cmd
         assert "--resume" not in cmd
-        prompt_arg = cmd[cmd.index("-p") + 1]
+        assert "-p" not in cmd
+        prompt_arg = captured["prompt"]
         assert "Server Conversation History" in prompt_arg
         assert "MCP-MARKER" in prompt_arg
         assert "Current User Request" in prompt_arg
@@ -6310,7 +6371,11 @@ class TestCliPlaneV2:
             returncode = 0
 
         async def fake_exec(*cmd, **kwargs):
-            captured["cmd"] = list(cmd)
+            argv = list(cmd)
+            captured["cmd"] = argv
+            captured["prompt"] = Path(
+                argv[argv.index("--prompt-file") + 1]
+            ).read_text(encoding="utf-8")
             return FakeProc()
 
         async def fake_communicate(proc, timeout_sec, input_data=None):
@@ -6337,7 +6402,8 @@ class TestCliPlaneV2:
         cmd = captured["cmd"]
         assert "--resume" not in cmd
         assert "--session-id" not in cmd
-        prompt_arg = cmd[cmd.index("-p") + 1]
+        assert "-p" not in cmd
+        prompt_arg = captured["prompt"]
         assert "EXPLICIT-MARKER" in prompt_arg
         assert prompt_arg.count("What marker did I give you?") == 1
         store.get_session.assert_not_awaited()
@@ -6360,7 +6426,11 @@ class TestCliPlaneV2:
             returncode = 0
 
         async def fake_exec(*cmd, **kwargs):
-            captured["cmd"] = list(cmd)
+            argv = list(cmd)
+            captured["cmd"] = argv
+            captured["prompt"] = Path(
+                argv[argv.index("--prompt-file") + 1]
+            ).read_text(encoding="utf-8")
             return FakeProc()
 
         payload = json_module.dumps({
@@ -6392,7 +6462,8 @@ class TestCliPlaneV2:
         cmd = captured["cmd"]
         assert cmd[cmd.index("--resume") + 1] == "native-cli-session"
         assert "--session-id" not in cmd
-        prompt_arg = cmd[cmd.index("-p") + 1]
+        assert "-p" not in cmd
+        prompt_arg = captured["prompt"]
         assert prompt_arg == "What marker did I give you?"
         assert "Server Conversation History" not in prompt_arg
         assert "API-MARKER" not in prompt_arg


### PR DESCRIPTION
## Summary
- CLI plane no longer puts the user prompt on `-p` (visible to `ps` / process inspectors for the child lifetime).
- Writes a private `0600` temp file and invokes Grok with `--prompt-file`.
- Regression coverage asserts the sentinel stays out of argv and the file mode is `0600`.
- Residual: `--system-prompt-override` still carries dynamic system text in argv (no file-backed CLI flag yet).

## Test plan
- [x] `uv run pytest -q tests/test_utils.py -k cli_`
- [x] `uv run pytest -q tests/test_subagent_surface_contract.py tests/test_swarm_engine.py::TestGenerationPlane::test_cli_argv_can_disable_plan_and_all_tools`
- [ ] CI green on draft PR


Made with [Cursor](https://cursor.com)