### PR TITLE
docs(design): gemma validators refactor plan - superiority loop 57

### DIFF
--- a/docs/design/gemma-validators-refactor-plan.md
+++ b/docs/design/gemma-validators-refactor-plan.md
@@ -1,0 +1,26 @@
+# `evals/.../validators.py` refactor plan (Loop 57)
+
+Status: **Ready for supervisor** — plan only. Campaign gemma_needle_2000_v1.
+
+## Baseline
+
+| Metric | Value |
+|--------|------:|
+| LOC | 465 |
+| Projected primary LOC | ~50 facade |
+| % LOC change (primary file) | **−89%** |
+| Hot class | `MechanicalValidators` ~383 LOC |
+
+## Hive / swarm
+
+Forge MCP Not connected — plan path.
+
+## Proposed modules
+
+| Module | Concern |
+|--------|---------|
+| `evals/.../validator_text.py` | `_iter_text_values` / projection helpers |
+| `evals/.../validator_mechanical.py` | MechanicalValidators methods |
+| `evals/.../validators.py` | facade ≤ 50 LOC |
+
+Move-only.


### PR DESCRIPTION
## Summary
- Superiority loop 57: plan-only refactor for `evals/campaigns/gemma_needle_2000_v1/validators.py` (~465 LOC → projected -89% primary shrink).
- Forge swarm: **Blocked** (MCP Not connected) — plan-PR path.
- No runtime extract in this PR.

## Test plan
- [ ] Review plan module boundaries
- [ ] Supervisor approves before extract

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no production code or validator behavior changes until a follow-up extract PR.
> 
> **Overview**
> Adds a **supervisor-ready, plan-only** design doc for splitting `evals/campaigns/gemma_needle_2000_v1/validators.py` (~465 LOC, mostly `MechanicalValidators`) into **`validator_text.py`**, **`validator_mechanical.py`**, and a **≤50 LOC facade** in `validators.py` — projected **−89%** on the primary file, **move-only** (no behavior change).
> 
> Documents baseline metrics and notes **Forge MCP not connected**, so this PR is the plan path with **no runtime extract** until supervisor approval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe49de48c977f88d1994b21ce0616f0c8bef6ea7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->