### PR TITLE
docs(changelog): catch up [Unreleased] through #505 and link the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,33 @@ All notable changes to the public UniGrok gateway.
 
 ## [Unreleased]
 
+### Added
+- `grok_mcp_onboard_client` installs a public **unigrok-visuals** skill pack for
+  every client alongside `using-unigrok`: one capability-ladder core (markdown →
+  Mermaid/SVG → host-native rich surface → hosted artifact) plus a thin adapter
+  per host (Claude Code, Codex, Antigravity, Cursor, GitHub Copilot,
+  generic/Grok), emitted into each host's native skill or rules location at
+  global and project scope.
+
+### Security
+- Control center (`/ui`) responses carry a per-response script nonce and a
+  stricter Content-Security-Policy; a new `SecurityHeadersMiddleware` adds
+  baseline hardening (X-Frame-Options, nosniff, COOP/CORP, permissions-policy,
+  default-deny CSP) to every HTTP response that has no route-specific CSP.
+
 ### Documentation
 - Document the `@grok review` PR workflow (maintainer comment trigger, read-only
   default-branch execution, job-level concurrency, hosted vs lab configuration) in
   `docs/reference.md`, with a matching README feature-table row.
 - Document the `depth` compatibility parameter (`auto`/`deep`/`hive`) alongside the
   preferred `level` ladder in `docs/reference.md`.
+- Contributor and reporting setup: issue templates (bug reports capture the
+  level/depth knobs and receipt fields, feature, docs; security routed to
+  `SECURITY.md`) and a `CONTRIBUTING.md` covering local checks plus the CI and
+  `@grok review` expectations.
+- `docs/known-limits.md`: what has limited soak in 1.1.0, which behaviors are
+  expected rather than bugs, and how to report a depth-mode miss — linked from
+  the README, `docs/reference.md`, and the bug-report form.
 
 ### Fixed
 - Non-answer detection + one same-plane recovery + bounded cross-plane fallback now

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,9 @@ Security issues go through [SECURITY.md](SECURITY.md), not public issues.
    docker compose config --quiet
    ```
 
-3. Open a PR with a short description of the problem and the change. Keep PRs
+3. If the change is behavior-visible, add a line to the `[Unreleased]` section of
+   [CHANGELOG.md](CHANGELOG.md) (Added/Changed/Fixed/Security/Documentation as fits).
+4. Open a PR with a short description of the problem and the change. Keep PRs
    single-purpose — small ones land fast.
 
 Every PR gets CI plus an automated `@grok` review pass; you can re-trigger a review by

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ See [SECURITY.md](SECURITY.md) for the complete public runtime boundary.
 | Drive `agent` from an IDE agent | [Technical reference](docs/reference.md#how-an-ide-agent-should-drive-agent) |
 | Develop or acceptance-test UniGrok | [Development guide](docs/development.md) |
 | See what has limited soak and how to report a miss | [Known limits](docs/known-limits.md) |
+| See what changed between versions | [Changelog](CHANGELOG.md) |
 | Report a security issue | [Security policy](SECURITY.md) |
 
 ## License


### PR DESCRIPTION
## What

Catch-up pass on the existing Keep-a-Changelog file, plus discoverability and discipline so this is the last catch-up:

- **CHANGELOG.md `[Unreleased]`**: adds the three PRs merged since #502 — #503 (contributor/reporting setup) and #504 (known-limits note) under *Documentation*; #505 split into *Added* (public unigrok-visuals onboarding pack for all six clients) and *Security* (control-center CSP script nonce + `SecurityHeadersMiddleware` baseline headers).
- **README**: new "Go deeper" row — *See what changed between versions → Changelog*.
- **CONTRIBUTING.md**: new step asking behavior-visible PRs to add an `[Unreleased]` line. Deliberately no CI enforcement — a hard `src/`↔changelog gate is overkill for this repo's size and invites escape-label noise; a weekly maintenance sweep backstops misses.

Docs-only; no runtime changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, config, or security behavior changes in this diff.
> 
> **Overview**
> **Changelog catch-up** — `[Unreleased]` now records recent shipped work that was missing from the log: **unigrok-visuals** onboarding via `grok_mcp_onboard_client` (*Added*), control-center CSP/nonce plus `SecurityHeadersMiddleware` (*Security*), and contributor/issue-template/known-limits documentation (*Documentation*).
> 
> **Discoverability & habit** — README’s “Go deeper” table adds a row pointing to `CHANGELOG.md`. `CONTRIBUTING.md` adds a step to append an `[Unreleased]` line for behavior-visible changes (no CI gate).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e4946b9d85cacf2bec420f7b2d5d88219523264. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->