### PR TITLE
GitHub Copilot client onboarding (mcp-config, instructions, allow-tool)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the public UniGrok gateway.
 ## [1.1.0] - 2026-07-17
 
 ### Added
+- GitHub Copilot client onboarding: gh Copilot CLI `~/.copilot/mcp-config.json`
+  merge entry (repo-level `.copilot/mcp-config.json` at project scope, `.vscode/mcp.json`
+  alternative for VS Code), a namespaced `.github/instructions/unigrok.instructions.md`
+  routing rule, and `--allow-tool 'grok(agent)'` session flags for auto-approve.
 - Per-IDE "never prompt for @grok" auto-approve in the onboarding plan, each via its
   native mechanism: Claude Code `permissions.allow` (per-tool `mcp__grok__agent`), Codex
   `config.toml` MCP tool `approval_mode = "auto"`, Gemini/Antigravity server `trust: true`,

--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -529,13 +529,79 @@ def _cursor_hooks(scope: str) -> dict[str, Any]:
     }
 
 
+COPILOT_INSTRUCTIONS = """---
+applyTo: "**"
+---
+
+# Using UniGrok from GitHub Copilot
+
+UniGrok is a local Grok gateway. Its `agent` tool is your `@grok`.
+
+- Reach for the UniGrok `agent` tool when you want: web/X research, hard reasoning or
+  plan critique, cross-project memory (named sessions and durable facts), or code you
+  want adversarially reviewed before delivery (`level: "ultra"` runs a parallel hive).
+- UniGrok picks the model, effort, and plane for you and returns a plane and cost
+  receipt on every answer. Relay the cost to the user; never hide metered spend.
+- For ordinary local edits, use Copilot's native tools. Escalate to the UniGrok `agent`
+  tool for dual-plane routing, research, memory, or review.
+- Identity: keep `"X-Client-ID": "github-copilot"` in the MCP server headers. It is a
+  telemetry label, not authentication.
+- Never place `XAI_API_KEY` in Copilot, VS Code, or repository configuration —
+  credentials live inside UniGrok.
+"""
+
+
+def _copilot_mcp_server(scope: str) -> dict[str, Any]:
+    """The Copilot CLI mcp-config.json merge entry pointing Copilot at the gateway.
+
+    gh Copilot CLI reads ~/.copilot/mcp-config.json (user) and .copilot/mcp-config.json
+    (repository); both use an mcpServers object. VS Code uses .vscode/mcp.json with a
+    `servers` key instead — emitted as an alternative so either surface works. Merge
+    only; never overwrite other servers.
+    """
+    return {
+        "target": (
+            "~/.copilot/mcp-config.json" if scope == "global" else ".copilot/mcp-config.json"
+        ),
+        "merge_into": "mcpServers",
+        "merge_policy": (
+            "Add this server to the existing mcpServers object; do not overwrite other "
+            "servers. If a 'grok' server already exists, show a diff before replacing. "
+            "COPILOT_HOME relocates the user-level directory when set."
+        ),
+        "entry": {
+            "mcpServers": {
+                "grok": {
+                    "type": "http",
+                    "url": CURSOR_MCP_URL,
+                    "headers": {"X-Client-ID": "github-copilot"},
+                }
+            }
+        },
+        "vscode_alternative": {
+            "target": ".vscode/mcp.json",
+            "merge_into": "servers",
+            "entry": {
+                "servers": {
+                    "grok": {
+                        "type": "http",
+                        "url": CURSOR_MCP_URL,
+                        "headers": {"X-Client-ID": "github-copilot"},
+                    }
+                }
+            },
+        },
+    }
+
+
 def _auto_approve(client: str, scope: str) -> dict[str, Any] | None:
     """Per-IDE 'never prompt for @grok' config, using each client's REAL mechanism.
 
     Verified formats: Claude Code permissions.allow globs (mcp__grok__agent), Codex
-    config.toml MCP tool approval mode, Gemini/Antigravity server trust flag. Each
-    assumes the UniGrok MCP server is registered under the name `grok`. Emitted as an
-    optional merge the IDE previews before applying.
+    config.toml MCP tool approval mode, Gemini/Antigravity server trust flag, and gh
+    Copilot CLI --allow-tool session flags. Each assumes the UniGrok MCP server is
+    registered under the name `grok`. Emitted as an optional merge the IDE previews
+    before applying.
     """
     if client == "claude_code":
         target = "~/.claude/settings.json" if scope == "global" else ".claude/settings.json"
@@ -581,6 +647,20 @@ def _auto_approve(client: str, scope: str) -> dict[str, Any] | None:
                 "is your own local gateway. Keep other servers untouched."
             ),
             "entry": {"mcpServers": {"grok": {"trust": True}}},
