### PR TITLE
Regenerate uv.lock (root version 1.0.0 -> 1.1.0)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -490,7 +490,7 @@ wheels = [
 
 [[package]]
 name = "grok-mcp-server"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
Pure mechanical `uv lock` regen — one-line diff syncing the root package version with the v1.1.0 pyproject bump. `uv sync --frozen` tolerated the drift; `--locked` would fail. No dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only metadata sync with no runtime or dependency graph changes.
> 
> **Overview**
> **Regenerates `uv.lock`** so the editable root package `grok-mcp-server` is recorded as **1.1.0** instead of **1.0.0**, matching the version already set in `pyproject.toml`.
> 
> No dependency pins or hashes change beyond that single version field. This keeps `uv sync --locked` (and CI that uses it) from failing on lockfile drift after the 1.1.0 release bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8292e7aec9690ea9780bda7e35491be90a9b6d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->