### PR TITLE
Port Cursor beforeMCPExecution hook (auto-approve agent tool)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the public UniGrok gateway.
 ## [1.1.0] - 2026-07-17
 
 ### Added
-- Cursor client onboarding: `grok_mcp_onboard_client` now emits a `.cursor/mcp.json` merge entry (points Cursor at the Grok gateway with `X-Client-ID: cursor`, carries no credentials) plus a `.cursor/rules/using-unigrok.mdc` routing rule. Cursor is a client, not an execution plane — ported from the old public version's static `.cursor/` setup.
+- Cursor client onboarding: `grok_mcp_onboard_client` now emits a `.cursor/mcp.json` merge entry (points Cursor at the Grok gateway with `X-Client-ID: cursor`, carries no credentials), a `.cursor/rules/using-unigrok.mdc` routing rule, and a `.cursor/hooks.json` + `before-unigrok-agent.py` beforeMCPExecution hook that auto-approves ONLY the `agent` tool so `@grok` never stalls on a permission prompt. Cursor is a client, not an execution plane — ported from the old public version's static `.cursor/` setup.
 - Depth modes `deep` (cached j-space harness prompt, harness-leak guard, final polish loop) and `hive` (draft → parallel persona votes with numbered-line dif-vote anchors → always-on xhigh merge; voters split across CLI/API planes; per-stage plane+cost receipts)
 - Public level ladder `none`→`ultra` via `level` parameter and `voters` override
 - Auto++ router: three flat-rate parallel intent votes (route/depth/voter-count) replacing the metered routing pass on unclear tasks, with dynamic voter sizing

--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -471,6 +471,63 @@ def _cursor_mcp_server(scope: str) -> dict[str, Any]:
         },
     }
 
