### PR TITLE
docs: add issue templates and CONTRIBUTING.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,61 @@
+name: Bug report
+description: Something misbehaved — a wrong answer, a crash, a fallback you didn't expect.
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. Receipts make depth/hive bugs reproducible — the `usage`,
+        `resolved_plane`, and `hive.stages` fields in the tool result tell us most of the story.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you ask UniGrok to do, and what went wrong?
+      placeholder: e.g. `level: ultra` returned a merge with an empty vote stage
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+    validations:
+      required: true
+  - type: dropdown
+    id: level
+    attributes:
+      label: Level / depth used
+      description: The `level` (or legacy `depth`) you set, or "unset" if you let UniGrok choose.
+      options:
+        - unset (auto)
+        - none / minimal / low
+        - medium / high / xhigh
+        - max (deep harness)
+        - ultra (hive)
+        - legacy depth param (deep / hive)
+    validations:
+      required: true
+  - type: textarea
+    id: receipts
+    attributes:
+      label: Receipts from the result
+      description: >
+        Paste the relevant result fields: `resolved_plane`, `fallback_occurred` /
+        `fallback_reason`, `resolved_depth`, `usage`, and `hive.stages` if present.
+        Redact anything sensitive.
+      render: json
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, how you run the gateway (docker compose / other), version or commit, and which IDE/client is connected.
+      placeholder: |
+        macOS 15, docker compose, v1.1.0, Claude Code via /mcp
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Smallest sequence that triggers it. If it only reproduces sometimes, say roughly how often.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security report
+    url: https://github.com/djtelicloud/grok-mcp-server/blob/main/SECURITY.md
+    about: Please report security issues privately per SECURITY.md, not as public issues.

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,23 @@
+name: Docs issue
+description: Something in the README, reference, or onboarding docs is wrong, missing, or confusing.
+title: "[docs] "
+labels: ["documentation"]
+body:
+  - type: input
+    id: location
+    attributes:
+      label: Where
+      description: File and section (e.g. `docs/reference.md`, the `level` ladder).
+    validations:
+      required: true
+  - type: textarea
+    id: issue
+    attributes:
+      label: What's wrong or missing
+      description: Quote the confusing passage if short, or describe what you looked for and couldn't find.
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix (optional)

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: Feature request
+description: Propose a new capability or an improvement to an existing one.
+title: "[feature] "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you hitting?
+      description: Describe the situation where UniGrok falls short — the workflow matters more than the proposed mechanism.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: What should happen instead? If it touches levels, planes, or onboarding, say which.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you tried, or why existing levels / tools don't cover it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing to UniGrok
+
+Thanks for helping. Two ways to contribute: report what you hit, or send a change.
+
+## Reporting
+
+Open an issue with the matching template (bug, feature, docs). For bugs in the
+depth/level paths — `max`, `ultra`, hive voting, plane fallback — paste the receipt
+fields from the tool result (`resolved_plane`, `fallback_occurred`, `resolved_depth`,
+`usage`, `hive.stages`). Receipts are designed to make these reports reproducible;
+redact anything sensitive before posting.
+
+Security issues go through [SECURITY.md](SECURITY.md), not public issues.
+
+## Sending changes
+
+1. Fork and branch from `main`.
+2. Run the local checks (see [docs/development.md](docs/development.md)):
+
+   ```bash
+   uv sync --frozen
+   uv run pytest -q
+   uv run ruff check .
+   docker compose config --quiet
+   ```
+
+3. Open a PR with a short description of the problem and the change. Keep PRs
+   single-purpose — small ones land fast.
+
+Every PR gets CI plus an automated `@grok` review pass; you can re-trigger a review by
+commenting on the PR (see [docs/reference.md](docs/reference.md) for the workflow).
+Address or answer review comments before merge — disagreement with the bot is fine when
+you say why.
+
+## Scope
+
+This repo is the public, credential-free gateway: server, dashboard, docs, packaging.
+Feature ideas that need private infrastructure will be redirected to an issue discussion
+first.


### PR DESCRIPTION
Post-v1.1.0 community intake: with depth modes, hive voting, and per-IDE onboarding freshly shipped, external users need a structured way to report what they hit.

- Issue forms for bug / feature / docs. The bug form asks for the `level`/`depth` used and the receipt fields (`resolved_plane`, `fallback_occurred`, `resolved_depth`, `usage`, `hive.stages`) so depth-path reports arrive reproducible.
- Template chooser routes security reports to SECURITY.md instead of public issues.
- CONTRIBUTING.md: reporting guidance, the local check commands from docs/development.md, and the CI + @grok review expectations for PRs.

Docs-only, no runtime changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and GitHub metadata only; no runtime, auth, or deployment changes.
> 
> **Overview**
> Adds **structured GitHub issue intake** and a **contributor guide** so post–v1.1.0 reports (especially depth/hive paths) arrive with enough context to reproduce.
> 
> New **issue forms** for bugs, features, and docs, with auto labels and prefixed titles. The **bug** form requires level/depth and prompts for receipt JSON (`resolved_plane`, `fallback_*`, `usage`, `hive.stages`, etc.). **Template chooser** (`config.yml`) keeps blank issues enabled and adds a **Security report** link to `SECURITY.md` instead of public issues.
> 
> **`CONTRIBUTING.md`** documents reporting (receipt fields for `max`/`ultra`/hive/fallback), local checks from `docs/development.md`, PR expectations (CI + `@grok` review), and repo scope for public gateway work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5917075d1bd728c5edf565673853f2251e78e897. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->