### PR TITLE
docs(design): stage1_harness campaign module-split plan

### DIFF
--- a/docs/design/stage1-harness-refactor-plan.md
+++ b/docs/design/stage1-harness-refactor-plan.md
@@ -1,0 +1,45 @@
+# `evals/.../stage1_harness.py` refactor plan (Loop 8)
+
+Status: **Ready for supervisor** — plan only.  
+Campaign: `gemma_needle_2000_v1`.
+
+## Why not a mega rewrite
+
+**~1644 LOC**. Types/helpers small; **`Stage1SafetyHarness` ~1123 LOC / 18 methods** is the split core. Keep campaign CLI/entry stable.
+
+## Baseline (before)
+
+| Metric | Value |
+|--------|------:|
+| LOC | 1644 |
+| Bytes | 68553 |
+| Classes / funcs | 8 / 5 |
+| AST parse / compile | ~5 ms / ~5 ms |
+| Branch nodes | 57 |
+| Hot class | `Stage1SafetyHarness` ~1123 LOC |
+
+## Hive / swarm
+
+Forge MCP disconnected — plan path. Swarm later on leaf helpers after extract.
+
+## Proposed modules
+
+| Module | Concern | Projected LOC |
+|--------|---------|--------------:|
+| `evals/.../stage1_types.py` | errors, result dataclasses | 80–120 |
+| `evals/.../stage1_manifest.py` | `_load_and_verify_manifest`, digests/ids | 120–200 |
+| `evals/.../stage1_mock_executor.py` | `DeterministicMockRoleExecutor` | 200–250 |
+| `evals/.../stage1_harness_core.py` | `Stage1SafetyHarness` sliced methods | 600–900 |
+| `evals/.../stage1_harness.py` | thin entry/facade | ≤ 200 |
+
+## Migration order
+
+types → manifest helpers → mock executor → harness method groups (run / verify / persist) → facade. Pair campaign safety tests.
+
+## Risk
+
+Stage-1 live Needle still auth-gated — no behavior change in extracts. Move-only.
+
+## Non-goals
+
+Starting Stage 1 live gen; landing `main`.


### PR DESCRIPTION
## Summary
- Loop 8: evals/.../stage1_harness.py (~1.6k LOC); Stage1SafetyHarness ~1123 LOC is the split core.
- Forge MCP disconnected — plan path.

## Test plan
- [ ] Pair with campaign safety tests
- [ ] Docs only

Exact HEAD: 9bd603d097a617202e35da21d01c988591a683ea

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime or harness code changes in this PR.
> 
> **Overview**
> Adds **Loop 8** design doc for splitting `evals/campaigns/gemma_needle_2000_v1/stage1_harness.py` (~1644 LOC) without a mega-rewrite, scoped to campaign `gemma_needle_2000_v1`.
> 
> The plan proposes five modules (`stage1_types`, `stage1_manifest`, `stage1_mock_executor`, `stage1_harness_core`, thin `stage1_harness` facade), records baseline metrics, and defines migration order (types → manifest → mock executor → harness method groups → facade) with campaign safety tests paired to each step. **Move-only** extracts; stable CLI/entry; Forge MCP swarm deferred until after extract. Non-goals: Stage 1 live gen and landing on `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bd603d097a617202e35da21d01c988591a683ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->