### PR TITLE
Per-IDE @grok auto-approve in onboarding (native mechanism each)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the public UniGrok gateway.
 ## [1.1.0] - 2026-07-17
 
 ### Added
+- Per-IDE "never prompt for @grok" auto-approve in the onboarding plan, each via its
+  native mechanism: Claude Code `permissions.allow` (per-tool `mcp__grok__agent`), Codex
+  `config.toml` MCP tool `approval_mode = "auto"`, Gemini/Antigravity server `trust: true`,
+  Cursor the beforeMCPExecution hook. GitHub Copilot/generic get none (no verified format).
 - Cursor client onboarding: `grok_mcp_onboard_client` now emits a `.cursor/mcp.json` merge entry (points Cursor at the Grok gateway with `X-Client-ID: cursor`, carries no credentials), a `.cursor/rules/using-unigrok.mdc` routing rule, and a `.cursor/hooks.json` + `before-unigrok-agent.py` beforeMCPExecution hook that auto-approves ONLY the `agent` tool so `@grok` never stalls on a permission prompt. Cursor is a client, not an execution plane — ported from the old public version's static `.cursor/` setup.
 - Depth modes `deep` (cached j-space harness prompt, harness-leak guard, final polish loop) and `hive` (draft → parallel persona votes with numbered-line dif-vote anchors → always-on xhigh merge; voters split across CLI/API planes; per-stage plane+cost receipts)
 - Public level ladder `none`→`ultra` via `level` parameter and `voters` override

--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -528,6 +528,63 @@ def _cursor_hooks(scope: str) -> dict[str, Any]:
         },
     }
 
