### PR TITLE
docs(design): evals/runner.py offline-live split plan

### DIFF
--- a/docs/design/evals-runner-refactor-plan.md
+++ b/docs/design/evals-runner-refactor-plan.md
@@ -1,0 +1,27 @@
+# `evals/runner.py` refactor plan (Loop 39)
+
+Status: **Ready for supervisor** — plan only.
+
+## Baseline
+
+| Metric | Value |
+|--------|------:|
+| LOC | 659 |
+| Projected primary LOC | ~100 facade |
+| % LOC change (primary file) | **−85%** |
+| Classes / funcs | 1 / 20 |
+
+## Hive / swarm
+
+Forge MCP Not connected — plan path.
+
+## Proposed modules
+
+| Module | Concern |
+|--------|---------|
+| `evals/runner_task.py` | EvalTask |
+| `evals/runner_offline.py` | `_run_one_offline` / tool trace |
+| `evals/runner_live.py` | `_run_live_batch` |
+| `evals/runner.py` | facade ≤ 100 LOC |
+
+Move-only; no Stage-1 live auth bypass.


### PR DESCRIPTION
## Summary
- Loop 39: evals/runner.py (~659 LOC) task/offline/live split; primary file projected −85% LOC.
- Forge MCP Not connected — plan path.

## Test plan
- [ ] Docs only

Exact HEAD: a6b217fb5e19c0d82aa3740ded2175c0391e8b0f

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime or eval harness behavior changes.
> 
> **Overview**
> Adds **Loop 39** design doc `docs/design/evals-runner-refactor-plan.md` — plan-only, marked ready for supervisor; no implementation in this PR.
> 
> It records baseline metrics for monolithic `evals/runner.py` (~659 LOC, 1 class / 20 funcs) and proposes a **move-only** split into `runner_task.py` (`EvalTask`), `runner_offline.py` (`_run_one_offline` / tool trace), `runner_live.py` (`_run_live_batch`), leaving `runner.py` as a ≤100 LOC facade (~85% LOC reduction on the primary file). Explicit constraint: **no Stage-1 live auth bypass** changes. Notes Forge MCP not connected, so this follows the plan path rather than hive/swarm execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6b217fb5e19c0d82aa3740ded2175c0391e8b0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->