### PR TITLE
Guard fast routes with non-answer detection + recovery (live preamble-only repro)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to the public UniGrok gateway.
 
 ## [Unreleased]
 
+### Fixed
+- Non-answer detection + one same-plane recovery + bounded cross-plane fallback now
+  guard every prose-producing route, including the non-agentic fast paths (`chat`,
+  hive merge, deep-mode polish) that previously accepted a preamble-only completion
+  as `final_answer` (live repro 2026-07-17: `"I'll ground the checklist in the
+  actual flow, then start the answer at '## Checklist'"` with no body shipped as
+  the final reply). Bounded internal JSON votes opt out via
+  `nonanswer_recovery=False` — a malformed vote still just drops.
+- `is_nonanswer_completion` gains a generic bare-preamble guard: a short
+  single-paragraph `"I'll/let me <verb> ..."` promise with no delivered body is a
+  non-answer even when the verb is outside the curated action list. Clarifying
+  questions, stated blockers (`I'll need X from you`), and delivered content after
+  a delimiter are untouched.
+- `chat` now uses `cross_plane` fallback, matching the documented
+  `one_same_plane_retry_before_bounded_api_fallback` contract that `agent` follows.
+- Deep-mode final polish failures no longer discard the already-good answer; the
+  unpolished text ships instead.
+
 ### Changed
 - Antigravity auto-approve now uses `globalPermissionGrants.allow` with per-tool
   grants (`mcp(grok/agent)`, `mcp(grok/agent_result)`) — the battle-tested pack

--- a/src/unigrok_public/harness.py
+++ b/src/unigrok_public/harness.py
@@ -429,6 +429,50 @@ _PLACEHOLDER_RE = re.compile(
     r"(?:i\s+)?will\s+(?:follow\s+up|report|return|provide|deliver|share)|"
     r"not\s+yet|no\s+(?:result|answer)\s+yet)\b"
 )
+# Generic promise prefix: any "I'll/let me <verb>" opener, not just the curated
+# _PROMISE_ACTION list. "need/require/want" are excluded because "I'll need X from
+# you" is a legitimate blocker statement, not a deferred deliverable.
+_GENERIC_PROMISE_PREFIX_RE = re.compile(
+    rf"""(?ix)^\s*(?:[>*#-]+\s*)?{_PROMISE_WRAPPER}(?:
+      i(?:['’]ll|\s+will)
+      | i(?:['’]m|\s+am)\s+(?:going|about)\s+to
+      | let\s+me
+      | we(?:['’]ll|\s+will|\s+are\s+going\s+to)
+    )\s+(?!(?:need|require|want)\b)\w"""
+)
+_SUBSTANTIVE_LINE_RE = re.compile(r"(?m)^\s*(?:#{1,6}\s|```|[-*+]\s|\d+[.)]\s|\|)")
+_PREAMBLE_DELIVERY_SPLIT_RE = re.compile(r"(?:[:—–]|\s+-\s+|\.\s+)\s*(?P<value>\S[\s\S]*)")
+_FORWARD_REFERENCE_RE = re.compile(
+    r"(?i)^(?:then\b|next\b|after\s|and\s+then\b|i(?:['’]ll|\s+will)\b|"
+    r"let\s+me\b|we(?:['’]ll|\s+will)\b|starting\b|beginning\b)"
+)
+
+
+def _is_bare_promise_preamble(text: str) -> bool:
+    """A short single-paragraph promise that never delivers a body.
+
+    Catches preambles whose verb falls outside _PROMISE_ACTION — live CLI fast-route
+    sample: "I'll ground the checklist in the actual flow, then start the answer at
+    '## Checklist'" followed by nothing. Anything with real structure (headings,
+    lists, code), a clarifying question, or delivered content after a delimiter is
+    left alone.
+    """
+    if len(text) > 300 or "\n\n" in text or "?" in text:
+        return False
+    if not _GENERIC_PROMISE_PREFIX_RE.match(text):
+        return False
+    if _SUBSTANTIVE_LINE_RE.search(text):
+        return False
+    delivery = _PREAMBLE_DELIVERY_SPLIT_RE.search(text)
+    if delivery:
+        value = delivery.group("value").strip()
+        if (
+            len(value) >= 16
+            and not _PLACEHOLDER_RE.match(value)
+            and not _FORWARD_REFERENCE_RE.match(value)
+        ):
+            return False
+    return True
 
 
 def _prompt_requests_plan(prompt: str) -> bool:
