### PR TITLE
Format P95 latency tile with thousands separator

### DIFF
--- a/src/unigrok_public/static/dashboard.html
+++ b/src/unigrok_public/static/dashboard.html
@@ -67,7 +67,7 @@ async function refresh(){try{const [ready,b]=await Promise.all([fetch('/readyz')
   for(const p of ['cli','api']){const on=!!ready.planes?.[p]?.ready;$(p).textContent=`${p.toUpperCase()} ${on?'ready':'offline'}`;$(p).className='pill '+(on?'ok':'')}
   $('updated').textContent=new Date().toLocaleTimeString();$('samples').textContent=t.sample_size||0;
   $('success').textContent=t.verified_success_rate==null?'—':`${Math.round(t.verified_success_rate*100)}%`;
-  $('p95').innerHTML=`${t.latency_ms?.p95||0} <small>ms</small>`;$('cost').textContent=`$${Number(t.cost_usd||0).toFixed(4)}`;
+  $('p95').innerHTML=`${Math.round(t.latency_ms?.p95||0).toLocaleString('en-US')} <small>ms</small>`;$('cost').textContent=`$${Number(t.cost_usd||0).toFixed(4)}`;
   bars('routes',t.routes||[]);bars('models',t.models||[]);bars('callers',t.callers||[]);bars('fallbacks',(t.fallbacks||[]).filter(x=>x.name!=='unknown'));
   const bs=b.circuit_breakers||{};$('breakers').innerHTML=Object.keys(bs).length?Object.entries(bs).map(([k,v])=>
     `<div class="breaker ${v.open?'open':''}"><b>${esc(k)}</b> · ${v.open?'OPEN':'closed'} · failures ${v.failures} · trips ${v.trips}</div>`).join(''):'<div class="empty">No provider calls recorded.</div>';


### PR DESCRIPTION
The "P95 latency" stat tile on the public dashboard rendered the raw millisecond value (e.g. `119367`) while the Recent receipts table formats latency as `NNNN ms`. This rounds and localizes the tile value so it reads `119,367 ms`, consistent with console house style.

Verified against the live local gateway at `localhost:4765/ui`: current telemetry p95 is `119367`, new template renders `119,367 ms`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line display formatting in static dashboard HTML with no backend, auth, or data-handling impact.
> 
> **Overview**
> The **P95 latency** stat tile on the public control center dashboard now **rounds** the telemetry value and formats it with a **US thousands separator** (e.g. `119,367 ms` instead of `119367`), matching console house style for large millisecond readings.
> 
> Only the `refresh()` template for `#p95` in `dashboard.html` changes; telemetry APIs and the Recent receipts table are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2794415bef82a0e21330d0d2aa7cf7c76d187d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->