### PR TITLE
Move review concurrency to job level (any comment cancelled live reviews)

### DIFF
--- a/.github/workflows/grok-review.yml
+++ b/.github/workflows/grok-review.yml
@@ -14,10 +14,6 @@ permissions:
   contents: read
   pull-requests: write
 
-concurrency:
-  group: unigrok-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
-  cancel-in-progress: true
-
 jobs:
   review:
     if: >-
@@ -27,6 +23,13 @@ jobs:
        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association) &&
        contains(github.event.comment.body, '@grok review'))
     name: UniGrok review
+    # Concurrency must live at the JOB level: workflow-level groups are claimed
+    # before the `if` gate runs, so any PR comment (bots included) would cancel
+    # that PR's in-flight review and then skip at the gate. Skipped jobs never
+    # enter a job-level group, so only real review runs dedupe each other.
+    concurrency:
+      group: unigrok-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number }}
+      cancel-in-progress: true
     # Production (hosted): set repository variables
     #   UNIGROK_REVIEW_RUNNER_JSON = "ubuntu-latest"
     #   UNIGROK_REVIEW_MCP_URL     = https://mcp.grokmcp.org/mcp


### PR DESCRIPTION
## Second finding from dogfooding the restored review path

Caught live two minutes after restoring the pipeline: dispatched a hosted review of #497 at 13:24:52; Cursor Bugbot commented at 13:24:54; the bot's `issue_comment` run **cancelled the in-flight review** ([run 29646098696](https://github.com/djtelicloud/grok-mcp-server/actions/runs/29646098696)) via the shared `unigrok-review-497` concurrency group — and then itself **skipped at the gate**. Net effect: any comment on a PR (bots included) kills that PR's live review.

### Root cause
Workflow-level `concurrency` groups are claimed **before** the job's `if` gate evaluates. A gate-rejected run still cancels the group's in-progress run.

### Fix
Relocate the identical `concurrency` block to the job level. Skipped jobs never enter a job-level group, so gate-rejected comment runs leave live reviews alone while real runs (dispatch or genuine `@grok review`) still dedupe/cancel per-PR. Group key unchanged.

### Verification
- YAML parses clean
- Post-merge E2E: dispatch a review, land a plain comment mid-flight, confirm the run survives to post its `<!-- unigrok-review -->` receipt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change; no application, auth, or data-path impact.
> 
> **Overview**
> Fixes a race where **any** PR comment (including bots) could kill an active UniGrok review: workflow-level `concurrency` was claimed before the job `if` gate, so skipped runs still cancelled the shared `unigrok-review-<PR>` group.
> 
> The same `concurrency` block (unchanged group key and `cancel-in-progress: true`) now sits on the `review` job. Skipped jobs do not join a job-level group, so only real review runs (dispatch or `@grok review`) dedupe and cancel each other per PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e11ae47697baaa446366d9c1a701a974b6b2b5be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->