### PR TITLE
Antigravity auto-approve via globalPermissionGrants (per-tool), not trust:true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to the public UniGrok gateway.
 
+## [Unreleased]
+
+### Changed
+- Antigravity auto-approve now uses `globalPermissionGrants.allow` with per-tool
+  grants (`mcp(grok/agent)`, `mcp(grok/agent_result)`) — the battle-tested pack
+  format — instead of whole-server `trust: true`. Global scope targets
+  `~/.gemini/config/config.json` under `userSettings`, project scope
+  `.gemini/settings.json`. The trust flag remains as a documented fallback for
+  Gemini CLI, which has no permission grants.
+
 ## [1.1.0] - 2026-07-17
 
 ### Added

--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -635,7 +635,7 @@ def _auto_approve(client: str, scope: str) -> dict[str, Any] | None:
         }
     if client == "antigravity":
         if scope == "global":
-            target = "~/.gemini/config/config.json (Antigravity user settings)"
+            target = "~/.gemini/config/config.json"
             merge_into = "userSettings.globalPermissionGrants.allow"
             entry: dict[str, Any] = {
                 "userSettings": {
@@ -663,7 +663,7 @@ def _auto_approve(client: str, scope: str) -> dict[str, Any] | None:
             ),
             "entry": entry,
             "gemini_cli_alternative": {
-                "target": "~/.gemini/settings.json (Gemini CLI)",
+                "target": "~/.gemini/settings.json",
                 "note": (
                     "Gemini CLI has no permission grants; set trust:true on the grok "
                     "mcpServers entry instead. That trusts the whole grok server — "

--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -598,8 +598,9 @@ def _auto_approve(client: str, scope: str) -> dict[str, Any] | None:
     """Per-IDE 'never prompt for @grok' config, using each client's REAL mechanism.
 
     Verified formats: Claude Code permissions.allow globs (mcp__grok__agent), Codex
-    config.toml MCP tool approval mode, Gemini/Antigravity server trust flag, and gh
-    Copilot CLI --allow-tool session flags. Each assumes the UniGrok MCP server is
+    config.toml MCP tool approval mode, Antigravity globalPermissionGrants allow
+    entries (mcp(grok/agent); trust flag fallback for Gemini CLI), and gh Copilot
+    CLI --allow-tool session flags. Each assumes the UniGrok MCP server is
     registered under the name `grok`. Emitted as an optional merge the IDE previews
     before applying.
     """
@@ -633,20 +634,43 @@ def _auto_approve(client: str, scope: str) -> dict[str, Any] | None:
             "assumes_server_name": "grok",
         }
     if client == "antigravity":
-        target = (
-            "~/.gemini/config/mcp_config.json (Antigravity) or ~/.gemini/settings.json "
-            "(Gemini CLI)"
-        )
+        if scope == "global":
+            target = "~/.gemini/config/config.json (Antigravity user settings)"
+            merge_into = "userSettings.globalPermissionGrants.allow"
+            entry: dict[str, Any] = {
+                "userSettings": {
+                    "globalPermissionGrants": {
+                        "allow": ["mcp(grok/agent)", "mcp(grok/agent_result)"]
+                    }
+                }
+            }
+        else:
+            target = ".gemini/settings.json"
+            merge_into = "globalPermissionGrants.allow"
+            entry = {
+                "globalPermissionGrants": {
+                    "allow": ["mcp(grok/agent)", "mcp(grok/agent_result)"]
+                }
+            }
         return {
-            "mechanism": "server trust flag (bypasses confirmations for the whole server)",
+            "mechanism": "permission grants allowlist (per-tool)",
             "target": target,
-            "merge_into": "mcpServers.grok",
+            "merge_into": merge_into,
             "merge_policy": (
-                "Set trust:true on the grok MCP server entry. Gemini/Antigravity has no "
-                "per-tool option, so this trusts the whole grok server — safe because it "
-                "is your own local gateway. Keep other servers untouched."
+                "Append these grants to the allow list; keep existing entries. "
+                "Auto-approves ONLY UniGrok's agent and agent_result tools; use "
+                "mcp(grok/*) instead to cover every grok tool."
             ),
-            "entry": {"mcpServers": {"grok": {"trust": True}}},
+            "entry": entry,
+            "gemini_cli_alternative": {
+                "target": "~/.gemini/settings.json (Gemini CLI)",
+                "note": (
+                    "Gemini CLI has no permission grants; set trust:true on the grok "
+                    "mcpServers entry instead. That trusts the whole grok server — "
+                    "acceptable because it is your own local gateway."
+                ),
+                "entry": {"mcpServers": {"grok": {"trust": True}}},
+            },
             "assumes_server_name": "grok",
         }
     if client == "github_copilot":

--- a/tests/test_public_boundary.py
+++ b/tests/test_public_boundary.py
@@ -710,7 +710,17 @@ def test_per_client_auto_approve_uses_native_mechanism() -> None:
     assert 'approval_mode = "auto"' in cx["toml"]
 
     ag = server._client_onboarding_plan("antigravity", "global")["auto_approve"]
-    assert ag["entry"]["mcpServers"]["grok"]["trust"] is True
+    assert ag["entry"]["userSettings"]["globalPermissionGrants"]["allow"] == [
+        "mcp(grok/agent)",
+        "mcp(grok/agent_result)",
+    ]
+    assert ag["gemini_cli_alternative"]["entry"]["mcpServers"]["grok"]["trust"] is True
+    ag_proj = server._auto_approve("antigravity", "project")
+    assert ag_proj["target"] == ".gemini/settings.json"
+    assert ag_proj["entry"]["globalPermissionGrants"]["allow"] == [
+        "mcp(grok/agent)",
+        "mcp(grok/agent_result)",
+    ]
 
     gh = server._client_onboarding_plan("github_copilot", "global")
     assert "--allow-tool 'grok(agent)'" in gh["auto_approve"]["command"]


### PR DESCRIPTION
Aligns the Gemini/Antigravity auto-approve emit with the battle-tested pack format.

- Primary mechanism is now `globalPermissionGrants.allow` with per-tool grants `mcp(grok/agent)` + `mcp(grok/agent_result)` — finer-grained than whole-server `trust: true`, and the exact format proven in the live Antigravity config.
- Global scope targets `~/.gemini/config/config.json` under `userSettings`; project scope targets `.gemini/settings.json`.
- `trust: true` remains as a documented `gemini_cli_alternative` for Gemini CLI, which has no permission grants.
- Test updated to assert both scopes and the fallback; CHANGELOG gets an Unreleased entry (1.1.0 is tagged and frozen).

All 66 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding emit and documentation only; no runtime MCP or auth behavior changes.
> 
> **Overview**
> **Antigravity/Gemini onboarding** no longer recommends whole-server `trust: true` on the `grok` MCP entry. Auto-approve is emitted as **`globalPermissionGrants.allow`** with per-tool grants `mcp(grok/agent)` and `mcp(grok/agent_result)` — global scope merges under `userSettings` in `~/.gemini/config/config.json`, project scope into `.gemini/settings.json`.
> 
> **Gemini CLI** still gets **`trust: true`** documented as `gemini_cli_alternative` because that client has no permission-grant format. Docstrings and **CHANGELOG [Unreleased]** reflect the switch; tests assert global grants, project scope, and the CLI fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2d89c1d40fd4cfc88ef119593aa7595e0bb0110. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->