### PR TITLE
docs(design): stage1 schema safety test-split plan

### DIFF
--- a/docs/design/test-stage1-schema-safety-refactor-plan.md
+++ b/docs/design/test-stage1-schema-safety-refactor-plan.md
@@ -1,0 +1,28 @@
+# `tests/.../test_stage1_schema_safety.py` refactor plan (Loop 33)
+
+Status: **Ready for supervisor** — plan only. Campaign gemma_needle_2000_v1.
+
+## Baseline
+
+| Metric | Value |
+|--------|------:|
+| LOC | 721 |
+| Projected primary LOC | ~90 shim |
+| % LOC change (primary file) | **−88%** |
+| Tests | ~21 |
+
+## Hive / swarm
+
+Forge MCP Not connected — plan path.
+
+## Proposed modules
+
+| File | Concern |
+|------|---------|
+| `tests/campaigns/gemma_needle_2000_v1/stage1/conftest.py` | `valid_envelope` helpers |
+| `tests/campaigns/.../stage1/test_oracle_authority.py` | oracle receipt/authority |
+| `tests/campaigns/.../stage1/test_blinded_review.py` | blinded review |
+| `tests/campaigns/.../stage1/test_digest_rejects.py` | unknown pack / frozen digest |
+| thin shim at current path | ≤ 90 LOC |
+
+Move-only; no Stage-1 live gen.


### PR DESCRIPTION
## Summary
- Loop 33: test_stage1_schema_safety.py (~721 LOC) oracle/blinded/digest split; primary file projected −88% LOC.
- Forge MCP Not connected — plan path.

## Test plan
- [ ] Docs only

Exact HEAD: e4369a4b83959b1d1c97b5c4bcd82156ec60af9f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only refactor plan with no runtime or test execution changes in this PR.
> 
> **Overview**
> Adds **`docs/design/test-stage1-schema-safety-refactor-plan.md`** for campaign **gemma_needle_2000_v1** (Loop 33): split the ~721 LOC **`test_stage1_schema_safety.py`** into **`stage1/conftest.py`** (`valid_envelope` helpers) and focused tests for **oracle authority**, **blinded review**, and **digest rejects**, leaving a **≤90 LOC** shim at the current path (~**−88%** on the primary file, ~21 tests unchanged).
> 
> Scope is **plan-only** (supervisor-ready); **Forge MCP not connected**. Explicitly **move-only**—no Stage-1 live generation changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4369a4b83959b1d1c97b5c4bcd82156ec60af9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->