### PR TITLE
docs(design): tests/test_evals.py concern-split plan

### DIFF
--- a/docs/design/test-evals-refactor-plan.md
+++ b/docs/design/test-evals-refactor-plan.md
@@ -1,0 +1,37 @@
+# `tests/test_evals.py` refactor plan (Loop 26)
+
+Status: **Ready for supervisor** — plan only.
+
+## Why not a mega rewrite
+
+**~926 LOC**, **9** classes, **~46** tests. Split offline replay, routing advisor, calibration.
+
+## Baseline (before)
+
+| Metric | Value |
+|--------|------:|
+| LOC | 926 |
+| Projected primary LOC | ~100 shim |
+| % LOC change (primary file) | **−89%** |
+| Classes / tests | 9 / ~46 |
+
+## Hive / swarm
+
+Forge MCP Not connected — plan path.
+
+## Proposed modules
+
+| File | Concern |
+|------|---------|
+| `tests/evals/test_offline_replay.py` | TestOfflineReplay |
+| `tests/evals/test_routing_calibration.py` | CalibrationStore + RoutingAdvisorCalibration |
+| `tests/evals/test_routing_semantic.py` | TestRoutingAdvisorSemantic |
+| `tests/test_evals.py` | shim ≤ 100 LOC |
+
+## Migration order
+
+replay → calibration → semantic → remaining → shim. Move-only.
+
+## Non-goals
+
+Eval harness semantics; landing `main`.


### PR DESCRIPTION
## Summary
- Loop 26: tests/test_evals.py (~926 LOC) replay/calibration/semantic split; primary file projected −89% LOC.
- Forge HTTP ready; MCP tools still Not connected — plan path. Reload UniGrok Forge MCP to enable swarm.

## Test plan
- [ ] Docs only

Exact HEAD: 1c352200ec7371e6dc68cdf451a473ccb653058b

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no code or test behavior changes in this PR.
> 
> **Overview**
> Adds **`docs/design/test-evals-refactor-plan.md`** (Loop 26): a supervisor-ready, **move-only** plan to split **`tests/test_evals.py`** (~926 LOC, 9 classes, ~46 tests) into concern-focused modules under **`tests/evals/`**, leaving a **≤100 LOC shim** in the primary file (~**−89%** LOC there).
> 
> Proposed targets: **`test_offline_replay.py`**, **`test_routing_calibration.py`**, **`test_routing_semantic.py`**, with migration order **replay → calibration → semantic → remaining → shim**. **Non-goals** are changing eval harness semantics or landing on **`main`**; Forge MCP swarm work stays on the plan path while MCP is not connected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c352200ec7371e6dc68cdf451a473ccb653058b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->