### PR TITLE
docs(design): src/providers/subscription.py stack-split plan

### DIFF
--- a/docs/design/subscription-providers-refactor-plan.md
+++ b/docs/design/subscription-providers-refactor-plan.md
@@ -1,0 +1,45 @@
+# `src/providers/subscription.py` refactor plan (Loop 10)
+
+Status: **Ready for supervisor** — plan only.  
+Pairs later with `tests/test_subscription_transports.py`.
+
+## Why not a mega rewrite
+
+**~1427 LOC**, **19** classes. Two stacks: Claude CLI process adapter and MCP client sampling. Split stacks; keep `build_subscription_registry` facade.
+
+## Baseline (before)
+
+| Metric | Value |
+|--------|------:|
+| LOC | 1427 |
+| Bytes | 52913 |
+| Classes / funcs | 19 / 16 |
+| AST parse / compile | ~5 ms / ~3 ms |
+| Branch nodes | 82 |
+| Hot spans | `MCPClientSamplingAdapter` ~425; `ClaudeCLIAdapter` ~146; process runner helpers |
+
+## Hive / swarm
+
+Forge MCP disconnected — plan path.
+
+## Proposed modules
+
+| Module | Concern | Projected LOC |
+|--------|---------|--------------:|
+| `src/providers/subscription_cli_process.py` | process runner, bounds, kill/reap | 200–280 |
+| `src/providers/subscription_claude_cli.py` | ClaudeCLI* models + adapter | 280–400 |
+| `src/providers/subscription_sampling_types.py` | sampling dataclasses / digests | 150–220 |
+| `src/providers/subscription_mcp_sampling.py` | `MCPClientSamplingAdapter` + bindings | 400–550 |
+| `src/providers/subscription.py` | registry builder + re-exports | ≤ 150 |
+
+## Migration order
+
+CLI process → Claude adapter → sampling types → MCP sampling → registry facade. Green subscription transport tests per slice.
+
+## Risk
+
+Delegation digests / sealed bindings are security-sensitive — move-only; no authority changes.
+
+## Non-goals
+
+Changing sampling authority model; landing `main`.


### PR DESCRIPTION
## Summary
- Loop 10: src/providers/subscription.py (~1.4k LOC) Claude CLI vs MCP sampling stack split.
- Forge MCP disconnected — plan path.

## Test plan
- [ ] Pair with subscription transport tests
- [ ] Docs only

Exact HEAD: 5089800975f40ff063015cd6e98e7e9904c360ca

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change; no runtime or security behavior is modified in this PR.
> 
> **Overview**
> Adds **`docs/design/subscription-providers-refactor-plan.md`**, a supervisor-ready design doc for splitting **`src/providers/subscription.py`** (~1.4k LOC, 19 classes) without a mega rewrite.
> 
> The plan keeps **`build_subscription_registry`** as the facade and proposes five modules: CLI process runner, Claude CLI adapter, sampling types/digests, MCP sampling adapter, and a slim registry module. **Migration order** is CLI process → Claude → types → MCP sampling → facade, with **green `tests/test_subscription_transports.py` per slice**. **Risk** is called out for delegation digests and sealed bindings (**move-only**, no authority changes). **Non-goals** include changing the sampling authority model or landing on `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5089800975f40ff063015cd6e98e7e9904c360ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->