### PR TITLE
fix(swarm): analyze reports verified-search needs as advisory, not blockers

### DIFF
--- a/src/swarm/analytics.py
+++ b/src/swarm/analytics.py
@@ -22,6 +22,13 @@ from ..subprocess_security import create_scrubbed_subprocess_exec
 from ..utils import redact_secrets
 
 MAX_SOURCE_BYTES = 256 * 1024
+
+# A verified/scored swarm search genuinely needs a correctness oracle (tests)
+# and a measurement (benchmark). Their absence does NOT make code-only analyze
+# impossible, so they are reported as advisory requirements for the opt-in
+# scored search rather than as hard blockers that would frame the free,
+# code-only analyze path as "blocked".
+SCORED_SEARCH_REQUIREMENTS = ["missing_tests", "missing_benchmark"]
 _CONTROL_NODES = (
     ast.If,
     ast.For,
@@ -225,7 +232,11 @@ def analyze_python_source(source: str) -> Dict[str, Any]:
             },
             "secret_warning": secret_warning,
             "functions": [],
-            "searchability": {"ready": False, "blockers": ["parse_error"]},
+            "searchability": {
+                "ready": False,
+                "blockers": ["parse_error"],
+                "scored_search_requirements": list(SCORED_SEARCH_REQUIREMENTS),
+            },
         }
 
     lines = encoded.splitlines(keepends=True)
@@ -251,7 +262,17 @@ def analyze_python_source(source: str) -> Dict[str, Any]:
             "unreferenced_private_names": _private_dead_names(tree),
         },
         "duplication": _duplication(source),
-        "searchability": {"ready": False, "blockers": [*blockers, "missing_tests", "missing_benchmark"]},
+        "searchability": {
+            # Code-only analyze is a real, useful result. ``ready`` reflects
+            # whether the source is analyzable and pickable as a target — it is
+            # NOT gated on tests/benchmark. Hard ``blockers`` are the things
+            # that actually make analysis or target-picking impossible; the
+            # oracle + measurement a verified search needs are surfaced as
+            # advisory ``scored_search_requirements`` instead.
+            "ready": not blockers,
+            "blockers": blockers,
+            "scored_search_requirements": list(SCORED_SEARCH_REQUIREMENTS),
+        },
         "tooling": {"python_ast": f"{sys.version_info.major}.{sys.version_info.minor}"},
     }
 