@@ -484,7 +528,7 @@ def is_nonanswer_completion(content: Any, *, prompt: str = "") -> bool:
         return not (_prompt_requests_plan(prompt) and _looks_like_plan(text))
     if _COMPLETION_EVIDENCE_RE.search(text) or _prompt_requests_plan(prompt):
         return False
-    return _looks_like_plan(text)
+    return _looks_like_plan(text) or _is_bare_promise_preamble(text)
 
 
 def completion_recovery_prompt(original_prompt: str) -> str:

--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -1740,6 +1740,7 @@ async def _run_unified(
     allow_code: bool,
     system_context: str | None = None,
     max_output_tokens: int | None = None,
+    nonanswer_recovery: bool = True,
 ) -> dict[str, Any]:
     # Silent-think doctrine (compute != print): reasoning effort stays high while a
     # tiny output cap is applied to KNOWN-SMALL emits (votes) so metered API output
@@ -1816,7 +1817,11 @@ async def _run_unified(
 
     async def _call_with_recovery(target: Literal["cli", "api"]) -> dict[str, Any]:
         initial = await _call(target, prompt)
-        if not agentic or not is_nonanswer_completion(initial.get("text"), prompt=prompt):
+        # Non-answer detection guards every prose-producing path, fast or agentic;
+        # only bounded internal JSON votes opt out (a malformed vote just drops).
+        if not nonanswer_recovery or not is_nonanswer_completion(
+            initial.get("text"), prompt=prompt
+        ):
             return initial
         retry = await _call(target, completion_recovery_prompt(prompt))
         if is_nonanswer_completion(retry.get("text"), prompt=prompt):
@@ -2057,6 +2062,7 @@ async def _hive_route(prompt: str) -> dict[str, Any] | None:
                 allow_x_search=False,
                 allow_code=False,
                 max_output_tokens=HIVE_VOTE_MAX_OUTPUT_TOKENS,
+                nonanswer_recovery=False,
             )
         except Exception:
             return None
@@ -2096,6 +2102,7 @@ async def _shadow_done_vote(request: str, reply: str) -> dict[str, Any] | None:
             allow_web=False,
             allow_x_search=False,
             allow_code=False,
+            nonanswer_recovery=False,
         )
     except Exception:
         return None
@@ -2176,6 +2183,7 @@ async def _run_hive(
                 # Silent-think: the vote is one-line JSON (~40 tokens). Cap the metered
                 # API emit generously; a truncated vote just drops and is filtered.
                 max_output_tokens=HIVE_VOTE_MAX_OUTPUT_TOKENS,
+                nonanswer_recovery=False,
             )
         except Exception:
             return None
@@ -2386,18 +2394,22 @@ async def _execute_team_turn(
         }
     if depth == "deep" and needs_final_polish(str(result.get("text") or "")):
         # One cleanup loop: strip deliberation residue while keeping the answer.
-        polish = await _run_unified(
-            final_polish_prompt(str(result.get("text") or "")),
-            model=None,
-            effort="low",
-            plane="auto",
-            fallback_policy="cross_plane",
-            agentic=False,
-            max_turns=1,
-            allow_web=False,
-            allow_x_search=False,
-            allow_code=False,
-        )
+        # Polish is optional — if it fails outright, keep the unpolished answer.
+        try:
+            polish = await _run_unified(
+                final_polish_prompt(str(result.get("text") or "")),
+                model=None,
+                effort="low",
+                plane="auto",
+                fallback_policy="cross_plane",
+                agentic=False,
+                max_turns=1,
+                allow_web=False,
+                allow_x_search=False,
+                allow_code=False,
+            )
+        except Exception:
+            polish = {}
         polished_text = str(polish.get("text") or "").strip()
         if polished_text and not leaks_deep_harness(polished_text):
             result["text"] = polished_text
