### PR TITLE
docs: add 1.1.0 known-limits note with depth-miss reporting guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,6 +8,7 @@ body:
       value: |
         Thanks for reporting. Receipts make depth/hive bugs reproducible — the `usage`,
         `resolved_plane`, and `hive.stages` fields in the tool result tell us most of the story.
+        Not sure whether it is a bug? Check [known limits](https://github.com/djtelicloud/grok-mcp-server/blob/main/docs/known-limits.md) first.
   - type: textarea
     id: what-happened
     attributes:

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ See [SECURITY.md](SECURITY.md) for the complete public runtime boundary.
 | See every tool and routing rule | [Technical reference](docs/reference.md) |
 | Drive `agent` from an IDE agent | [Technical reference](docs/reference.md#how-an-ide-agent-should-drive-agent) |
 | Develop or acceptance-test UniGrok | [Development guide](docs/development.md) |
+| See what has limited soak and how to report a miss | [Known limits](docs/known-limits.md) |
 | Report a security issue | [Security policy](SECURITY.md) |
 
 ## License

--- a/docs/known-limits.md
+++ b/docs/known-limits.md
@@ -1,0 +1,68 @@
+# Known limits
+
+Honest notes on what shipped, what has had limited soak time, and how to file a
+report that we can actually reproduce. One section per release, newest first.
+
+## 1.1.0
+
+### Depth modes are new — here is what a "miss" looks like
+
+`max` (deep harness) and `ultra` (hive voting) shipped in 1.1.0 and have had
+limited soak time across task shapes. If one of these misbehaves for you, that
+is exactly the feedback we need. A depth-mode miss usually looks like one of:
+
+- **Preamble-only or non-answer output** — the result reads like the model
+  announcing what it will do instead of doing it. 1.1.0 guards the fast routes
+  against this and rejects such completions with an error; if a non-answer
+  still reaches you as a *successful* result, report it.
+- **Harness leakage** — internal harness or persona instructions showing up in
+  the answer text.
+- **A hive merge that discards a clearly better voter draft** — the
+  `hive.stages` receipt shows each stage; include it.
+- **Depth resolving lower than you asked for** — every result echoes the
+  requested and resolved depth/level. If they differ and no documented
+  downgrade rule applies, report it.
+
+### Plane fallback is visible — check the receipts
+
+The subscription CLI plane is the default; the metered xAI API plane is for
+selected specialists and bounded recovery. Every result carries
+`resolved_plane`, `fallback_occurred` / `fallback_reason`, and `usage`. If
+those receipts show a fallback to the API plane that you did not expect, file
+a bug with those fields — they tell most of the story.
+
+### Expected behavior, not bugs
+
+- **`xhigh` on the API plane auto-downgrades to `high`** instead of erroring.
+  The downgrade is echoed in the resolved level.
+- **Interrupted jobs return status `"lost"` after a gateway restart.** Job
+  *results* persist to SQLite once complete; a job that was mid-flight during
+  a restart is reported lost rather than silently re-run. Durable facts and
+  session history are unaffected.
+
+### Auto++ router mis-routes
+
+On unclear tasks the router picks route, depth, and voter count via three
+flat-rate intent votes. If it chooses a depth or voter count that is obviously
+wrong for your task, report it and include the task text — routing quality is
+tuned from real task shapes.
+
+### How to report
+
+Use the [bug report form](https://github.com/djtelicloud/grok-mcp-server/issues/new?template=bug_report.yml). The form
+asks for the three things that make depth/hive reports reproducible:
+
+1. the `level` / `depth` you set (or "unset" if you let UniGrok choose),
+2. the receipt fields from the result — `resolved_plane`,
+   `fallback_occurred` / `fallback_reason`, `resolved_depth`, `usage`, and
+   `hive.stages` if present,
+3. the task text (redacted as needed) and steps to reproduce.
+
+For router mis-routes, the task text plus the requested and resolved depth is
+the minimum useful report. Per-IDE onboarding problems (a client that never
+connects, a merge entry written to the wrong path) use the same bug form —
+include the IDE and the install path involved; those are setup issues, not
+depth misses.
+
+**Do not paste** API keys, tokens, private source code, or full system
+prompts into a report. Receipts and redacted task text are enough.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2,6 +2,7 @@
 
 The README is the public quick start. This page contains the complete tool surface and
 runtime contract for agents, integrators, and advanced users.
+Known limits of the current release are tracked in [Known limits](known-limits.md).
 
 ## How an IDE agent should drive `agent`
 


### PR DESCRIPTION
## Summary
- New [docs/known-limits.md](https://github.com/djtelicloud/grok-mcp-server/blob/docs/known-limits/docs/known-limits.md): per-release honest-limits note, 1.1.0 first — what a depth-mode miss looks like (preamble-only output, harness leakage, hive merge discarding a better voter draft, depth resolving below request), receipt-based unexpected-fallback reporting, an **Expected behavior, not bugs** section (xhigh→high API downgrade, `lost` jobs after restart), auto++ router mis-route reports, and a do-not-paste redaction note.
- Linked from three places: README **Go deeper** table, docs/reference.md intro, and the bug report form intro (with a "check known limits first" pointer).

Follows up #503: the bug form captures the receipts; this note tells users when and how to use it. Content drawn from the v1.1.0 release notes only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, API, or security behavior changes.
> 
> **Overview**
> Adds **`docs/known-limits.md`**, a per-release note starting with **1.1.0**: what depth-mode misses look like (`max` / `ultra`), how to use receipt fields for unexpected plane fallback, **expected behavior** (API `xhigh`→`high`, jobs marked `lost` after restart), auto++ router mis-routes, and reporting/redaction guidance tied to the bug form.
> 
> **Discovery:** new README “Go deeper” row, a one-line link in `docs/reference.md`, and a “check known limits first” pointer in the bug report template intro.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba08bc4231b5beab7af167baa0d25b94b0f4becd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->