### PR TITLE
docs: add release checklist to development guide

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -39,3 +39,26 @@ uv run python scripts/smoke_team_harness.py \
 Before release, also compare MCP `tools/list` with `grok_mcp_discover_self`, verify
 `/healthz`, `/readyz`, and `/runtimez`, exercise both configured credential planes, and
 test from a real IDE opened on an unrelated project.
+
+## Cutting a release
+
+One version bump commit, then tag and publish — the version string lives in three
+places that must move together:
+
+1. Bump the version in `pyproject.toml`, `src/unigrok_public/__init__.py`, and the
+   README version badge. Promote the `[Unreleased]` section of `CHANGELOG.md` to
+   `## [X.Y.Z] — <date>`, leaving an empty `[Unreleased]` above it. Commit as
+   `chore(release): X.Y.Z` and push (or merge via PR).
+2. Tag and publish the GitHub release:
+
+   ```bash
+   git tag -a vX.Y.Z -m "vX.Y.Z - <release title>"
+   git push origin vX.Y.Z
+   gh release create vX.Y.Z --title "vX.Y.Z - <release title>" --notes-file <notes>
+   ```
+
+3. The npm companion package `@djtelicloud/unigrok` is versioned in lockstep with
+   gateway releases and republished by the maintainer at each tag. It prints verified
+   setup steps; it is not the server itself.
+4. Verify: the release page renders, `/healthz` on a rebuilt service reports the new
+   version, and `npm view @djtelicloud/unigrok version` matches the tag.


### PR DESCRIPTION
Adds a "Cutting a release" section to docs/development.md: single version-bump commit covering pyproject.toml, `src/unigrok_public/__init__.py`, and the README version badge; CHANGELOG `[Unreleased]` promotion; tag + `gh release` commands; npm companion lockstep note; post-release verification.

Docs-only. Closes the release-process gap noted after the 1.1.0 npm version drift (npm stub lagged the gateway release because no checklist tied them together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, auth, or deployment code modifications.
> 
> **Overview**
> Documents the **release workflow** in `docs/development.md` so gateway and npm versions stay aligned (addressing the 1.1.0 companion-package drift).
> 
> The new **Cutting a release** section spells out a single `chore(release): X.Y.Z` commit that bumps `pyproject.toml`, `src/unigrok_public/__init__.py`, and the README badge; promotes `CHANGELOG.md` `[Unreleased]`; then tags and runs `gh release create`. It also notes that `@djtelicloud/unigrok` must be republished in lockstep and lists smoke checks (release page, `/healthz` version, `npm view` version).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34133b6770a0bae538036a6fca2ef093da29f8aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->