### PR TITLE
feat(mcp_ui): progressive-disclosure swarm UX with auto-scaffolded verification

### DIFF
--- a/mcp_ui/app.js
+++ b/mcp_ui/app.js
@@ -1,9 +1,9 @@
-import { parseMarkdown, sanitizeHref } from "./markdown.js?v=grok-v0.6.0-r13";
+import { parseMarkdown, sanitizeHref } from "./markdown.js?v=grok-v0.6.0-r14";
 
 // Must match the <meta name="unigrok-ui-version"> baked into index.html and
 // src/version.py UI_ASSET_VERSION; a mismatch means the browser paired a
 // cached page with a different script build (the stale-skew failure class).
-const UI_ASSET_VERSION = "grok-v0.6.0-r13";
+const UI_ASSET_VERSION = "grok-v0.6.0-r14";
 
 const LAYOUT_KEY = "unigrok.mcp.console.layout.v2";
 

--- a/mcp_ui/index.html
+++ b/mcp_ui/index.html
@@ -7,9 +7,9 @@
     <meta name="unigrok-ui-regions" content="navigation,workbench,rpc-inspector,rpc-logs,result-facts" />
     <!-- Version handshake: app.js compares this against its own build constant
          and self-heals a stale-cached page with one revalidating reload. -->
-    <meta name="unigrok-ui-version" content="grok-v0.6.0-r13" />
-  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r13" />
-  <link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r13" />
+    <meta name="unigrok-ui-version" content="grok-v0.6.0-r14" />
+  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r14" />
+  <link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r14" />
   </head>
   <body>
     <main class="app-shell">
@@ -523,6 +523,6 @@ docker compose up --build -d</code></pre>
 
       </section>
     </main>
-  <script type="module" src="./app.js?v=grok-v0.6.0-r13"></script>
+  <script type="module" src="./app.js?v=grok-v0.6.0-r14"></script>
   </body>
 </html>

--- a/mcp_ui/swarm.html
+++ b/mcp_ui/swarm.html
@@ -9,8 +9,8 @@
        skew. The swarm page now reuses the Control Center's shared fluid system
        (tokens.css identity + styles.css container-query grid) rather than a
        bespoke inline stylesheet that re-aliased the tokens. -->
-  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r13" />
-  <link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r13" />
+  <link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r14" />
+  <link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r14" />
 </head>
 <body>
   <main class="swarm-app" data-detail="dock">
@@ -48,7 +48,7 @@
                 <button id="pasteExampleBtn" type="button">Use slow example</button>
                 <span id="analysisMsg" class="muted" role="status" aria-live="polite"></span>
               </div>
-              <div id="privacyNote" class="privacy-note">Analysis starts in this browser. Verified execution is local-only and requires tests plus a benchmark.</div>
+              <div id="privacyNote" class="privacy-note">Analysis starts in this browser and never runs your code. Scoring rewrites is opt-in and local-only.</div>
             </div>
             <div id="analysisResults" class="analysis-results">
               <h3>What you will get</h3>
@@ -56,18 +56,43 @@
             </div>
           </div>
           <details id="searchSetup" class="advanced">
-            <summary>Run verified local search: add tests and benchmark</summary>
+            <summary>Score it against your tests (opt-in)</summary>
+            <p class="scaffold-intro muted">Free analysis above never runs your code. To <em>rank</em> rewrites the swarm needs a way to check them, so give one honest input — sample inputs — and we scaffold a benchmark and a baseline-equivalence test you can edit. Both start valid; strengthen them for real correctness.</p>
             <div class="paste-actions">
-              <label>Function <select id="focusPicker"><option value="">analyze code first</option></select></label>
+              <label>Hotspot <select id="focusPicker"><option value="">analyze code first</option></select></label>
               <label>Goal <select id="goalPicker"><option value="balanced">balanced</option><option value="latency">latency</option><option value="memory">memory</option><option value="size">size</option></select></label>
-              <label>Strategy <select id="strategyPicker"><option value="elite_offspring">evolve from elites</option><option value="baseline_batch">baseline batch</option></select></label>
+            </div>
+            <div class="sample-field">
+              <div class="code-label">Sample inputs (JSON) · the one input we need</div>
+              <textarea id="sampleInput" class="code-input oracle-input" spellcheck="false" maxlength="65536"
+                placeholder="[ [[3, 1, 3, 2, 1]], [[5, 5, 5, 5]] ]  — a JSON array of calls; each element is the positional-argument list for one call"></textarea>
+              <div class="privacy-note">Each element is the positional-argument list for one call. Example: <code>[[[3, 1, 3, 2, 1]]]</code> calls the hotspot once with <code>[3, 1, 3, 2, 1]</code>.</div>
+              <span id="sampleMsg" class="muted" role="status" aria-live="polite"></span>
+              <button id="rescaffoldBtn" type="button">Regenerate scaffold from sample inputs</button>
             </div>
             <div class="paste-grid oracle-grid">
