### PR TITLE
Restore hosted @grok PR-review path (workflow + broker scripts)

### DIFF
--- a/.github/workflows/grok-review.yml
+++ b/.github/workflows/grok-review.yml
@@ -66,4 +66,6 @@ jobs:
           UNIGROK_MCP_RESOURCE_URL: ${{ vars.UNIGROK_MCP_RESOURCE_URL || 'https://mcp.grokmcp.org/mcp' }}
           # Optional lab/static override only — unused when mint secret is set.
           UNIGROK_CLIENT_TOKEN: ${{ secrets.UNIGROK_CLIENT_TOKEN }}
-        run: uv run python scripts/github-grok-review.py
+        # --frozen: use the committed lock as-is (matches ci.yml's uv sync --frozen);
+        # plain `uv run` re-resolves and mutates uv.lock when pyproject/lock diverge.
+        run: uv run --frozen python scripts/github-grok-review.py

--- a/.github/workflows/grok-review.yml
+++ b/.github/workflows/grok-review.yml
@@ -1,0 +1,69 @@
+name: UniGrok PR Review
+
+on:
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number
+        required: true
+        type: number
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: unigrok-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
+       contains(github.event.comment.body, '@grok review'))
+    name: UniGrok review
+    # Production (hosted): set repository variables
+    #   UNIGROK_REVIEW_RUNNER_JSON = "ubuntu-latest"
+    #   UNIGROK_REVIEW_MCP_URL     = https://mcp.grokmcp.org/mcp
+    #   UNIGROK_REVIEW_PLANE       = api
+    # Auth: set repository secret UNIGROK_MCP_TOKEN_SECRET to the same value as
+    # Control Center MCP_TOKEN_SECRET (Secret Manager:
+    # unigrok-control-center-mcp-token-secret). The job mints a ~120s
+    # service:github-review-broker token at runtime — never put XAI_API_KEY
+    # here and do not install static UNIGROK_API_KEYS on the Cloud Run twin.
+    # Lab fallback when vars unset: self-hosted + loopback CLI (Mac required).
+    # See docs/design/hosted-review-p0.md and docs/chatgpt-github-app.md.
+    runs-on: ${{ fromJSON(vars.UNIGROK_REVIEW_RUNNER_JSON || '["self-hosted","unigrok-review"]') }}
+    timeout-minutes: 15
+    steps:
+      # Run only trusted default-branch code. Never check out, execute, install,
+      # or import code from the reviewed PR.
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.3.2
+        with:
+          enable-cache: true
+
+      - name: Run read-only Grok review
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          INPUT_PR_NUMBER: ${{ inputs.pr_number }}
+          # Hosted production: set UNIGROK_REVIEW_MCP_URL to https://mcp.grokmcp.org/mcp
+          UNIGROK_MCP_URL: ${{ vars.UNIGROK_REVIEW_MCP_URL || 'http://127.0.0.1:4765/mcp' }}
+          UNIGROK_REVIEW_PLANE: ${{ vars.UNIGROK_REVIEW_PLANE || 'cli' }}
+          # OAuth service mint (production). Same secret as Control MCP_TOKEN_SECRET.
+          UNIGROK_MCP_TOKEN_SECRET: ${{ secrets.UNIGROK_MCP_TOKEN_SECRET }}
+          UNIGROK_OAUTH_ISSUER: ${{ vars.UNIGROK_OAUTH_ISSUER || 'https://control.grokmcp.org' }}
+          UNIGROK_MCP_RESOURCE_URL: ${{ vars.UNIGROK_MCP_RESOURCE_URL || 'https://mcp.grokmcp.org/mcp' }}
+          # Optional lab/static override only — unused when mint secret is set.
+          UNIGROK_CLIENT_TOKEN: ${{ secrets.UNIGROK_CLIENT_TOKEN }}
+        run: uv run python scripts/github-grok-review.py

