### PR TITLE
docs(design): gemma provider_adapters split plan

### DIFF
--- a/docs/design/gemma-provider-adapters-refactor-plan.md
+++ b/docs/design/gemma-provider-adapters-refactor-plan.md
@@ -1,0 +1,26 @@
+# `evals/.../provider_adapters.py` refactor plan (Loop 40)
+
+Status: **Ready for supervisor** — plan only. Campaign gemma_needle_2000_v1.
+
+## Baseline
+
+| Metric | Value |
+|--------|------:|
+| LOC | 623 |
+| Projected primary LOC | ~80 facade |
+| % LOC change (primary file) | **−87%** |
+| Classes / funcs | 3 / 16 |
+
+## Hive / swarm
+
+Forge MCP Not connected — plan path.
+
+## Proposed modules
+
+| Module | Concern |
+|--------|---------|
+| `evals/.../provider_secret_guards.py` | secret reject helpers |
+| `evals/.../provider_adapter_core.py` | ProviderAdapter (~363 LOC) |
+| `evals/.../provider_adapters.py` | facade ≤ 80 LOC |
+
+Move-only; secret-reject guards stay fail-closed.


### PR DESCRIPTION
## Summary
- Loop 40: evals/.../provider_adapters.py (~623 LOC) guards/adapter split; primary file projected −87% LOC.
- Forge MCP Not connected — plan path.

## Test plan
- [ ] Docs only

Exact HEAD: b88d4b7cd50e9d687f025f0dc34f13a8a4016e4d