### PR TITLE
README: note the npx @djtelicloud/unigrok helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Grok access. UniGrok runs on two Grok planes, in this order:
 
 Set up plane 1 to get going; add plane 2 whenever you want the extras.
 
+> In a hurry? `npx @djtelicloud/unigrok` prints these setup steps in your terminal.
+> (A full launcher that runs the setup for you is planned; today UniGrok installs via
+> Docker, below.)
+
 ### 1. Download and build
 
 ```bash


### PR DESCRIPTION
Adds an honest one-line note that `npx @djtelicloud/unigrok` prints the setup steps (placeholder package; full launcher planned). Docker remains the real install. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only documentation with no runtime, dependency, or credential changes.
> 
> **Overview**
> The **Get running** section now includes a short callout for users who want setup steps in the terminal: run `npx @djtelicloud/unigrok` to print the same flow documented on the page.
> 
> The note is explicit that this is a **placeholder** today (prints steps only) and that a fuller launcher is planned; **Docker remains the actual install path**, with the existing clone/build steps unchanged below.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5a1bbb9689c049461942b34978b024863c9aae9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->