+
+# Cursor beforeMCPExecution hook: auto-approve UniGrok's `agent` tool so `@grok` never
+# stalls on a per-call permission prompt. Fail-open, matcher-scoped to the agent tool,
+# and it grants no other authority. This is the "plugin-like" piece Cursor needs that
+# other IDEs do not (ported from the old .cursor/hooks/before-unigrok-agent.py, with the
+# removed-platform Canvas/sponsor tip stripped out).
+CURSOR_AGENT_HOOK = '''#!/usr/bin/env python3
+"""Cursor beforeMCPExecution hook: auto-allow UniGrok's agent tool (fail-open)."""
+from __future__ import annotations
+
+import json
+import sys
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        payload = {}
+    tool = str(payload.get("tool_name") or payload.get("toolName") or "").lower()
+    # The hooks.json matcher already scopes this to the agent tool; auto-approve it so
+    # @grok runs without a permission prompt. Never deny; unknown shapes fail open.
+    decision = "allow" if ("agent" in tool or tool == "") else "ask"
+    sys.stdout.write(json.dumps({"permission": decision}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+'''
+
+
+def _cursor_hooks(scope: str) -> dict[str, Any]:
+    """The .cursor/hooks.json merge entry wiring the auto-allow agent hook."""
+    hook_cmd = (
+        "~/.cursor/hooks/before-unigrok-agent.py"
+        if scope == "global"
+        else ".cursor/hooks/before-unigrok-agent.py"
+    )
+    return {
+        "target": "~/.cursor/hooks.json" if scope == "global" else ".cursor/hooks.json",
+        "merge_into": "hooks",
+        "merge_policy": (
+            "Add this beforeMCPExecution entry to the existing hooks object; keep other "
+            "hooks. Make the referenced script executable (chmod +x). This auto-approves "
+            "ONLY UniGrok's agent tool so @grok does not prompt on every call."
+        ),
+        "entry": {
+            "version": 1,
+            "hooks": {
+                "beforeMCPExecution": [
+                    {"command": hook_cmd, "matcher": "agent", "timeout": 5}
+                ]
+            },
+        },
+    }
+
 CLIENT_ADAPTERS: dict[str, dict[str, Any]] = {
     "antigravity": {
         "label": "Google Antigravity / Gemini",
@@ -623,7 +680,11 @@ def _client_onboarding_plan(client: str, scope: str) -> dict[str, Any]:
         }
         if client == "cursor":
             plan["files"].append(_owned_file(".cursor/rules/using-unigrok.mdc", CURSOR_RULE))
+            plan["files"].append(
+                _owned_file(".cursor/hooks/before-unigrok-agent.py", CURSOR_AGENT_HOOK)
+            )
             plan["mcp_server"] = _cursor_mcp_server("project")
+            plan["hooks"] = _cursor_hooks("project")
         return plan
     files = _global_files(client)
     plan = {
@@ -644,12 +705,19 @@ def _client_onboarding_plan(client: str, scope: str) -> dict[str, Any]:
         "reload": adapter["reload"],
     }
     if client == "cursor":
-        # Ported Cursor client setup: the one essential artifact is the mcp.json entry
-        # that points Cursor at the Grok gateway; the routing rule is the useful extra.
+        # Ported Cursor client setup: the essential mcp.json entry that points Cursor at
+        # the Grok gateway, the routing rule, and the beforeMCPExecution hook that
+        # auto-approves the agent tool so @grok never prompts (Cursor's "plugin" piece).
         plan["mcp_server"] = _cursor_mcp_server("global")
-        plan["files"] = [*files, _owned_file(".cursor/rules/using-unigrok.mdc", CURSOR_RULE)]
+        plan["hooks"] = _cursor_hooks("global")
+        plan["files"] = [
+            *files,
+            _owned_file(".cursor/rules/using-unigrok.mdc", CURSOR_RULE),
+            _owned_file("~/.cursor/hooks/before-unigrok-agent.py", CURSOR_AGENT_HOOK),
+        ]
         plan["reload"] = (
-            "Reload Cursor after adding the MCP server, then call grok_mcp_discover_self."
+            "Reload Cursor after adding the MCP server and hook, then call "
+            "grok_mcp_discover_self."
         )
     return plan
 

--- a/tests/test_public_boundary.py
+++ b/tests/test_public_boundary.py
@@ -315,6 +315,15 @@ def test_client_onboarding_detection_and_safe_non_filesystem_fallback() -> None:
     assert set(grok_server) == {"url", "headers"}
     assert set(grok_server["headers"]) == {"X-Client-ID"}
     assert "CURSOR_API_KEY" not in json.dumps(cursor)
+    # Cursor's "plugin": the beforeMCPExecution hook that auto-approves ONLY the agent
+    # tool, plus the hook script shipped as an owned file.
+    hooks = cursor["hooks"]
+    assert hooks["target"] == "~/.cursor/hooks.json"
+    before = hooks["entry"]["hooks"]["beforeMCPExecution"][0]
+    assert before["matcher"] == "agent"
+    assert "~/.cursor/hooks/before-unigrok-agent.py" in rule_paths
+    # The hook auto-allows the agent tool and defers (ask) on anything else.
+    assert '"allow"' in server.CURSOR_AGENT_HOOK and '"ask"' in server.CURSOR_AGENT_HOOK
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Cursor's 'plugin' piece: onboarding now emits a .cursor/hooks.json merge entry + before-unigrok-agent.py hook that auto-approves ONLY UniGrok's agent tool (matcher-scoped, fail-open, defers 'ask' otherwise) so @grok never prompts per call. Removed-platform tip stripped. 65 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The change auto-approves MCP execution for the UniGrok `agent` tool on the user's machine; scope is narrow (matcher + script logic) but it is a client-side permission bypass for that one tool.
> 
> **Overview**
> Extends **Cursor** onboarding from MCP + rules only to also ship a **`beforeMCPExecution`** hook so `@grok` does not block on per-call MCP permission prompts.
> 
> `grok_mcp_onboard_client` now includes a **`hooks`** merge plan (`.cursor/hooks.json` or `~/.cursor/hooks.json`) and an owned **`before-unigrok-agent.py`** script for both **global** and **project** scopes. The hook is matcher-scoped to **`agent`**, returns **`allow`** for that tool (and fail-open on bad stdin), and **`ask`** for anything else—no deny path. Reload guidance mentions installing the hook; **CHANGELOG** documents the addition. **Tests** assert hook targets, matcher, script path, and allow/ask behavior in `CURSOR_AGENT_HOOK`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 103a79977c82983124b8e8fa98fc25d1ef81bca9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->