--- a/src/tools/swarm.py
+++ b/src/tools/swarm.py
@@ -352,7 +352,13 @@ async def start_paste_swarm(
         (scratch / "test_focus.py").write_text(test_code, encoding="utf-8")
         (scratch / "bench_focus.py").write_text(bench_code, encoding="utf-8")
         analytics["source"] = "paste"
-        analytics["searchability"] = {"ready": True, "blockers": []}
+        # Paste swarm supplies its own test + benchmark, so the scored-search
+        # requirements are satisfied and there are no blockers.
+        analytics["searchability"] = {
+            "ready": True,
+            "blockers": [],
+            "scored_search_requirements": [],
+        }
         budget = swarm_config.swarm_default_budget_usd() if budget_usd is None else float(budget_usd)
         budget = max(0.0, min(budget, swarm_config.swarm_max_budget_usd()))
 

--- a/tests/test_swarm_analytics.py
+++ b/tests/test_swarm_analytics.py
@@ -45,8 +45,36 @@ def test_inventory_and_measured_metrics_are_stable():
     assert choose["max_nesting"] == 3
     assert result["imports"] == ["json", "os"]
     assert result["dead_code"]["unused_imports"] == ["js", "os"]
-    assert result["searchability"]["ready"] is False
-    assert "missing_tests" in result["searchability"]["blockers"]
+    # Code-only analyze on parseable code with functions is NOT "blocked":
+    # ready is true and the hard blockers list is empty. The oracle +
+    # measurement a verified/scored search needs are reported as advisory
+    # requirements, never as hard blockers.
+    search = result["searchability"]
+    assert search["ready"] is True
+    assert search["blockers"] == []
+    assert "missing_tests" not in search["blockers"]
+    assert "missing_benchmark" not in search["blockers"]
+    assert search["scored_search_requirements"] == ["missing_tests", "missing_benchmark"]
+
+
+def test_no_functions_is_a_hard_blocker_but_requirements_stay_advisory():
+    # Nothing to search: this is a genuine hard blocker, so ready is False and
+    # "no_functions" appears in blockers. The scored-search requirements are
+    # still reported advisorily and never leak into the hard blockers list.
+    result = analyze_python_source("x = 1\n")
+    search = result["searchability"]
+    assert search["ready"] is False
+    assert search["blockers"] == ["no_functions"]
+    assert search["scored_search_requirements"] == ["missing_tests", "missing_benchmark"]
+    assert "missing_tests" not in search["blockers"]
+
+
+def test_parse_error_reports_requirements_and_is_blocked():
+    result = analyze_python_source("def broken(:\n")
+    search = result["searchability"]
+    assert search["ready"] is False
+    assert search["blockers"] == ["parse_error"]
+    assert search["scored_search_requirements"] == ["missing_tests", "missing_benchmark"]
 
 
 def test_parse_error_and_secret_warning_never_echo_secret():


### PR DESCRIPTION
## What

Part of Phase 2 of the console redesign. `analyze_code_for_swarm` is code-only, but `src/swarm/analytics.py` unconditionally stamped `missing_tests`/`missing_benchmark` into `searchability.blockers`, so even the free zero-cost analyze path advertised the pasted code as "blocked." This softens that **truthfully and backward-compatibly**: a verified/scored search genuinely still needs an oracle + measurement, but code-only analysis is not blocked.

New shape (additive — `blockers` key preserved):
```
searchability: { ready: bool, blockers: string[], scored_search_requirements: string[] }
```
- `missing_tests`/`missing_benchmark` **moved out of `blockers`** into the new `scored_search_requirements` (advisory).
- `ready` is now driven only by hard blockers (`parse_error`/`no_functions`/`secret_like_source`); code-only parseable input → `ready: true` (was always false).
- `blockers` now holds hard blockers only; the paste-swarm override (tests+bench supplied) → `requirements: []`.

Companion UI PR (#TBD, stacked on #344) reads `scored_search_requirements` and reframes it as "optional to verify — we'll scaffold it."

## Changed paths
- `src/swarm/analytics.py`, `src/tools/swarm.py`, `tests/test_swarm_analytics.py`

## Tests
- Full suite **2204 passed**; `test_swarm_analytics.py` 7 passed. New tests pin: code-only analyze → `ready:true`, empty `blockers`, advisory requirements present; `no_functions`/`parse_error` still drive `ready:false`. Verified no downstream consumer reads `searchability.ready`; `plan_swarm_campaign`'s unrelated string field left untouched. Attribution: passed.

## Handoff
- Draft — awaiting Codex landing. Independent (off main). Sponsor: David Johnston (@djtelicloud).

Agent-Assisted-By: Anthropic Claude | model=Fable 5 | model-source=user-reported | surface=Claude Code | role=implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API shape on analytics payloads with behavior change confined to searchability semantics; tests cover the new contract and paste-swarm override.
> 
> **Overview**
> **Swarm paste analytics** no longer marks code-only analyze as blocked when tests or a benchmark are missing. `missing_tests` and `missing_benchmark` move out of `searchability.blockers` into a new additive field **`scored_search_requirements`**, while **`ready`** is true only when there are no hard blockers (`parse_error`, `no_functions`, `secret_like_source`).
> 
> Parseable pasted code with functions now returns **`ready: true`** with an empty **`blockers`** list and advisory requirements still listed. Parse errors and **`no_functions`** keep **`ready: false`** with the appropriate hard blockers; advisory requirements are still included.
> 
> **`start_paste_swarm`** overrides searchability to **`scored_search_requirements: []`** because the caller supplies test and benchmark code. Tests in **`test_swarm_analytics.py`** lock in the new contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92bbf025b1a2b30662b444d5ae73d15715afadc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->