### PR TITLE
README: lead with the two Grok planes; backlog Cursor as third plane

### DIFF
--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -44,6 +44,13 @@ Status legend: [ ] open · [x] done · [~] partially proven
 
 ## Post-launch backlog (approved ideas, deliberately deferred)
 
+- Cursor plane (third plane, xAI family). Order: Grok Build CLI (1) → xAI API (2)
+  → Cursor (3). Cursor CLI (`curl https://cursor.com/install -fsS | bash`) +
+  `CURSOR_API_KEY`. Now viable in the PUBLIC gateway (not just intelligence),
+  because SpaceX/xAI acquired Cursor — it is xAI-family, not a subordinate
+  competitor like the Anthropic/Gemini/OpenAI providers we removed. Gate:
+  deal close is pending regulatory approval (Q3 2026), so keep public copy
+  neutral until it closes. Free-tier Cursor API keys allow headless CLI use.
 - Courier bridge: caller-run tests/bench couriered back for *proven* user-code
   optimization (forge loop for arbitrary files).
 - Function-path router; self-healing error messages; readability hive-vote

--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ http://localhost:4765/mcp
 
 ## Get running in three minutes
 
-You need [Docker Desktop](https://www.docker.com/products/docker-desktop/) and Git. For
-Grok access you need **one** of:
+You need [Docker Desktop](https://www.docker.com/products/docker-desktop/) and Git, plus
+Grok access. UniGrok runs on two Grok planes, in this order:
 
-- a Grok subscription (flat-rate, recommended), or
-- an [xAI developer API key](https://console.x.ai/) (metered).
+1. **Grok Build subscription** — the default, flat-rate plane. This is all you need.
+2. **xAI developer API key** ([console.x.ai](https://console.x.ai/)) — optional, metered;
+   adds vision, image/video, X search, and silent failover.
 
-No Grok yet? You can start with [Cursor](https://cursor.com/referral?code=VJWHUMXIKTHG)
-(referral link) and come back once you have a Grok credential.
+Set up plane 1 to get going; add plane 2 whenever you want the extras.
 
 ### 1. Download and build
 
@@ -79,6 +79,9 @@ curl --fail --silent http://localhost:4765/readyz
 ```
 
 You are ready when the response says `"status":"ready"`.
+
+> New to Grok-powered coding? [Cursor](https://cursor.com/referral?code=VJWHUMXIKTHG)
+> (referral link) is an easy on-ramp — set up a Grok plane above whenever you're ready.
 
 ## Connect your IDE
 


### PR DESCRIPTION
Getting-started now numbers the two Grok planes (Grok Build subscription 1, xAI API 2); Cursor referral moved to a lower aside. LAUNCH backlog repositions Cursor as a public-gateway third plane (xAI family). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only copy and planning notes; no runtime, auth, or routing behavior changes.
> 
> **Overview**
> **Getting started** now centers on **two Grok planes** in order: Grok Build subscription (required default) and optional xAI API key for metered extras. The old “Grok subscription **or** API key **or** start with Cursor” framing is gone; Cursor is demoted to a short post-`readyz` aside for newcomers.
> 
> **LAUNCH backlog** adds a deferred **Cursor as a third public-gateway plane** (after Grok Build CLI and xAI API), with CLI/`CURSOR_API_KEY` notes, xAI-family rationale, and a regulatory-approval gate before neutral public copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dfd8608e13cd3b249ed3badd5fedbe600dc2e00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->