+
+def _auto_approve(client: str, scope: str) -> dict[str, Any] | None:
+    """Per-IDE 'never prompt for @grok' config, using each client's REAL mechanism.
+
+    Verified formats: Claude Code permissions.allow globs (mcp__grok__agent), Codex
+    config.toml MCP tool approval mode, Gemini/Antigravity server trust flag. Each
+    assumes the UniGrok MCP server is registered under the name `grok`. Emitted as an
+    optional merge the IDE previews before applying.
+    """
+    if client == "claude_code":
+        target = "~/.claude/settings.json" if scope == "global" else ".claude/settings.json"
+        return {
+            "mechanism": "permissions allowlist (per-tool)",
+            "target": target,
+            "merge_into": "permissions.allow",
+            "merge_policy": (
+                "Append these entries to permissions.allow; keep existing entries. "
+                "Auto-approves ONLY UniGrok's agent and agent_result tools."
+            ),
+            "entry": {"permissions": {"allow": ["mcp__grok__agent", "mcp__grok__agent_result"]}},
+            "assumes_server_name": "grok",
+        }
+    if client == "codex":
+        return {
+            "mechanism": "MCP tool approval mode (config.toml)",
+            "target": "~/.codex/config.toml",
+            "merge_policy": (
+                "Merge under the grok MCP server; set the agent tool to auto approval. "
+                "Keep other servers and settings intact."
+            ),
+            "toml": (
+                "[mcp_servers.grok.tools.agent]\n"
+                'approval_mode = "auto"\n'
+                "[mcp_servers.grok.tools.agent_result]\n"
+                'approval_mode = "auto"\n'
+            ),
+            "assumes_server_name": "grok",
+        }
+    if client == "antigravity":
+        target = (
+            "~/.gemini/config/mcp_config.json (Antigravity) or ~/.gemini/settings.json "
+            "(Gemini CLI)"
+        )
+        return {
+            "mechanism": "server trust flag (bypasses confirmations for the whole server)",
+            "target": target,
+            "merge_into": "mcpServers.grok",
+            "merge_policy": (
+                "Set trust:true on the grok MCP server entry. Gemini/Antigravity has no "
+                "per-tool option, so this trusts the whole grok server — safe because it "
+                "is your own local gateway. Keep other servers untouched."
+            ),
+            "entry": {"mcpServers": {"grok": {"trust": True}}},
+            "assumes_server_name": "grok",
+        }
+    return None
+
 CLIENT_ADAPTERS: dict[str, dict[str, Any]] = {
     "antigravity": {
         "label": "Google Antigravity / Gemini",
@@ -719,6 +776,12 @@ def _client_onboarding_plan(client: str, scope: str) -> dict[str, Any]:
             "Reload Cursor after adding the MCP server and hook, then call "
             "grok_mcp_discover_self."
         )
+    else:
+        # Same "never prompt for @grok" outcome for the other IDEs, each via its own
+        # native mechanism (optional; the IDE previews before applying).
+        auto_approve = _auto_approve(client, "global")
+        if auto_approve is not None:
+            plan["auto_approve"] = auto_approve
     return plan
 
 PROJECT_ONBOARDING = {

--- a/tests/test_public_boundary.py
+++ b/tests/test_public_boundary.py
@@ -696,3 +696,26 @@ def test_media_generation_detector_and_guard() -> None:
     msg = _media_unavailable_result("image")
     assert "XAI_API_KEY" in msg["text"] and msg["cost_usd"] == 0.0
     assert "won't fake" in msg["text"]
+
+
+def test_per_client_auto_approve_uses_native_mechanism() -> None:
+    from unigrok_public import server
+
+    cc = server._client_onboarding_plan("claude_code", "global")["auto_approve"]
+    assert cc["merge_into"] == "permissions.allow"
+    assert cc["entry"]["permissions"]["allow"] == ["mcp__grok__agent", "mcp__grok__agent_result"]
+
+    cx = server._client_onboarding_plan("codex", "global")["auto_approve"]
+    assert cx["target"].endswith("config.toml")
+    assert 'approval_mode = "auto"' in cx["toml"]
+
+    ag = server._client_onboarding_plan("antigravity", "global")["auto_approve"]
+    assert ag["entry"]["mcpServers"]["grok"]["trust"] is True
+
+    # Clients without a verified mechanism must NOT fabricate one.
+    assert "auto_approve" not in server._client_onboarding_plan("github_copilot", "global")
+    assert "auto_approve" not in server._client_onboarding_plan("generic", "global")
+    # None of the auto-approve configs carry a credential.
+    for c in ("claude_code", "codex", "antigravity"):
+        blob = json.dumps(server._client_onboarding_plan(c, "global"))
+        assert "XAI_API_KEY" not in blob and "CURSOR_API_KEY" not in blob


### PR DESCRIPTION
grok_mcp_onboard_client now emits a 'never prompt for @grok' config per client, each via its verified-real mechanism: Claude Code permissions.allow (per-tool), Codex config.toml approval_mode=auto, Gemini/Antigravity trust:true, Cursor hook. Copilot/generic get none (no verified format — not faked). No credentials in any. 66 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding-only optional config merges with no credential emission; scope is limited to MCP tool approval UX, not runtime auth or billing.
> 
> **Overview**
> **`grok_mcp_onboard_client`** global plans for non-Cursor IDEs now include an optional **`auto_approve`** block so `@grok` can run without repeated MCP permission prompts, using each host’s documented settings shape instead of a one-size-fits-all hack.
> 
> **Claude Code** gets merge hints for `permissions.allow` with `mcp__grok__agent` and `mcp__grok__agent_result`. **Codex** gets TOML snippets setting `approval_mode = "auto"` for those tools under `mcp_servers.grok`. **Antigravity/Gemini** gets a `trust: true` merge on the `grok` MCP server entry (whole-server trust, documented in merge policy). **Cursor** is unchanged here—it still relies on the existing `beforeMCPExecution` hook path. **GitHub Copilot** and **generic** clients omit `auto_approve` when there is no verified format.
> 
> The **CHANGELOG** documents the feature. **`test_per_client_auto_approve_uses_native_mechanism`** asserts the right payloads per client, no `auto_approve` for copilot/generic, and no credentials in serialized plans.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f8d1229327f24d5d16979581bf38feed19d6b50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->