### PR TITLE
docs: document the @grok review PR workflow and the depth compatibility param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the public UniGrok gateway.
 
 ## [Unreleased]
 
+### Documentation
+- Document the `@grok review` PR workflow (maintainer comment trigger, read-only
+  default-branch execution, job-level concurrency, hosted vs lab configuration) in
+  `docs/reference.md`, with a matching README feature-table row.
+- Document the `depth` compatibility parameter (`auto`/`deep`/`hive`) alongside the
+  preferred `level` ladder in `docs/reference.md`.
+
 ### Fixed
 - Non-answer detection + one same-plane recovery + bounded cross-plane fallback now
   guard every prose-producing route, including the non-agentic fast paths (`chat`,

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ you. Every answer comes back with a plane and cost receipt.
 | 🧾 | **Receipts on every answer** — plane, cost, route, and fallback, so nothing is hidden |
 | 🧠 | **Sessions and memory** — named sessions and facts you control, kept locally |
 | 🎨 | **Images, video, vision, files, web + X search** when you add an API key |
+| 🤖 | **PR reviews on comment** — a maintainer types `@grok review` on a pull request and a read-only Grok review answers |
 | 🔐 | **One credential boundary** — keys live in UniGrok, not in every project |
 
 <div align="center">

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -14,6 +14,9 @@ runtime contract for agents, integrators, and advanced users.
   auto-routing. Use `ultra` when you want an artifact adversarially reviewed and are
   fine spending a few cents of API voters; on hard tasks it is typically 2–5× faster
   than a single high-effort call. `voters` (int) overrides the hive reviewer count.
+- **`depth`** (optional, compatibility): `auto` (default) · `deep` (silent
+  deep-reasoning harness) · `hive` (draft → persona votes → merge). Prefer `level` —
+  `max` and `ultra` engage the same harnesses; `depth` remains for existing callers.
 - **Receipts:** every result reports `resolved_plane`, `cost_usd`, `orchestration.route`,
   `fallback_reason`, `resolved_depth`; hive adds `hive.stages` with per-stage plane+cost.
   Relay cost/plane to the user; do not hide metered spend.
@@ -63,6 +66,26 @@ Transport: Streamable HTTP. The MCP handshake, `/healthz`, `/readyz`, `/runtimez
 
 The complete 29-tool surface remains visible when the API is not configured. API tools
 then return a clear setup error instead of disappearing from client discovery.
+
+## PR reviews on comment (`@grok review`)
+
+A repository maintainer (author association `OWNER`, `MEMBER`, or `COLLABORATOR`)
+comments `@grok review` on a pull request — or dispatches the **UniGrok PR Review**
+workflow with a PR number — and `.github/workflows/grok-review.yml` runs a read-only
+Grok review and posts the result back to the PR.
+
+- The job checks out only trusted default-branch code; code from the reviewed PR is
+  never executed, installed, or imported.
+- One live review per PR: job-level concurrency cancels a superseded in-flight run
+  when a newer `@grok review` lands, while unrelated PR comments never touch it.
+- Hosted mode is selected with repository variables (`UNIGROK_REVIEW_RUNNER_JSON`,
+  `UNIGROK_REVIEW_MCP_URL`, `UNIGROK_REVIEW_PLANE`) and mints a short-lived service
+  token at runtime from the `UNIGROK_MCP_TOKEN_SECRET` repository secret — no static
+  API keys live in the workflow. With the variables unset, the workflow falls back to
+  a self-hosted runner talking to the loopback gateway.
+
+The `review_pull_request` MCP tool is the same capability for IDE callers: it reviews
+a bounded caller-supplied diff without GitHub or Git access.
 
 ## Routing and billing
 


### PR DESCRIPTION
The hosted `@grok review` path has been live since #496–#498 (job-level concurrency since #498) but had no public documentation anywhere — no README mention, no reference entry, no changelog trail.

Docs-only, 31 added lines:
- `docs/reference.md`: new **PR reviews on comment** section — maintainer comment trigger, read-only default-branch execution guarantee, job-level concurrency semantics, hosted-vs-lab configuration (all facts sourced from the public `grok-review.yml`), plus the `review_pull_request` MCP-tool relationship.
- `docs/reference.md`: `depth` compatibility parameter (`auto`/`deep`/`hive`) documented next to the preferred `level` ladder; previously only implied via `resolved_depth` receipts.
- README: one feature-table row for PR reviews on comment.
- CHANGELOG: Documentation entries under [Unreleased].

Routine hygiene per standing instruction; no code or workflow changes, insider design docs stay insider-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, workflow, or security behavior modifications.
> 
> **Overview**
> Public docs now describe capabilities that already shipped in earlier PRs but were undocumented.
> 
> **`@grok review`:** `docs/reference.md` adds a section on maintainer-triggered PR reviews (`@grok review` comment or workflow dispatch), read-only default-branch checkout (PR code never executed), per-PR job concurrency, hosted vs self-hosted configuration via repo variables/secrets, and how that relates to the `review_pull_request` MCP tool. README gains a matching feature-table row. CHANGELOG records both doc additions under **[Unreleased] → Documentation**.
> 
> **`depth` compatibility:** `docs/reference.md` documents `depth` (`auto` / `deep` / `hive`) next to the preferred `level` ladder, clarifying that `max`/`ultra` map to the same harnesses for existing callers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64cc6f8a0e128b1cac7d0282156fc9b7bd3e3636. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->