### PR TITLE
docs(design): stage1 mock harness test-split plan

### DIFF
--- a/docs/design/test-stage1-mock-harness-refactor-plan.md
+++ b/docs/design/test-stage1-mock-harness-refactor-plan.md
@@ -1,0 +1,28 @@
+# `tests/.../test_stage1_mock_harness.py` refactor plan (Loop 54)
+
+Status: **Ready for supervisor** — plan only. Campaign gemma_needle_2000_v1.
+
+## Baseline
+
+| Metric | Value |
+|--------|------:|
+| LOC | 477 |
+| Projected primary LOC | ~60 shim |
+| % LOC change (primary file) | **−87%** |
+| Tests | ~7 |
+
+## Hive / swarm
+
+Forge MCP Not connected — plan path.
+
+## Proposed modules
+
+| File | Concern |
+|------|---------|
+| `tests/campaigns/.../stage1/test_mock_topology.py` | transport-free/private/resumable |
+| `tests/campaigns/.../stage1/test_reviewer_blindness.py` | content without authority |
+| `tests/campaigns/.../stage1/test_crash_takeover.py` | indeterminate/no-retry |
+| `tests/campaigns/.../stage1/test_seed_binding.py` | wrong seed fails root profile |
+| thin shim at current path | ≤ 60 LOC |
+
+Move-only; no Stage-1 live gen.


### PR DESCRIPTION
## Summary
- Loop 54: test_stage1_mock_harness.py (~477 LOC) topology/blindness/crash/seed split; primary file projected −87% LOC.
- Forge MCP Not connected — plan path.
- Does not touch README/public-artifact packets.

## Test plan
- [ ] Docs only

Exact HEAD: 5662c24d53ce38db399d319d5454e4f09ff0ba39

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no code, tests, or runtime behavior changes.
> 
> **Overview**
> Adds a **Loop 54** design doc (`test-stage1-mock-harness-refactor-plan.md`) that plans splitting `test_stage1_mock_harness.py` (~477 LOC, ~7 tests) into focused stage1 test modules plus a thin ≤60 LOC shim at the current path (**−87%** on the primary file).
> 
> The split maps concerns to **mock topology**, **reviewer blindness**, **crash takeover**, and **seed binding**; scope is **move-only** with no Stage-1 live generation. Status is **ready for supervisor** (plan only) for campaign `gemma_needle_2000_v1`, with **Forge MCP not connected** noted on the plan path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5662c24d53ce38db399d319d5454e4f09ff0ba39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->