### PR TITLE
feat(mcp_ui): rebuild swarm on fluid container-query grid

### DIFF
--- a/mcp_ui/app.js
+++ b/mcp_ui/app.js
@@ -1,9 +1,9 @@
-import { parseMarkdown, sanitizeHref } from "./markdown.js?v=grok-v0.6.0-r12";
+import { parseMarkdown, sanitizeHref } from "./markdown.js?v=grok-v0.6.0-r13";
 
 // Must match the <meta name="unigrok-ui-version"> baked into index.html and
 // src/version.py UI_ASSET_VERSION; a mismatch means the browser paired a
 // cached page with a different script build (the stale-skew failure class).
-const UI_ASSET_VERSION = "grok-v0.6.0-r12";
+const UI_ASSET_VERSION = "grok-v0.6.0-r13";
 
 const LAYOUT_KEY = "unigrok.mcp.console.layout.v2";
 

--- a/mcp_ui/index.html
+++ b/mcp_ui/index.html
@@ -7,9 +7,9 @@
     <meta name="unigrok-ui-regions" content="navigation,workbench,rpc-inspector,rpc-logs,result-facts" />
     <!-- Version handshake: app.js compares this against its own build constant
          and self-heals a stale-cached page with one revalidating reload. -->
-    <meta name="unigrok-ui-version" content="grok-v0.6.0-r12" />
-  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r12" />
-  <link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r12" />
+    <meta name="unigrok-ui-version" content="grok-v0.6.0-r13" />
+  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r13" />
+  <link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r13" />
   </head>
   <body>
     <main class="app-shell">
@@ -523,6 +523,6 @@ docker compose up --build -d</code></pre>
 
       </section>
     </main>
-  <script type="module" src="./app.js?v=grok-v0.6.0-r12"></script>
+  <script type="module" src="./app.js?v=grok-v0.6.0-r13"></script>
   </body>
 </html>

--- a/mcp_ui/styles.css
+++ b/mcp_ui/styles.css
@@ -2452,3 +2452,425 @@ pre {
   color: var(--ink);
 }
 .console-grid[data-nav="rail"] .nav-link { justify-content: center; padding-inline: 5px; }