+            "assumes_server_name": "grok",
+        }
+    if client == "github_copilot":
+        return {
+            "mechanism": "session flags (gh Copilot CLI --allow-tool)",
+            "target": "copilot invocation (no persistent allowlist file is documented)",
+            "merge_policy": (
+                "Launch Copilot CLI with these flags, or wrap them in a shell alias. "
+                "grok(agent) scopes approval to UniGrok's agent tools only; plain "
+                "--allow-tool 'grok' would trust the whole server."
+            ),
+            "command": (
+                "copilot --allow-tool 'grok(agent)' --allow-tool 'grok(agent_result)'"
+            ),
             "assumes_server_name": "grok",
         }
     return None
@@ -742,6 +822,11 @@ def _client_onboarding_plan(client: str, scope: str) -> dict[str, Any]:
             )
             plan["mcp_server"] = _cursor_mcp_server("project")
             plan["hooks"] = _cursor_hooks("project")
+        if client == "github_copilot":
+            plan["files"].append(
+                _owned_file(".github/instructions/unigrok.instructions.md", COPILOT_INSTRUCTIONS)
+            )
+            plan["mcp_server"] = _copilot_mcp_server("project")
         return plan
     files = _global_files(client)
     plan = {
@@ -782,6 +867,15 @@ def _client_onboarding_plan(client: str, scope: str) -> dict[str, Any]:
         auto_approve = _auto_approve(client, "global")
         if auto_approve is not None:
             plan["auto_approve"] = auto_approve
+        if client == "github_copilot":
+            # gh Copilot CLI reads ~/.copilot/mcp-config.json; VS Code uses .vscode/
+            # mcp.json (carried as vscode_alternative). Project instructions live in
+            # the namespaced .github/instructions file, offered at project scope.
+            plan["mcp_server"] = _copilot_mcp_server("global")
+            plan["reload"] = (
+                "Restart Copilot CLI (or check /mcp show) after adding the MCP server, "
+                "then call grok_mcp_discover_self."
+            )
     return plan
 
 PROJECT_ONBOARDING = {

--- a/tests/test_public_boundary.py
+++ b/tests/test_public_boundary.py
@@ -712,10 +712,20 @@ def test_per_client_auto_approve_uses_native_mechanism() -> None:
     ag = server._client_onboarding_plan("antigravity", "global")["auto_approve"]
     assert ag["entry"]["mcpServers"]["grok"]["trust"] is True
 
+    gh = server._client_onboarding_plan("github_copilot", "global")
+    assert "--allow-tool 'grok(agent)'" in gh["auto_approve"]["command"]
+    assert gh["mcp_server"]["target"] == "~/.copilot/mcp-config.json"
+    assert gh["mcp_server"]["entry"]["mcpServers"]["grok"]["url"].endswith("/mcp")
+    assert gh["mcp_server"]["vscode_alternative"]["target"] == ".vscode/mcp.json"
+    gh_proj = server._client_onboarding_plan("github_copilot", "project")
+    assert gh_proj["mcp_server"]["target"] == ".copilot/mcp-config.json"
+    assert any(
+        f["path"] == ".github/instructions/unigrok.instructions.md" for f in gh_proj["files"]
+    )
+
     # Clients without a verified mechanism must NOT fabricate one.
-    assert "auto_approve" not in server._client_onboarding_plan("github_copilot", "global")
     assert "auto_approve" not in server._client_onboarding_plan("generic", "global")
     # None of the auto-approve configs carry a credential.
-    for c in ("claude_code", "codex", "antigravity"):
+    for c in ("claude_code", "codex", "antigravity", "github_copilot"):
         blob = json.dumps(server._client_onboarding_plan(c, "global"))
         assert "XAI_API_KEY" not in blob and "CURSOR_API_KEY" not in blob


### PR DESCRIPTION
Completes per-client onboarding: Copilot now gets a verified plan — gh Copilot CLI ~/.copilot/mcp-config.json merge entry (repo-level .copilot/mcp-config.json at project scope, .vscode/mcp.json servers-key alternative for VS Code), a namespaced .github/instructions/unigrok.instructions.md routing rule, and --allow-tool 'grok(agent)' session flags as auto-approve (no persistent allowlist file is documented, so none is invented). No credentials in any config. 66 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Consent-first onboarding metadata and documentation only; no runtime agent or auth changes, and tests enforce no secrets in emitted plans.
> 
> **Overview**
> Adds **verified GitHub Copilot / VS Code** support to `grok_mcp_onboard_client`, matching the pattern used for Cursor and other IDEs.
> 
> **Global and project plans** now emit merge-only MCP entries: `~/.copilot/mcp-config.json` or repo `.copilot/mcp-config.json` (HTTP `grok` server with `X-Client-ID: github-copilot`, no API keys), plus a **`.vscode/mcp.json`** alternative under a `servers` key for VS Code. Project scope also ships **`.github/instructions/unigrok.instructions.md`** for when to use UniGrok vs native Copilot tools.
> 
> **Auto-approve** for Copilot uses documented **gh Copilot CLI** session flags (`--allow-tool 'grok(agent)'` and `agent_result`) instead of inventing a persistent allowlist file. Changelog and `_auto_approve` docs are updated accordingly; boundary tests assert targets, instructions path, and that onboarding blobs still contain no credentials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abe612c6f42466ff14264642d52813052a37c29c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->