### PR TITLE
fix(forge): install async pytest runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,8 +229,10 @@ jobs:
           for _ in $(seq 1 30); do
             if curl -fsS http://127.0.0.1:4765/healthz > /dev/null \
               && curl -fsS -H "Authorization: Bearer ci-client-key" \
-                http://127.0.0.1:4765/docs/okf/api-reference.md > /dev/null; then
-              echo "healthz and OKF API reference OK"
+                http://127.0.0.1:4765/docs/okf/api-reference.md > /dev/null \
+              && docker exec grok-mcp-ci /app/.venv/bin/python -c \
+                "import pytest_asyncio"; then
+              echo "healthz, OKF API reference, and Forge async pytest runtime OK"
               exit 0
             fi
             sleep 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
 forge = [
     "coverage>=7.15.1",
     "pytest>=9.1.1",
+    "pytest-asyncio>=1.4.0",
     "ruff>=0.9",
 ]
 # Source-checkout synthetic-data campaign runners use Vertex through standard

--- a/tests/test_release_hygiene.py
+++ b/tests/test_release_hygiene.py
@@ -149,7 +149,7 @@ def test_forge_execution_tools_are_not_core_runtime_dependencies():
     forge = set(metadata["project"]["optional-dependencies"]["forge"])
     dev = set(metadata["dependency-groups"]["dev"])
 
-    for name in ("coverage", "pytest", "ruff"):
+    for name in ("coverage", "pytest", "pytest-asyncio", "ruff"):
         assert not any(dep.startswith(name) for dep in core)
         assert any(dep.startswith(name) for dep in forge)
         assert any(dep.startswith(name) for dep in dev)

--- a/uv.lock
+++ b/uv.lock
@@ -919,6 +919,7 @@ campaign = [
 forge = [
     { name = "coverage" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -944,6 +945,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.13.4" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pytest", marker = "extra == 'forge'", specifier = ">=9.1.1" },
+    { name = "pytest-asyncio", marker = "extra == 'forge'", specifier = ">=1.4.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "ruff", marker = "extra == 'forge'", specifier = ">=0.9" },
     { name = "starlette", specifier = ">=1.3.1" },


### PR DESCRIPTION
## Summary

- add `pytest-asyncio` to the contributor Forge optional dependency set
- keep it outside stable core dependencies
- pin the contract in release-hygiene and Docker runtime smoke checks

## Root cause

After #476 landed and the contributor image rebuilt, real `SwarmSandbox.run_preflight` correctly imported `src.swarm.pareto` but every focused test errored because the image used `--no-dev --extra forge` and the Forge extra omitted `pytest-asyncio`. The repository's session-scoped async autouse fixture therefore had no plugin.

## Exact handoff

- Exact head: `a8d22b268ebcea7572becaf5a12003062c077121`
- Base: merged main `560245cac0c75dad09628713c14c6beddbc2b3b0`
- Changed paths: `.github/workflows/ci.yml`, `pyproject.toml`, `uv.lock`, `tests/test_release_hygiene.py`
- Risk: low; one existing locked package moves into the already-installed Forge extra
- Human sponsor: djtelicloud
- Provider/model provenance: OpenAI Codex, GPT-5 user-reported, Codex Desktop

## Verification

- focused repository tests: **61 passed**
- generated OKF, compile, attribution, diff hygiene: passed
- full repository suite: **2,254 passed in 96.97s**
- real Docker image built from this head installs `pytest-asyncio 1.4.0`
- real containerized Pareto preflight: module `src.swarm.pareto`, provenance **ok**, baseline tests **1.148s**, focus coverage **86.7%**, stable benchmark **0.123339 ms**, peak traced memory **1,336 bytes**

No model generation or provider spend occurred. Grok remains HOLD until normal Codex lands this repair and the running contributor Forge passes the same gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and CI contract only; pytest-asyncio stays out of core deps and is added to an already-installed Forge extra.
> 
> **Overview**
> Adds **`pytest-asyncio>=1.4.0`** to the contributor **Forge** optional dependency set (and **`uv.lock`**) so images built with `--no-dev --extra forge` can run async pytest and session-scoped async fixtures during Swarm/Forge preflight—without pulling it into core gateway dependencies.
> 
> **`test_forge_execution_tools_are_not_core_runtime_dependencies`** now treats **`pytest-asyncio`** like **`pytest`**, **`coverage`**, and **`ruff`**: present in **forge** and **dev**, absent from core.
> 
> Docker CI readiness waits on **`import pytest_asyncio`** inside **`grok-mcp-ci`**, alongside **`/healthz`** and the OKF API reference check, so a missing Forge async runtime fails the image smoke instead of surfacing only at contributor test time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8d22b268ebcea7572becaf5a12003062c077121. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->