### PR TITLE
Null-guard ghost users in review broker (hosted @grok finding)

### DIFF
--- a/scripts/github-grok-review.py
+++ b/scripts/github-grok-review.py
@@ -238,7 +238,9 @@ def _upsert_comment(api: str, repository: str, number: int, token: str, body: st
             item
             for item in comments
             if MARKER in str(item.get("body", ""))
-            and item.get("user", {}).get("login") == "github-actions[bot]"
+            # Ghost/deleted accounts serialize as "user": null — guard with `or {}`
+            # so one ghost comment cannot crash the whole upsert scan.
+            and (item.get("user") or {}).get("login") == "github-actions[bot]"
         ),
         None,
     )
@@ -250,6 +252,16 @@ def _upsert_comment(api: str, repository: str, number: int, token: str, body: st
 
 def _load_event() -> dict[str, Any]:
     return json.loads(Path(_required("GITHUB_EVENT_PATH")).read_text(encoding="utf-8"))
+
+
+def _build_discussion(reviews: list[dict[str, Any]]) -> str:
+    return "\n".join(
+        # Ghost/deleted reviewers serialize as "user": null — `or {}` keeps one
+        # ghost review from crashing the whole discussion build.
+        f"- {(item.get('user') or {}).get('login', 'unknown')}: "
+        f"{item.get('state', 'COMMENTED')} — {item.get('body') or '(no body)'}"
+        for item in reviews
+    )[:MAX_DISCUSSION_CHARS]
 
 
 async def main() -> None:
@@ -286,11 +298,7 @@ async def main() -> None:
         accept="application/vnd.github.v3.diff",
     )
     reviews = _github_request(f"{pr_url}/reviews?per_page=100", token)
-    discussion = "\n".join(
-        f"- {item.get('user', {}).get('login', 'unknown')}: "
-        f"{item.get('state', 'COMMENTED')} — {item.get('body') or '(no body)'}"
-        for item in reviews
-    )[:MAX_DISCUSSION_CHARS]
+    discussion = _build_discussion(reviews)
     truncated = len(diff) > MAX_DIFF_CHARS
     diff = diff[:MAX_DIFF_CHARS]
     if truncated:

--- a/tests/test_review_scripts.py
+++ b/tests/test_review_scripts.py
@@ -529,6 +529,9 @@ def test_upsert_comment_patches_existing_marker_comment(
         [],
         [{"url": "u", "body": "<!-- unigrok-review --> hi", "user": {"login": "someone"}}],
         [{"url": "u", "body": "plain comment", "user": {"login": "github-actions[bot]"}}],
+        # Ghost/deleted account: GitHub serializes "user": null. Must not crash
+        # the scan, and a null-user marker comment is not the bot's.
+        [{"url": "u", "body": "<!-- unigrok-review --> ghost", "user": None}],
     ],
 )
 def test_upsert_comment_posts_when_no_bot_marker_comment(
@@ -541,6 +544,31 @@ def test_upsert_comment_posts_when_no_bot_marker_comment(
         "https://api.example/repos/owner/repo/issues/7/comments",
         {"body": "NEW-BODY"},
     )
+
+
+def test_upsert_comment_survives_ghost_comment_before_bot_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ghost = {"url": "g", "body": "who was I", "user": None}
+    existing = {
+        "url": "https://api.example/repos/owner/repo/issues/comments/11",
+        "body": f"{review.MARKER}\nold body",
+        "user": {"login": "github-actions[bot]"},
+    }
+    recorder = _run_upsert(monkeypatch, [ghost, existing])
+    assert [call[0] for call in recorder.calls] == ["GET", "PATCH"]
+    assert recorder.calls[1] == ("PATCH", existing["url"], {"body": "NEW-BODY"})
+
+
+def test_build_discussion_handles_ghost_reviewer() -> None:
+    discussion = review._build_discussion(
+        [
+            {"user": None, "state": "COMMENTED", "body": "drive-by note"},
+            {"user": {"login": "alice"}, "state": "APPROVED", "body": ""},
+        ]
+    )
+    assert "- unknown: COMMENTED — drive-by note" in discussion
+    assert "- alice: APPROVED — (no body)" in discussion
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Fix the `user: null` crash flagged by the restored hosted review path

First finding of the freshly restored pipeline — the hosted `@grok review` E2E on #496 ([run 29645947312](https://github.com/djtelicloud/grok-mcp-server/actions/runs/29645947312)) flagged that ghost/deleted GitHub accounts serialize as `"user": null`, and both these sites crash on them with `AttributeError` (key present → `.get("user", {})` returns `None`):

- `_upsert_comment` scan — one ghost comment anywhere in the thread fails the whole job **before** posting
- review-discussion build — one ghost reviewer kills the evidence pack

### Changes
- Guard both sites with `(item.get("user") or {})`
- Extract the inline discussion build into `_build_discussion()` (unit-testable, addresses the review's "no test for `user: null`" gap)
- 3 regression tests: ghost marker comment, ghost-before-bot ordering, ghost reviewer

### Verification
- Old pattern crash reproduced: `AttributeError: 'NoneType' object has no attribute 'get'`
- `uv run --frozen pytest`: **149 passed** (146 + 3 new) · `ruff check .` clean

Note: the review's finding #2 (deps not in lock) is empirically refuted — the E2E run itself executed `github-grok-review.py` end-to-end under `uv run --frozen`, so `httpx`/`mcp` resolve from the lock; the minter uses stdlib `hmac`/`hashlib`, not `cryptography`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive parsing changes in the GitHub Actions review script with unit tests; no auth, data, or merge-path behavior changes.
> 
> **Overview**
> Fixes crashes in the hosted `@grok` GitHub review broker when GitHub returns **`"user": null`** for deleted/ghost accounts (`.get("user", {})` still yields `None` when the key is present).
> 
> **`_upsert_comment`** now uses `(item.get("user") or {})` when matching the bot’s marker comment, so a ghost comment in the thread no longer aborts the job before POST/PATCH. **Review discussion** for the evidence pack is built via new **`_build_discussion()`** with the same guard, labeling missing users as `unknown`.
> 
> Adds regression tests for ghost marker comments, ghost-before-bot ordering, and ghost reviewers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f7b5a04faeff21c5596386d5bb48e4393187088. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->