### PR TITLE
docs(design): src/rag.py pipeline module-split plan

### DIFF
--- a/docs/design/rag-refactor-plan.md
+++ b/docs/design/rag-refactor-plan.md
@@ -1,0 +1,39 @@
+# `src/rag.py` refactor plan (Loop 23)
+
+Status: **Ready for supervisor** — plan only.  
+Pairs with: test_task_rag plan #359.
+
+## Why not a mega rewrite
+
+**~1001 LOC**. **`TaskMemoryMirror` ~278 LOC** plus fusion/backfill helpers. Split by RAG pipeline stage.
+
+## Baseline (before)
+
+| Metric | Value |
+|--------|------:|
+| LOC | 1001 |
+| Projected primary LOC | ~150 facade |
+| % LOC change (primary file) | **−85%** |
+| Classes / funcs | 2 / 27 |
+
+## Hive / swarm
+
+Forge MCP Not connected — plan path.
+
+## Proposed modules
+
+| Module | Concern | Projected LOC |
+|--------|---------|--------------:|
+| `src/rag/mirror.py` | TaskMemoryMirror | 250–320 |
+| `src/rag/fusion.py` | fuse_task_evidence | 80–120 |
+| `src/rag/semantic.py` | gather_semantic_evidence | 80–120 |
+| `src/rag/backfill.py` | `_rag_backfill` | 80–120 |
+| `src/rag.py` | facade re-exports | ≤ 150 |
+
+## Migration order
+
+mirror → fusion → semantic → backfill → facade. Pair #359 tests.
+
+## Non-goals
+
+RAG policy changes; landing `main`.


### PR DESCRIPTION
## Summary
- Loop 23: src/rag.py (~1.0k LOC) mirror/fusion/semantic/backfill split; primary file projected −85% LOC.
- Forge HTTP ready; MCP tools still Not connected — plan path. Reload UniGrok Forge MCP to enable swarm.

## Test plan
- [ ] Docs only

Exact HEAD: ee5a1efc98b5f6f202119a331283178ade0c1f22

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no application or RAG behavior changes in this PR.
> 
> **Overview**
> Adds **`docs/design/rag-refactor-plan.md`**, a supervisor-ready design doc for Loop 23 that proposes splitting monolithic **`src/rag.py`** (~1001 LOC) into stage-based modules under **`src/rag/`** (`mirror`, `fusion`, `semantic`, `backfill`) while shrinking the primary file to a ≤150 LOC facade (**~85% LOC reduction** on the main entry).
> 
> The doc records baseline metrics (2 classes / 27 functions), a fixed migration order (mirror → fusion → semantic → backfill → facade), pairing with test plan **#359**, and explicit **non-goals** (no RAG policy changes, no landing on `main` yet). Forge MCP is noted as not connected, so this remains plan-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee5a1efc98b5f6f202119a331283178ade0c1f22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->