@@ -2798,7 +2810,9 @@ async def chat(
         model=None,
         effort=None,
         plane="auto",
-        fallback_policy="same_plane",
+        # Same contract as agent: one same-plane retry, then one bounded
+        # cross-plane recovery — a persistent non-answer must not ship as final.
+        fallback_policy="cross_plane",
         agentic=False,
         max_turns=1,
         allow_web=False,

--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -2411,7 +2411,13 @@ async def _execute_team_turn(
         except Exception:
             polish = {}
         polished_text = str(polish.get("text") or "").strip()
-        if polished_text and not leaks_deep_harness(polished_text):
+        # A polish pass that returns a non-answer is a polish failure, not a
+        # better answer — keep the unpolished text, same as the exception path.
+        if (
+            polished_text
+            and not leaks_deep_harness(polished_text)
+            and not is_nonanswer_completion(polished_text)
+        ):
             result["text"] = polished_text
         result["cost_usd"] = float(result.get("cost_usd") or 0.0) + float(
             polish.get("cost_usd") or 0.0

--- a/tests/test_team_harness.py
+++ b/tests/test_team_harness.py
@@ -459,3 +459,101 @@ def test_done_vote_parse_and_prompt() -> None:
     assert parse_done_vote('{"done":"maybe"}') is None
     prompt = build_done_vote_prompt("solve x", "the answer is 42")
     assert "## Request" in prompt and "## Reply" in prompt
+
+
+def _deep_polish_turn_fixture(monkeypatch: pytest.MonkeyPatch, polish_behavior):
+    """Drive _execute_team_turn in deep mode with a stubbed _run_unified.
+
+    First call produces the main (messy but substantive) deep answer; the
+    second call is the polish pass, whose behavior the test injects.
+    """
+    messy = "## Ranking note (internal)\n1. 60\n2. 59\n\nThe answer is 60."
+    calls: list[str] = []
+    catalogs = {
+        "cli": {"ready": True, "models": ["grok-test"], "default_model": "grok-test"},
+        "api": {"ready": False, "models": []},
+    }
+
+    async def fake_catalogs():
+        return catalogs
+
+    async def fake_run_unified(prompt: str, **kwargs: object) -> dict:
+        calls.append(prompt)
+        if len(calls) == 1:
+            return {
+                "text": messy,
+                "model": "grok-test",
+                "resolved_plane": "cli",
+                "cost_usd": 0.0,
+            }
+        return await polish_behavior(prompt)
+
+    monkeypatch.setattr(server, "_catalogs", fake_catalogs)
+    monkeypatch.setattr(server, "_run_unified", fake_run_unified)
+    return messy, calls
+
+
+async def _run_deep_turn() -> dict:
+    return await server._execute_team_turn(
+        prompt="What is the maximum sum?",
+        session=None,
+        workspace_context="",
+        workspace_label="",
+        caller_instructions="",
+        memory_scope=None,
+        use_memory=False,
+        model=None,
+        effort=None,
+        mode="reasoning",
+        plane="auto",
+        fallback_policy="cross_plane",
+        turns=1,
+        allow_web=False,
+        allow_x_search=False,
+        allow_code=False,
+        depth="deep",
+    )
+
+
+@pytest.mark.asyncio
+async def test_deep_polish_nonanswer_keeps_unpolished_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A polish pass that returns a bare-promise non-answer must not clobber
+    the already-good deep answer (hosted @grok review of PR #500, blocking)."""
+
+    async def polish_returns_nonanswer(prompt: str) -> dict:
+        return {
+            "text": "I'll tidy up the draft and share the polished version.",
+            "model": "grok-test",
+            "resolved_plane": "cli",
+            "cost_usd": 0.0,
+        }
+
+    messy, calls = _deep_polish_turn_fixture(monkeypatch, polish_returns_nonanswer)
+    result = await _run_deep_turn()
+    assert len(calls) == 2
+    assert result["text"] == messy
+    assert result["final_polish"] == {
+        "attempted": True,
+        "applied": False,
+        "plane": "cli",
+    }
+
+
+@pytest.mark.asyncio
+async def test_deep_polish_exception_keeps_unpolished_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def polish_raises(prompt: str) -> dict:
+        raise RuntimeError("polish plane fell over")
+
+    messy, calls = _deep_polish_turn_fixture(monkeypatch, polish_raises)
+    result = await _run_deep_turn()
+    assert len(calls) == 2
+    assert result["text"] == messy
+    assert result["final_polish"] == {
+        "attempted": True,
+        "applied": False,
+        "plane": None,
+    }

--- a/tests/test_team_harness.py
+++ b/tests/test_team_harness.py
@@ -95,6 +95,153 @@ def test_history_format_and_nonanswer_contract() -> None:
     )
 
 
+def test_nonanswer_catches_generic_promise_preambles() -> None:
+    # Live fast-route regression (2026-07-17): Grok returned exactly this preamble
+    # with finish_reason final_answer and no body; "ground" is outside the curated
+    # action-verb list, so only the generic bare-preamble guard catches it.
+    live_sample = (
+        "I'll ground the checklist in the actual flow, then start the answer "
+        "at '## Checklist'"
+    )
+    prompt = "Update the contributor checklist. No preamble, start with ## Checklist."
+    assert is_nonanswer_completion(live_sample, prompt=prompt)
+    assert is_nonanswer_completion(
+        "Sure — I'll structure the response around your three questions.", prompt=prompt
+    )
+    # Legitimate short replies must survive: delivered content after a delimiter,
+    # a clarifying question, and a stated blocker are all real answers.
+    assert not is_nonanswer_completion(
+        "Sure thing, I'll be brief — the fix is to pin the revision.", prompt=prompt
+    )
+    assert not is_nonanswer_completion(
+        "I'll assume you mean the staging cluster — is that right?", prompt=prompt
+    )
+    assert not is_nonanswer_completion(
+        "I'll need the deploy logs from you before I can diagnose this.", prompt=prompt
+    )
+    assert not is_nonanswer_completion("The answer is 42.", prompt=prompt)
+
+
+@pytest.mark.asyncio
+async def test_fast_route_runs_nonanswer_recovery_and_cross_plane_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The non-agentic (fast/chat) route must reject a canned preamble-only CLI
+    completion, retry once on the same plane, and then fall back CLI->API."""
+    preamble = (
+        "I'll ground the checklist in the actual flow, then start the answer "
+        "at '## Checklist'"
+    )
+    build_calls: list[str] = []
+    catalogs = {
+        "cli": {"ready": True, "models": ["grok-test"], "default_model": "grok-test"},
+        "api": {
+            "ready": True,
+            "models": [{"id": "grok-api"}],
+            "default_model": "grok-api",
+        },
+    }
+
+    async def fake_resolve(*args, **kwargs):
+        return "cli", catalogs
+
+    async def fake_system(*args, **kwargs):
+        return "system"
+
+    async def fake_build(prompt: str, **kwargs: object) -> dict:
+        build_calls.append(prompt)
+        return {"text": preamble, "model": "grok-test", "cost_usd": 0.0}
+
+    async def fake_alternate(current: str, model, *, requires_api: bool) -> str:
+        return "api"
+
+    async def fake_api_chat(*args: object, **kwargs: object) -> dict:
+        return {"text": "## Checklist\n- [ ] ship it", "model": "grok-api", "cost_usd": 0.01}
+
+    monkeypatch.setattr(server, "_resolve_plane", fake_resolve)
+    monkeypatch.setattr(server, "_system_prompt", fake_system)
+    monkeypatch.setattr(server.BUILD_ACP, "run", fake_build)
+    monkeypatch.setattr(server, "_alternate_plane", fake_alternate)
+    monkeypatch.setattr(server.xai_api, "chat", fake_api_chat)
+    result = await server._run_unified(
+        "Update the checklist. No preamble, start with ## Checklist.",
+        model=None,
+        effort=None,
+        plane="auto",
+        fallback_policy="cross_plane",
+        agentic=False,
+        max_turns=1,
+        allow_web=False,
+        allow_x_search=False,
+        allow_code=False,
+    )
+    # Two CLI attempts (initial + same-plane recovery), then the bounded API fallback.
+    assert len(build_calls) == 2
+    assert "previous response" in build_calls[1]
+    assert result["text"].startswith("## Checklist")
+    assert result["resolved_plane"] == "api"
+    assert result["fallback_occurred"] is True
+    assert result["fallback_reason"] == "cli_incomplete_response"
+
+
+@pytest.mark.asyncio
+async def test_bounded_votes_skip_nonanswer_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    build_calls: list[str] = []
+    catalogs = {
+        "cli": {"ready": True, "models": ["grok-test"], "default_model": "grok-test"},
+        "api": {"ready": False, "models": []},
+    }
+
+    async def fake_resolve(*args, **kwargs):
+        return "cli", catalogs
+
+    async def fake_system(*args, **kwargs):
+        return "system"
+
+    async def fake_build(prompt: str, **kwargs: object) -> dict:
+        build_calls.append(prompt)
+        return {"text": "I'll tally the vote shortly.", "model": "grok-test", "cost_usd": 0.0}
+
+    monkeypatch.setattr(server, "_resolve_plane", fake_resolve)
+    monkeypatch.setattr(server, "_system_prompt", fake_system)
+    monkeypatch.setattr(server.BUILD_ACP, "run", fake_build)
+    result = await server._run_unified(
+        "vote prompt",
+        model=None,
+        effort="low",
+        plane="cli",
+        fallback_policy="same_plane",
+        agentic=False,
+        max_turns=1,
+        allow_web=False,
+        allow_x_search=False,
+        allow_code=False,
+        nonanswer_recovery=False,
+    )
+    # Opted-out internal votes accept the reply as-is: no retry, no error.
+    assert len(build_calls) == 1
+    assert result["text"] == "I'll tally the vote shortly."
+
+
+@pytest.mark.asyncio
+async def test_chat_tool_requests_cross_plane_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict = {}
+
+    async def fake_unified(prompt: str, **kwargs) -> dict:
+        captured.update(prompt=prompt, **kwargs)
+        return {"text": "done", "resolved_plane": "cli", "cost_usd": 0.0}
+
+    monkeypatch.setattr(server, "_run_unified", fake_unified)
+    result = await server.chat("What is the pinned revision convention?")
+    assert result["text"] == "done"
+    assert captured["fallback_policy"] == "cross_plane"
+    assert captured.get("nonanswer_recovery", True) is True
+
+
 @pytest.mark.asyncio
 async def test_unified_agent_recovers_one_nonanswer_on_same_plane(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Salvaged from the pre-reset lab lineage (worktree branch `claude/peaceful-babbage-992b59`, authored 2026-07-17) — this live-repro fix never made it into the reset public tree.

Live receipts 2026-07-17: the CLI fast route shipped "I'll ground the checklist in the actual flow, then start the answer at '## Checklist'" as `finish_reason=final_answer` with no body and no failover. Two gaps closed:

- `_run_unified` skipped `is_nonanswer_completion` whenever `agentic=False`, so chat, hive merge, and deep polish accepted preamble-only finals.
- Bare-promise preambles (generic "I'll do X" with no substantive content) weren't classified as non-answers at all; added `_is_bare_promise_preamble` detection plus recovery/cross-plane-fallback wiring and bounded-vote exemption.

Cherry-picked clean onto current main; `ruff check` passes and all 153 tests pass (4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible reply selection and routing for chat and unified calls; bounded vote opt-out limits blast radius on internal JSON paths.
> 
> **Overview**
> **Stops preamble-only Grok replies from shipping as final answers** on non-agentic paths (`chat`, hive merge, deep polish) that previously skipped non-answer checks when `agentic=False`.
> 
> `is_nonanswer_completion` now treats short **bare promise preambles** (generic "I'll/let me …" with no delivered body, including verbs outside the curated action list) as non-answers, while leaving clarifying questions, blocker statements, and real content after a delimiter unchanged.
> 
> **`_run_unified`** applies same-plane recovery and optional cross-plane fallback for all prose-producing calls via a new `nonanswer_recovery` flag (default `true`). Internal JSON vote calls set `nonanswer_recovery=False` so malformed votes still drop without retries. **`chat`** now uses `cross_plane` fallback like **`agent`**.
> 
> **Deep-mode final polish** no longer replaces a good answer when polish fails or returns a non-answer; the unpolished text is kept.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe4ef5a91030f84292000596443b1072b0ea71b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->