+
+/* ========================================================================
+   Swarm Optimizer — Pareto Playground
+   Rebuilt on the same fluid container-query system as the Control Center
+   (index.html). It reuses the shared identity tokens (tokens.css) and the
+   shared .panel-splitter directly — no page-local re-aliasing of --accent /
+   --green / --muted onto the tokens, and no viewport @media reflow. Panes
+   reflow on their OWN container width; the detail pane is a resizable, keyboard
+   -accessible splitter column; the code editor is a resize:horizontal pane
+   clamped by cqw. minmax(0,...) + min-width/height:0 keep everything on-canvas.
+   ======================================================================== */
+
+.swarm-app {
+  height: 100%;
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  container: swarm-app / size;
+  overflow: hidden;
+}
+
+.swarm-topbar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: clamp(12px, 2vw, 24px);
+  padding: clamp(14px, 2vw, 24px) clamp(12px, 2vw, 20px) 16px;
+  border-bottom: 1px solid var(--border);
+  background: radial-gradient(circle at 16% -40%, rgba(79, 231, 255, 0.12), transparent 42%);
+}
+
+.swarm-topbar h1 {
+  font-size: clamp(21px, 3vw, 30px);
+  line-height: 1.15;
+  margin: 4px 0 5px;
+  letter-spacing: -0.03em;
+}
+
+.swarm-topbar .product-law { max-width: 44rem; }
+
+.swarm-nav {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.swarm-nav a {
+  color: var(--ink);
+  text-decoration: none;
+  font-size: 12px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  border-radius: 999px;
+  padding: 7px 12px;
+  white-space: nowrap;
+}
+
+.swarm-nav a:hover { border-color: var(--border-strong); }
+
+/* Runtime banner — same-origin session, no manual bearer field, no live
+   cross-port link (single-origin). Forge is referenced only as a locked note. */
+.runtime-banner {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  margin: clamp(10px, 1.6vw, 14px) clamp(12px, 2vw, 20px) 0;
+  padding: 11px 14px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 9px;
+}
+
+.runtime-banner .dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--ink-soft);
+  flex: 0 0 auto;
+}
+
+.runtime-banner.ready .dot { background: var(--teal); box-shadow: var(--glow-teal); }
+.runtime-banner strong { display: block; font-size: 12px; }
+.runtime-banner span { color: var(--ink-soft); font-size: 11px; }
+.runtime-banner .forge-note {
+  margin-left: auto;
+  color: var(--ink-faint);
+  font-size: 11px;
+  max-width: 22rem;
+  text-align: right;
+}
+.runtime-banner .forge-note[hidden] { display: none; }
+
+/* The resizable shell: main workspace | splitter | detail receipt. */
+.swarm-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) var(--swarm-splitter, 6px) var(--swarm-detail, 360px);
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  container: swarm-shell / inline-size;
+}
+
+.swarm-main {
+  min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
+  padding: clamp(12px, 1.6vw, 16px) clamp(12px, 2vw, 20px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(12px, 1.4vw, 14px);
+  container: swarm-main / inline-size;
+}
+
+.swarm-detail {
+  min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
+  align-self: stretch;
+  margin: clamp(12px, 1.6vw, 16px) clamp(12px, 2vw, 20px) clamp(12px, 1.6vw, 16px) 0;
+}
+
+.swarm-detail h2 { font-size: 15px; margin: 0 0 10px; }
+
+.swarm-panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px;
+  box-shadow: var(--shadow);
+}
+
+.swarm-app .section-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+.swarm-app .section-head h2 { font-size: 17px; margin: 2px 0 0; }
+
+.source-badge {
+  color: var(--ink-soft);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 3px 8px;
+  font-size: 10px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.source-badge.live { color: var(--teal); border-color: var(--border-strong); }
+
+/* Form controls scoped to the swarm surface (Control Center uses *-btn-glow). */
+.swarm-app button,
+.swarm-app input,
+.swarm-app select,
+.swarm-app textarea { font: inherit; }
+
+.swarm-app input[type="text"] {
+  background: var(--surface-soft);
+  color: var(--ink);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 8px;
+  min-width: min(230px, 100%);
+}
+.swarm-app select {
+  background: var(--surface-soft);
+  color: var(--ink);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 8px;
+  max-width: 100%;
+}
+.swarm-app button {
+  background: var(--surface-soft);
+  color: var(--ink);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 12px;
+  cursor: pointer;
+}
+.swarm-app button:hover { border-color: var(--border-strong); }
+.swarm-app button.primary {
+  background: var(--cyan);
+  border-color: var(--cyan);
+  color: #08101f;
+  font-weight: 700;
+}
+.swarm-app button:disabled { opacity: 0.45; cursor: not-allowed; }
+
+/* Paste grid: left code editor is a resize:horizontal pane clamped by cqw
+   (schema-list pattern); the analysis panel takes the remaining track. */
+.paste-grid {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 12px;
+}
+.paste-editor {
+  min-width: 0;
+  width: clamp(300px, 52cqw, 640px);
+  min-width: 260px;
+  max-width: min(680px, 70cqw);
+  resize: horizontal;
+  overflow: auto;
+}
+.oracle-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.oracle-grid > div { min-width: 0; }
+
+.code-input {
+  width: 100%;
+  min-height: clamp(180px, 34cqi, 300px);
+  resize: vertical;
+  background: var(--page-deep);
+  color: #dce6f3;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px;
+  font: 12px/1.55 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  tab-size: 4;
+}
+.code-input:focus { outline: 2px solid var(--border-strong); border-color: var(--cyan); }
+.oracle-input { min-height: clamp(110px, 20cqi, 200px); }
+
+.paste-actions { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-top: 8px; }
+.privacy-note { color: var(--ink-soft); font-size: 11px; margin-top: 7px; }
+
+.analysis-results {
+  min-width: 0;
+  min-height: clamp(180px, 32cqi, 300px);
+  background: var(--surface-soft);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 11px;
+}
+.analysis-results h3 { font-size: 13px; margin: 0 0 8px; }
+
+.function-list { display: grid; gap: 6px; margin-top: 10px; }
+.function-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) repeat(3, auto);
+  gap: 8px;
+  align-items: center;
+  padding: 7px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 11px;
+}
+.function-row code { overflow-wrap: anywhere; }
+.fn-chip { color: var(--ink-soft); white-space: nowrap; }
+
+.advanced { margin-top: 10px; border-top: 1px solid var(--border); padding-top: 9px; }
+.advanced summary { color: var(--ink-soft); cursor: pointer; font-size: 11px; user-select: none; }
+.advanced .controls { margin-top: 9px; }
+.advanced .paste-actions label { display: inline-flex; align-items: center; gap: 6px; }
+
+.controls { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+
+.swarm-app .scorecard {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: 8px;
+  margin-top: 12px;
+}
+.swarm-app .stat {
+  background: var(--surface-soft);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 10px;
+}
+.swarm-app .stat .k { color: var(--ink-soft); font-size: 11px; text-transform: uppercase; letter-spacing: 0.04em; }
+.swarm-app .stat .v { font-size: 16px; font-weight: 600; margin-top: 2px; overflow-wrap: anywhere; }
+
+.journeys {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(230px, 100%), 1fr));
+  gap: 9px;
+}
+.journey {
+  display: flex;
+  flex-direction: column;
+  min-height: 144px;
+  background: var(--surface-soft);
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  padding: 11px;
+}
+.journey.primary {
+  border-color: var(--border-strong);
+  background: linear-gradient(145deg, var(--cyan-soft), var(--surface-soft) 65%);
+}
+.journey .step { color: var(--ink-soft); font-size: 10px; letter-spacing: 0.12em; }
+.journey h3 { font-size: 13px; margin: 5px 0 3px; }
+.journey p { color: var(--ink-soft); font-size: 11px; margin: 0 0 10px; flex: 1; }
+.journey .controls { gap: 6px; }
+.journey select { min-width: 0; width: 100%; }
+
+#loadMsg { display: block; min-height: 20px; margin-top: 9px; font-size: 11px; }
+.swarm-app .muted { color: var(--ink-soft); }
+.swarm-app .err { color: var(--red); }
+
+.insight {
+  margin: 10px 0 2px;
+  padding: 9px 11px;
+  background: var(--cyan-soft);
+  border-left: 3px solid var(--cyan);
+  border-radius: 6px;
+  font-size: 12px;
+}
+
+.legend {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+  margin: 10px 0 4px;
+  color: var(--ink-soft);
+  font-size: 12px;
+}
+.legend span::before { content: "●"; margin-right: 5px; }
+.lg-red::before { color: var(--red); }
+.lg-orange::before { color: var(--orange); }
+.lg-gray::before { color: var(--ink-faint); }
+.lg-green::before { color: var(--teal); }
+
+.swarm-chart {
+  display: block;
+  width: 100%;
+  height: auto;
+  background: var(--surface-soft);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.timeline { display: flex; gap: 10px; align-items: center; margin-top: 10px; }
+.timeline input[type="range"] { flex: 1; min-width: 0; }
+.gutter-note { font-size: 11px; margin-top: 6px; }
+
+circle.dot { cursor: pointer; outline: none; }
+circle.dot:focus { stroke: #fff; stroke-width: 2px; }
+circle.elite { filter: drop-shadow(0 0 4px var(--teal)); }
+text.gutter-more { cursor: default; }
+
+.outcome-pill {
+  display: inline-block;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 2px 7px;
+  font-size: 10px;
+  margin-bottom: 9px;
+}
+.receipt-grid { display: grid; grid-template-columns: 96px minmax(0, 1fr); gap: 5px 8px; }
+.receipt-value { overflow-wrap: anywhere; }
+.receipt-json { margin-top: 10px; }
+.receipt-json summary { color: var(--ink-soft); cursor: pointer; font-size: 11px; }
+.code-label { color: var(--ink-soft); font-size: 10px; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: -3px; }
+.diff-grid { display: grid; grid-template-columns: 1fr; gap: 8px; }
+
+.swarm-detail pre {
+  background: var(--surface-soft);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px;
+  overflow: auto;
+  max-height: min(40cqb, 320px);
+  font-size: 12px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.honesty {
+  color: var(--ink-soft);
+  font-size: 11px;
+  padding: 10px clamp(12px, 2vw, 20px) 18px;
+  max-width: 1280px;
+}
+.honesty code { color: var(--ink); }
+
+/* Reflow is driven by each pane's OWN container width, never the viewport.
+   Below the shell breakpoint the detail pane drops under the main column and
+   the whole shell scrolls as one; the splitter has nothing to resize. */
+/* Collapse is driven by the ancestor swarm-app container: an element cannot
+   size-query the container it declares itself, so swarm-shell must be
+   restyled from a parent context. */
+@container swarm-app (max-width: 900px) {
+  /* Stack as a flex column, not grid: a bounded-height grid distributes its
+     height across the two rows and each pane's taller content overflows onto
+     the next. A flex column sizes each pane to its own content and scrolls the
+     shell as one. */
+  .swarm-shell {
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+  }
+  .swarm-shell .panel-splitter { display: none; }
+  .swarm-main,
+  .swarm-detail {
+    height: auto;
+    min-height: 0;
+    flex: 0 0 auto;
+    overflow: visible;
+  }
+  .swarm-detail {
+    margin: 0 clamp(12px, 2vw, 20px) clamp(12px, 1.6vw, 16px);
+  }
+}
+
+@container swarm-main (max-width: 640px) {
+  .paste-grid,
+  .oracle-grid,
+  .journeys { grid-template-columns: minmax(0, 1fr); }
+  /* Stacked: the draggable editor width no longer applies. !important because
+     a native resize drag persists as an inline width that would otherwise win
+     with no handle left to undo it. */
+  .paste-editor {
+    width: auto !important;
+    min-width: 0;
+    max-width: none !important;
+    resize: none;
+  }
+}
+

--- a/mcp_ui/swarm.html
+++ b/mcp_ui/swarm.html
@@ -4,272 +4,158 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>UniGrok Swarm Optimizer — Pareto Playground</title>
-  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r12" />
-  <style>
-    /* Page vocabulary aliases onto the shared UniGrok tokens (tokens.css) so
-       the Swarm Optimizer and the Control Center read as one product. */
-    :root {
-      --bg: var(--page); --panel: var(--surface); --panel2: var(--surface-soft);
-      --text: var(--ink); --muted: var(--ink-soft);
-      --gray: var(--ink-faint); --green: var(--teal);
-      --accent: var(--cyan); --accent-soft: var(--cyan-soft);
-    }
-    * { box-sizing: border-box; }
-    body { margin: 0; background: var(--page-deep); color: var(--text);
-           font-size: 14px; line-height: 1.5; }
-    header { display: flex; align-items: center; justify-content: space-between; gap: 24px;
-             padding: 24px 20px 18px; border-bottom: 1px solid var(--border);
-             background: radial-gradient(circle at 16% -40%, rgba(79, 140, 255, .24), transparent 42%); }
-    header h1 { font-size: clamp(21px, 3vw, 30px); line-height: 1.15; margin: 3px 0 5px; letter-spacing: -.03em; }
-    header p { color: var(--muted); margin: 0; max-width: 700px; }
-    header a { color: var(--text); text-decoration: none; font-size: 12px; border: 1px solid var(--border);
-               background: var(--panel); border-radius: 999px; padding: 7px 12px; white-space: nowrap; }
-    header a:hover { border-color: var(--accent); }
-    .eyebrow { color: var(--cyan); font-size: 10px; font-weight: 700; letter-spacing: .16em; text-transform: uppercase; }
-    .runtime-banner { display: flex; align-items: center; gap: 11px; margin: 14px 20px 0; padding: 11px 14px;
-                      max-width: 1760px; background: var(--panel); border: 1px solid var(--border); border-radius: 9px; }
-    .runtime-banner .dot { width: 9px; height: 9px; border-radius: 50%; background: var(--muted); flex: 0 0 auto; }
-    .runtime-banner.ready .dot { background: var(--green); box-shadow: 0 0 10px var(--green); }
-    .runtime-banner strong { display: block; font-size: 12px; }
-    .runtime-banner span { color: var(--muted); font-size: 11px; }
-    .runtime-banner a { color: var(--accent); font-size: 11px; margin-left: auto; text-decoration: none; white-space: nowrap; }
-    .wrap { display: grid; grid-template-columns: minmax(0, 1fr) minmax(min(280px, 100%), 380px);
-            gap: 14px; padding: 14px 20px; max-width: 1800px; }
-    .panel { background: var(--panel); border: 1px solid var(--border);
-             border-radius: 10px; padding: 14px; box-shadow: var(--shadow); }
-    .section-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
-    .section-head h2 { font-size: 17px; margin: 2px 0 0; }
-    .source-badge { color: var(--muted); border: 1px solid var(--border); border-radius: 999px;
-                    padding: 3px 8px; font-size: 10px; letter-spacing: .06em; text-transform: uppercase; }
-    .source-badge.live { color: var(--green); border-color: rgba(48, 164, 108, .45); }
-    .journeys { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(230px, 100%), 1fr)); gap: 9px; }
-    .journey { display: flex; flex-direction: column; min-height: 144px; background: var(--panel2);
-               border: 1px solid var(--border); border-radius: 9px; padding: 11px; }
-    .journey.primary { border-color: rgba(79, 140, 255, .52); background: linear-gradient(145deg, var(--accent-soft), var(--panel2) 65%); }
-    .journey .step { color: var(--muted); font-size: 10px; letter-spacing: .12em; }
-    .journey h3 { font-size: 13px; margin: 5px 0 3px; }
-    .journey p { color: var(--muted); font-size: 11px; margin: 0 0 10px; flex: 1; }
-    .journey .controls { gap: 6px; }
-    .journey select { min-width: 0; width: 100%; }
-    .controls { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
-    button, input, select { font: inherit; }
-    input[type=text], input[type=password] { background: var(--panel2); color: var(--text);
-      border: 1px solid var(--border); border-radius: 6px; padding: 6px 8px; min-width: min(230px, 100%); }
-    select { background: var(--panel2); color: var(--text); border: 1px solid var(--border);
-             border-radius: 6px; padding: 6px 8px; max-width: 100%; }
-    button { background: var(--panel2); color: var(--text); border: 1px solid var(--border);
-             border-radius: 6px; padding: 6px 12px; cursor: pointer; }
-    button:hover { border-color: var(--accent); }
-    button.primary { background: var(--accent); border-color: var(--accent); color: #08101f; font-weight: 700; }
-    button:disabled { opacity: .45; cursor: not-allowed; }
-    .paste-grid { display: grid; grid-template-columns: minmax(0, 1.45fr) minmax(min(280px, 100%), .75fr);
-                  gap: 12px; }
-    textarea.code-input { width: 100%; min-height: clamp(180px, 34vh, 300px); resize: vertical; background: #0b0d10;
-      color: #dce6f3; border: 1px solid var(--border); border-radius: 8px; padding: 12px;
-      font: 12px/1.55 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-      tab-size: 4; }
-    textarea.code-input:focus { outline: 2px solid rgba(110, 157, 255, .45); border-color: var(--accent); }
-    textarea.oracle-input { min-height: clamp(110px, 18vh, 200px); }
-    .paste-actions { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-top: 8px; }
-    .privacy-note { color: var(--muted); font-size: 11px; margin-top: 7px; }
-    .analysis-results { min-height: clamp(180px, 32vh, 300px); background: var(--panel2); border: 1px solid var(--border);
-                        border-radius: 8px; padding: 11px; }
-    .analysis-results h3 { font-size: 13px; margin: 0 0 8px; }
-    .function-list { display: grid; gap: 6px; margin-top: 10px; }
-    .function-row { display: grid; grid-template-columns: minmax(0, 1fr) repeat(3, auto); gap: 8px;
-                    align-items: center; padding: 7px 8px; border: 1px solid var(--border);
-                    border-radius: 6px; font-size: 11px; }
-    .function-row code { overflow-wrap: anywhere; }
-    .metric-chip { color: var(--muted); white-space: nowrap; }
-    .scorecard { display: grid; grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
-                 gap: 8px; margin-top: 12px; }
-    .advanced { margin-top: 10px; border-top: 1px solid var(--border); padding-top: 9px; }
-    .advanced summary { color: var(--muted); cursor: pointer; font-size: 11px; user-select: none; }
-    .advanced .controls { margin-top: 9px; }
-    #loadMsg { display: block; min-height: 20px; margin-top: 9px; font-size: 11px; }
-    .insight { margin: 10px 0 2px; padding: 9px 11px; background: var(--accent-soft);
-               border-left: 3px solid var(--accent); border-radius: 6px; font-size: 12px; }
-    .stat { background: var(--panel2); border: 1px solid var(--border); border-radius: 8px;
-            padding: 8px 10px; }
-    .stat .k { color: var(--muted); font-size: 11px; text-transform: uppercase;
-               letter-spacing: .04em; }
-    .stat .v { font-size: 16px; font-weight: 600; margin-top: 2px; }
-    .legend { display: flex; gap: 14px; flex-wrap: wrap; margin: 10px 0 4px;
-              color: var(--muted); font-size: 12px; }
-    .legend span::before { content: "●"; margin-right: 5px; }
-    .lg-red::before { color: var(--red); } .lg-orange::before { color: var(--orange); }
-    .lg-gray::before { color: var(--gray); } .lg-green::before { color: var(--green); }
-    #chart { width: 100%; background: var(--panel2); border: 1px solid var(--border);
-             border-radius: 8px; }
-    .timeline { display: flex; gap: 10px; align-items: center; margin-top: 10px; }
-    .timeline input[type=range] { flex: 1; }
-    #detail pre { background: var(--panel2); border: 1px solid var(--border);
-                  border-radius: 6px; padding: 8px; overflow: auto; max-height: min(32vh, 320px);
-                  font-size: 12px; white-space: pre-wrap; }
-    .diff-grid { display: grid; grid-template-columns: 1fr; gap: 8px; }
-    .muted { color: var(--muted); }
-    .honesty { color: var(--muted); font-size: 11px; padding: 10px 20px 20px; max-width: 1280px; }
-    .err { color: var(--red); }
-    circle.dot { cursor: pointer; outline: none; }
-    circle.dot:focus { stroke: #fff; stroke-width: 2px; }
-    circle.elite { filter: drop-shadow(0 0 4px var(--green)); }
-    #detail { min-width: 0; align-self: start; }
-    #detail h2 { font-size: 15px; margin: 0 0 10px; }
-    .outcome-pill { display: inline-block; border: 1px solid var(--border); border-radius: 999px;
-                    padding: 2px 7px; font-size: 10px; margin-bottom: 9px; }
-    .receipt-grid { display: grid; grid-template-columns: 96px minmax(0, 1fr); gap: 5px 8px; }
-    .receipt-value { overflow-wrap: anywhere; }
-    .receipt-json { margin-top: 10px; }
-    .receipt-json summary { color: var(--muted); cursor: pointer; font-size: 11px; }
-    .code-label { color: var(--muted); font-size: 10px; letter-spacing: .08em; text-transform: uppercase; margin-bottom: -3px; }
-    @media (max-width: 900px) {
-      .wrap { grid-template-columns: 1fr; }
-      .journeys { grid-template-columns: 1fr; }
-      .journey { min-height: 0; }
-      .runtime-banner { align-items: flex-start; }
-      .paste-grid { grid-template-columns: 1fr; }
-    }
-  </style>
+  <!-- Version handshake token shared with src/version.py UI_ASSET_VERSION and
+       every ?v= pin; a pytest asserts the copies agree so HTML/JS can never
+       skew. The swarm page now reuses the Control Center's shared fluid system
+       (tokens.css identity + styles.css container-query grid) rather than a
+       bespoke inline stylesheet that re-aliased the tokens. -->
+  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r13" />
+  <link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r13" />
 </head>
 <body>
-  <header>
-    <div>
-      <div class="eyebrow">Contributor lab · verified optimization</div>
-      <h1>Swarm Optimizer</h1>
-      <p>Watch candidate rewrites hit static, test, and performance gates—then inspect the verified Pareto trade-offs.</p>
+  <main class="swarm-app" data-detail="dock">
+    <header class="swarm-topbar">
+      <div class="brand-block">
+        <div class="eyebrow">Contributor lab · verified optimization</div>
+        <h1>Swarm Optimizer</h1>
+        <p class="product-law">Watch candidate rewrites hit static, test, and performance gates—then inspect the verified Pareto trade-offs.</p>
+      </div>
+      <nav class="swarm-nav" aria-label="Product navigation">
+        <a href="./index.html">← Control Center</a>
+        <a href="https://grokmcp.org" target="_blank" rel="noopener noreferrer">grokmcp.org ↗</a>
+      </nav>
+    </header>
+
+    <div id="runtimeBanner" class="runtime-banner" role="status" aria-live="polite">
+      <span class="dot" aria-hidden="true"></span>
+      <div><strong id="runtimeTitle">Checking this gateway…</strong><span id="runtimeCopy">Finding live Swarm capabilities.</span></div>
+      <span id="forgeNote" class="forge-note" hidden>Live Swarm tools stay isolated in contributor Forge (single-origin: no cross-port link from here).</span>
     </div>
-    <nav style="display:flex; gap:8px; flex-wrap:wrap; justify-content:flex-end" aria-label="Product navigation">
-      <a href="./index.html">← Control Center</a>
-      <a href="https://grokmcp.org" target="_blank" rel="noopener noreferrer">grokmcp.org ↗</a>
-    </nav>
-  </header>
 
-  <div id="runtimeBanner" class="runtime-banner" role="status" aria-live="polite">
-    <span class="dot" aria-hidden="true"></span>
-    <div><strong id="runtimeTitle">Checking this gateway…</strong><span id="runtimeCopy">Finding live Swarm capabilities.</span></div>
-    <a id="forgeLink" href="http://127.0.0.1:4766/ui/swarm.html" hidden>Open contributor Forge →</a>
-  </div>
-
-  <div class="wrap">
-    <div>
-      <div class="panel">
-        <div class="section-head">
-          <div><div class="eyebrow">Your code · zero-cost analysis</div><h2>Paste Python and see where optimization is worth it</h2></div>
-          <span id="analysisBadge" class="source-badge">not analyzed</span>
-        </div>
-        <div class="paste-grid">
-          <div>
-            <textarea id="codeInput" class="code-input" spellcheck="false" maxlength="262144"
-              aria-label="Python code to analyze" placeholder="Paste a Python function or file here…"></textarea>
+    <section class="swarm-shell" aria-label="Swarm workspace">
+      <div class="swarm-main">
+        <div class="swarm-panel">
+          <div class="section-head">
+            <div><div class="eyebrow">Your code · zero-cost analysis</div><h2>Paste Python and see where optimization is worth it</h2></div>
+            <span id="analysisBadge" class="source-badge">not analyzed</span>
+          </div>
+          <div class="paste-grid">
+            <div class="paste-editor">
+              <textarea id="codeInput" class="code-input" spellcheck="false" maxlength="262144"
+                aria-label="Python code to analyze" placeholder="Paste a Python function or file here…"></textarea>
+              <div class="paste-actions">
+                <button id="analyzeBtn" class="primary" type="button">Analyze code</button>
+                <button id="pasteExampleBtn" type="button">Use slow example</button>
+                <span id="analysisMsg" class="muted" role="status" aria-live="polite"></span>
+              </div>
+              <div id="privacyNote" class="privacy-note">Analysis starts in this browser. Verified execution is local-only and requires tests plus a benchmark.</div>
+            </div>
+            <div id="analysisResults" class="analysis-results">
+              <h3>What you will get</h3>
+              <div class="muted">Function inventory, complexity, nesting, size, import hygiene, duplication signals, and explicit blockers before any model call.</div>
+            </div>
+          </div>
+          <details id="searchSetup" class="advanced">
+            <summary>Run verified local search: add tests and benchmark</summary>
             <div class="paste-actions">
-              <button id="analyzeBtn" class="primary" type="button">Analyze code</button>
-              <button id="pasteExampleBtn" type="button">Use slow example</button>
-              <span id="analysisMsg" class="muted" role="status" aria-live="polite"></span>
+              <label>Function <select id="focusPicker"><option value="">analyze code first</option></select></label>
+              <label>Goal <select id="goalPicker"><option value="balanced">balanced</option><option value="latency">latency</option><option value="memory">memory</option><option value="size">size</option></select></label>
+              <label>Strategy <select id="strategyPicker"><option value="elite_offspring">evolve from elites</option><option value="baseline_batch">baseline batch</option></select></label>
             </div>
-            <div id="privacyNote" class="privacy-note">Analysis starts in this browser. Verified execution is local-only and requires tests plus a benchmark.</div>
-          </div>
-          <div id="analysisResults" class="analysis-results">
-            <h3>What you will get</h3>
-            <div class="muted">Function inventory, complexity, nesting, size, import hygiene, duplication signals, and explicit blockers before any model call.</div>
-          </div>
+            <div class="paste-grid oracle-grid">
+              <div><div class="code-label">pytest code · required</div><textarea id="testInput" class="code-input oracle-input" spellcheck="false" maxlength="131072" placeholder="from module_under_test import your_function&#10;&#10;def test_behavior(): ..."></textarea></div>
+              <div><div class="code-label">benchmark script · required</div><textarea id="benchInput" class="code-input oracle-input" spellcheck="false" maxlength="65536" placeholder="Print one SWARM_BENCH JSON line with latency_ms and peak_mem_bytes"></textarea></div>
+            </div>
+            <div class="paste-actions">
+              <button id="runPasteBtn" class="primary" type="button" disabled>Run verified swarm</button>
+              <span id="pasteRunMsg" class="muted" role="status" aria-live="polite">Available in contributor Forge after exact analysis.</span>
+            </div>
+          </details>
         </div>
-        <details id="searchSetup" class="advanced">
-          <summary>Run verified local search: add tests and benchmark</summary>
-          <div class="paste-actions">
-            <label>Function <select id="focusPicker"><option value="">analyze code first</option></select></label>
-            <label>Goal <select id="goalPicker"><option value="balanced">balanced</option><option value="latency">latency</option><option value="memory">memory</option><option value="size">size</option></select></label>
-            <label>Strategy <select id="strategyPicker"><option value="elite_offspring">evolve from elites</option><option value="baseline_batch">baseline batch</option></select></label>
-          </div>
-          <div class="paste-grid" style="margin-top:10px">
-            <div><div class="code-label">pytest code · required</div><textarea id="testInput" class="code-input oracle-input" spellcheck="false" maxlength="131072" placeholder="from module_under_test import your_function\n\ndef test_behavior(): ..."></textarea></div>
-            <div><div class="code-label">benchmark script · required</div><textarea id="benchInput" class="code-input oracle-input" spellcheck="false" maxlength="65536" placeholder="Print one SWARM_BENCH JSON line with latency_ms and peak_mem_bytes"></textarea></div>
-          </div>
-          <div class="paste-actions">
-            <button id="runPasteBtn" class="primary" type="button" disabled>Run verified swarm</button>
-            <span id="pasteRunMsg" class="muted" role="status" aria-live="polite">Available in contributor Forge after exact analysis.</span>
-          </div>
-        </details>
-      </div>
 
-      <div class="panel" style="margin-top:14px">
-        <div class="section-head">
-          <div><div class="eyebrow">Start here</div><h2>Choose how you want to explore</h2></div>
-          <span id="sourceBadge" class="source-badge">loading</span>
-        </div>
-        <div class="journeys">
-          <article class="journey primary">
-            <span class="step">01 · instant tour</span>
-            <h3>Explore a verified run</h3>
-            <p>Already loaded: two real Pareto elites, one test-wall candidate, and the honest speed-versus-memory trade-off.</p>
-            <button id="sampleBtn" class="primary" type="button" title="Recorded run of the golden dedup target — scripted candidates, real measurements">Replay recorded run</button>
-          </article>
-          <article class="journey">
-            <span class="step">02 · your history</span>
-            <h3>Open a recent swarm</h3>
-            <p>Choose a persisted live run from this contributor gateway.</p>
+        <div class="swarm-panel">
+          <div class="section-head">
+            <div><div class="eyebrow">Start here</div><h2>Choose how you want to explore</h2></div>
+            <span id="sourceBadge" class="source-badge">loading</span>
+          </div>
+          <div class="journeys">
+            <article class="journey primary">
+              <span class="step">01 · instant tour</span>
+              <h3>Explore a verified run</h3>
+              <p>Already loaded: two real Pareto elites, one test-wall candidate, and the honest speed-versus-memory trade-off.</p>
+              <button id="sampleBtn" class="primary" type="button" title="Recorded run of the golden dedup target — scripted candidates, real measurements">Replay recorded run</button>
+            </article>
+            <article class="journey">
+              <span class="step">02 · your history</span>
+              <h3>Open a recent swarm</h3>
+              <p>Choose a persisted live run from this contributor gateway.</p>
+              <div class="controls">
+                <select id="taskPicker" title="Recent swarms on this gateway"><option value="">checking gateway…</option></select>
+                <button id="refreshTasksBtn" type="button" title="Refresh recent swarms" aria-label="Refresh recent swarms">⟳</button>
+              </div>
+            </article>
+            <article class="journey">
+              <span class="step">03 · live experiment</span>
+              <h3>Run the golden demo</h3>
+              <p id="demoHint">Requires contributor mode and <code>UNIGROK_SWARM=dry_run</code>. Gate refusals stay visible.</p>
+              <button id="demoBtn" type="button" title="Runs start_code_swarm on the golden O(N²) dedup target">🐝 Run demo swarm</button>
+            </article>
+          </div>
+          <details class="advanced">
+            <summary>Advanced: task ID or JSON export</summary>
             <div class="controls">
-              <select id="taskPicker" title="Recent swarms on this gateway"><option value="">checking gateway…</option></select>
-              <button id="refreshTasksBtn" type="button" title="Refresh recent swarms" aria-label="Refresh recent swarms">⟳</button>
+              <input id="taskId" type="text" placeholder="swarm task id" />
+              <button id="loadBtn" type="button">Load task</button>
+              <label><button id="fileBtn" type="button">Load JSON export…</button><input id="fileInput" type="file" accept=".json" style="display:none" /></label>
             </div>
-          </article>
-          <article class="journey">
-            <span class="step">03 · live experiment</span>
-            <h3>Run the golden demo</h3>
-            <p id="demoHint">Requires contributor mode and <code>UNIGROK_SWARM=dry_run</code>. Gate refusals stay visible.</p>
-            <button id="demoBtn" type="button" title="Runs start_code_swarm on the golden O(N²) dedup target">🐝 Run demo swarm</button>
-          </article>
+          </details>
+          <span id="loadMsg" class="muted" role="status" aria-live="polite"></span>
+          <div id="scorecard" class="scorecard"></div>
         </div>
-        <details class="advanced">
-          <summary>Advanced: task ID, bearer token, or JSON export</summary>
-          <div class="controls">
-            <input id="taskId" type="text" placeholder="swarm task id" />
-            <input id="token" type="password" placeholder="bearer token (optional)" />
-            <button id="loadBtn">Load task</button>
-            <label><button id="fileBtn" type="button">Load JSON export…</button><input id="fileInput" type="file" accept=".json" style="display:none" /></label>
+
+        <div class="swarm-panel">
+          <div class="legend">
+            <span class="lg-red">static wall (parse/signature/compile/lint)</span>
+            <span class="lg-orange">test wall</span>
+            <span class="lg-gray">feasible, dominated</span>
+            <span class="lg-green">Pareto elite</span>
+            <span>★ baseline</span>
           </div>
-        </details>
-        <span id="loadMsg" class="muted" role="status" aria-live="polite"></span>
-        <div id="scorecard" class="scorecard"></div>
-      </div>
-
-      <div class="panel" style="margin-top:14px">
-        <div class="legend">
-          <span class="lg-red">static wall (parse/signature/compile/lint)</span>
-          <span class="lg-orange">test wall</span>
-          <span class="lg-gray">feasible, dominated</span>
-          <span class="lg-green">Pareto elite</span>
-          <span>★ baseline</span>
-        </div>
-        <div id="tradeoffSummary" class="insight">Loading the recorded golden run…</div>
-        <svg id="chart" viewBox="0 0 860 420" role="img"
-             aria-label="Latency versus peak memory scatter of swarm candidates"></svg>
-        <div class="timeline">
-          <button id="playBtn">▶ Play</button>
-          <input id="genSlider" type="range" min="1" max="1" value="1" />
-          <span id="genLabel" class="muted">generation –</span>
-        </div>
-        <div class="muted" style="font-size:11px">
-          Unmeasured candidates (killed at a wall before bench) stack in the left
-          gutter — plotting them at invented coordinates would be fiction.
+          <div id="tradeoffSummary" class="insight">Loading the recorded golden run…</div>
+          <svg id="chart" class="swarm-chart" viewBox="0 0 720 380" preserveAspectRatio="xMidYMid meet" role="img"
+               aria-label="Latency versus peak memory scatter of swarm candidates"></svg>
+          <div class="timeline">
+            <button id="playBtn" type="button">▶ Play</button>
+            <input id="genSlider" type="range" min="1" max="1" value="1" aria-label="Generation" />
+            <span id="genLabel" class="muted">generation –</span>
+          </div>
+          <div class="muted gutter-note">
+            Unmeasured candidates (killed at a wall before bench) stack in the left
+            gutter — plotting them at invented coordinates would be fiction.
+          </div>
         </div>
       </div>
+
+      <div id="detailSplitter" class="panel-splitter" data-side="detail" role="separator"
+           aria-label="Resize candidate receipt" aria-controls="detail" aria-orientation="vertical"
+           aria-valuemin="280" aria-valuemax="560" aria-valuenow="360" tabindex="0"></div>
+
+      <aside class="swarm-panel swarm-detail" id="detail">
+        <div class="muted">Loading the best verified candidate…</div>
+      </aside>
+    </section>
+
+    <div class="honesty">
+      Every value on this page is read from the swarm's SQLite rows via
+      <code>get_swarm_status(view="json")</code> (format
+      <code>unigrok-swarm-status-v2</code>, with v1 export compatibility) or a
+      static export of the same payload.
+      Nothing is simulated. Fields this stack does not measure — hardware
+      instruction counters, LLM semantic scores — are absent by design, not
+      hidden. "Verified" means: the task's own <code>test_target</code> passed.
     </div>
+  </main>
 
-    <div class="panel" id="detail">
-      <div class="muted">Loading the best verified candidate…</div>
-    </div>
-  </div>
-
-  <div class="honesty">
-    Every value on this page is read from the swarm's SQLite rows via
-    <code>get_swarm_status(view="json")</code> (format
-    <code>unigrok-swarm-status-v2</code>, with v1 export compatibility) or a
-    static export of the same payload.
-    Nothing is simulated. Fields this stack does not measure — hardware
-    instruction counters, LLM semantic scores — are absent by design, not
-    hidden. "Verified" means: the task's own <code>test_target</code> passed.
-  </div>
-
-  <script src="./swarm.js?v=grok-v0.6.0-r12"></script>
+  <script src="./swarm.js?v=grok-v0.6.0-r13"></script>
 </body>
 </html>

--- a/mcp_ui/swarm.js
+++ b/mcp_ui/swarm.js
@@ -4,21 +4,29 @@
 // rendering is the local/public symmetry). No frameworks, no CDN, no
 // simulated data: unmeasured candidates stack in a gutter instead of being
 // plotted at invented coordinates.
+//
+// Layout is the shared fluid container-query system (styles.css); this module
+// only owns behavior: the resizable detail splitter, the responsive/clamped
+// Pareto SVG, and the run flow that consumes a structured task_id (with a
+// list_swarm_tasks poll fallback — never a regex scrape of prose).
 
 "use strict";
 
 // Must match src/version.py UI_ASSET_VERSION and the query token on the
 // swarm.js reference in swarm.html. The sample uses the same token so a
 // revalidated page cannot pair new logic with a heuristically cached payload.
-const UI_ASSET_VERSION = "grok-v0.6.0-r12";
+const UI_ASSET_VERSION = "grok-v0.6.0-r13";
 
 const $ = (id) => document.getElementById(id);
 const SVG_NS = "http://www.w3.org/2000/svg";
+// Colors come straight from the shared tokens (tokens.css). The old page
+// re-aliased --green/--gray/--text/--muted onto tokens; this uses the real
+// token names directly so there is one palette, not two.
 const COLORS = {
   static_wall: "var(--red)",
   test_wall: "var(--orange)",
-  dominated: "var(--gray)",
-  pareto_elite: "var(--green)",
+  dominated: "var(--ink-faint)",
+  pareto_elite: "var(--teal)",
 };
 const STATUS_FORMATS = new Set(["unigrok-swarm-status-v1", "unigrok-swarm-status-v2"]);
 
@@ -29,9 +37,14 @@ const state = {
   shownGen: 1,
   playing: null,
   runtimeMode: "unknown",
+  lastChartWidth: 0,
 };
 
+const clampN = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
+
 // ── MCP plumbing (same JSON-RPC shape the Control Center uses) ──────────────
+// Same-origin session: the browser sends its own cookies/credentials to /mcp.
+// There is no manual bearer-token field (removed for single-origin honesty).
 
 let rpcId = 1;
 async function mcpCall(toolName, args) {
@@ -40,8 +53,6 @@ async function mcpCall(toolName, args) {
     "Accept": "application/json, text/event-stream",
     "X-Client-ID": "mcp-ui-swarm",
   };
-  const token = $("token").value.trim();
-  if (token) headers["Authorization"] = `Bearer ${token}`;
   const res = await fetch("/mcp", {
     method: "POST",
     headers,
@@ -68,7 +79,8 @@ async function mcpCall(toolName, args) {
 // ── Loading ──────────────────────────────────────────────────────────────────
 
 async function loadLive() {
-  const taskId = $("taskId").value.trim();
+  const field = $("taskId");
+  const taskId = field ? field.value.trim() : "";
   if (!taskId) { setMsg("enter a task id", true); return; }
   setMsg("loading…");
   try {
@@ -100,6 +112,7 @@ function loadFile(file) {
 
 function setMsg(text, isError) {
   const el = $("loadMsg");
+  if (!el) return;
   el.textContent = text;
   el.className = isError ? "err" : "muted";
 }
@@ -110,12 +123,17 @@ function setPayload(payload, sourceLabel, source) {
   state.source = source;
   state.maxGen = Math.max(1, ...(payload.generations || []).map((g) => g.generation));
   state.shownGen = state.maxGen;
-  $("genSlider").max = String(state.maxGen);
-  $("genSlider").value = String(state.maxGen);
+  const slider = $("genSlider");
+  if (slider) {
+    slider.max = String(state.maxGen);
+    slider.value = String(state.maxGen);
+  }
   setMsg(`loaded (${sourceLabel})`);
   const badge = $("sourceBadge");
-  badge.textContent = source === "live" ? "live gateway data" : sourceLabel;
-  badge.className = source === "live" ? "source-badge live" : "source-badge";
+  if (badge) {
+    badge.textContent = source === "live" ? "live gateway data" : sourceLabel;
+    badge.className = source === "live" ? "source-badge live" : "source-badge";
+  }
   // Each render step is independent diagnostics; one failing panel must not
   // blank the rest of the page.
   for (const step of [renderScorecard, renderTradeoffSummary, renderChart]) {
@@ -131,8 +149,9 @@ function setPayload(payload, sourceLabel, source) {
     || candidates.find((candidate) => candidate.outcome === "pareto_elite" && candidate.code)
     || candidates.find((candidate) => candidate.code)
     || candidates[0];
+  const detail = $("detail");
   if (firstUseful) renderDetail(firstUseful);
-  else $("detail").innerHTML = '<div class="muted">No candidates have landed yet.</div>';
+  else if (detail) detail.innerHTML = '<div class="muted">No candidates have landed yet.</div>';
 }
 
 function normalizePayload(payload) {
@@ -166,6 +185,8 @@ function fmtMemoryImprovement(v) {
 }
 
 function renderScorecard() {
+  const board = $("scorecard");
+  if (!board) return;
   const p = state.payload;
   const agg = p.aggregates || {};
   const oracle = p.oracle || {};
@@ -178,21 +199,24 @@ function renderScorecard() {
       : `${(agg.feasibility_rate * 100).toFixed(0)}% of ${agg.candidates_total}`],
     ["best latency", fmtLatencyImprovement(agg.best_latency_improvement_pct)],
     ["memory impact", fmtMemoryImprovement(agg.best_memory_improvement_pct)],
+    // Budget ceiling is shown before any Run: spent / ceiling.
     ["cost to optimize", `${fmtUsd(agg.cost_to_optimize_usd)} / $${(p.budget?.budget_usd ?? 0).toFixed(2)}`],
     ["focus coverage", oracle.focus_coverage_pct == null ? "n/a" : `${oracle.focus_coverage_pct}%`],
     ["bench", `${bench.stability || "n/a"} (floor ${bench.noise_floor_pct ?? "?"}%)`],
     ["generations", String(p.budget?.generations_run ?? 0)],
   ];
-  $("scorecard").innerHTML = cards
+  board.innerHTML = cards
     .map(([k, v]) => `<div class="stat"><div class="k">${esc(k)}</div><div class="v">${esc(v)}</div></div>`)
     .join("");
 }
 
 function renderTradeoffSummary() {
+  const el = $("tradeoffSummary");
+  if (!el) return;
   const agg = state.payload?.aggregates || {};
   const latency = fmtLatencyImprovement(agg.best_latency_improvement_pct);
   const memory = fmtMemoryImprovement(agg.best_memory_improvement_pct);
-  $("tradeoffSummary").textContent = latency === "n/a"
+  el.textContent = latency === "n/a"
     ? "No benchmark-qualified candidate is available yet."
     : `Pareto readout: the fastest verified candidate is ${latency} and uses ${memory} peak memory. Neither axis is hidden.`;
 }
@@ -203,21 +227,43 @@ function esc(value) {
 }
 
 // ── Chart ────────────────────────────────────────────────────────────────────
-
-const M = { l: 70, r: 20, t: 16, b: 42 };
-const W = 860, H = 420;
-const GUTTER_X = 34; // unmeasured candidates stack here, outside the axes
+// The SVG is responsive (viewBox measured from the pane's own width) AND safe:
+// every coordinate is clamped inside the plot box, and the unmeasured "walls"
+// gutter is capped to what fits and rolled up into a "+N more" marker so no dot
+// ever marches off-canvas.
 
 function candidatesUpTo(gen) {
   return (state.payload.generations || [])
     .filter((g) => g.generation <= gen)
-    .flatMap((g) => g.candidates);
+    .flatMap((g) => g.candidates || []);
+}
+
+function chartMetrics(svg) {
+  const rect = svg.getBoundingClientRect ? svg.getBoundingClientRect() : { width: 0 };
+  const W = clampN(Math.round(rect.width) || 720, 360, 1400);
+  const H = clampN(Math.round(W * 0.52), 300, 460);
+  const compact = W < 560;
+  const M = {
+    l: compact ? 52 : 70,
+    r: compact ? 14 : 20,
+    t: 16,
+    b: compact ? 36 : 42,
+  };
+  const ticks = compact ? 3 : 4;
+  const gutterX = clampN(M.l - (compact ? 28 : 36), 14, M.l - 12);
+  return { W, H, M, ticks, gutterX, compact };
 }
 
 function renderChart() {
   const svg = $("chart");
+  if (!svg) return;
   svg.innerHTML = "";
   const p = state.payload;
+  if (!p) return;
+  const { W, H, M, ticks, gutterX, compact } = chartMetrics(svg);
+  svg.setAttribute("viewBox", `0 0 ${W} ${H}`);
+  state.lastChartWidth = W;
+
   const shown = candidatesUpTo(state.shownGen);
   const measured = shown.filter((c) => c.feasible && c.latency_ms != null);
   const walls = shown.filter((c) => !(c.feasible && c.latency_ms != null));
@@ -227,17 +273,42 @@ function renderChart() {
   const ys = measured.map((c) => c.peak_mem_bytes).concat(baseline.peak_mem_bytes ?? []);
   const [x0, x1] = pad(Math.min(...xs, Infinity), Math.max(...xs, -Infinity));
   const [y0, y1] = pad(Math.min(...ys, Infinity), Math.max(...ys, -Infinity));
-  const sx = (v) => M.l + ((v - x0) / (x1 - x0)) * (W - M.l - M.r);
-  const sy = (v) => H - M.b - ((v - y0) / (y1 - y0)) * (H - M.t - M.b);
+  const sx = (v) => clampN(M.l + ((v - x0) / (x1 - x0)) * (W - M.l - M.r), M.l, W - M.r);
+  const sy = (v) => clampN(H - M.b - ((v - y0) / (y1 - y0)) * (H - M.t - M.b), M.t, H - M.b);
 
-  drawAxes(svg, x0, x1, y0, y1, sx, sy);
+  drawAxes(svg, x0, x1, y0, y1, sx, sy, W, H, M, ticks);
 
   // Gutter stack: killed-before-measurement candidates, deterministic order.
-  walls.forEach((c, i) => {
-    dot(svg, GUTTER_X, H - M.b - 10 - i * 12, 4, COLORS[c.outcome] || "var(--red)", c, false);
+  // Capped to the plot height with a "+N more" rollup so nothing draws off the
+  // canvas; every y is clamped inside [gutterTop, gutterBottom].
+  const spacing = 12;
+  const gutterTop = M.t + 6;
+  const gutterBottom = H - M.b - 10;
+  const capacity = Math.max(1, Math.floor((gutterBottom - gutterTop) / spacing));
+  const visibleWalls = walls.length > capacity ? walls.slice(0, capacity - 1) : walls;
+  const wallR = compact ? 3 : 4;
+  visibleWalls.forEach((c, i) => {
+    const y = clampN(gutterBottom - i * spacing, gutterTop, gutterBottom);
+    dot(svg, gutterX, y, wallR, COLORS[c.outcome] || "var(--red)", c, false);
   });
+  const hiddenWalls = walls.length - visibleWalls.length;
+  if (hiddenWalls > 0) {
+    const y = clampN(gutterBottom - visibleWalls.length * spacing, gutterTop, gutterBottom);
+    const more = document.createElementNS(SVG_NS, "text");
+    more.setAttribute("x", gutterX);
+    more.setAttribute("y", y);
+    more.setAttribute("text-anchor", "middle");
+    more.setAttribute("fill", "var(--ink-soft)");
+    more.setAttribute("font-size", "10");
+    more.setAttribute("class", "gutter-more");
+    more.textContent = `+${hiddenWalls} more`;
+    const title = document.createElementNS(SVG_NS, "title");
+    title.textContent = `${hiddenWalls} more unmeasured candidate(s) killed at a wall before bench`;
+    more.appendChild(title);
+    svg.appendChild(more);
+  }
   if (walls.length) {
-    label(svg, GUTTER_X, H - M.b + 16, "walls", "middle");
+    label(svg, gutterX, H - M.b + 16, "walls", "middle");
   }
 
   // Baseline star.
@@ -246,7 +317,7 @@ function renderChart() {
     el.setAttribute("x", sx(baseline.latency_ms));
     el.setAttribute("y", sy(baseline.peak_mem_bytes) + 5);
     el.setAttribute("text-anchor", "middle");
-    el.setAttribute("fill", "var(--text)");
+    el.setAttribute("fill", "var(--ink)");
     el.setAttribute("font-size", "16");
     el.textContent = "★";
     svg.appendChild(el);
@@ -260,7 +331,7 @@ function renderChart() {
     const line = document.createElementNS(SVG_NS, "polyline");
     line.setAttribute("points", elites.map((c) => `${sx(c.latency_ms)},${sy(c.peak_mem_bytes)}`).join(" "));
     line.setAttribute("fill", "none");
-    line.setAttribute("stroke", "var(--green)");
+    line.setAttribute("stroke", "var(--teal)");
     line.setAttribute("stroke-width", "1.5");
     line.setAttribute("stroke-dasharray", "4 3");
     svg.appendChild(line);
@@ -270,14 +341,17 @@ function renderChart() {
   measured
     .sort((a, b) => (a.outcome === "pareto_elite") - (b.outcome === "pareto_elite"))
     .forEach((c) => {
-      const r = 4 + Math.min(6, Math.sqrt((c.diff_bytes || 0) / 12));
+      const r = clampN(4 + Math.min(6, Math.sqrt((c.diff_bytes || 0) / 12)), 3, compact ? 8 : 10);
       dot(svg, sx(c.latency_ms), sy(c.peak_mem_bytes), r,
-          COLORS[c.outcome] || "var(--gray)", c, c.outcome === "pareto_elite");
+          COLORS[c.outcome] || "var(--ink-faint)", c, c.outcome === "pareto_elite");
     });
 
-  const newCandidates = (p.generations || [])
-    .find((generation) => generation.generation === state.shownGen)?.candidates?.length || 0;
-  $("genLabel").textContent = `generation ${state.shownGen}/${state.maxGen} · ${newCandidates ? `${newCandidates} new` : "no new candidates"}`;
+  const genLabel = $("genLabel");
+  if (genLabel) {
+    const newCandidates = (p.generations || [])
+      .find((generation) => generation.generation === state.shownGen)?.candidates?.length || 0;
+    genLabel.textContent = `generation ${state.shownGen}/${state.maxGen} · ${newCandidates ? `${newCandidates} new` : "no new candidates"}`;
+  }
 }
 
 function pad(lo, hi) {
@@ -287,7 +361,7 @@ function pad(lo, hi) {
   return [Math.max(0, lo - span * 0.08), hi + span * 0.08];
 }
 
-function drawAxes(svg, x0, x1, y0, y1, sx, sy) {
+function drawAxes(svg, x0, x1, y0, y1, sx, sy, W, H, M, ticks) {
   const axis = (x1p, y1p, x2p, y2p) => {
     const l = document.createElementNS(SVG_NS, "line");
     l.setAttribute("x1", x1p); l.setAttribute("y1", y1p);
@@ -297,9 +371,9 @@ function drawAxes(svg, x0, x1, y0, y1, sx, sy) {
   };
   axis(M.l, H - M.b, W - M.r, H - M.b);
   axis(M.l, M.t, M.l, H - M.b);
-  for (let i = 0; i <= 4; i++) {
-    const xv = x0 + ((x1 - x0) * i) / 4;
-    const yv = y0 + ((y1 - y0) * i) / 4;
+  for (let i = 0; i <= ticks; i++) {
+    const xv = x0 + ((x1 - x0) * i) / ticks;
+    const yv = y0 + ((y1 - y0) * i) / ticks;
     label(svg, sx(xv), H - M.b + 16, xv.toFixed(2), "middle");
     label(svg, M.l - 8, sy(yv) + 4, humanBytes(yv), "end");
   }
@@ -307,7 +381,7 @@ function drawAxes(svg, x0, x1, y0, y1, sx, sy) {
   const yl = document.createElementNS(SVG_NS, "text");
   yl.setAttribute("transform", `translate(14 ${(M.t + H - M.b) / 2}) rotate(-90)`);
   yl.setAttribute("text-anchor", "middle");
-  yl.setAttribute("fill", "var(--muted)");
+  yl.setAttribute("fill", "var(--ink-soft)");
   yl.setAttribute("font-size", "11");
   yl.textContent = "peak_mem_bytes (lower is better)";
   svg.appendChild(yl);
@@ -317,7 +391,7 @@ function label(svg, x, y, text, anchor) {
   const el = document.createElementNS(SVG_NS, "text");
   el.setAttribute("x", x); el.setAttribute("y", y);
   el.setAttribute("text-anchor", anchor);
-  el.setAttribute("fill", "var(--muted)");
+  el.setAttribute("fill", "var(--ink-soft)");
   el.setAttribute("font-size", "10");
   el.textContent = text;
   svg.appendChild(el);
@@ -354,8 +428,13 @@ function dot(svg, x, y, r, color, candidate, elite) {
 }
 
 // ── Detail panel ─────────────────────────────────────────────────────────────
+// Measured-only candidate receipts: fields the stack did not measure read
+// "not measured", never an invented number. All values escaped; no raw model
+// output is ever assigned as innerHTML.
 
 function renderDetail(candidate) {
+  const host = $("detail");
+  if (!host) return;
   const p = state.payload;
   const rows = [
     ["candidate", candidate.candidate_id],
@@ -406,67 +485,138 @@ function renderDetail(candidate) {
                <span class="muted" style="font-size:11px"> ${esc(reason)}</span>
              </div><div id="applyOut" class="muted" style="margin-top:6px;font-size:12px"></div>`;
   }
-  $("detail").innerHTML = html;
+  host.innerHTML = html;
   const copyBtn = $("copyBtn");
   if (copyBtn) {
     copyBtn.addEventListener("click", async () => {
+      const out = $("applyOut");
       try {
         await navigator.clipboard.writeText(candidate.code);
-        $("applyOut").textContent = "Best verified code copied exactly.";
+        if (out) out.textContent = "Best verified code copied exactly.";
       } catch (_error) {
-        $("applyOut").textContent = "Clipboard access was blocked; select the code above and copy it.";
+        if (out) out.textContent = "Clipboard access was blocked; select the code above and copy it.";
       }
     });
   }
   const applyBtn = $("applyBtn");
   if (applyBtn && !applyBtn.disabled) {
     applyBtn.addEventListener("click", async () => {
+      // Never auto-commit a winner: apply re-runs the tests and reverts the
+      // file on failure, and only after an explicit confirmation.
       if (!window.confirm(
         `Apply ${candidate.candidate_id} to ${p.target?.path}? Tests re-run before it lands; the file reverts on failure.`
       )) return;
       applyBtn.disabled = true;
+      const out = $("applyOut");
       try {
-        $("applyOut").textContent = await mcpCall("apply_swarm_winner", {
+        const result = await mcpCall("apply_swarm_winner", {
           candidate_id: candidate.candidate_id,
         });
+        if (out) out.textContent = result;
       } catch (err) {
-        $("applyOut").textContent = String(err.message || err);
+        if (out) out.textContent = String(err.message || err);
       }
     });
   }
+}
+
+// ── Detail splitter (keyboard-accessible, right-docked, clamped) ─────────────
+// Mirrors the Control Center's inspector splitter: the detail pane is right-
+// docked, so dragging left grows it. Width is clamped in JS (the CSS max is
+// cqw-relative) and written to --swarm-detail on the shell.
+
+function setupDetailSplitter() {
+  const splitter = $("detailSplitter");
+  const shell = document.querySelector(".swarm-shell");
+  if (!splitter || !shell) return;
+  const MIN = 280;
+  const HARD_MAX = 560;
+  const maxFor = () => {
+    const shellW = Math.round(shell.getBoundingClientRect().width) || (HARD_MAX * 2);
+    return Math.min(HARD_MAX, Math.max(MIN, Math.round(shellW * 0.6)));
+  };
+  const current = () => {
+    const raw = parseInt(getComputedStyle(shell).getPropertyValue("--swarm-detail"), 10);
+    return Number.isFinite(raw) ? raw : 360;
+  };
+  const setWidth = (w) => {
+    const width = clampN(Math.round(w), MIN, maxFor());
+    shell.style.setProperty("--swarm-detail", `${width}px`);
+    splitter.setAttribute("aria-valuenow", String(width));
+  };
+  splitter.addEventListener("pointerdown", (event) => {
+    const startX = event.clientX;
+    const startWidth = current();
+    splitter.setPointerCapture(event.pointerId);
+    splitter.classList.add("dragging");
+    const move = (nextEvent) => setWidth(startWidth - (nextEvent.clientX - startX));
+    const end = () => {
+      splitter.classList.remove("dragging");
+      splitter.removeEventListener("pointermove", move);
+    };
+    splitter.addEventListener("pointermove", move);
+    splitter.addEventListener("pointerup", end, { once: true });
+    splitter.addEventListener("pointercancel", end, { once: true });
+  });
+  splitter.addEventListener("keydown", (event) => {
+    if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+    event.preventDefault();
+    const step = event.shiftKey ? 24 : 8;
+    // ArrowLeft grows the right-docked pane.
+    setWidth(current() + (event.key === "ArrowLeft" ? step : -step));
+  });
+}
+
+function observeChartResize() {
+  const svg = $("chart");
+  if (!svg || typeof ResizeObserver === "undefined") return;
+  let frame = 0;
+  const observer = new ResizeObserver((entries) => {
+    if (!state.payload) return;
+    const width = Math.round(entries[0]?.contentRect?.width ?? 0);
+    if (Math.abs(width - state.lastChartWidth) < 2) return;
+    cancelAnimationFrame(frame);
+    frame = requestAnimationFrame(() => {
+      try { renderChart(); } catch (err) { console.error("renderChart failed:", err); }
+    });
+  });
+  observer.observe(svg);
 }
 
 // ── Timeline / play ──────────────────────────────────────────────────────────
 
 function stopPlaying() {
   if (state.playing) { clearInterval(state.playing); state.playing = null; }
-  $("playBtn").textContent = "▶ Play";
+  const btn = $("playBtn");
+  if (btn) btn.textContent = "▶ Play";
 }
 
-$("playBtn").addEventListener("click", () => {
+$("playBtn")?.addEventListener("click", () => {
   if (!state.payload) return;
   if (state.playing) { stopPlaying(); return; }
   state.shownGen = 0;
-  $("playBtn").textContent = "⏸ Stop";
+  const btn = $("playBtn");
+  if (btn) btn.textContent = "⏸ Stop";
   state.playing = setInterval(() => {
     state.shownGen = Math.min(state.maxGen, state.shownGen + 1);
-    $("genSlider").value = String(state.shownGen);
+    const slider = $("genSlider");
+    if (slider) slider.value = String(state.shownGen);
     renderChart();
     if (state.shownGen >= state.maxGen) stopPlaying();
   }, 650);
 });
 
-$("genSlider").addEventListener("input", (event) => {
+$("genSlider")?.addEventListener("input", (event) => {
   if (!state.payload) return;
   stopPlaying();
   state.shownGen = Number(event.target.value);
   renderChart();
 });
 
-$("loadBtn").addEventListener("click", loadLive);
-$("fileBtn").addEventListener("click", () => $("fileInput").click());
-$("taskId").addEventListener("keydown", (e) => { if (e.key === "Enter") loadLive(); });
-$("fileInput").addEventListener("change", (e) => {
+$("loadBtn")?.addEventListener("click", loadLive);
+$("fileBtn")?.addEventListener("click", () => $("fileInput")?.click());
+$("taskId")?.addEventListener("keydown", (e) => { if (e.key === "Enter") loadLive(); });
+$("fileInput")?.addEventListener("change", (e) => {
   if (e.target.files && e.target.files[0]) loadFile(e.target.files[0]);
 });
 
@@ -500,6 +650,72 @@ async function loadSample() {
   } catch (err) {
     setMsg(`sample unavailable: ${err.message || err}`, true);
   }
+}
+
+// ── Structured task_id resolution (no regex-scrape of prose) ─────────────────
+// A run tool's response may already carry a structured task_id (the companion
+// change adds it). If not, we fall back to polling list_swarm_tasks for a
+// task_id that did not exist before the run. We NEVER pull a task id out of a
+// human-readable sentence, so re-wording a message can't silently break Run.
+
+function isTaskId(candidate) {
+  return typeof candidate === "string" && /^[0-9a-f]{8,}$/i.test(candidate.trim());
+}
+
+function parseStructuredTaskId(output) {
+  if (typeof output !== "string") return null;
+  // Preferred: the wording-independent launch receipt the swarm tools append
+  // as an HTML-comment trailer (unigrok-swarm-launch-v1). Deterministic parse,
+  // never regex over human prose.
+  const receipt = output.match(/<!--unigrok-swarm-launch-v1 (\{.*?\})-->/);
+  if (receipt) {
+    try {
+      const payload = JSON.parse(receipt[1]);
+      const id = payload && (payload.task_id ?? payload.taskId);
+      if (isTaskId(id)) return id.trim();
+    } catch (_error) {
+      /* fall through to the bare-JSON shape */
+    }
+  }
+  // Fallback: a bare-JSON tool response carrying task_id directly.
+  const trimmed = output.trim();
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return null;
+  try {
+    const obj = JSON.parse(trimmed);
+    const candidate = obj && (obj.task_id ?? obj.taskId);
+    if (isTaskId(candidate)) return candidate.trim();
+  } catch (_error) {
+    return null;
+  }
+  return null;
+}
+
+async function snapshotTaskIds() {
+  try {
+    const raw = await mcpCall("list_swarm_tasks", { limit: 50 });
+    const tasks = JSON.parse(raw);
+    return new Set((Array.isArray(tasks) ? tasks : []).map((t) => t.task_id));
+  } catch (_error) {
+    return new Set();
+  }
+}
+
+async function resolveTaskId(output, priorIds) {
+  const structured = parseStructuredTaskId(output);
+  if (structured) return structured;
+  // Poll the task list for a run that appeared after we started.
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      const raw = await mcpCall("list_swarm_tasks", { limit: 50 });
+      const tasks = JSON.parse(raw);
+      const fresh = (Array.isArray(tasks) ? tasks : []).find((t) => t.task_id && !priorIds.has(t.task_id));
+      if (fresh) return fresh.task_id;
+    } catch (_error) {
+      // fall through and retry
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+  }
+  return null;
 }
 
 // ── Paste analysis ──────────────────────────────────────────────────────────
@@ -554,10 +770,14 @@ function browserAnalyzePython(code) {
 
 function renderAnalysis(result, exact) {
   const badge = $("analysisBadge");
-  badge.textContent = exact ? "exact local AST" : "client-side preview";
-  badge.className = exact ? "source-badge live" : "source-badge";
+  if (badge) {
+    badge.textContent = exact ? "exact local AST" : "client-side preview";
+    badge.className = exact ? "source-badge live" : "source-badge";
+  }
+  const panel = $("analysisResults");
+  if (!panel) return;
   if (result.error) {
-    $("analysisResults").innerHTML = `<h3>Could not analyze</h3><div class="err">${esc(result.error)}</div>`;
+    panel.innerHTML = `<h3>Could not analyze</h3><div class="err">${esc(result.error)}</div>`;
     return;
   }
   // Only a real parser failure is a parse error. The approximate browser
@@ -565,47 +785,55 @@ function renderAnalysis(result, exact) {
   // must not be misreported as invalid Python.
   if (!result.parse_ok && result.parse_error) {
     const error = result.parse_error;
-    $("analysisResults").innerHTML = `<h3>Fix the parse error first</h3><div class="err">Line ${esc(error.line ?? "?")}: ${esc(error.message || "invalid Python")}</div>`;
+    panel.innerHTML = `<h3>Fix the parse error first</h3><div class="err">Line ${esc(error.line ?? "?")}: ${esc(error.message || "invalid Python")}</div>`;
     return;
   }
   const rows = (result.functions || []).map((fn) => `
     <div class="function-row">
       <code>${esc(fn.focus_node)}</code>
-      <span class="metric-chip">${esc(fn.loc)} LOC</span>
-      <span class="metric-chip">CC ${esc(fn.cyclomatic_complexity)}</span>
-      <span class="metric-chip">nest ${esc(fn.max_nesting)}</span>
+      <span class="fn-chip">${esc(fn.loc)} LOC</span>
+      <span class="fn-chip">CC ${esc(fn.cyclomatic_complexity)}</span>
+      <span class="fn-chip">nest ${esc(fn.max_nesting)}</span>
     </div>`).join("");
   const ruffCount = Object.values(result.ruff?.counts_by_code || {})
     .reduce((sum, value) => sum + Number(value || 0), 0);
-  $("analysisResults").innerHTML = `
+  panel.innerHTML = `
     <h3>${(result.functions || []).length} function${(result.functions || []).length === 1 ? "" : "s"} found</h3>
     <div class="muted">${esc(result.loc ?? 0)} source lines · ${esc(result.bytes ?? 0)} bytes${exact ? ` · ${ruffCount} Ruff finding${ruffCount === 1 ? "" : "s"}` : " · approximate browser metrics"}</div>
     ${result.secret_warning ? '<div class="err" style="margin-top:7px">Secret-like text detected. Remove it before export or search.</div>' : ""}
     <div class="function-list">${rows || `<div class="muted">${exact ? "No functions found." : "No top-level functions detected by the approximate browser scanner."}</div>`}</div>
     <div class="privacy-note">Search blockers: ${esc((result.searchability?.blockers || []).join(", ") || "none")}</div>`;
   const picker = $("focusPicker");
-  picker.replaceChildren(new Option(
-    (result.functions || []).length ? "choose a function…" : "no functions found", ""
-  ));
-  for (const fn of result.functions || []) {
-    picker.appendChild(new Option(
-      `${fn.focus_node} · CC ${fn.cyclomatic_complexity} · ${fn.loc} LOC`, fn.focus_node
+  if (picker) {
+    picker.replaceChildren(new Option(
+      (result.functions || []).length ? "choose a function…" : "no functions found", ""
     ));
+    for (const fn of result.functions || []) {
+      picker.appendChild(new Option(
+        `${fn.focus_node} · CC ${fn.cyclomatic_complexity} · ${fn.loc} LOC`, fn.focus_node
+      ));
+    }
+    if ((result.functions || []).length) picker.value = result.functions[0].focus_node;
   }
-  if ((result.functions || []).length) picker.value = result.functions[0].focus_node;
   const canSearch = exact && state.runtimeMode === "contributor" && (result.functions || []).length > 0;
-  $("runPasteBtn").disabled = !canSearch;
-  $("pasteRunMsg").textContent = canSearch
-    ? "Tests and benchmark are required; every winner is re-measured."
-    : "Verified execution is available only in contributor Forge after exact analysis.";
+  const runBtn = $("runPasteBtn");
+  if (runBtn) runBtn.disabled = !canSearch;
+  const runMsg = $("pasteRunMsg");
+  if (runMsg) {
+    runMsg.textContent = canSearch
+      ? "Tests and benchmark are required; every winner is re-measured."
+      : "Verified execution is available only in contributor Forge after exact analysis.";
+  }
 }
 
 async function analyzePastedCode() {
-  const code = $("codeInput").value;
+  const input = $("codeInput");
+  const msg = $("analysisMsg");
+  const code = input ? input.value : "";
   const size = new TextEncoder().encode(code).length;
-  if (!code.trim()) { $("analysisMsg").textContent = "paste Python first"; return; }
-  if (size > 256 * 1024) { $("analysisMsg").textContent = "code exceeds 256 KiB"; return; }
-  $("analysisMsg").textContent = "analyzing…";
+  if (!code.trim()) { if (msg) msg.textContent = "paste Python first"; return; }
+  if (size > 256 * 1024) { if (msg) msg.textContent = "code exceeds 256 KiB"; return; }
+  if (msg) msg.textContent = "analyzing…";
   let result;
   let exact = false;
   // "not uploaded" may only be claimed when no gateway call was attempted;
@@ -626,27 +854,31 @@ async function analyzePastedCode() {
     usedBrowserFallback = true;
   }
   renderAnalysis(result, exact);
+  if (!msg) return;
   if (exact) {
-    $("analysisMsg").textContent = "analyzed locally without a model call";
+    msg.textContent = "analyzed locally without a model call";
   } else if (usedBrowserFallback && submittedToGateway) {
-    $("analysisMsg").textContent = "gateway unreachable; showing approximate browser metrics (the paste was submitted to the local gateway)";
+    msg.textContent = "gateway unreachable; showing approximate browser metrics (the paste was submitted to the local gateway)";
   } else if (submittedToGateway) {
     // Gateway returned an error object — the panel shows it; no browser metrics.
-    $("analysisMsg").textContent = "gateway analysis failed — see the error above (the paste was submitted to the local gateway)";
+    msg.textContent = "gateway analysis failed — see the error above (the paste was submitted to the local gateway)";
   } else {
-    $("analysisMsg").textContent = "analyzed in this browser; source was not uploaded";
+    msg.textContent = "analyzed in this browser; source was not uploaded";
   }
 }
 
-$("analyzeBtn").addEventListener("click", analyzePastedCode);
-$("pasteExampleBtn").addEventListener("click", () => {
-  $("codeInput").value = SLOW_EXAMPLE;
-  $("testInput").value = `from module_under_test import deduplicate
+$("analyzeBtn")?.addEventListener("click", analyzePastedCode);
+$("pasteExampleBtn")?.addEventListener("click", () => {
+  const code = $("codeInput");
+  const test = $("testInput");
+  const bench = $("benchInput");
+  if (code) code.value = SLOW_EXAMPLE;
+  if (test) test.value = `from module_under_test import deduplicate
 
 def test_order_and_duplicates():
     assert deduplicate([3, 1, 3, 2, 1]) == [3, 1, 2]
 `;
-  $("benchInput").value = `import json
+  if (bench) bench.value = `import json
 import time
 import tracemalloc
 from module_under_test import deduplicate
@@ -667,46 +899,57 @@ print("SWARM_BENCH " + json.dumps({"latency_ms": latency_ms, "peak_mem_bytes": p
 
 async function runPasteSwarm() {
   const button = $("runPasteBtn");
+  const runMsg = $("pasteRunMsg");
   const args = {
-    code: $("codeInput").value,
-    test_code: $("testInput").value,
-    bench_code: $("benchInput").value,
-    focus_node: $("focusPicker").value,
-    search_strategy: $("strategyPicker").value,
-    primary_goal: $("goalPicker").value,
+    code: $("codeInput")?.value ?? "",
+    test_code: $("testInput")?.value ?? "",
+    bench_code: $("benchInput")?.value ?? "",
+    focus_node: $("focusPicker")?.value ?? "",
+    search_strategy: $("strategyPicker")?.value ?? "",
+    primary_goal: $("goalPicker")?.value ?? "",
   };
   if (!args.focus_node || !args.test_code.trim() || !args.bench_code.trim()) {
-    $("pasteRunMsg").textContent = "Choose a function and provide both tests and benchmark.";
+    if (runMsg) runMsg.textContent = "Choose a function and provide both tests and benchmark.";
     return;
   }
-  button.disabled = true;
-  $("pasteRunMsg").textContent = "materializing a private local scratch task…";
+  if (button) button.disabled = true;
+  if (runMsg) runMsg.textContent = "materializing a private local scratch task…";
   try {
+    const priorIds = await snapshotTaskIds();
     const output = await mcpCall("start_paste_swarm", args);
-    const match = output.match(/`([0-9a-f]{16,})`/);
-    if (!match) { $("pasteRunMsg").textContent = output.replace(/\s+/g, " ").trim(); return; }
-    $("taskId").value = match[1];
-    $("pasteRunMsg").textContent = "verified swarm running…";
-    const final = await pollUntilDone(match[1]);
-    if (final && final.status === "completed") {
-      $("pasteRunMsg").textContent = "Search complete. Copy Best Verified Code from the receipt.";
-    } else if (final) {
-      $("pasteRunMsg").textContent = `Swarm ended with status ${final.status} — inspect the receipt before trusting any candidate.`;
-    } else {
-      $("pasteRunMsg").textContent = "Run did not complete — see the run status message for details.";
+    const taskId = await resolveTaskId(output, priorIds);
+    if (!taskId) {
+      // No structured id and nothing new in the task list: surface the tool's
+      // own words verbatim (a gate refusal or an error is instructive).
+      if (runMsg) runMsg.textContent = output.replace(/\s+/g, " ").trim();
+      return;
+    }
+    const idField = $("taskId");
+    if (idField) idField.value = taskId;
+    if (runMsg) runMsg.textContent = "verified swarm running…";
+    const final = await pollUntilDone(taskId);
+    if (runMsg) {
+      if (final && final.status === "completed") {
+        runMsg.textContent = "Search complete. Copy Best Verified Code from the receipt.";
+      } else if (final) {
+        runMsg.textContent = `Swarm ended with status ${final.status} — inspect the receipt before trusting any candidate.`;
+      } else {
+        runMsg.textContent = "Run did not complete — see the run status message for details.";
+      }
     }
     refreshTaskPicker();
   } catch (error) {
-    $("pasteRunMsg").textContent = String(error.message || error);
+    if (runMsg) runMsg.textContent = String(error.message || error);
   } finally {
-    button.disabled = state.runtimeMode !== "contributor";
+    if (button) button.disabled = state.runtimeMode !== "contributor";
   }
 }
 
-$("runPasteBtn").addEventListener("click", runPasteSwarm);
+$("runPasteBtn")?.addEventListener("click", runPasteSwarm);
 
 async function refreshTaskPicker() {
   const picker = $("taskPicker");
+  if (!picker) return;
   if (state.runtimeMode !== "contributor") {
     picker.replaceChildren(new Option("live runs are available in contributor Forge", ""));
     picker.disabled = true;
@@ -733,65 +976,75 @@ async function refreshTaskPicker() {
 
 async function discoverRuntime() {
   const banner = $("runtimeBanner");
+  const title = $("runtimeTitle");
+  const copy = $("runtimeCopy");
+  const forgeNote = $("forgeNote");
+  const demoBtn = $("demoBtn");
+  const refreshBtn = $("refreshTasksBtn");
+  const demoHint = $("demoHint");
   try {
     const response = await fetch("/runtimez", { headers: { Accept: "application/json" } });
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
     const runtime = await response.json();
     state.runtimeMode = runtime.service?.mode || "unknown";
-    banner.classList.add("ready");
+    banner?.classList.add("ready");
     if (state.runtimeMode === "contributor" && runtime.service?.workspace_attached) {
-      $("runtimeTitle").textContent = "Contributor Forge connected";
-      $("runtimeCopy").textContent = "Live task history and real demo runs are available from the attached workspace.";
-      $("forgeLink").hidden = true;
-      $("demoBtn").disabled = false;
-      $("refreshTasksBtn").disabled = false;
-      $("demoHint").innerHTML = "Runs against the attached golden target. If Swarm is off, the exact gate instruction appears below.";
+      if (title) title.textContent = "Contributor Forge connected";
+      if (copy) copy.textContent = "Live task history and real demo runs are available from the attached workspace.";
+      if (forgeNote) forgeNote.hidden = true;
+      if (demoBtn) demoBtn.disabled = false;
+      if (refreshBtn) refreshBtn.disabled = false;
+      if (demoHint) demoHint.textContent = "Runs against the attached golden target. If Swarm is off, the exact gate instruction appears below.";
     } else {
-      $("runtimeTitle").textContent = "Stable gateway connected — exploration mode";
-      $("runtimeCopy").textContent = "The recorded tour works here. Live Swarm tools stay isolated in contributor Forge on port 4766.";
-      $("demoBtn").disabled = true;
-      $("refreshTasksBtn").disabled = true;
-      $("demoHint").textContent = "Live execution is intentionally unavailable on the workspace-neutral stable service.";
-      if (["127.0.0.1", "localhost"].includes(window.location.hostname)) {
-        $("forgeLink").href = `${window.location.protocol}//${window.location.hostname}:4766/ui/swarm.html`;
-        $("forgeLink").hidden = false;
-      }
+      if (title) title.textContent = "Stable gateway connected — exploration mode";
+      if (copy) copy.textContent = "The recorded tour works here. Live Swarm tools stay isolated in contributor Forge.";
+      if (demoBtn) demoBtn.disabled = true;
+      if (refreshBtn) refreshBtn.disabled = true;
+      if (demoHint) demoHint.textContent = "Live execution is intentionally unavailable on the workspace-neutral stable service.";
+      // Single-origin: reference Forge as a visible-but-locked note only. No
+      // live cross-port link is ever emitted from this page.
+      if (forgeNote) forgeNote.hidden = false;
     }
   } catch (err) {
     const isLocal = ["127.0.0.1", "localhost", "::1"].includes(window.location.hostname);
     state.runtimeMode = isLocal ? "unknown" : "public";
-    $("runtimeTitle").textContent = isLocal
-      ? "Gateway capability check unavailable"
-      : "Public showcase — client-side analysis only";
-    $("runtimeCopy").textContent = isLocal
-      ? "The recorded tour still works; live controls may not."
-      : "Pasted source stays in this browser. Verified search and Apply require the local contributor Forge.";
-    $("demoBtn").disabled = true;
-    $("refreshTasksBtn").disabled = true;
+    if (title) {
+      title.textContent = isLocal
+        ? "Gateway capability check unavailable"
+        : "Public showcase — client-side analysis only";
+    }
+    if (copy) {
+      copy.textContent = isLocal
+        ? "The recorded tour still works; live controls may not."
+        : "Pasted source stays in this browser. Verified search and Apply require the local contributor Forge.";
+    }
+    if (demoBtn) demoBtn.disabled = true;
+    if (refreshBtn) refreshBtn.disabled = true;
   }
 }
 
 async function runGoldenDemo() {
   const btn = $("demoBtn");
-  btn.disabled = true;
+  if (btn) btn.disabled = true;
   setMsg("starting demo swarm on the golden O(N²) dedup target…");
   try {
+    const priorIds = await snapshotTaskIds();
     const out = await mcpCall("start_code_swarm", GOLDEN_DEMO);
-    const match = out.match(/`([0-9a-f]{16,})`/);
-    if (!match) {
+    const taskId = await resolveTaskId(out, priorIds);
+    if (!taskId) {
       // Refusals (mode off, stable service, no workspace) are instructive —
       // show the tool's own words verbatim.
       setMsg(out.replace(/\s+/g, " ").trim(), true);
       return;
     }
-    const taskId = match[1];
-    $("taskId").value = taskId;
+    const idField = $("taskId");
+    if (idField) idField.value = taskId;
     await pollUntilDone(taskId);
     refreshTaskPicker();
   } catch (err) {
     setMsg(String(err.message || err), true);
   } finally {
-    btn.disabled = false;
+    if (btn) btn.disabled = false;
   }
 }
 
@@ -817,16 +1070,19 @@ async function pollUntilDone(taskId, intervalMs = 3000, maxPolls = 200) {
   return null;
 }
 
-$("sampleBtn").addEventListener("click", loadSample);
-$("demoBtn").addEventListener("click", runGoldenDemo);
-$("refreshTasksBtn").addEventListener("click", refreshTaskPicker);
-$("taskPicker").addEventListener("change", (event) => {
+$("sampleBtn")?.addEventListener("click", loadSample);
+$("demoBtn")?.addEventListener("click", runGoldenDemo);
+$("refreshTasksBtn")?.addEventListener("click", refreshTaskPicker);
+$("taskPicker")?.addEventListener("change", (event) => {
   if (!event.target.value) return;
-  $("taskId").value = event.target.value;
+  const idField = $("taskId");
+  if (idField) idField.value = event.target.value;
   loadLive();
 });
 
 async function bootstrap() {
+  setupDetailSplitter();
+  observeChartResize();
   await loadSample();
   await discoverRuntime();
   await refreshTaskPicker();

--- a/src/version.py
+++ b/src/version.py
@@ -7,4 +7,4 @@ __version__ = "0.6.0"
 # runtime handshake in app.js).
 # Bump the -rN suffix whenever any /ui asset changes; a pytest asserts every
 # copy of this string agrees so HTML and JS can never skew apart silently.
-UI_ASSET_VERSION = "grok-v0.6.0-r12"
+UI_ASSET_VERSION = "grok-v0.6.0-r13"

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -47,9 +47,9 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert index.status_code == 200
     assert "<title>UniGrok Gateway Console v0.6.0</title>" in index.text
     assert '<span class="version-badge">v0.6.0</span>' in index.text
-    assert 'script type="module" src="./app.js?v=grok-v0.6.0-r12"' in index.text
-    assert '<link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r12" />' in index.text
-    assert '<link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r12" />' in index.text
+    assert 'script type="module" src="./app.js?v=grok-v0.6.0-r13"' in index.text
+    assert '<link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r13" />' in index.text
+    assert '<link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r13" />' in index.text
     assert "Console" in index.text
     assert 'id="surfaceModeBadge"' in index.text
     assert 'id="tab-btn-schemas"' not in index.text
@@ -269,7 +269,24 @@ def test_mcp_ui_swarm_playground_is_served_and_honest(monkeypatch):
     assert "nsquared_dedup" in script.text  # the golden demo target
     assert 'fetch("/runtimez"' in script.text
     assert "Stable gateway connected" in script.text
-    assert ":4766/ui/swarm.html" in script.text
+    # Single-origin: the hardcoded cross-port :4766 Forge link is retired. Forge
+    # is referenced only as a visible-but-locked note, never a live link.
+    assert "4766" not in script.text
+    assert "4766" not in page.text
+    assert 'id="forgeNote"' in page.text
+    # The manual bearer-token field is gone (same-origin session).
+    assert 'id="token"' not in page.text
+    assert 'type="password"' not in page.text
+    assert '$("token")' not in script.text
+    # Run flow consumes a structured task_id, else polls list_swarm_tasks — it
+    # never scrapes a task id out of prose with a backtick regex.
+    assert "parseStructuredTaskId" in script.text
+    assert "resolveTaskId" in script.text
+    assert "match(/`" not in script.text
+    # Shared fluid system: the bespoke inline stylesheet is deleted; the page
+    # links the shared styles.css and reuses the shared .panel-splitter.
+    assert "<style>" not in page.text
+    assert 'href="./styles.css' in page.text
     assert "await loadSample()" in script.text  # useful content, not empty boxes, on arrival
     assert "rpc.result?.isError" in script.text
     assert 'c.setAttribute("tabindex", "0")' in script.text
@@ -466,7 +483,7 @@ def test_mcp_ui_markdown_renderer_is_shared_and_escape_first():
     assert "\\u000E-\\u001F" in renderer.text
     # app.js imports the shared renderer at the current cache-bust version and
     # no longer defines its own.
-    assert 'from "./markdown.js?v=grok-v0.6.0-r12"' in script.text
+    assert 'from "./markdown.js?v=grok-v0.6.0-r13"' in script.text
     assert "import { parseMarkdown" in script.text
     assert "function parseMarkdown" not in script.text
     assert "renderMarkdownInto" in script.text
@@ -632,6 +649,9 @@ def test_mcp_ui_asset_version_is_single_sourced():
     assert f'const UI_ASSET_VERSION = "{UI_ASSET_VERSION}"' in script
     assert f'from "./markdown.js?v={UI_ASSET_VERSION}"' in script
     assert f'href="./tokens.css?v={UI_ASSET_VERSION}"' in swarm
+    # The swarm page now also links the shared styles.css (its bespoke inline
+    # stylesheet was retired); that pin must move in lockstep too.
+    assert f'href="./styles.css?v={UI_ASSET_VERSION}"' in swarm
     assert f'src="./swarm.js?v={UI_ASSET_VERSION}"' in swarm
     assert f'const UI_ASSET_VERSION = "{UI_ASSET_VERSION}"' in swarm_script
     assert (
@@ -719,6 +739,41 @@ def test_mcp_ui_reflow_is_container_driven():
     assert "@media (max-width: 768px)" not in styles
     # Fixed sidebar columns became user-resizable with clamps.
     assert "resize: horizontal" in styles
+
+
+def test_mcp_ui_swarm_reflow_is_container_driven():
+    """The swarm page reflows on its OWN container widths (swarm-shell /
+    swarm-main), not the viewport: the brittle single @media(max-width:900px)
+    plus the fixed 380px detail sidebar and vw/vh pane sizing are retired in
+    favor of container queries, a keyboard-accessible resizable .panel-splitter
+    detail pane, and a resize:horizontal editor clamped by cqw."""
+    with TestClient(create_app(), base_url="http://localhost:8080") as client:
+        styles = client.get("/ui/styles.css").text
+        page = client.get("/ui/swarm.html").text
+        script = client.get("/ui/swarm.js").text
+
+    # Swarm reflow is authored as container queries on the swarm contexts.
+    assert "container: swarm-shell / inline-size" in styles
+    assert "container: swarm-main / inline-size" in styles
+    # The shell collapse is driven by the ancestor swarm-app container — an
+    # element cannot size-query the container it declares itself.
+    assert "@container swarm-app (max-width: 900px)" in styles
+    assert "@container swarm-main (max-width: 640px)" in styles
+    # The old brittle viewport reflow is gone from the whole sheet.
+    assert "@media (max-width: 900px)" not in styles
+    # The detail pane is a real, keyboard-accessible splitter (shared class),
+    # and the code editor is user-resizable — both like the Control Center.
+    assert ".panel-splitter" in styles
+    assert "resize: horizontal" in styles
+    assert 'id="detailSplitter"' in page
+    assert 'class="panel-splitter"' in page
+    assert 'role="separator"' in page
+    assert "setupDetailSplitter" in script
+    assert "pointerdown" in script
+    # The bespoke inline stylesheet (with its re-aliased tokens and fixed
+    # 380px sidebar) is deleted, not just overridden.
+    assert "<style>" not in page
+    assert "380px" not in page
 
 
 def test_ui_root_redirects_to_trailing_slash(monkeypatch):


### PR DESCRIPTION
## What

Phase 1 of the console redesign (design: #323 / integrated in #331). Rebuilds the brittle standalone swarm page on `index.html`'s proven responsive system, keeping `tokens.css` verbatim and every honesty literal. Pairs with #343 (structured `task_id`) — this PR consumes that receipt and **falls back to polling**, so it doesn't hard-depend on #343 landing first.

## Brittle patterns retired

- **Inline 275-line `<style>` block deleted** from `swarm.html`, including its token re-aliasing (`--accent:var(--cyan)` etc.) — one palette now, via shared `tokens.css` + a `.swarm-*` section in `styles.css`.
- **Viewport sizing → container queries.** The single `@media(max-width:900px)` + fixed non-resizable 380px sidebar + `vw/vh` sizing are replaced by `@container` contexts (panes size on their **own** width — correct when embedded same-origin) and a keyboard-accessible resizable `.panel-splitter` detail pane; editor uses `resize:horizontal` clamped by `cqw`; `minmax(0,…)` + `min-width/height:0` so nothing overflows.
- **Pareto SVG made responsive and safe.** viewBox is measured from the pane each render; every coordinate is clamped; the unbounded `y=H-M.b-10-i*12` walls stack (which marched 30+ walls off-canvas at negative y) is capped with a `"+N more"` roll-up. Stress-verified live: 40 walls → 31 drawn, 0 off-canvas, min cy=48, `"+11 more"` shown. `ResizeObserver` re-renders on width change.
- **Regex-scrape removed.** The fragile `output.match(/\`([0-9a-f]{16,})\`/)` is gone; `parseStructuredTaskId` reads the #343 receipt deterministically, else snapshots `list_swarm_tasks` and polls.
- **Manual bearer field removed** (same-origin session); **hardcoded cross-port `:4766` Forge link removed** (single-origin / no tunnel).
- Every `getElementById` null-guarded; skeletons resolve to honest empty/error states.

## Preserved verbatim

Measured-only receipts, honest "walls" for unmeasured candidates, "verified = your test_target passed", the `original_span_stale` diff guard, apply gated with visible reasons, "Nothing is simulated", "never auto-commit a winner", budget ceiling before Run. No inline `on*` handlers, no eval, no CDN (CSP `script-src 'self'`).

## Changed paths
- `mcp_ui/swarm.html`, `mcp_ui/swarm.js`, `mcp_ui/styles.css`, `src/version.py` (+ version-only lines in `index.html`/`app.js` to keep the asset-version single-sourced), `tests/test_mcp_ui.py`

## Tests
- Full suite **2203 passed**; focused `test_mcp_ui.py` + `test_markdown_renderer.py` **52 passed**. Revised `test_mcp_ui_swarm_playground_is_served_and_honest` (honesty/CSP/auth assertions intact); added `test_mcp_ui_swarm_reflow_is_container_driven` (requires `@container`, forbids the old viewport `@media`, requires `resize:horizontal`). Attribution: passed. `UI_ASSET_VERSION` bumped r12→r13 in lockstep.

## Not in this PR
Progressive-disclosure swarm UX (scaffolded tests/bench, opt-in verify) = Phase 2. Console shell unification = Phase 3.

## Handoff
- Draft — awaiting Codex landing. Sponsor: David Johnston (@djtelicloud). Client-side; lands against current main independently.

Agent-Assisted-By: Anthropic Claude | model=Fable 5 | model-source=user-reported | surface=Claude Code | role=implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side MCP UI and styling only; no server auth or data-path changes beyond removing optional bearer UI and hardcoded Forge URLs.
> 
> **Overview**
> **Swarm Optimizer (Pareto Playground)** is rebuilt to match the Control Center’s responsive system instead of a ~275-line inline stylesheet in `swarm.html`.
> 
> The page now loads shared `tokens.css` + `styles.css` (new `.swarm-*` section), uses a `swarm-shell` grid with a keyboard-accessible **`.panel-splitter`** detail pane and **`resize:horizontal`** paste editor, and reflows via **`@container`** on `swarm-app` / `swarm-main` rather than viewport `@media` and a fixed sidebar.
> 
> **`swarm.js`** drops the manual bearer token and cross-port Forge link (same-origin session + locked Forge note), resolves run **`task_id`** via structured launch receipt / `list_swarm_tasks` polling instead of backtick regex, makes the Pareto SVG width-aware with clamped coordinates and capped “walls” gutter + **`ResizeObserver`**, and null-guards DOM access.
> 
> **`UI_ASSET_VERSION`** bumps **r12→r13** across `index.html`, `app.js`, swarm assets, and `src/version.py`; tests extend swarm honesty and add container-driven reflow assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed2428290eee3b56a4ddc6e7f23a209a552d0e24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->