-              <div><div class="code-label">pytest code · required</div><textarea id="testInput" class="code-input oracle-input" spellcheck="false" maxlength="131072" placeholder="from module_under_test import your_function&#10;&#10;def test_behavior(): ..."></textarea></div>
-              <div><div class="code-label">benchmark script · required</div><textarea id="benchInput" class="code-input oracle-input" spellcheck="false" maxlength="65536" placeholder="Print one SWARM_BENCH JSON line with latency_ms and peak_mem_bytes"></textarea></div>
+              <div>
+                <div class="code-label">baseline-equivalence pytest · scaffolded, editable</div>
+                <textarea id="testInput" class="code-input oracle-input" spellcheck="false" maxlength="131072"></textarea>
+                <div class="privacy-note">We scaffolded this; it checks equivalence on your sample inputs — strengthen it for real correctness.</div>
+                <span id="testFieldMsg" class="err" role="status" aria-live="polite"></span>
+              </div>
+              <div>
+                <div class="code-label">SWARM_BENCH harness · scaffolded, editable</div>
+                <textarea id="benchInput" class="code-input oracle-input" spellcheck="false" maxlength="65536"></textarea>
+                <div class="privacy-note">We scaffolded this; it prints the measured SWARM_BENCH contract line — nothing is simulated.</div>
+                <span id="benchFieldMsg" class="err" role="status" aria-live="polite"></span>
+              </div>
             </div>
+            <details class="advanced">
+              <summary>Advanced: strategy &amp; budget</summary>
+              <div class="paste-actions">
+                <label>Strategy <select id="strategyPicker"><option value="elite_offspring">evolve from elites</option><option value="baseline_batch">baseline batch</option></select></label>
+                <span class="muted">Budget ceiling is enforced server-side and shown in the scorecard before any run.</span>
+              </div>
+            </details>
             <div class="paste-actions">
-              <button id="runPasteBtn" class="primary" type="button" disabled>Run verified swarm</button>
+              <button id="runPasteBtn" class="primary" type="button">Score it — run verified swarm</button>
               <span id="pasteRunMsg" class="muted" role="status" aria-live="polite">Available in contributor Forge after exact analysis.</span>
             </div>
           </details>
@@ -156,6 +181,6 @@
     </div>
   </main>
 
-  <script src="./swarm.js?v=grok-v0.6.0-r13"></script>
+  <script src="./swarm.js?v=grok-v0.6.0-r14"></script>
 </body>
 </html>

--- a/mcp_ui/swarm.js
+++ b/mcp_ui/swarm.js
@@ -15,7 +15,7 @@
 // Must match src/version.py UI_ASSET_VERSION and the query token on the
 // swarm.js reference in swarm.html. The sample uses the same token so a
 // revalidated page cannot pair new logic with a heuristically cached payload.
-const UI_ASSET_VERSION = "grok-v0.6.0-r13";
+const UI_ASSET_VERSION = "grok-v0.6.0-r14";
 
 const $ = (id) => document.getElementById(id);
 const SVG_NS = "http://www.w3.org/2000/svg";
@@ -764,8 +764,235 @@ function browserAnalyzePython(code) {
     bytes: new TextEncoder().encode(code).length,
     loc: lines.filter((line) => line.trim()).length,
     functions,
-    searchability: { ready: false, blockers: ["missing_tests", "missing_benchmark"] },
+    // Mirror the server's 3-key shape: a verified/scored search still needs an
+    // oracle + measurement (advisory), but code-only analysis is not "blocked".
+    searchability: {
+      ready: functions.length > 0,
+      blockers: functions.length > 0 ? [] : ["no_functions"],
+      scored_search_requirements: ["missing_tests", "missing_benchmark"],
+    },
   };
