### PR TITLE
Port Cursor client onboarding (mcp.json entry + routing rule)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the public UniGrok gateway.
 ## [1.1.0] - 2026-07-17
 
 ### Added
+- Cursor client onboarding: `grok_mcp_onboard_client` now emits a `.cursor/mcp.json` merge entry (points Cursor at the Grok gateway with `X-Client-ID: cursor`, carries no credentials) plus a `.cursor/rules/using-unigrok.mdc` routing rule. Cursor is a client, not an execution plane — ported from the old public version's static `.cursor/` setup.
 - Depth modes `deep` (cached j-space harness prompt, harness-leak guard, final polish loop) and `hive` (draft → parallel persona votes with numbered-line dif-vote anchors → always-on xhigh merge; voters split across CLI/API planes; per-stage plane+cost receipts)
 - Public level ladder `none`→`ultra` via `level` parameter and `voters` override
 - Auto++ router: three flat-rate parallel intent votes (route/depth/voter-count) replacing the metered routing pass on unclear tasks, with dynamic voter sizing

--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -420,6 +420,57 @@ include only bounded project context that is actually needed, and report the sel
 model, credential plane, and any metered cost from the returned receipt.
 """
 
+# Cursor client integration (ported from the old public version's .cursor/ setup).
+# Cursor is an IDE CLIENT that connects TO UniGrok over HTTP MCP — never an execution
+# plane. The X-Client-ID header is a telemetry label, not authentication.
+CURSOR_MCP_URL = "http://localhost:4765/mcp"
+CURSOR_RULE = """---
+description: >-
+  When and how to reach UniGrok's Grok gateway from Cursor. Use for @grok, a Grok
+  second opinion, web/X research, cross-project memory, or adversarial code review.
+alwaysApply: true
+---
+
+# Using UniGrok from Cursor
+
+UniGrok is a local Grok gateway. Its `agent` tool is your `@grok`.
+
+- Reach for the UniGrok `agent` tool when you want: web/X research, hard reasoning or
+  plan critique, cross-project memory (named sessions and durable facts), or code you
+  want adversarially reviewed before delivery (`level: "ultra"` runs a parallel hive).
+- UniGrok picks the model, effort, and plane for you and returns a plane and cost
+  receipt on every answer. Relay the cost to the user; never hide metered spend.
+- For ordinary local edits, use Cursor's native agent. Escalate to the UniGrok `agent`
+  tool for dual-plane routing, research, memory, or review.
+- Identity: keep `"X-Client-ID": "cursor"` in `.cursor/mcp.json`. It is a telemetry
+  label, not authentication.
+- Never place `XAI_API_KEY` in Cursor configuration — credentials live inside UniGrok.
+"""
+
+
+def _cursor_mcp_server(scope: str) -> dict[str, Any]:
+    """The .cursor/mcp.json merge entry that points Cursor at the Grok gateway.
+
+    Emitted as a MERGE (never a full-file overwrite) so existing Cursor MCP servers
+    survive. The calling IDE performs the merge with a conflict preview.
+    """
+    return {
+        "target": "~/.cursor/mcp.json" if scope == "global" else ".cursor/mcp.json",
+        "merge_into": "mcpServers",
+        "merge_policy": (
+            "Add this server to the existing mcpServers object; do not overwrite other "
+            "servers. If a 'grok' server already exists, show a diff before replacing."
+        ),
+        "entry": {
+            "mcpServers": {
+                "grok": {
+                    "url": CURSOR_MCP_URL,
+                    "headers": {"X-Client-ID": "cursor"},
+                }
+            }
+        },
+    }
+
 CLIENT_ADAPTERS: dict[str, dict[str, Any]] = {
     "antigravity": {
         "label": "Google Antigravity / Gemini",
@@ -555,7 +606,7 @@ def _client_onboarding_plan(client: str, scope: str) -> dict[str, Any]:
             "files": [],
         }
     if scope == "project":
-        return {
+        plan = {
             **common,
             "status": "approved_plan",
             "recommended": False,
@@ -570,8 +621,12 @@ def _client_onboarding_plan(client: str, scope: str) -> dict[str, Any]:
                 "AGENTS.md",
             ],
         }
+        if client == "cursor":
+            plan["files"].append(_owned_file(".cursor/rules/using-unigrok.mdc", CURSOR_RULE))
+            plan["mcp_server"] = _cursor_mcp_server("project")
+        return plan
     files = _global_files(client)
-    return {
+    plan = {
         **common,
         "status": "approved_plan",
         "recommended": True,
@@ -583,11 +638,20 @@ def _client_onboarding_plan(client: str, scope: str) -> dict[str, Any]:
         "client_settings_instruction": (
             "Add a concise, user-invoked UniGrok instruction through the client's global "
             "customization UI; do not create repository files."
-            if not files
+            if not files and client != "cursor"
             else None
         ),
         "reload": adapter["reload"],
     }
+    if client == "cursor":
+        # Ported Cursor client setup: the one essential artifact is the mcp.json entry
+        # that points Cursor at the Grok gateway; the routing rule is the useful extra.
+        plan["mcp_server"] = _cursor_mcp_server("global")
+        plan["files"] = [*files, _owned_file(".cursor/rules/using-unigrok.mdc", CURSOR_RULE)]
+        plan["reload"] = (
+            "Reload Cursor after adding the MCP server, then call grok_mcp_discover_self."
+        )
+    return plan
 
 PROJECT_ONBOARDING = {
     "recommended_scope": "global_client_namespace",

--- a/tests/test_public_boundary.py
+++ b/tests/test_public_boundary.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import json
 from pathlib import Path
 
 import pytest
@@ -299,8 +300,21 @@ def test_client_onboarding_detection_and_safe_non_filesystem_fallback() -> None:
     assert server._client_kind("Visual Studio Code") == "github_copilot"
     assert server._client_kind("unknown") == "generic"
     cursor = server._client_onboarding_plan("cursor", "global")
-    assert cursor["files"] == []
-    assert cursor["client_settings_instruction"]
+    # Cursor now gets the ported client setup: an mcp.json merge entry pointing at the
+    # Grok gateway and a routing rule (no longer an empty client_settings-only plan).
+    assert cursor["client_settings_instruction"] is None
+    entry = cursor["mcp_server"]
+    assert entry["target"] == "~/.cursor/mcp.json"
+    assert entry["entry"]["mcpServers"]["grok"]["headers"]["X-Client-ID"] == "cursor"
+    assert entry["entry"]["mcpServers"]["grok"]["url"].endswith("/mcp")
+    rule_paths = [f["path"] for f in cursor["files"]]
+    assert ".cursor/rules/using-unigrok.mdc" in rule_paths
+    # The emitted MCP config carries NO credential — only the URL and the non-secret
+    # X-Client-ID telemetry header (Cursor is a client, never an execution plane).
+    grok_server = entry["entry"]["mcpServers"]["grok"]
+    assert set(grok_server) == {"url", "headers"}
+    assert set(grok_server["headers"]) == {"X-Client-ID"}
+    assert "CURSOR_API_KEY" not in json.dumps(cursor)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
grok_mcp_onboard_client now emits a Cursor install plan: a `.cursor/mcp.json` merge entry pointing Cursor at the Grok gateway (X-Client-ID: cursor, no credentials) plus a `.cursor/rules/using-unigrok.mdc` routing rule. Ported from the old public version's static .cursor/ setup. Cursor is a client, never an execution plane. 65 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding plan output and tests only; no runtime auth or gateway behavior changes.
> 
> **Overview**
> **Cursor onboarding** for `grok_mcp_onboard_client` is no longer a settings-only empty plan. Global and project scopes now include a **merge** payload for `.cursor/mcp.json` (or `~/.cursor/mcp.json`) that adds a `grok` MCP server at the local gateway URL with **`X-Client-ID: cursor`** and **no API keys**, plus owned content for **`.cursor/rules/using-unigrok.mdc`** describing when to use UniGrok vs Cursor’s native agent.
> 
> The plan sets **`client_settings_instruction`** to null for Cursor global, adjusts **reload** guidance, and documents merge policy so existing MCP servers are not blindly overwritten. **CHANGELOG** records the feature; **tests** assert the new plan shape and that emitted JSON contains no credentials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54cc766038df6456efcd765092bd8f29a91c501c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->