### PR TITLE
perf(swarm): compare each Pareto pair once

### DIFF
--- a/src/swarm/pareto.py
+++ b/src/swarm/pareto.py
@@ -35,17 +35,20 @@ def fast_non_dominated_sort(
     """Return fronts as lists of indices; front 0 is the Pareto-optimal set.
     O(MN^2) — fine for the tens-of-candidates scale here."""
     n = len(points)
+    if n == 0:
+        return []
     dominated_by: List[List[int]] = [[] for _ in range(n)]
     domination_count = [0] * n
     fronts: List[List[int]] = [[]]
     for p in range(n):
-        for q in range(n):
-            if p == q:
-                continue
+        for q in range(p + 1, n):
             if dominates(points[p], points[q]):
                 dominated_by[p].append(q)
+                domination_count[q] += 1
             elif dominates(points[q], points[p]):
+                dominated_by[q].append(p)
                 domination_count[p] += 1
+    for p in range(n):
         if domination_count[p] == 0:
             fronts[0].append(p)
     i = 0

--- a/tests/test_swarm_pareto.py
+++ b/tests/test_swarm_pareto.py
@@ -54,6 +54,9 @@ class TestDomination:
 
 
 class TestNonDominatedSort:
+    def test_empty_points(self):
+        assert fast_non_dominated_sort([]) == []
+
     def test_matches_brute_force_on_random_fixtures(self):
         rng = random.Random(7)
         for _ in range(50):

--- a/tests/test_swarm_pareto.py
+++ b/tests/test_swarm_pareto.py
@@ -26,6 +26,26 @@ def _brute_front(points):
     return set(front)
 
 
+def _brute_fronts(points):
+    """Peel every non-dominated front with the simple reference oracle."""
+    remaining = list(range(len(points)))
+    fronts = []
+    while remaining:
+        front = [
+            i
+            for i in remaining
+            if not any(
+                dominates(points[j], points[i])
+                for j in remaining
+                if j != i
+            )
+        ]
+        fronts.append(front)
+        selected = set(front)
+        remaining = [i for i in remaining if i not in selected]
+    return fronts
+
+
 class TestDomination:
     def test_strict_domination(self):
         assert dominates((1.0, 1.0), (2.0, 2.0))
@@ -43,6 +63,7 @@ class TestNonDominatedSort:
                 for _ in range(n)
             ]
             fronts = fast_non_dominated_sort(points)
+            assert fronts == _brute_fronts(points)
             assert set(fronts[0]) == _brute_front(points)
             # Every index appears in exactly one front.
             flat = list(itertools.chain.from_iterable(fronts))


### PR DESCRIPTION
## Summary

- replaces the duplicate ordered pair scan with one unordered half-matrix pass
- preserves every Pareto front and adds an all-front reference-oracle regression
- keeps generated public documentation unchanged

## Verification

- exact commit: `c12126bb4b5099d53825c7c6bfd99ef416145b61`
- changed paths: `src/swarm/pareto.py`, `tests/test_swarm_pareto.py`
- focused: 60 passed
- full suite: 2,260 passed
- Ruff, compile, generated OKF check, attribution, and diff hygiene passed
- independent randomized comparison: 5,100 full partitions matched the original

Detailed experiment receipts remain private pending supervisor approval. Forge Swarm did not generate this candidate because the contributor service is intentionally dry-run; attribution is limited to the actual virtual/Hive/Codex work.

Risk note: ordering and membership across later fronts. The new reference-oracle test covers the full partition, not only front zero.

Human sponsor: @djtelicloud

Agent provenance:
- Cursor Composer / Grok 4.5 — original implementation candidate
- OpenAI Codex / GPT-5 — independent reproduction, repair, tests, and integration packaging

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure algorithm tweak in swarm candidate ranking with strong brute-force regression coverage; scale stays small (tens of points).
> 
> **Overview**
> **`fast_non_dominated_sort`** now compares each unordered point pair once (`q > p`) instead of scanning all ordered pairs, and returns **`[]`** immediately when there are no points.
> 
> The domination bookkeeping is aligned with the usual NSGA-II shape: when **`q`** dominates **`p`**, **`p`** is recorded on **`dominated_by[q]`** so later fronts peel correctly—not only front 0.
> 
> Tests add **`_brute_fronts`** (peeling oracle) so randomized fixtures assert the **full front partition** matches the reference, plus an explicit empty-input case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c12126bb4b5099d53825c7c6bfd99ef416145b61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->