### PR TITLE
docs(design): scripts/install_unigrok_theme.py command-split plan

### DIFF
--- a/docs/design/install-unigrok-theme-refactor-plan.md
+++ b/docs/design/install-unigrok-theme-refactor-plan.md
@@ -1,0 +1,27 @@
+# `scripts/install_unigrok_theme.py` refactor plan (Loop 53)
+
+Status: **Ready for supervisor** — plan only.
+
+## Baseline
+
+| Metric | Value |
+|--------|------:|
+| LOC | 478 |
+| Projected primary LOC | ~60 facade |
+| % LOC change (primary file) | **−87%** |
+| Funcs | 16 |
+
+## Hive / swarm
+
+Forge MCP Not connected — plan path.
+
+## Proposed modules
+
+| Module | Concern |
+|--------|---------|
+| `scripts/theme_install_core.py` | install |
+| `scripts/theme_check.py` | check |
+| `scripts/theme_enable.py` | enable_config |
+| `scripts/install_unigrok_theme.py` | main facade ≤ 60 LOC |
+
+Move-only; no README/public-artifact edits in this packet.


### PR DESCRIPTION
## Summary
- Loop 53: scripts/install_unigrok_theme.py (~478 LOC) install/check/enable split; primary file projected −87% LOC.
- Forge MCP Not connected — plan path.
- Does not touch README/public-artifact packets.

## Test plan
- [ ] Docs only

Exact HEAD: 5ec95352cf9fd82e2984a585a8c526302b69f818

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no installer or theme logic is modified in this PR.
> 
> **Overview**
> Adds **`docs/design/install-unigrok-theme-refactor-plan.md`**, a supervisor-ready **plan-only** packet for Loop 53.
> 
> It documents splitting **`scripts/install_unigrok_theme.py`** (~478 LOC, 16 functions) into **`theme_install_core.py`**, **`theme_check.py`**, and **`theme_enable.py`**, leaving the entry script as a **≤60 LOC facade** (~**−87%** LOC on the primary file). The work is described as **move-only**, with **no README or public-artifact** edits in this packet. **Forge MCP** is noted as not connected, so this follows the plan path only—**no runtime installer behavior changes** in the diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ec95352cf9fd82e2984a585a8c526302b69f818. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->