### PR TITLE
feat(swarm): return structured task_id from launch tools

### DIFF
--- a/src/tools/swarm.py
+++ b/src/tools/swarm.py
@@ -167,6 +167,28 @@ def _file_hash(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+# The launch tools stay human-readable str returns (their prose carries the
+# honesty framing and every consumer/test that reads the backtick id keeps
+# working). This trailer rides ALONGSIDE that prose as a wording-independent,
+# machine-stable line — same "format":"unigrok-…-vN" convention the swarm's
+# other machine payloads use — so the workbench can drive a run off a stable
+# id instead of regex-scraping the sentence, where any wording change silently
+# breaks the parse.
+SWARM_LAUNCH_FORMAT = "unigrok-swarm-launch-v1"
+
+
+def _launch_receipt(task_id: str, input_kind: str) -> str:
+    """A deterministic, prose-independent launch receipt appended to the human
+    message. Emitted as an HTML comment so it is invisible when the message is
+    rendered but trivially parseable from the raw tool text:
+    ``<!--unigrok-swarm-launch-v1 {"task_id":"…","input_kind":"…"}-->``."""
+    body = json.dumps(
+        {"format": SWARM_LAUNCH_FORMAT, "task_id": task_id, "input_kind": input_kind},
+        separators=(",", ":"),
+    )
+    return f"\n\n<!--{SWARM_LAUNCH_FORMAT} {body}-->"
+
+
 async def analyze_code_for_swarm(code: str, language: str = "python") -> str:
     """Analyze pasted Python without a model call, import, or user-code execution.
 
@@ -263,6 +285,7 @@ async def _launch_code_swarm(
         f"(mode={swarm_config.swarm_mode()}, strategy={strategy}, goal={goal}, "
         f"budget=${budget:.2f}). "
         f"Poll with get_swarm_status('{task_id}')."
+        + _launch_receipt(task_id, "workspace")
     )
 
 
@@ -390,6 +413,7 @@ async def start_paste_swarm(
             f"Paste swarm `{task_id}` started for `{focus_node}` "
             f"(strategy={strategy}, goal={goal}, mode={swarm_config.swarm_mode()}). "
             f"Poll with get_swarm_status('{task_id}')."
+            + _launch_receipt(task_id, "paste")
         )
 
 

--- a/tests/test_swarm_tools.py
+++ b/tests/test_swarm_tools.py
@@ -322,6 +322,63 @@ print("SWARM_BENCH " + json.dumps({"latency_ms": 5.0, "peak_mem_bytes": 2048}))
         assert "secret-like" in secret
 
     @pytest.mark.asyncio
+    async def test_launch_emits_structured_task_id_receipt(self, wired, monkeypatch):
+        """Both launch tools ride a wording-independent machine receipt next to
+        the human prose so the workbench can drive a run off a stable id instead
+        of regex-scraping the sentence. The prose (and its backtick id) is left
+        intact, and the receipt's task_id equals the id actually created."""
+        import json as jsonlib
+        import re
+
+        store, _ws = wired
+        monkeypatch.setenv("UNIGROK_SWARM", "dry_run")
+        monkeypatch.setenv("UNIGROK_SWARM_MAX_GENERATIONS", "2")
+        monkeypatch.setenv("UNIGROK_SWARM_POPULATION", "4")
+        monkeypatch.setenv("UNIGROK_SWARM_BENCH_REPEATS", "3")
+
+        def parse_receipt(text):
+            match = re.search(
+                r"<!--unigrok-swarm-launch-v1 (\{.*?\})-->", text
+            )
+            assert match, f"no structured launch receipt in: {text!r}"
+            return jsonlib.loads(match.group(1))
+
+        code_out = await swarm_tools.start_code_swarm(
+            "pkg/dedup.py", "function:dedup", "pkg/test_dedup.py",
+            "python pkg/bench_dedup.py", allow_unstable_bench=True,
+        )
+        code_receipt = parse_receipt(code_out)
+        assert code_receipt["format"] == "unigrok-swarm-launch-v1"
+        assert code_receipt["input_kind"] == "workspace"
+        # The receipt id matches both the legacy backtick prose id and a real row.
+        assert code_receipt["task_id"] == code_out.split("`")[1]
+        assert await store.get_swarm_task(code_receipt["task_id"]) is not None
+        await swarm_tools._get_runner().wait(code_receipt["task_id"], timeout=60.0)
+
+        source = (GOLDEN / "dedup.py").read_text()
+        test_code = (
+            "from module_under_test import dedup\n\n"
+            "def test_dedup():\n    assert dedup([1, 2, 1]) == [1, 2]\n"
+        )
+        bench_code = (
+            "import json\n"
+            "from module_under_test import dedup\n"
+            "dedup([1, 2, 1])\n"
+            'print("SWARM_BENCH " + json.dumps({"latency_ms": 5.0, "peak_mem_bytes": 2048}))\n'
+        )
+        paste_out = await swarm_tools.start_paste_swarm(
+            source, test_code, bench_code, "function:dedup",
+            search_strategy="elite_offspring", allow_unstable_bench=True,
+        )
+        paste_receipt = parse_receipt(paste_out)
+        assert paste_receipt["format"] == "unigrok-swarm-launch-v1"
+        assert paste_receipt["input_kind"] == "paste"
+        assert paste_receipt["task_id"] == paste_out.split("`")[1]
+        paste_task = await store.get_swarm_task(paste_receipt["task_id"])
+        assert paste_task is not None and paste_task["input_kind"] == "paste"
+        await swarm_tools._get_runner().wait(paste_receipt["task_id"], timeout=60.0)
+
+    @pytest.mark.asyncio
     async def test_dry_run_finds_front_and_refuses_apply(self, wired, monkeypatch):
         store, _ws = wired
         monkeypatch.setenv("UNIGROK_SWARM", "dry_run")


### PR DESCRIPTION
## What

Enabling change for the swarm UI rebuild (companion: #TBD). `start_paste_swarm` and `start_code_swarm` append a wording-independent launch receipt to their existing human-readable return, so the UI can drive runs off a stable id instead of regex-scraping prose:

```
<!--unigrok-swarm-launch-v1 {"format":"unigrok-swarm-launch-v1","task_id":"<hex>","input_kind":"workspace|paste"}-->
```

- **Additive / non-breaking:** the prose (including the backtick id and every honesty literal) is unchanged — the receipt is a suffix. Existing consumers that read the backtick id keep working.
- **Matches repo convention:** reuses the existing `"format":"unigrok-…-vN"` machine-payload tag (alongside `unigrok-swarm-status-v2`, `-campaign-plan-v1`, `-analytics-v1`) — not a new protocol. Deliberately kept the `-> str` return (the prose carries the honesty framing and is what the UI reads); a dict return would bury the prose.
- **HTML-comment form** stays invisible if the message is ever markdown-rendered, while parsing deterministically as `/<!--unigrok-swarm-launch-v1 (\{.*?\})-->/` → `JSON.parse`.

## Changed paths
- `src/tools/swarm.py`, `tests/test_swarm_tools.py`

## Tests
- Full suite **2203 passed**; new `test_launch_emits_structured_task_id_receipt` asserts (both tools) the receipt parses, carries `format` + correct `input_kind`, and its `task_id` equals both the legacy backtick id and a real created store row. Attribution check: passed.

## Handoff
- Draft — awaiting Codex landing. Sponsor: David Johnston (@djtelicloud). Small additive server change.

Agent-Assisted-By: Anthropic Claude | model=Fable 5 | model-source=user-reported | surface=Claude Code | role=implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive suffix on tool return strings only; launch behavior and existing backtick-id consumers are unchanged.
> 
> **Overview**
> **`start_code_swarm`** and **`start_paste_swarm`** still return the same human-readable prose (including the backtick **`task_id`**), but each response now ends with a hidden HTML comment carrying a stable **`unigrok-swarm-launch-v1`** JSON payload: **`task_id`** and **`input_kind`** (`workspace` or `paste`).
> 
> The workbench can read that receipt instead of regex-parsing launch wording. **`SWARM_LAUNCH_FORMAT`** and **`_launch_receipt`** centralize the format, aligned with other swarm machine payloads like **`unigrok-swarm-status-v2`**.
> 
> Tests add **`test_launch_emits_structured_task_id_receipt`**, which checks both launch paths parse the comment, match the prose id, and resolve to a real store row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 611677d17928fa622b24de7797dab895b4ec6b05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->