--- a/scripts/github-grok-review.py
+++ b/scripts/github-grok-review.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+"""Fetch a PR as untrusted evidence, ask UniGrok over MCP, update one comment."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+
+import httpx
+from mcp import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+
+MARKER = "<!-- unigrok-review -->"
+MAX_DIFF_CHARS = 90_000
+MAX_DISCUSSION_CHARS = 8_000
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _required(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"missing required environment variable: {name}")
+    return value
+
+
+def _github_request(
+    url: str,
+    token: str,
+    *,
+    accept: str = "application/vnd.github+json",
+    method: str = "GET",
+    payload: dict[str, Any] | None = None,
+) -> Any:
+    body = json.dumps(payload).encode() if payload is not None else None
+    # URLs are GitHub REST API https endpoints built from the runner's
+    # GITHUB_API_URL / GitHub-returned resource links — no untrusted schemes.
+    request = urllib.request.Request(  # noqa: S310
+        url,
+        data=body,
+        method=method,
+        headers={
+            "Accept": accept,
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "unigrok-review",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:  # noqa: S310
+            raw = response.read()
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:1_000]
+        raise RuntimeError(f"GitHub API {exc.code} for {url}: {detail}") from exc
+    if accept.endswith(".diff"):
+        return raw.decode("utf-8", errors="replace")
+    return json.loads(raw or b"{}")
+
+
+def _pull_number(event: dict[str, Any]) -> int:
+    manual = os.environ.get("INPUT_PR_NUMBER", "").strip()
+    if manual:
+        return int(manual)
+    pull = event.get("pull_request") or event.get("issue", {}).get("pull_request")
+    if event.get("pull_request"):
+        return int(event["pull_request"]["number"])
+    if pull:
+        return int(event["issue"]["number"])
+    raise RuntimeError("event does not identify a pull request")
+
+
+def _commit_sha(value: Any, *, label: str) -> str:
+    sha = str(value or "").strip().lower()
+    if not SHA_RE.fullmatch(sha):
+        raise RuntimeError(f"GitHub returned an invalid {label} commit SHA")
+    return sha
+
+
+def _expected_head_sha(event: dict[str, Any]) -> str | None:
+    configured = os.environ.get("EXPECTED_HEAD_SHA", "").strip()
+    event_sha = (event.get("pull_request") or {}).get("head", {}).get("sha")
+    value = configured or event_sha
+    return _commit_sha(value, label="expected head") if value else None
+
+
+def _expected_base_sha(event: dict[str, Any]) -> str | None:
+    configured = os.environ.get("EXPECTED_BASE_SHA", "").strip()
+    event_sha = (event.get("pull_request") or {}).get("base", {}).get("sha")
+    value = configured or event_sha
+    return _commit_sha(value, label="expected base") if value else None
+
+
+def _evidence_provenance(
+    *,
+    repository: str,
+    number: int,
+    pr: dict[str, Any],
+    diff: str,
+    discussion: str,
+) -> dict[str, str]:
+    head_sha = _commit_sha(pr.get("head", {}).get("sha"), label="head")
+    base_sha = _commit_sha(pr.get("base", {}).get("sha"), label="base")
+    envelope = {
+        "base_sha": base_sha,
+        "diff": diff,
+        "discussion": discussion,
+        "head_sha": head_sha,
+        "pull_number": number,
+        "repository": repository,
+        "title": str(pr.get("title") or ""),
+    }
+    digest = hashlib.sha256(
+        json.dumps(
+            envelope,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    ).hexdigest()
+    return {
+        "base_sha": base_sha,
+        "evidence_sha256": digest,
+        "head_sha": head_sha,
+    }
+
+
+def _workflow_run_url(repository: str) -> str | None:
+    run_id = os.environ.get("GITHUB_RUN_ID", "").strip()
+    if not run_id.isdigit():
+        return None
+    server = os.environ.get("GITHUB_SERVER_URL", "https://github.com").rstrip("/")
+    if server not in {"https://github.com", "https://github.com/"}:
+        return None
+    return f"https://github.com/{repository}/actions/runs/{run_id}"
+
+
+def _gateway_bearer_token() -> str:
+    """Resolve MCP auth: mint when possible, else use the static fallback.
+
+    Production twin validates via Control introspection. Long-lived static
+    client keys must not be installed on Cloud Run. When
+    ``UNIGROK_MCP_TOKEN_SECRET`` is set (same as Control ``MCP_TOKEN_SECRET``),
+    mint ``service:github-review-broker`` with ``unigrok:review``.
+    """
+    secret = os.environ.get("UNIGROK_MCP_TOKEN_SECRET", "").strip()
+    if not secret:
+        return os.environ.get("UNIGROK_CLIENT_TOKEN", "").strip()
+    # Import path works when run as ``uv run python scripts/github-grok-review.py``
+    # with repo root on sys.path (uv / Actions checkout default).
+    try:
+        from scripts.mint_mcp_service_token import mint_service_access_token
+    except ImportError:  # pragma: no cover - script dir execution
+        sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+        from scripts.mint_mcp_service_token import mint_service_access_token
+    issuer = os.environ.get("UNIGROK_OAUTH_ISSUER", "https://control.grokmcp.org").strip()
+    resource = os.environ.get(
+        "UNIGROK_MCP_RESOURCE_URL",
+        os.environ.get("UNIGROK_MCP_URL", "https://mcp.grokmcp.org/mcp").strip(),
+    ).strip()
+    if resource.endswith("/"):
+        resource = resource.rstrip("/")
+    # Resource must be the OAuth audience (.../mcp), not a path typo.
+    if not resource.endswith("/mcp"):
+        if resource.endswith(".org") or resource.endswith(".com"):
+            resource = f"{resource}/mcp"
+    raw_ttl = os.environ.get("UNIGROK_TOKEN_TTL_SECONDS", "").strip()
+    try:
+        ttl_seconds = int(raw_ttl) if raw_ttl else None
+    except ValueError as exc:
+        raise ValueError("UNIGROK_TOKEN_TTL_SECONDS must be an integer") from exc
+    return mint_service_access_token(
+        secret=secret,
+        issuer=issuer,
+        resource=resource,
+        service=os.environ.get("UNIGROK_SERVICE_NAME", "github-review-broker").strip(),
+        scope=os.environ.get("UNIGROK_SERVICE_SCOPE", "unigrok:review").strip(),
+        ttl_seconds=ttl_seconds,
+    )
+
+
+async def _call_unigrok(arguments: dict[str, Any]) -> dict[str, Any]:
+    url = os.environ.get("UNIGROK_MCP_URL", "http://127.0.0.1:4765/mcp")
+    headers = {"X-Client-ID": "github-actions", "X-Caller": "github-review-broker"}
+    gateway_token = _gateway_bearer_token()
+    if gateway_token:
+        headers["Authorization"] = f"Bearer {gateway_token}"
+    timeout = httpx.Timeout(connect=15.0, read=540.0, write=30.0, pool=15.0)
+    async with httpx.AsyncClient(headers=headers, timeout=timeout) as client:
+        async with streamable_http_client(url, http_client=client) as (read, write, _):
+            async with ClientSession(
+                read, write, read_timeout_seconds=timedelta(seconds=540)
+            ) as session:
+                await session.initialize()
+                result = await session.call_tool("review_pull_request", arguments)
+    if result.isError:
+        text = "\n".join(getattr(item, "text", "") for item in result.content)
+        raise RuntimeError(text or "UniGrok review tool failed")
+    structured = result.structuredContent
+    if not isinstance(structured, dict):
+        raise RuntimeError("UniGrok returned no structured review payload")
+    return structured
+
+
+def _format_comment(
+    data: dict[str, Any],
+    *,
+    provenance: dict[str, str],
+    run_url: str | None = None,
+) -> str:
+    review = str(data.get("review") or "No review returned.")
+    run = f" · [workflow run]({run_url})" if run_url else ""
+    return (
+        f"{MARKER}\n## @grok review for Codex\n\n{review}\n\n"
+        "---\n"
+        f"Model: `{data.get('model', 'unknown')}` · Plane: `{data.get('plane', 'unknown')}` · "
+        f"Route: `{data.get('route', 'unknown')}` · "
+        f"Cost: `${float(data.get('cost_usd') or 0):.5f}`\n\n"
+        f"Reviewed head: `{provenance['head_sha']}` · Base: `{provenance['base_sha']}`\n\n"
+        f"Evidence: `sha256:{provenance['evidence_sha256']}`{run}\n\n"
+        "This is advisory evidence. Codex remains the sole landing and merge authority."
+    )
+
+
+def _upsert_comment(api: str, repository: str, number: int, token: str, body: str) -> None:
+    comments_url = f"{api}/repos/{repository}/issues/{number}/comments?per_page=100"
+    comments = _github_request(comments_url, token)
+    existing = next(
+        (
+            item
+            for item in comments
+            if MARKER in str(item.get("body", ""))
+            and item.get("user", {}).get("login") == "github-actions[bot]"
+        ),
+        None,
+    )
+    if existing:
+        _github_request(existing["url"], token, method="PATCH", payload={"body": body})
+    else:
+        _github_request(comments_url.split("?", 1)[0], token, method="POST", payload={"body": body})
+
+
+def _load_event() -> dict[str, Any]:
+    return json.loads(Path(_required("GITHUB_EVENT_PATH")).read_text(encoding="utf-8"))
+
+
+async def main() -> None:
+    token = _required("GITHUB_TOKEN")
+    repository = _required("GITHUB_REPOSITORY")
+    event = _load_event()
+    number = _pull_number(event)
+    api = os.environ.get("GITHUB_API_URL", "https://api.github.com").rstrip("/")
+    pr_url = f"{api}/repos/{repository}/pulls/{number}"
+    pr = _github_request(pr_url, token)
+    expected_head = _expected_head_sha(event)
+    expected_base = _expected_base_sha(event)
+    fetched_head = _commit_sha(pr.get("head", {}).get("sha"), label="head")
+    fetched_base = _commit_sha(pr.get("base", {}).get("sha"), label="base")
+    if expected_head and fetched_head != expected_head:
+        raise RuntimeError(
+            "refusing stale review: event head "
+            f"{expected_head} no longer matches PR head {fetched_head}"
+        )
+    if expected_base and fetched_base != expected_base:
+        raise RuntimeError(
+            "refusing stale review: event base "
+            f"{expected_base} no longer matches PR base {fetched_base}"
+        )
+    # The PR diff endpoint is mutable. Fetching it after recording the PR SHAs
+    # permits an A -> B -> A race to bind B's diff to A's provenance. Comparing
+    # two validated full commit ids makes the reviewed evidence immutable.
+    compare_url = (
+        f"{api}/repos/{repository}/compare/{fetched_base}...{fetched_head}"
+    )
+    diff = _github_request(
+        compare_url,
+        token,
+        accept="application/vnd.github.v3.diff",
+    )
+    reviews = _github_request(f"{pr_url}/reviews?per_page=100", token)
+    discussion = "\n".join(
+        f"- {item.get('user', {}).get('login', 'unknown')}: "
+        f"{item.get('state', 'COMMENTED')} — {item.get('body') or '(no body)'}"
+        for item in reviews
+    )[:MAX_DISCUSSION_CHARS]
+    truncated = len(diff) > MAX_DIFF_CHARS
+    diff = diff[:MAX_DIFF_CHARS]
+    if truncated:
+        diff += "\n\n[Diff truncated by UniGrok GitHub review safety limit.]"
+    provenance = _evidence_provenance(
+        repository=repository,
+        number=number,
+        pr=pr,
+        diff=diff,
+        discussion=discussion,
+    )
+    data = await _call_unigrok(
+        {
+            "repository": repository,
+            "pull_number": number,
+            "title": pr.get("title") or "",
+            "diff": diff,
+            "ci_summary": (
+                "GitHub Actions evidence is reviewed separately by Codex's maintainer sweep.\n"
+                "Trusted fetcher provenance:\n"
+                f"- head: {provenance['head_sha']}\n"
+                f"- base: {provenance['base_sha']}\n"
+                f"- bounded evidence sha256: {provenance['evidence_sha256']}"
+            ),
+            "review_comments": discussion,
+            "plane": os.environ.get("UNIGROK_REVIEW_PLANE", "cli"),
+        }
+    )
+    current = _github_request(pr_url, token)
+    current_head = _commit_sha(current.get("head", {}).get("sha"), label="current head")
+    current_base = _commit_sha(current.get("base", {}).get("sha"), label="current base")
+    if (
+        current_head != provenance["head_sha"]
+        or current_base != provenance["base_sha"]
+    ):
+        raise RuntimeError(
+            "refusing stale review comment: PR base/head changed while Grok was "
+            "reviewing "
+            f"(base {provenance['base_sha']} -> {current_base}; "
+            f"head {provenance['head_sha']} -> {current_head})"
+        )
+    _upsert_comment(
+        api,
+        repository,
+        number,
+        token,
+        _format_comment(
+            data,
+            provenance=provenance,
+            run_url=_workflow_run_url(repository),
+        ),
+    )
+    print(
+        f"Updated UniGrok review for {repository}#{number} "
+        f"at {provenance['head_sha']} ({provenance['evidence_sha256']})"
+    )
+
+
+def _format_exc(exc: BaseException) -> str:
+    """Surface nested ExceptionGroup / TaskGroup causes for Actions logs."""
+    parts = [f"{type(exc).__name__}: {exc}"]
+    if isinstance(exc, BaseExceptionGroup):
+        for i, sub in enumerate(exc.exceptions, 1):
+            parts.append(f"  [{i}] {_format_exc(sub)}")
+    cause = exc.__cause__
+    if cause is None and not exc.__suppress_context__:
+        cause = exc.__context__
+    if cause is not None and cause is not exc:
+        parts.append(f"  caused by: {_format_exc(cause)}")
+    return "\n".join(parts)
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except Exception as exc:
+        print(f"error: {_format_exc(exc)}", file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/scripts/mint_mcp_service_token.py
+++ b/scripts/mint_mcp_service_token.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Mint a short-lived UniGrok MCP service access token (Control-compatible).
+
+Matches Control Center ``createServiceAccessToken``:
+HMAC-SHA256 over base64url(JSON claims), token prefix ``ugtoken.``.
+
+Production remote MCP validates via Control introspection — never install a
+long-lived static client key on Cloud Run. This script only produces short-lived
+tokens for GitHub Actions, Cursor Cloud agents, and ops smoke.
+
+Environment (required):
+  UNIGROK_MCP_TOKEN_SECRET  — same value as Control ``MCP_TOKEN_SECRET``
+  UNIGROK_OAUTH_ISSUER      — e.g. https://control.grokmcp.org
+  UNIGROK_MCP_RESOURCE_URL  — e.g. https://mcp.grokmcp.org/mcp
+
+Optional:
+  UNIGROK_SERVICE_NAME      — github-review-broker | cursor-cloud
+  UNIGROK_SERVICE_SCOPE     — unigrok:review (broker) | unigrok:invoke (cursor-cloud)
+  UNIGROK_TOKEN_TTL_SECONDS — default per service (max 600)
+
+Prints the bearer token to stdout only (no logs of the secret).
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import secrets
+import sys
+import time
+from collections.abc import Mapping
+from typing import Any
+
+from cryptography.hazmat.primitives import hashes, hmac
+
+TOKEN_PREFIX = "ugtoken."  # noqa: S105 - token type prefix, not a credential
+MAX_TTL = 600
+
+# service → primary capability scope (connect is always included)
+SERVICE_SPECS: dict[str, dict[str, Any]] = {
+    "github-review-broker": {
+        "scopes": frozenset({"unigrok:review"}),
+        "default_scope": "unigrok:review",
+        # Hosted review allows a 9-minute model read. Keep one bounded token
+        # valid for that stream instead of expiring mid-response.
+        "default_ttl": 600,
+        "max_ttl": 600,
+    },
+    # Cursor Cloud / headless IDE agents: invoke + status (discover/status tools).
+    "cursor-cloud": {
+        # Status is granted only inside the fixed cursor-cloud bundle below.
+        "scopes": frozenset({"unigrok:invoke"}),
+        "default_scope": "unigrok:invoke",
+        "default_ttl": 600,
+        "max_ttl": 600,
+    },
+}
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise SystemExit(f"missing required environment variable: {name}")
+    return value
+
+
+def sign_cookie_payload(payload: Mapping[str, Any], secret: str) -> str:
+    """Mirror Control ``signCookiePayload`` (HMAC-SHA256 over base64url body)."""
+    if not (32 <= len(secret) <= 4_096):
+        raise ValueError("MCP token secret length is invalid")
+    body = _b64url(json.dumps(payload, separators=(",", ":"), ensure_ascii=True).encode("utf-8"))
+    if len(body) > 4_096:
+        raise ValueError("cookie payload is too large")
+    signer = hmac.HMAC(secret.encode("utf-8"), hashes.SHA256())
+    signer.update(body.encode("utf-8"))
+    signature = signer.finalize()
+    return f"{body}.{_b64url(signature)}"
+
+
+def _service_token_parameters(
+    service: str,
+    scope: str | None,
+    ttl_seconds: int | None,
+) -> tuple[str, int, list[str]]:
+    """Validate a service request and return its exact scope/TTL bundle."""
+    if service not in SERVICE_SPECS:
+        raise ValueError(f"service not allowed: {service}")
+    spec = SERVICE_SPECS[service]
+    primary = (scope or spec["default_scope"]).strip()
+    if primary not in spec["scopes"]:
+        raise ValueError(f"scope not allowed for service {service}: {primary}")
+    ttl = int(ttl_seconds if ttl_seconds is not None else spec["default_ttl"])
+    max_ttl = int(spec["max_ttl"])
+    if not (1 <= ttl <= min(max_ttl, MAX_TTL)):
+        raise ValueError(f"ttl_seconds must be 1..{min(max_ttl, MAX_TTL)} for {service}")
+    if service == "cursor-cloud":
+        granted = ["unigrok:connect", "unigrok:invoke", "unigrok:status"]
+    else:
+        granted = ["unigrok:connect", primary]
+    return primary, ttl, granted
+
+
+def _service_access_claims(
+    *,
+    issuer: str,
+    resource: str,
+    service: str = "github-review-broker",
+    scope: str | None = None,
+    ttl_seconds: int | None = None,
+    now: int | None = None,
+    jti: str | None = None,
+) -> dict[str, Any]:
+    _primary, ttl, granted = _service_token_parameters(service, scope, ttl_seconds)
+    if not issuer.startswith("https://") or issuer.endswith("/"):
+        raise ValueError("issuer must be an https origin without trailing slash")
+    if not resource.startswith("https://") or not resource.endswith("/mcp"):
+        raise ValueError("resource must be https://…/mcp")
+    iat = int(now if now is not None else time.time())
+    return {
+        "aud": resource,
+        "exp": iat + ttl,
+        "iat": iat,
+        "iss": issuer,
+        "jti": jti or _b64url(secrets.token_bytes(24)),
+        "kind": "service",
+        "scope": granted,
+        "sub": f"service:{service}",
+        "v": 1,
+    }
+
+
+def _mint_service_access_token_with_claims(
+    *,
+    secret: str,
+    issuer: str,
+    resource: str,
+    service: str = "github-review-broker",
+    scope: str | None = None,
+    ttl_seconds: int | None = None,
+    now: int | None = None,
+    jti: str | None = None,
+) -> tuple[str, dict[str, Any]]:
+    claims = _service_access_claims(
+        issuer=issuer,
+        resource=resource,
+        service=service,
+        scope=scope,
+        ttl_seconds=ttl_seconds,
+        now=now,
+        jti=jti,
+    )
+    token = f"{TOKEN_PREFIX}{sign_cookie_payload(claims, secret)}"
+    return token, claims
+
+
+def mint_service_access_token(
+    *,
+    secret: str,
+    issuer: str,
+    resource: str,
+    service: str = "github-review-broker",
+    scope: str | None = None,
+    ttl_seconds: int | None = None,
+    now: int | None = None,
+    jti: str | None = None,
+) -> str:
+    token, _claims = _mint_service_access_token_with_claims(
+        secret=secret,
+        issuer=issuer,
+        resource=resource,
+        service=service,
+        scope=scope,
+        ttl_seconds=ttl_seconds,
+        now=now,
+        jti=jti,
+    )
+    return token
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--print-claims",
+        action="store_true",
+        help="print JSON claims metadata to stderr (never the secret)",
+    )
+    args = parser.parse_args(argv)
+
+    secret = _required_env("UNIGROK_MCP_TOKEN_SECRET")
+    issuer = os.environ.get("UNIGROK_OAUTH_ISSUER", "https://control.grokmcp.org").strip()
+    resource = os.environ.get("UNIGROK_MCP_RESOURCE_URL", "https://mcp.grokmcp.org/mcp").strip()
+    service = os.environ.get("UNIGROK_SERVICE_NAME", "github-review-broker").strip()
+    scope = os.environ.get("UNIGROK_SERVICE_SCOPE", "").strip() or None
+    raw_ttl = os.environ.get("UNIGROK_TOKEN_TTL_SECONDS", "").strip()
+    try:
+        ttl = int(raw_ttl) if raw_ttl else None
+    except ValueError as exc:
+        raise SystemExit("UNIGROK_TOKEN_TTL_SECONDS must be an integer") from exc
+
+    token, claims = _mint_service_access_token_with_claims(
+        secret=secret,
+        issuer=issuer,
+        resource=resource,
+        service=service,
+        scope=scope,
+        ttl_seconds=ttl,
+    )
+    if args.print_claims:
+        claims_metadata = {
+            "exp": claims["exp"],
+            "scope": claims["scope"],
+            "sub": claims["sub"],
+        }
+        print(json.dumps(claims_metadata, sort_keys=True), file=sys.stderr)
+    output = token.encode("ascii")
+    if sys.stdout.isatty():
+        output += b"\n"
+    os.write(sys.stdout.fileno(), output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_review_scripts.py
+++ b/tests/test_review_scripts.py
@@ -1,0 +1,614 @@
+# Covers the restored hosted-review broker scripts:
+# scripts/github-grok-review.py and scripts/mint_mcp_service_token.py.
+import base64
+import hashlib
+import hmac
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+
+SECRET = "test-only-secret-0123456789ABCDEFGH-not-real"  # noqa: S105 - invented test value
+WRONG_SECRET = "wrong-secret-value-ZZZZ-0123456789abcdefgh"  # noqa: S105 - invented test value
+ISSUER = "https://control.grokmcp.org"
+RESOURCE = "https://mcp.grokmcp.org/mcp"
+FIXED_NOW = 1_752_700_000
+FIXED_JTI = "fixed-jti-0001"
+TOKEN_RE = re.compile(r"ugtoken\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+")
+SCRIPT_ENV_VARS = (
+    "INPUT_PR_NUMBER",
+    "EXPECTED_HEAD_SHA",
+    "EXPECTED_BASE_SHA",
+    "GITHUB_RUN_ID",
+    "GITHUB_SERVER_URL",
+    "UNIGROK_MCP_TOKEN_SECRET",
+    "UNIGROK_CLIENT_TOKEN",
+    "UNIGROK_OAUTH_ISSUER",
+    "UNIGROK_MCP_RESOURCE_URL",
+    "UNIGROK_MCP_URL",
+    "UNIGROK_TOKEN_TTL_SECONDS",
+    "UNIGROK_SERVICE_NAME",
+    "UNIGROK_SERVICE_SCOPE",
+)
+
+
+def _load_script(module_name: str, filename: str) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(module_name, SCRIPTS_DIR / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+mint = _load_script("mint_mcp_service_token", "mint_mcp_service_token.py")
+review = _load_script("github_grok_review", "github-grok-review.py")
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in SCRIPT_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def _b64url_decode(value: str) -> bytes:
+    return base64.urlsafe_b64decode(value + "=" * (-len(value) % 4))
+
+
+def _independent_verify(token: str, secret: str) -> dict[str, Any] | None:
+    """Stdlib-only verifier built from the docstring spec, never the module signer."""
+    if not token.startswith("ugtoken."):
+        return None
+    parts = token.removeprefix("ugtoken.").split(".")
+    if len(parts) != 2 or not all(re.fullmatch(r"[A-Za-z0-9_-]+", part) for part in parts):
+        return None
+    body, signature = parts
+    expected = (
+        base64.urlsafe_b64encode(
+            hmac.new(secret.encode("utf-8"), body.encode("utf-8"), hashlib.sha256).digest()
+        )
+        .decode("ascii")
+        .rstrip("=")
+    )
+    if not hmac.compare_digest(expected, signature):
+        return None
+    return json.loads(_b64url_decode(body))
+
+
+def _flip_char(value: str, index: int) -> str:
+    replacement = "A" if value[index] != "A" else "B"
+    return value[:index] + replacement + value[index + 1 :]
+
+
+# ---------------------------------------------------------------------------
+# mint_mcp_service_token: round-trip, claims, tamper, bounds
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("service", ["github-review-broker", "cursor-cloud"])
+def test_mint_roundtrip_independent_verifier(service: str) -> None:
+    token = mint.mint_service_access_token(
+        secret=SECRET, issuer=ISSUER, resource=RESOURCE, service=service
+    )
+    claims = _independent_verify(token, SECRET)
+    assert claims is not None
+    body, signature = token.removeprefix("ugtoken.").split(".")
+    reserialized = (
+        base64.urlsafe_b64encode(
+            json.dumps(claims, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+        )
+        .decode("ascii")
+        .rstrip("=")
+    )
+    assert reserialized == body
+    assert len(signature) == 43  # 32-byte HMAC -> 43 unpadded base64url chars
+    assert _independent_verify(token, WRONG_SECRET) is None
+
+
+@pytest.mark.parametrize(
+    ("service", "expected_scope"),
+    [
+        ("github-review-broker", ["unigrok:connect", "unigrok:review"]),
+        ("cursor-cloud", ["unigrok:connect", "unigrok:invoke", "unigrok:status"]),
+    ],
+)
+@pytest.mark.parametrize("ttl", [1, 137, 600])
+def test_mint_claims_exact(service: str, expected_scope: list[str], ttl: int) -> None:
+    token = mint.mint_service_access_token(
+        secret=SECRET,
+        issuer=ISSUER,
+        resource=RESOURCE,
+        service=service,
+        ttl_seconds=ttl,
+        now=FIXED_NOW,
+        jti=FIXED_JTI,
+    )
+    claims = _independent_verify(token, SECRET)
+    assert claims == {
+        "aud": RESOURCE,
+        "exp": FIXED_NOW + ttl,
+        "iat": FIXED_NOW,
+        "iss": ISSUER,
+        "jti": FIXED_JTI,
+        "kind": "service",
+        "scope": expected_scope,
+        "sub": f"service:{service}",
+        "v": 1,
+    }
+
+
+def test_mint_jti_unique_and_shaped() -> None:
+    jtis = [
+        mint._service_access_claims(issuer=ISSUER, resource=RESOURCE)["jti"] for _ in range(50)
+    ]
+    assert len(set(jtis)) == 50
+    assert all(re.fullmatch(r"[A-Za-z0-9_-]{32}", jti) for jti in jtis)
+
+
+@pytest.mark.parametrize("tamper", ["flip_body", "flip_sig", "strip_prefix", "wrong_secret"])
+def test_mint_tamper_rejected(tamper: str) -> None:
+    token = mint.mint_service_access_token(secret=SECRET, issuer=ISSUER, resource=RESOURCE)
+    body, signature = token.removeprefix("ugtoken.").split(".")
+    if tamper == "flip_body":
+        forged = f"ugtoken.{_flip_char(body, len(body) // 2)}.{signature}"
+    elif tamper == "flip_sig":
+        forged = f"ugtoken.{body}.{_flip_char(signature, len(signature) // 2)}"
+    elif tamper == "strip_prefix":
+        forged = f"{body}.{signature}"
+    else:
+        resigned = (
+            base64.urlsafe_b64encode(
+                hmac.new(WRONG_SECRET.encode(), body.encode(), hashlib.sha256).digest()
+            )
+            .decode("ascii")
+            .rstrip("=")
+        )
+        forged = f"ugtoken.{body}.{resigned}"
+    assert _independent_verify(forged, SECRET) is None
+
+
+@pytest.mark.parametrize("ttl", [0, 601, -5])
+def test_mint_ttl_out_of_bounds_rejected(ttl: int) -> None:
+    with pytest.raises(ValueError, match="ttl_seconds must be 1..600"):
+        mint.mint_service_access_token(
+            secret=SECRET, issuer=ISSUER, resource=RESOURCE, ttl_seconds=ttl
+        )
+
+
+@pytest.mark.parametrize("ttl", [1, 600])
+def test_mint_ttl_boundary_accepted(ttl: int) -> None:
+    token = mint.mint_service_access_token(
+        secret=SECRET, issuer=ISSUER, resource=RESOURCE, ttl_seconds=ttl, now=FIXED_NOW
+    )
+    claims = _independent_verify(token, SECRET)
+    assert claims is not None
+    assert claims["exp"] - claims["iat"] == ttl
+
+
+@pytest.mark.parametrize(
+    ("length", "valid"), [(31, False), (32, True), (4096, True), (4097, False)]
+)
+def test_mint_secret_length_bounds(length: int, valid: bool) -> None:
+    secret = "s" * length
+    if valid:
+        token = mint.mint_service_access_token(secret=secret, issuer=ISSUER, resource=RESOURCE)
+        assert _independent_verify(token, secret) is not None
+    else:
+        with pytest.raises(ValueError, match="secret length is invalid"):
+            mint.mint_service_access_token(secret=secret, issuer=ISSUER, resource=RESOURCE)
+
+
+def test_mint_unknown_service_rejected() -> None:
+    with pytest.raises(ValueError, match="service not allowed"):
+        mint.mint_service_access_token(
+            secret=SECRET, issuer=ISSUER, resource=RESOURCE, service="evil-svc"
+        )
+
+
+@pytest.mark.parametrize(
+    ("service", "scope"),
+    [
+        ("github-review-broker", "unigrok:invoke"),
+        ("cursor-cloud", "unigrok:review"),
+        ("github-review-broker", "unigrok:connect"),
+    ],
+)
+def test_mint_disallowed_scope_rejected(service: str, scope: str) -> None:
+    with pytest.raises(ValueError, match="scope not allowed"):
+        mint.mint_service_access_token(
+            secret=SECRET, issuer=ISSUER, resource=RESOURCE, service=service, scope=scope
+        )
+
+
+@pytest.mark.parametrize(
+    ("issuer", "resource", "match"),
+    [
+        ("http://control.grokmcp.org", RESOURCE, "issuer must be an https origin"),
+        ("https://control.grokmcp.org/", RESOURCE, "issuer must be an https origin"),
+        (ISSUER, "https://mcp.grokmcp.org/", "resource must be https://"),
+        (ISSUER, "https://mcp.grokmcp.org/mcp/", "resource must be https://"),
+        (ISSUER, "http://mcp.grokmcp.org/mcp", "resource must be https://"),
+    ],
+)
+def test_mint_issuer_and_resource_validation(issuer: str, resource: str, match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        mint.mint_service_access_token(secret=SECRET, issuer=issuer, resource=resource)
+
+
+# ---------------------------------------------------------------------------
+# mint_mcp_service_token: CLI subprocess surface
+# ---------------------------------------------------------------------------
+
+
+def _run_mint_cli(
+    args: list[str] | None = None, extra_env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "UNIGROK_MCP_TOKEN_SECRET": SECRET,
+        "UNIGROK_OAUTH_ISSUER": ISSUER,
+        "UNIGROK_MCP_RESOURCE_URL": RESOURCE,
+    }
+    env.update(extra_env or {})
+    return subprocess.run(
+        [sys.executable, str(SCRIPTS_DIR / "mint_mcp_service_token.py"), *(args or [])],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=False,
+    )
+
+
+def test_cli_default_prints_token_to_stdout_only() -> None:
+    result = _run_mint_cli()
+    assert result.returncode == 0
+    assert TOKEN_RE.fullmatch(result.stdout)  # token only, no trailing newline when piped
+    assert result.stderr == ""
+    assert SECRET not in result.stdout + result.stderr
+    claims = _independent_verify(result.stdout, SECRET)
+    assert claims is not None
+    assert claims["sub"] == "service:github-review-broker"
+    assert claims["exp"] - claims["iat"] == 600
+
+
+def test_cli_print_claims_writes_metadata_only_to_stderr() -> None:
+    result = _run_mint_cli(
+        args=["--print-claims"],
+        extra_env={
+            "UNIGROK_SERVICE_NAME": "cursor-cloud",
+            "UNIGROK_SERVICE_SCOPE": "unigrok:invoke",
+            "UNIGROK_TOKEN_TTL_SECONDS": "300",
+        },
+    )
+    assert result.returncode == 0
+    assert TOKEN_RE.fullmatch(result.stdout)
+    metadata = json.loads(result.stderr)
+    assert set(metadata) == {"exp", "scope", "sub"}
+    assert metadata["sub"] == "service:cursor-cloud"
+    assert metadata["scope"] == ["unigrok:connect", "unigrok:invoke", "unigrok:status"]
+    assert SECRET not in result.stdout + result.stderr
+    claims = _independent_verify(result.stdout, SECRET)
+    assert claims is not None
+    assert claims["exp"] - claims["iat"] == 300
+
+
+@pytest.mark.parametrize(
+    ("ttl", "message"),
+    [("601", "ttl_seconds must be 1..600"), ("abc", "must be an integer")],
+)
+def test_cli_bad_ttl_env_fails_without_leaking(ttl: str, message: str) -> None:
+    result = _run_mint_cli(extra_env={"UNIGROK_TOKEN_TTL_SECONDS": ttl})
+    assert result.returncode != 0
+    assert result.stdout == ""
+    assert message in result.stderr
+    assert SECRET not in result.stdout + result.stderr
+
+
+# ---------------------------------------------------------------------------
+# github-grok-review: evidence provenance and SHA validation
+# ---------------------------------------------------------------------------
+
+
+def _provenance_kwargs() -> dict[str, Any]:
+    return {
+        "repository": "owner/repo",
+        "number": 42,
+        "pr": {"head": {"sha": "a" * 40}, "base": {"sha": "b" * 40}, "title": "Title"},
+        "diff": "diff --git a/f b/f",
+        "discussion": "- user: COMMENTED — ok",
+    }
+
+
+def test_evidence_provenance_deterministic() -> None:
+    first = review._evidence_provenance(**_provenance_kwargs())
+    second = review._evidence_provenance(**_provenance_kwargs())
+    assert first == second
+    assert set(first) == {"base_sha", "evidence_sha256", "head_sha"}
+    assert re.fullmatch(r"[0-9a-f]{64}", first["evidence_sha256"])
+    assert first["head_sha"] == "a" * 40
+    assert first["base_sha"] == "b" * 40
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("repository", "owner/other"),
+        ("number", 43),
+        ("diff", "diff --git a/f b/f "),
+        ("discussion", "- user: COMMENTED — ok!"),
+    ],
+)
+def test_evidence_provenance_field_change_flips_digest(field: str, value: Any) -> None:
+    baseline = review._evidence_provenance(**_provenance_kwargs())
+    kwargs = _provenance_kwargs()
+    kwargs[field] = value
+    assert review._evidence_provenance(**kwargs)["evidence_sha256"] != baseline["evidence_sha256"]
+
+
+@pytest.mark.parametrize(
+    "mutate_pr",
+    [
+        lambda pr: pr.update(title="Title!"),
+        lambda pr: pr["head"].update(sha="c" * 40),
+        lambda pr: pr["base"].update(sha="d" * 40),
+    ],
+)
+def test_evidence_provenance_pr_change_flips_digest(mutate_pr: Any) -> None:
+    baseline = review._evidence_provenance(**_provenance_kwargs())
+    kwargs = _provenance_kwargs()
+    mutate_pr(kwargs["pr"])
+    assert review._evidence_provenance(**kwargs)["evidence_sha256"] != baseline["evidence_sha256"]
+
+
+def test_evidence_provenance_rejects_invalid_head_sha() -> None:
+    kwargs = _provenance_kwargs()
+    kwargs["pr"]["head"]["sha"] = "not-a-sha"
+    with pytest.raises(RuntimeError, match="invalid head commit SHA"):
+        review._evidence_provenance(**kwargs)
+
+
+def test_commit_sha_accepts_valid_and_lowercases_uppercase() -> None:
+    sha = "0123456789abcdef0123456789abcdef01234567"
+    assert review._commit_sha(sha, label="head") == sha
+    assert review._commit_sha(sha.upper(), label="head") == sha
+    assert review._commit_sha(f"  {sha}  ", label="head") == sha
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["a" * 39, "a" * 41, "g" * 40, None, "", 1234567890, "deadbeef"],
+)
+def test_commit_sha_rejects_invalid(value: Any) -> None:
+    with pytest.raises(RuntimeError, match="invalid expected head commit SHA"):
+        review._commit_sha(value, label="expected head")
+
+
+# ---------------------------------------------------------------------------
+# github-grok-review: event parsing and run URL
+# ---------------------------------------------------------------------------
+
+
+def test_pull_number_env_override_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("INPUT_PR_NUMBER", "45")
+    assert review._pull_number({"pull_request": {"number": 7}}) == 45
+
+
+def test_pull_number_from_pull_request_event() -> None:
+    assert review._pull_number({"pull_request": {"number": 7}}) == 7
+
+
+def test_pull_number_from_issue_comment_event() -> None:
+    event = {"issue": {"number": 9, "pull_request": {"url": "https://example.invalid"}}}
+    assert review._pull_number(event) == 9
+
+
+@pytest.mark.parametrize("event", [{}, {"issue": {"number": 5}}])
+def test_pull_number_rejects_non_pr_events(event: dict[str, Any]) -> None:
+    with pytest.raises(RuntimeError, match="does not identify a pull request"):
+        review._pull_number(event)
+
+
+def test_workflow_run_url_for_digit_run_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_RUN_ID", "123456")
+    assert review._workflow_run_url("o/r") == "https://github.com/o/r/actions/runs/123456"
+    monkeypatch.setenv("GITHUB_SERVER_URL", "https://github.com/")
+    assert review._workflow_run_url("o/r") == "https://github.com/o/r/actions/runs/123456"
+
+
+@pytest.mark.parametrize("run_id", ["", "abc", "12 34", "-5"])
+def test_workflow_run_url_none_for_non_digit_run_id(
+    monkeypatch: pytest.MonkeyPatch, run_id: str
+) -> None:
+    monkeypatch.setenv("GITHUB_RUN_ID", run_id)
+    assert review._workflow_run_url("o/r") is None
+
+
+def test_workflow_run_url_none_for_foreign_server(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_RUN_ID", "123456")
+    monkeypatch.setenv("GITHUB_SERVER_URL", "https://ghe.example.com")
+    assert review._workflow_run_url("o/r") is None
+
+
+# ---------------------------------------------------------------------------
+# github-grok-review: comment rendering and upsert
+# ---------------------------------------------------------------------------
+
+PROVENANCE = {"head_sha": "a" * 40, "base_sha": "b" * 40, "evidence_sha256": "c" * 64}
+
+
+def test_format_comment_renders_marker_metadata_and_run_url() -> None:
+    data = {
+        "review": "Looks good.",
+        "model": "grok-4.5",
+        "plane": "cli",
+        "route": "direct",
+        "cost_usd": 0.000049999,
+    }
+    run_url = "https://github.com/o/r/actions/runs/1"
+    body = review._format_comment(data, provenance=PROVENANCE, run_url=run_url)
+    assert body.startswith(review.MARKER + "\n")
+    assert "Looks good." in body
+    assert "Model: `grok-4.5` · Plane: `cli` · Route: `direct` · Cost: `$0.00005`" in body
+    assert f"Reviewed head: `{'a' * 40}` · Base: `{'b' * 40}`" in body
+    assert f"Evidence: `sha256:{'c' * 64}`" in body
+    assert f"[workflow run]({run_url})" in body
+
+
+def test_format_comment_defaults_without_run_url() -> None:
+    body = review._format_comment({}, provenance=PROVENANCE, run_url=None)
+    assert "No review returned." in body
+    assert "Model: `unknown` · Plane: `unknown` · Route: `unknown`" in body
+    assert "workflow run" not in body
+
+
+@pytest.mark.parametrize(
+    ("cost", "rendered"),
+    [
+        (None, "$0.00000"),
+        (0, "$0.00000"),
+        ("0.12345", "$0.12345"),
+        (5, "$5.00000"),
+    ],
+)
+def test_format_comment_cost_variants(cost: Any, rendered: str) -> None:
+    body = review._format_comment({"cost_usd": cost}, provenance=PROVENANCE)
+    assert f"Cost: `{rendered}`" in body
+
+
+class _GithubRecorder:
+    def __init__(self, comments: list[dict[str, Any]]) -> None:
+        self.comments = comments
+        self.calls: list[tuple[str, str, dict[str, Any] | None]] = []
+
+    def __call__(
+        self,
+        url: str,
+        token: str,
+        *,
+        accept: str = "application/vnd.github+json",
+        method: str = "GET",
+        payload: dict[str, Any] | None = None,
+    ) -> Any:
+        self.calls.append((method, url, payload))
+        return self.comments if method == "GET" else {}
+
+
+def _run_upsert(
+    monkeypatch: pytest.MonkeyPatch, comments: list[dict[str, Any]]
+) -> _GithubRecorder:
+    recorder = _GithubRecorder(comments)
+    monkeypatch.setattr(review, "_github_request", recorder)
+    review._upsert_comment("https://api.example", "owner/repo", 7, "gh-token", "NEW-BODY")
+    return recorder
+
+
+def test_upsert_comment_patches_existing_marker_comment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing = {
+        "url": "https://api.example/repos/owner/repo/issues/comments/11",
+        "body": f"{review.MARKER}\nold body",
+        "user": {"login": "github-actions[bot]"},
+    }
+    recorder = _run_upsert(monkeypatch, [existing])
+    assert [call[0] for call in recorder.calls] == ["GET", "PATCH"]
+    assert recorder.calls[1] == ("PATCH", existing["url"], {"body": "NEW-BODY"})
+
+
+@pytest.mark.parametrize(
+    "comments",
+    [
+        [],
+        [{"url": "u", "body": "<!-- unigrok-review --> hi", "user": {"login": "someone"}}],
+        [{"url": "u", "body": "plain comment", "user": {"login": "github-actions[bot]"}}],
+    ],
+)
+def test_upsert_comment_posts_when_no_bot_marker_comment(
+    monkeypatch: pytest.MonkeyPatch, comments: list[dict[str, Any]]
+) -> None:
+    recorder = _run_upsert(monkeypatch, comments)
+    assert [call[0] for call in recorder.calls] == ["GET", "POST"]
+    assert recorder.calls[1] == (
+        "POST",
+        "https://api.example/repos/owner/repo/issues/7/comments",
+        {"body": "NEW-BODY"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# github-grok-review: gateway auth resolution
+# ---------------------------------------------------------------------------
+
+
+def test_gateway_bearer_static_fallback_without_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert review._gateway_bearer_token() == ""
+    monkeypatch.setenv("UNIGROK_CLIENT_TOKEN", "  static-client-token  ")
+    assert review._gateway_bearer_token() == "static-client-token"
+
+
+def test_gateway_bearer_mints_broker_token_from_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("UNIGROK_MCP_TOKEN_SECRET", SECRET)
+    claims = _independent_verify(review._gateway_bearer_token(), SECRET)
+    assert claims is not None
+    assert claims["aud"] == "https://mcp.grokmcp.org/mcp"
+    assert claims["iss"] == "https://control.grokmcp.org"
+    assert claims["sub"] == "service:github-review-broker"
+    assert claims["kind"] == "service"
+    assert claims["v"] == 1
+    assert claims["scope"] == ["unigrok:connect", "unigrok:review"]
+    assert claims["exp"] - claims["iat"] == 600
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected_aud"),
+    [
+        ("https://mcp.grokmcp.org", "https://mcp.grokmcp.org/mcp"),
+        ("https://mcp.grokmcp.org/mcp/", "https://mcp.grokmcp.org/mcp"),
+        ("https://foo.com/", "https://foo.com/mcp"),
+    ],
+)
+def test_gateway_bearer_normalizes_resource_to_mcp_audience(
+    monkeypatch: pytest.MonkeyPatch, configured: str, expected_aud: str
+) -> None:
+    monkeypatch.setenv("UNIGROK_MCP_TOKEN_SECRET", SECRET)
+    monkeypatch.setenv("UNIGROK_MCP_RESOURCE_URL", configured)
+    claims = _independent_verify(review._gateway_bearer_token(), SECRET)
+    assert claims is not None
+    assert claims["aud"] == expected_aud
+
+
+# ---------------------------------------------------------------------------
+# github-grok-review: error rendering
+# ---------------------------------------------------------------------------
+
+
+def test_format_exc_renders_nested_exception_group() -> None:
+    leaf = ValueError("leaf failure")
+    leaf.__cause__ = KeyError("root cause")
+    group = ExceptionGroup("outer", [leaf, ExceptionGroup("inner", [TypeError("typed")])])
+    text = review._format_exc(group)
+    assert text.startswith("ExceptionGroup: outer")
+    assert "[1] ValueError: leaf failure" in text
+    assert "caused by: KeyError: 'root cause'" in text
+    assert "[2] ExceptionGroup: inner" in text
+    assert "[1] TypeError: typed" in text
+
+
+def test_format_exc_shows_context_unless_suppressed() -> None:
+    chained = RuntimeError("wrapper")
+    chained.__context__ = OSError("root")
+    assert review._format_exc(chained) == "RuntimeError: wrapper\n  caused by: OSError: root"
+    chained.__suppress_context__ = True
+    assert review._format_exc(chained) == "RuntimeError: wrapper"


### PR DESCRIPTION
## Restore the hosted @grok PR-review path

The public-history reset dropped the three files that make hosted contributor review work — so the flagship "review never depends on the developer Mac" feature is silently dead: nothing on any PR triggers it. The hosted infrastructure itself survived intact. This restores the missing pieces.

**Opened as a draft on purpose** — see the merge gate below. Even merged, the workflow cannot self-fire (it is owner/member-comment-gated), so this adds no live attack surface while it waits.

### What this restores
| File | Role |
|------|------|
| `.github/workflows/grok-review.yml` | `issue_comment` + `workflow_dispatch` trigger, owner/member/collaborator-gated, requires `@grok review` |
| `scripts/github-grok-review.py` | Trusted fetcher → MCP `review_pull_request`, upserts one advisory comment |
| `scripts/mint_mcp_service_token.py` | Bounded (≤600s) HMAC `service:github-review-broker` token, scope `unigrok:review` |

### Why it's safe to restore (audit: `unigrok-ui/docs/review-path-audit-2026-07-17`)
- **Contract already matches** the slim v1.1 gateway key-for-key: `review_pull_request(repository, pull_number, title, diff, ci_summary="", review_comments="")`.
- **Infra already present** — repo vars `UNIGROK_REVIEW_MCP_URL` / `_PLANE` / `_RUNNER_JSON` and secret `UNIGROK_MCP_TOKEN_SECRET` survived the reset. **No new secrets required.**
- The workflow is **already hardened** — the gates a reviewer would ask for are built in, not follow-ups:
  - Not `pull_request_target`; checks out **default branch only** (`persist-credentials: false`) and **never runs PR code**.
  - Least privilege: `contents: read`, `pull-requests: write`. No `id-token`, no contents write.
  - Owner/member/collaborator gate + `@grok review` required; `concurrency` with cancel-in-progress.
  - Token mint is bounded (≤600s), narrowly scoped, HMAC-signed, secret never logged.
  - The fetcher treats the PR as **untrusted evidence**: sha256 evidence provenance and **anti-race stale-review protection** (validates head/base SHA before *and* after review, refusing if the PR mutated mid-flight).

### Delta from the audited originals (behavior-preserving)
Ported verbatim except lint conformance to this repo's stricter ruleset (`E,F,I,UP,B,ASYNC,S` vs the old repo's defaults):
- `ruff --fix`: `UP045` (`Optional[X]`→`X | None`), `UP035`, import sort — annotation/import only.
- Long-line wraps + adjacent f-string splits (identical output); one sync `_load_event()` helper to clear `ASYNC240`.
- Three justified `# noqa`: `S310` ×2 (trusted GitHub-API https `urlopen`), `S105` ×1 (false-positive `TOKEN_PREFIX` prefix).

**Verification:** `ruff check .` clean · 66 tests pass · `py_compile` OK · **mint output proven byte-identical** to the original for both `github-review-broker` and `cursor-cloud` paths.

---

### ⚠️ Merge gate — do not merge until (per @grok deep-review, contributor-strategy session)
- [ ] **P0 — rotate the leaked donor credentials.** The `unigrok-intelligence` donor `gemini` branch tracks a live GitHub PAT + xAI API key already pushed to its private remote. Force-push being David-gated does **not** un-leak keys already copied. This is independent of this PR but outranks it — restoring a review path while credentials are live is furniture-rearranging during a fire drill.
- [ ] **P2 — confirm `unigrok-remote-mcp` (mcp.grokmcp.org) is on the v1.1 image.** Contract already matches, so no workflow/script change is needed either way — but reviewing against a lagging remote produces false "CI is broken" reports that aren't in these three files.

### E2E after merge (autonomous — no new secrets)
Comment `@grok review` on any PR as owner, or `gh workflow run grok-review.yml -f pr_number=N`. Success = a `<!-- unigrok-review -->` comment with model / plane / cost receipt. Exercises token mint (~120s `service:github-review-broker`), Control OAuth introspection, and the remote review tool.

---
🤖 Drafted autonomously during the UniGrok synapse ritual (scheduled). Verdict + re-rank by @grok (grok-4.5, `grok_build_oauth` plane, deep harness, $0.00 subscription). Ranking folded in: security P0 promoted above this restore; verbatim port rejected in favor of a hardened-and-verified one.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI auth (runtime token mint from `UNIGROK_MCP_TOKEN_SECRET`) and PR comment writes, but the workflow avoids `pull_request_target`, never executes PR code, and gates triggers to trusted collaborators.
> 
> **Overview**
> **Restores the hosted `@grok review` path** that was dropped in a prior reset: a gated GitHub Actions workflow, a trusted-fetch broker, and MCP token minting, plus broad unit tests.
> 
> Adds **`.github/workflows/grok-review.yml`**, which runs on trusted members’ `@grok review` comments or `workflow_dispatch`, checks out **default branch only** (never PR code), and invokes the broker with repo vars/secrets for hosted MCP.
> 
> Adds **`scripts/github-grok-review.py`**: fetches PR metadata and a **compare-based diff** (not the mutable PR diff endpoint), caps diff/discussion size, computes **SHA256 evidence provenance**, refuses stale head/base before and after the MCP call, mints or falls back on MCP auth, calls **`review_pull_request`**, and **upserts** one `<!-- unigrok-review -->` advisory comment.
> 
> Adds **`scripts/mint_mcp_service_token.py`** for Control-compatible **≤600s** `ugtoken.` HMAC service tokens (`github-review-broker` / `cursor-cloud` scopes).
> 
> Adds **`tests/test_review_scripts.py`** covering mint round-trip/tamper bounds, provenance, comment upsert, and gateway bearer resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 811e3a68b89942f15873246864f2839d702c8e32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->