+}
+
+// ── Optional-verification scaffolding ────────────────────────────────────────
+// Progressive disclosure: free analyze is code-only. Scoring rewrites is opt-in
+// and needs exactly ONE honest input — sample inputs — from which we scaffold a
+// SWARM_BENCH harness and a baseline-equivalence pytest. Both are pre-filled,
+// valid-on-open, and fully editable. We label them honestly: they only prove
+// equivalence on the sample inputs; the user strengthens them for real
+// correctness. The tool still receives test_code + bench_code — the UI wrote
+// them from one input instead of forcing two hand-authored code blocks.
+
+// The `missing_tests` / `missing_benchmark` searchability markers are NOT hard
+// blockers here: the UI scaffolds both. We feature-detect either shape — the
+// original server listed them under searchability.blockers; the softened server
+// (claude/swarm-analyze-advisory) moves them to
+// searchability.scored_search_requirements and sets ready=true for code-only
+// input. We read every field name so the two compose whichever lands.
+const SCAFFOLDABLE_MARKERS = new Set(["missing_tests", "missing_benchmark"]);
+
+function classifySearchability(searchability) {
+  const s = searchability || {};
+  const blockers = Array.isArray(s.blockers) ? s.blockers : [];
+  const advisory = [
+    ...(Array.isArray(s.scored_search_requirements) ? s.scored_search_requirements : []),
+    ...(Array.isArray(s.advisory) ? s.advisory : []),
+    ...(Array.isArray(s.optional) ? s.optional : []),
+  ];
+  // Hard blockers are anything the UI cannot scaffold away.
+  const hardBlockers = blockers.filter((b) => !SCAFFOLDABLE_MARKERS.has(b));
+  // Optional-to-verify = the scaffoldable markers wherever the server put them.
+  const optional = [...new Set([
+    ...advisory,
+    ...blockers.filter((b) => SCAFFOLDABLE_MARKERS.has(b)),
+  ])];
+  return { hardBlockers, optional };
+}
+
+function functionNameFromFocus(focus) {
+  if (typeof focus !== "string") return "";
+  const name = focus.includes(":") ? focus.split(":").pop() : focus;
+  return (name || "").trim();
+}
+
+// Rank the hottest function: highest cyclomatic complexity, then most LOC, then
+// deepest nesting. This is a heuristic hint — the picker stays fully editable.
+function topHotspot(functions) {
+  const list = Array.isArray(functions) ? functions.filter((fn) => fn && fn.focus_node) : [];
+  if (!list.length) return null;
+  return list.slice().sort((a, b) =>
+    (b.cyclomatic_complexity || 0) - (a.cyclomatic_complexity || 0)
+    || (b.loc || 0) - (a.loc || 0)
+    || (b.max_nesting || 0) - (a.max_nesting || 0)
+  )[0];
+}
+
+// JSON.stringify emits a valid Python (double-quoted) string literal for every
+// standard case (control chars → \n/\uXXXX, backslashes doubled, no \' or \/),
+// so we embed the frozen original source and the sample text without a fragile
+// triple-quote heredoc that a stray ''' in user code could break.
+function pyStr(value) {
+  return JSON.stringify(String(value));
+}
+
+function scaffoldEquivalenceTest(code, fnName, sampleText) {
+  const name = fnName || "your_function";
+  return `# Scaffolded baseline-equivalence check.
+# We scaffolded this; it checks that each candidate rewrite returns the SAME
+# result as your ORIGINAL code on the sample inputs below. It is a STARTER — it
+# only proves equivalence on THESE inputs. Strengthen it for real correctness.
+import copy
+import json
+
+from module_under_test import ${name} as _candidate
+
+# Frozen copy of your original implementation — the equivalence oracle. The
+# swarm replaces module_under_test with each candidate; this stays the baseline.
+_ORIGINAL_SOURCE = ${pyStr(code)}
+_original_ns = {"__name__": "original_reference"}
+exec(compile(_ORIGINAL_SOURCE, "original_reference.py", "exec"), _original_ns)
+_original = _original_ns[${pyStr(name)}]
+
+# Each element is the positional-argument list for one call.
+SAMPLE_INPUTS = json.loads(${pyStr(sampleText)})
+
+
+def test_candidate_matches_original_on_samples():
+    assert SAMPLE_INPUTS, "add at least one sample call to make this check meaningful"
+    for index, call_args in enumerate(SAMPLE_INPUTS):
+        # Deep-copy per call so a hotspot that mutates its inputs in place
+        # (e.g. list.sort()) does not let the first call taint the second.
+        candidate_out = _candidate(*copy.deepcopy(call_args))
+        original_out = _original(*copy.deepcopy(call_args))
+        assert candidate_out == original_out, (
+            f"candidate diverged from the original on sample #{index}: {call_args!r}"
+        )
+`;
+}
+
+function scaffoldBenchHarness(fnName, sampleText) {
+  const name = fnName || "your_function";
+  return `# Scaffolded SWARM_BENCH harness (same shape as scripts/swarm_bench.py).
+# We scaffolded this; it MEASURES latency and peak memory of the hotspot on your
+# sample inputs and prints the one contract line the swarm reads. Nothing is
+# simulated — these are real perf_counter + tracemalloc numbers.
+import json
+import time
+import tracemalloc
+
+from module_under_test import ${name} as target
+
+# Each element is the positional-argument list for one call.
+SAMPLE_INPUTS = json.loads(${pyStr(sampleText)})
+INNER_LOOPS = 200
+
+# Untimed warmup.
+for _call_args in SAMPLE_INPUTS:
+    target(*_call_args)
+
+tracemalloc.start()
+_started = time.perf_counter()
+for _ in range(INNER_LOOPS):
+    for _call_args in SAMPLE_INPUTS:
+        target(*_call_args)
+_latency_ms = (time.perf_counter() - _started) * 1000 / INNER_LOOPS
+_current, _peak = tracemalloc.get_traced_memory()
+tracemalloc.stop()
+
+print("SWARM_BENCH " + json.dumps({"latency_ms": _latency_ms, "peak_mem_bytes": int(_peak)}))
+`;
+}
+
+// A textarea we generated carries data-scaffolded="1"; a manual edit clears it
+// so re-scaffolding never clobbers the user's own work.
+function markScaffolded(el) { if (el) el.dataset.scaffolded = "1"; }
+function isScaffolded(el) { return !!el && el.dataset.scaffolded === "1"; }
+
+function validateSampleText(sampleText) {
+  const text = (sampleText || "").trim();
+  if (!text) return { ok: false, empty: true, message: "add at least one sample call" };
+  try {
+    const parsed = JSON.parse(text);
+    if (!Array.isArray(parsed)) {
+      return { ok: false, message: "sample inputs must be a JSON array of calls" };
+    }
+    return { ok: true, empty: parsed.length === 0, parsed };
+  } catch (err) {
+    return { ok: false, message: `not valid JSON: ${err.message}` };
+  }
+}
+
+// Write both scaffolds from the current hotspot + sample inputs. `force` regen
+// overwrites even manually-edited boxes (the explicit Regenerate button);
+// otherwise we only (re)write boxes that are still auto-generated or empty.
+function scaffoldOracles(force) {
+  const testEl = $("testInput");
+  const benchEl = $("benchInput");
+  const sampleEl = $("sampleInput");
+  if (!testEl || !benchEl) return;
+  const code = $("codeInput")?.value ?? "";
+  const fnName = functionNameFromFocus($("focusPicker")?.value ?? "");
+  const rawSample = sampleEl ? sampleEl.value : "";
+  // Keep scaffolds valid-on-open: fall back to an empty JSON array when the
+  // sample field is blank or not-yet-valid JSON. The pre-launch check still
+  // flags an empty array before any budget is spent.
+  const check = validateSampleText(rawSample);
+  const sampleText = check.ok ? rawSample.trim() : "[]";
+  const sampleMsg = $("sampleMsg");
+  if (sampleMsg) {
+    sampleMsg.textContent = check.ok
+      ? (check.empty ? "valid, but empty — add at least one call before you score" : "sample inputs look valid")
+      : (rawSample.trim() ? check.message : "");
+    sampleMsg.className = check.ok || !rawSample.trim() ? "muted" : "err";
+  }
+  if (force || isScaffolded(testEl) || !testEl.value.trim()) {
+    testEl.value = scaffoldEquivalenceTest(code, fnName, sampleText);
+    markScaffolded(testEl);
+  }
+  if (force || isScaffolded(benchEl) || !benchEl.value.trim()) {
+    benchEl.value = scaffoldBenchHarness(fnName, sampleText);
+    markScaffolded(benchEl);
+  }
+}
+
+// Inline pre-launch validation: sanity-check the oracles AT THE FIELD before a
+// swarm burns budget — the test must reference module_under_test + the hotspot,
+// and the bench must emit the SWARM_BENCH contract token.
+function validateOraclesBeforeRun() {
+  const testEl = $("testInput");
+  const benchEl = $("benchInput");
+  const testMsg = $("testFieldMsg");
+  const benchMsg = $("benchFieldMsg");
+  const sampleMsg = $("sampleMsg");
+  if (testMsg) testMsg.textContent = "";
+  if (benchMsg) benchMsg.textContent = "";
+  const fnName = functionNameFromFocus($("focusPicker")?.value ?? "");
+  const testCode = testEl?.value ?? "";
+  const benchCode = benchEl?.value ?? "";
+  const problems = [];
+  if (!fnName) problems.push({ el: sampleMsg, text: "choose a hotspot function first" });
+  if (!testCode.trim()) {
+    problems.push({ el: testMsg, text: "the equivalence test is empty" });
+  } else if (!testCode.includes("module_under_test")) {
+    problems.push({ el: testMsg, text: "test must import from module_under_test" });
+  } else if (fnName && !testCode.includes(fnName)) {
+    problems.push({ el: testMsg, text: `test does not reference ${fnName}` });
+  }
+  const sampleCheck = validateSampleText($("sampleInput")?.value ?? "");
+  if (sampleCheck.ok && sampleCheck.empty) {
+    problems.push({ el: sampleMsg, text: "add at least one sample call before scoring" });
+  } else if (!sampleCheck.ok) {
+    problems.push({ el: sampleMsg, text: sampleCheck.message });
+  }
+  if (!benchCode.trim()) {
+    problems.push({ el: benchMsg, text: "the benchmark is empty" });
+  } else if (!benchCode.includes("SWARM_BENCH")) {
+    problems.push({ el: benchMsg, text: "benchmark must print a SWARM_BENCH contract line" });
+  }
+  for (const problem of problems) {
+    if (problem.el) { problem.el.textContent = problem.text; problem.el.className = "err"; }
+  }
+  return problems.length === 0;
 }
 
 function renderAnalysis(result, exact) {
@@ -797,12 +1024,22 @@ function renderAnalysis(result, exact) {
     </div>`).join("");
   const ruffCount = Object.values(result.ruff?.counts_by_code || {})
     .reduce((sum, value) => sum + Number(value || 0), 0);
+  // Reframe searchability: real blockers stay red; the scaffoldable markers
+  // (missing_tests/missing_benchmark) become a neutral opt-in note — we scaffold
+  // them. Feature-detects both the current and softened server shapes.
+  const { hardBlockers, optional } = classifySearchability(result.searchability);
+  const hardBlockersHtml = hardBlockers.length
+    ? `<div class="err" style="margin-top:7px">Blockers: ${esc(hardBlockers.join(", "))}</div>`
+    : "";
+  const optionalHtml = optional.length
+    ? `<div class="privacy-note">Optional to verify: add a check and we'll scaffold it. Open “Score it against your tests” below — one Sample-inputs field fills a benchmark and a baseline-equivalence test for you.</div>`
+    : `<div class="privacy-note">Ready to score. Open “Score it against your tests” below to scaffold a benchmark and equivalence test from one Sample-inputs field.</div>`;
   panel.innerHTML = `
     <h3>${(result.functions || []).length} function${(result.functions || []).length === 1 ? "" : "s"} found</h3>
     <div class="muted">${esc(result.loc ?? 0)} source lines · ${esc(result.bytes ?? 0)} bytes${exact ? ` · ${ruffCount} Ruff finding${ruffCount === 1 ? "" : "s"}` : " · approximate browser metrics"}</div>
     ${result.secret_warning ? '<div class="err" style="margin-top:7px">Secret-like text detected. Remove it before export or search.</div>' : ""}
     <div class="function-list">${rows || `<div class="muted">${exact ? "No functions found." : "No top-level functions detected by the approximate browser scanner."}</div>`}</div>
-    <div class="privacy-note">Search blockers: ${esc((result.searchability?.blockers || []).join(", ") || "none")}</div>`;
+    ${hardBlockersHtml}${optionalHtml}`;
   const picker = $("focusPicker");
   if (picker) {
     picker.replaceChildren(new Option(
@@ -813,17 +1050,23 @@ function renderAnalysis(result, exact) {
         `${fn.focus_node} · CC ${fn.cyclomatic_complexity} · ${fn.loc} LOC`, fn.focus_node
       ));
     }
-    if ((result.functions || []).length) picker.value = result.functions[0].focus_node;
+    // Auto-pick the top-ranked hotspot (editable), not just the first def.
+    const hottest = topHotspot(result.functions);
+    if (hottest) picker.value = hottest.focus_node;
   }
+  // Verified EXECUTION stays gated to contributor Forge; scaffolding is free and
+  // available in any mode. If the opt-in panel is already open, refresh the
+  // scaffolds against the newly-picked hotspot (only the untouched ones).
   const canSearch = exact && state.runtimeMode === "contributor" && (result.functions || []).length > 0;
   const runBtn = $("runPasteBtn");
   if (runBtn) runBtn.disabled = !canSearch;
   const runMsg = $("pasteRunMsg");
   if (runMsg) {
     runMsg.textContent = canSearch
-      ? "Tests and benchmark are required; every winner is re-measured."
+      ? "Scaffolded benchmark + equivalence test are ready to edit; every winner is re-measured."
       : "Verified execution is available only in contributor Forge after exact analysis.";
   }
+  if ($("searchSetup")?.open) scaffoldOracles(false);
 }
 
 async function analyzePastedCode() {
@@ -868,33 +1111,28 @@ async function analyzePastedCode() {
 }
 
 $("analyzeBtn")?.addEventListener("click", analyzePastedCode);
-$("pasteExampleBtn")?.addEventListener("click", () => {
+// The example proves the whole flow is templatable: one paste + one Sample-
+// inputs value auto-scaffolds a working benchmark AND a baseline-equivalence
+// test — the user hand-authors neither.
+const SLOW_EXAMPLE_SAMPLE = `[
+  [[3, 1, 3, 2, 1]],
+  [[5, 5, 5, 5, 5, 5]]
+]`;
+
+$("pasteExampleBtn")?.addEventListener("click", async () => {
   const code = $("codeInput");
+  const sample = $("sampleInput");
   const test = $("testInput");
   const bench = $("benchInput");
   if (code) code.value = SLOW_EXAMPLE;
-  if (test) test.value = `from module_under_test import deduplicate
-
-def test_order_and_duplicates():
-    assert deduplicate([3, 1, 3, 2, 1]) == [3, 1, 2]
-`;
-  if (bench) bench.value = `import json
-import time
-import tracemalloc
-from module_under_test import deduplicate
-
-values = list(range(400)) * 3
-deduplicate(values[:50])
-tracemalloc.start()
-started = time.perf_counter()
-for _ in range(20):
-    deduplicate(values)
-latency_ms = (time.perf_counter() - started) * 1000 / 20
-_current, peak = tracemalloc.get_traced_memory()
-tracemalloc.stop()
-print("SWARM_BENCH " + json.dumps({"latency_ms": latency_ms, "peak_mem_bytes": peak}))
-`;
-  analyzePastedCode();
+  if (sample) sample.value = SLOW_EXAMPLE_SAMPLE;
+  // Reset scaffold ownership so the example regenerates both oracles cleanly.
+  if (test) { test.value = ""; delete test.dataset.scaffolded; }
+  if (bench) { bench.value = ""; delete bench.dataset.scaffolded; }
+  await analyzePastedCode();
+  const setup = $("searchSetup");
+  if (setup) setup.open = true;
+  scaffoldOracles(true);
 });
 
 async function runPasteSwarm() {
@@ -908,8 +1146,10 @@ async function runPasteSwarm() {
     search_strategy: $("strategyPicker")?.value ?? "",
     primary_goal: $("goalPicker")?.value ?? "",
   };
-  if (!args.focus_node || !args.test_code.trim() || !args.bench_code.trim()) {
-    if (runMsg) runMsg.textContent = "Choose a function and provide both tests and benchmark.";
+  // Inline pre-launch validation: surface any problem AT THE FIELD before a
+  // swarm burns budget — never after.
+  if (!validateOraclesBeforeRun()) {
+    if (runMsg) runMsg.textContent = "Fix the highlighted field(s) before scoring.";
     return;
   }
   if (button) button.disabled = true;
@@ -946,6 +1186,18 @@ async function runPasteSwarm() {
 }
 
 $("runPasteBtn")?.addEventListener("click", runPasteSwarm);
+
+// ── Opt-in scaffold wiring ───────────────────────────────────────────────────
+// Opening the panel pre-fills the oracles; editing sample inputs or the hotspot
+// regenerates only the still-untouched boxes; a manual edit takes ownership.
+$("searchSetup")?.addEventListener("toggle", (event) => {
+  if (event.target.open) scaffoldOracles(false);
+});
+$("sampleInput")?.addEventListener("input", () => scaffoldOracles(false));
+$("focusPicker")?.addEventListener("change", () => scaffoldOracles(false));
+$("rescaffoldBtn")?.addEventListener("click", () => scaffoldOracles(true));
+$("testInput")?.addEventListener("input", (event) => { delete event.target.dataset.scaffolded; });
+$("benchInput")?.addEventListener("input", (event) => { delete event.target.dataset.scaffolded; });
 
 async function refreshTaskPicker() {
   const picker = $("taskPicker");

--- a/src/version.py
+++ b/src/version.py
@@ -7,4 +7,4 @@ __version__ = "0.6.0"
 # runtime handshake in app.js).
 # Bump the -rN suffix whenever any /ui asset changes; a pytest asserts every
 # copy of this string agrees so HTML and JS can never skew apart silently.
-UI_ASSET_VERSION = "grok-v0.6.0-r13"
+UI_ASSET_VERSION = "grok-v0.6.0-r14"

--- a/tests/test_mcp_ui.py
+++ b/tests/test_mcp_ui.py
@@ -47,9 +47,9 @@ def test_mcp_ui_static_files_are_served(monkeypatch):
     assert index.status_code == 200
     assert "<title>UniGrok Gateway Console v0.6.0</title>" in index.text
     assert '<span class="version-badge">v0.6.0</span>' in index.text
-    assert 'script type="module" src="./app.js?v=grok-v0.6.0-r13"' in index.text
-    assert '<link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r13" />' in index.text
-    assert '<link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r13" />' in index.text
+    assert 'script type="module" src="./app.js?v=grok-v0.6.0-r14"' in index.text
+    assert '<link rel="stylesheet" href="./styles.css?v=grok-v0.6.0-r14" />' in index.text
+    assert '<link rel="stylesheet" href="./tokens.css?v=grok-v0.6.0-r14" />' in index.text
     assert "Console" in index.text
     assert 'id="surfaceModeBadge"' in index.text
     assert 'id="tab-btn-schemas"' not in index.text
@@ -303,6 +303,22 @@ def test_mcp_ui_swarm_playground_is_served_and_honest(monkeypatch):
     assert "analyze_code_for_swarm" in script.text
     assert 'state.runtimeMode === "contributor"' in script.text
     assert "source was not uploaded" in script.text
+    # Phase 2 progressive disclosure: scoring is opt-in and its oracle boxes are
+    # auto-scaffolded from ONE sample-inputs field, labeled honestly. The tool
+    # still receives test_code + bench_code — the UI writes them.
+    assert "Score it against your tests" in page.text
+    assert 'id="sampleInput"' in page.text
+    assert "Sample inputs (JSON)" in page.text
+    assert "We scaffolded this" in page.text
+    assert "strengthen it for real correctness" in page.text
+    assert "scaffoldOracles" in script.text
+    assert "SWARM_BENCH" in script.text  # the scaffolded bench emits the contract token
+    # The missing_tests/missing_benchmark markers are reframed as optional-to-
+    # verify and feature-detected across the current and softened server shapes.
+    assert "classifySearchability" in script.text
+    assert "Optional to verify" in script.text
+    # Inline pre-launch validation surfaces problems at the field, not post-burn.
+    assert "validateOraclesBeforeRun" in script.text
     # The bundled sample is a REAL recorded run and says so inside itself.
     with TestClient(create_app(), base_url="http://localhost:8080") as client:
         sample = client.get("/ui/swarm-sample.json")
@@ -319,6 +335,76 @@ def test_mcp_ui_swarm_playground_is_served_and_honest(monkeypatch):
     # Apply stays gated by mode in the UI exactly like the tool.
     assert "apply is disabled outside UNIGROK_SWARM=active" in script.text
     assert "apply is disabled while the swarm is still running" in script.text
+
+
+def test_mcp_ui_swarm_verification_is_opt_in_and_scaffolded(monkeypatch):
+    """The disabled-until-two-empty-boxes verification gate is gone. Free
+    analyze is code-only; scoring is an opt-in toggle whose oracle boxes are
+    auto-scaffolded from ONE sample-inputs field. start_paste_swarm still
+    receives test_code + bench_code — the UI generates them, not the user."""
+    monkeypatch.delenv("UNIGROK_RUNTIME", raising=False)
+    monkeypatch.delenv("UNIGROK_API_KEYS", raising=False)
+
+    with TestClient(create_app(), base_url="http://localhost:8080") as client:
+        page = client.get("/ui/swarm.html")
+        script = client.get("/ui/swarm.js")
+
+    assert page.status_code == 200
+    assert script.status_code == 200
+
+    # ── The old gate is gone ────────────────────────────────────────────────
+    # The Run button no longer starts hard-disabled in the markup, and the two
+    # "required" empty oracle textareas are no longer demanded up front.
+    assert 'id="runPasteBtn" class="primary" type="button" disabled' not in page.text
+    assert "pytest code · required" not in page.text
+    assert "benchmark script · required" not in page.text
+    assert "Run verified local search: add tests and benchmark" not in page.text
+    assert "Print one SWARM_BENCH JSON line" not in page.text
+
+    # ── The opt-in / scaffold affordance is present ─────────────────────────
+    assert "Score it against your tests" in page.text  # the opt-in summary
+    assert 'id="sampleInput"' in page.text            # the one honest input
+    assert "Sample inputs (JSON)" in page.text
+    assert 'id="rescaffoldBtn"' in page.text
+    # Both oracles still exist (the tool requires them) but are scaffolded and
+    # labeled honestly rather than hand-authored into two empty boxes.
+    assert 'id="testInput"' in page.text
+    assert 'id="benchInput"' in page.text
+    assert "baseline-equivalence pytest" in page.text
+    assert "SWARM_BENCH harness" in page.text
+    assert "We scaffolded this" in page.text
+    assert "strengthen it for real correctness" in page.text
+
+    # ── The scaffolds are generated client-side and honest ──────────────────
+    assert "scaffoldOracles" in script.text
+    assert "scaffoldBenchHarness" in script.text
+    assert "scaffoldEquivalenceTest" in script.text
+    assert "topHotspot" in script.text  # focus auto-picks the hottest function
+    assert "SWARM_BENCH" in script.text  # the bench scaffold prints the contract token
+    assert "module_under_test" in script.text  # the equivalence test imports the candidate
+
+    # ── missing_tests / missing_benchmark are optional-to-verify, not red ────
+    # Feature-detected across the current (blockers) and softened (advisory)
+    # server shapes — never hard-depended on one.
+    assert "classifySearchability" in script.text
+    assert "SCAFFOLDABLE_MARKERS" in script.text
+    assert "advisory" in script.text
+    assert "Optional to verify" in script.text
+
+    # ── Inline pre-launch validation surfaces problems at the field ─────────
+    assert "validateOraclesBeforeRun" in script.text
+    assert "must print a SWARM_BENCH contract line" in script.text
+    assert "must import from module_under_test" in script.text
+
+    # ── The tool still receives both UI-generated code blocks ───────────────
+    assert "start_paste_swarm" in script.text
+    assert "test_code:" in script.text
+    assert "bench_code:" in script.text
+
+    # ── CSP stays intact: no inline handlers, no JS eval, no CDN ────────────
+    assert "onclick=" not in page.text
+    assert " eval(" not in script.text
+    assert "<style>" not in page.text
 
 
 def test_mcp_ui_layout_engine_is_local_and_ide_first():
@@ -483,7 +569,7 @@ def test_mcp_ui_markdown_renderer_is_shared_and_escape_first():
     assert "\\u000E-\\u001F" in renderer.text
     # app.js imports the shared renderer at the current cache-bust version and
     # no longer defines its own.
-    assert 'from "./markdown.js?v=grok-v0.6.0-r13"' in script.text
+    assert 'from "./markdown.js?v=grok-v0.6.0-r14"' in script.text
     assert "import { parseMarkdown" in script.text
     assert "function parseMarkdown" not in script.text
     assert "renderMarkdownInto" in script.text


### PR DESCRIPTION
## What

Phase 2 of the swarm redesign — the UX fix for "it forces me to write test code just to optimize pasted code." **Stacked on #344** (base = `claude/swarm-fluid-rebuild`); pairs with #477 (server softening). Retarget to `main` once #344 lands.

The core problem was real, not just UI friction: `start_paste_swarm` *raises* without a test and a benchmark. So instead of forcing you to hand-author both, the UI now scaffolds them:

- **Free analyze stays code-only** and primary. `missing_tests`/`missing_benchmark` are reframed from red blockers to a neutral "optional to verify — we'll scaffold it" note. Reads the searchability response defensively across both the old and softened (#477) shapes.
- **The two-required-empty-boxes gate is deleted.** Replaced by an opt-in "Score it against your tests" toggle that opens **pre-filled**, not blank.
- **One honest input.** A "Sample inputs (JSON)" field. From the auto-picked top hotspot + those inputs, the UI generates two editable, honestly-labeled scaffolds: a starter `SWARM_BENCH` harness (emitting the exact contract line `scripts/swarm_bench.py` expects) and a baseline-equivalence pytest (candidate output == original on your samples). Labeled: "we scaffolded this — strengthen it for real correctness." `primary_goal` defaults to balanced; strategy/budget move under a closed Advanced.
- **Inline pre-launch validation** — checks the test references the function and the bench contains the contract token, at the field, before a swarm burns budget.
- `start_paste_swarm` still receives `test_code`+`bench_code` (the scaffolds), so the tool contract is satisfied — you just didn't hand-write them.

Every Phase-1 honesty literal preserved (nothing simulated, verified=test_target passed, budget ceiling before Run, never auto-commit a winner). CSP-clean (no eval/CDN/inline handlers).

## Composition with #477 (verified)
The scaffoldable markers are read from `searchability.scored_search_requirements` (the field #477 emits) as well as the legacy `blockers` shape and `advisory`/`optional`, so the advisory note renders whichever server shape is live — and the offline preview mock was updated to the new 3-key shape. The equivalence scaffold deep-copies args per call so an in-place-mutating hotspot can't taint the comparison.

## Changed paths
- `mcp_ui/swarm.html`, `mcp_ui/swarm.js`, `src/version.py` (+ version-only lines to keep the asset version single-sourced), `tests/test_mcp_ui.py`

## Tests
- Full suite **2204 passed**; `test_mcp_ui.py` 30 passed; `node --check` clean. Standalone scaffold check: the equivalence oracle passes on baseline and fails on a divergent rewrite (real gate, not a rubber stamp); the bench emits exactly one valid contract line. Attribution: passed.

## Handoff
- Draft — awaiting Codex landing; stacked on #344. Sponsor: David Johnston (@djtelicloud).

Agent-Assisted-By: Anthropic Claude | model=Fable 5 | model-source=user-reported | surface=Claude Code | role=implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Client-generated oracles gate verified swarm runs—mis-scaffolded or weak equivalence tests could rank bad rewrites, though the UI labels sample-only checks and validates before launch; contributor-only execution gating is unchanged.
> 
> **Overview**
> **Phase 2 swarm UX:** free **Analyze** stays primary and code-only; ranking rewrites moves behind an opt-in **“Score it against your tests”** panel instead of blocking on two empty required oracle textareas.
> 
> From **one “Sample inputs (JSON)” field** plus the auto-selected hotspot, the UI **scaffolds** an editable baseline-equivalence pytest and a **SWARM_BENCH** harness (still sent as `test_code` / `bench_code` to `start_paste_swarm`). **Regenerate**, manual-edit ownership (`data-scaffolded`), and **field-level pre-run validation** (`module_under_test`, `SWARM_BENCH`, non-empty samples) run before budget is spent.
> 
> **Searchability** handling is softened in the client: `missing_tests` / `missing_benchmark` are treated as scaffoldable opt-in requirements via `classifySearchability`, compatible with legacy `blockers` and advisory `scored_search_requirements` server shapes. Analysis UI reframes hard blockers vs optional-to-verify copy; focus picker defaults to **topHotspot** by complexity/LOC.
> 
> Copy and layout updates in `swarm.html` (strategy under Advanced, run button no longer hard-disabled in markup). **`UI_ASSET_VERSION` bumped to `grok-v0.6.0-r14`** across HTML/JS; tests assert the new affordances and removed gate strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e61bfe990f60ad6287a89061c3c4f370b6d7c94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->