### PR TITLE
docs(design): test_mcp_session_guard lifecycle-split plan

### DIFF
--- a/docs/design/test-mcp-session-guard-refactor-plan.md
+++ b/docs/design/test-mcp-session-guard-refactor-plan.md
@@ -1,0 +1,46 @@
+# `tests/test_mcp_session_guard.py` refactor plan (Loop 11)
+
+Status: **Ready for supervisor** — plan only.  
+Pairs with: `src/mcp_session_guard.py` (later queue).
+
+## Why not a mega rewrite
+
+**~1397 LOC**, **13** fakes, **~40** tests. Density in TTL/cancel/shutdown races. Split by lifecycle concern; shared fakes in conftest.
+
+## Baseline (before)
+
+| Metric | Value |
+|--------|------:|
+| LOC | 1397 |
+| Bytes | 48235 |
+| Classes (fakes) / tests | 13 / ~40 |
+| AST parse / compile | ~6 ms / ~5 ms |
+| Branch nodes | 31 |
+| Dense clusters | sdk_private, cancelled_shutdown, max_ttl, concurrent/cancel races |
+
+## Hive / swarm
+
+Forge MCP disconnected — plan path.
+
+## Proposed modules
+
+| File | Concern |
+|------|---------|
+| `tests/mcp_session/conftest.py` | FakeClock/Transport/Registry/Revoker/App fakes |
+| `tests/mcp_session/test_ttl_idle.py` | idle/max TTL, expired cleanup |
+| `tests/mcp_session/test_cancel_shutdown.py` | cancel/shutdown races |
+| `tests/mcp_session/test_session_binding.py` | binding / unbound failures |
+| `tests/mcp_session/test_sdk_interop.py` | sdk_private / guard interop |
+| `tests/test_mcp_session_guard.py` | thin shim ≤ 120 LOC |
+
+## Migration order
+
+conftest → TTL → binding → cancel/shutdown → sdk interop → shim. Move-only.
+
+## Risk
+
+Timing/race tests sensitive to fixture moves — keep FakeClock semantics identical.
+
+## Non-goals
+
+Assertion rewrites; landing `main`.


### PR DESCRIPTION
## Summary
- Loop 11: tests/test_mcp_session_guard.py (~1.4k LOC) lifecycle-split plan.
- Forge MCP disconnected — plan path.

Exact HEAD: 29b1ac0b32bc2e058c7bb45613ea423bfe5dcd37

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime or test code changes.
> 
> **Overview**
> Adds **Loop 11** design doc `docs/design/test-mcp-session-guard-refactor-plan.md` — supervisor-ready **plan only** (no test moves in this PR).
> 
> It documents splitting the monolithic **`tests/test_mcp_session_guard.py`** (~1.4k LOC, 13 fakes, ~40 tests) into **`tests/mcp_session/`** modules by lifecycle (shared fakes in `conftest`, TTL/idle, cancel/shutdown, binding, SDK interop) and leaving a **≤120 LOC shim** at the original path. **Migration order** is move-only: conftest → TTL → binding → cancel/shutdown → SDK interop → shim; **non-goals** include assertion rewrites and landing on `main`. Notes pairing with a later **`src/mcp_session_guard.py`** queue and **FakeClock** semantics for race-sensitive tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29b1ac0b32bc2e058c7bb45613ea423bfe5dcd37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->