### PR TITLE
fix(ci): close Forge async review gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
             fi
             sleep 2
           done
-          echo "healthz never became ready" >&2
+          echo "healthz, OKF API reference, or Forge async pytest runtime check failed" >&2
           docker logs grok-mcp-ci >&2
           exit 1
 

--- a/tests/test_release_hygiene.py
+++ b/tests/test_release_hygiene.py
@@ -145,14 +145,22 @@ def test_local_provider_credentials_are_ignored_and_not_force_included():
 
 def test_forge_execution_tools_are_not_core_runtime_dependencies():
     metadata = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
-    core = set(metadata["project"]["dependencies"])
-    forge = set(metadata["project"]["optional-dependencies"]["forge"])
-    dev = set(metadata["dependency-groups"]["dev"])
+    def requirement_name(spec: str) -> str:
+        return re.split(r"[<>=!~;\s\[]", spec, maxsplit=1)[0].lower().replace(
+            "_", "-"
+        )
+
+    core = {requirement_name(dep) for dep in metadata["project"]["dependencies"]}
+    forge = {
+        requirement_name(dep)
+        for dep in metadata["project"]["optional-dependencies"]["forge"]
+    }
+    dev = {requirement_name(dep) for dep in metadata["dependency-groups"]["dev"]}
 
     for name in ("coverage", "pytest", "pytest-asyncio", "ruff"):
-        assert not any(dep.startswith(name) for dep in core)
-        assert any(dep.startswith(name) for dep in forge)
-        assert any(dep.startswith(name) for dep in dev)
+        assert name not in core
+        assert name in forge
+        assert name in dev
 
 
 def test_sdist_configuration_excludes_generated_dependency_trees():


### PR DESCRIPTION
## Summary

- compare normalized dependency names exactly so `pytest-asyncio` cannot satisfy the `pytest` contract
- report the full Docker readiness gate on timeout instead of blaming only healthz

## Context

This closes the two valid review threads that arrived immediately after #479 merged.

## Risk

- Risk: high (workflow path; behavior change is test/diagnostic only)
- Human sponsor: djtelicloud
- Provider/model provenance: OpenAI Codex, GPT-5 user-reported, Codex Desktop

## Verification

- `uv run pytest -q tests/test_release_hygiene.py` — 21 passed
- generated OKF, compile, and diff hygiene passed

Agent-Assisted-By: OpenAI Codex | model=GPT-5 | model-source=user-reported | surface=Codex Desktop | role=implementation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CI diagnostic changes only; no runtime or auth behavior changes.
> 
> **Overview**
> **Release hygiene** now compares **normalized** PyPI names (`pytest` vs `pytest-asyncio`) when asserting Forge tools stay out of core deps and appear in `forge` and `dev`, closing a false pass from prefix matching.
> 
> **Docker CI** failure text on the grok-mcp smoke loop now names the full gate—healthz, OKF API reference fetch, and in-container `pytest_asyncio` import—not only healthz.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bfa7e5061c0deadd87136c3e55a18302224440c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->