### PR TITLE
P1: thin forge-surface hooks (UNIGROK_SURFACE + runtime UI mount + insider deny-list)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,5 +17,6 @@ jobs:
           enable-cache: true
       - run: uv sync --frozen
       - run: uv run ruff check .
+      - run: bash scripts/ci-insider-denylist.sh
       - run: uv run pytest -q
 

--- a/scripts/ci-insider-denylist.sh
+++ b/scripts/ci-insider-denylist.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Insider-boundary deny-list (CI gate).
+#
+# The public gateway image must never ship contributor/forge UI assets, private
+# deploy overlays, or secret material. Forge deployments mount their private
+# console at runtime (UNIGROK_UI_ROOT); nothing insider is ever committed here.
+# This checks TRACKED PATHS, so the deny-list itself can be documented freely.
+set -euo pipefail
+
+deny_patterns=(
+  '^mcp_ui/'                 # private forge console tree
+  '^sites/'                  # private control-center app tree
+  '(^|/)forge-console'       # private launch tooling
+  '\.override\.ya?ml$'       # private compose overlays
+  '(^|/)\.env($|\.)'         # environment secret files
+  'client_secret'            # OAuth secret material
+  '(^|/)id_(rsa|ed25519)'    # private keys
+  '\.pem$'
+)
+
+fail=0
+tracked="$(git ls-files)"
+for pattern in "${deny_patterns[@]}"; do
+  if hits="$(grep -E "$pattern" <<<"$tracked")"; then
+    echo "insider-denylist: FORBIDDEN tracked path(s) matching '$pattern':" >&2
+    echo "$hits" >&2
+    fail=1
+  fi
+done
+
+# example.env is the one sanctioned env template.
+if [ "$fail" -ne 0 ]; then
+  echo "insider-denylist: FAILED — insider or secret material must not land in the public repo" >&2
+  exit 1
+fi
+echo "insider-denylist: OK (no insider paths, overlays, or secret files tracked)"

--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -6,6 +6,7 @@ import contextlib
 import hashlib
 import ipaddress
 import json
+import mimetypes
 import os
 import re
 import secrets
@@ -24,7 +25,7 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field
 from starlette.requests import Request
-from starlette.responses import HTMLResponse, JSONResponse, PlainTextResponse
+from starlette.responses import HTMLResponse, JSONResponse, PlainTextResponse, Response
 
 from . import __version__, xai_api
 from .grok_build import GrokBuildACPManager
@@ -258,6 +259,12 @@ SHADOW_DONE_VOTE = os.environ.get("UNIGROK_SHADOW_DONE_VOTE", "off").strip().low
     "yes",
     "on",
 }
+# Surface selection (thin forge hooks). "public" is the default and changes nothing.
+# "forge" additionally registers skeleton contributor control-plane routes that answer
+# 401 until the real OAuth slice lands. The public image never ships forge UI assets;
+# a forge deployment mounts its private console at runtime via UNIGROK_UI_ROOT.
+SURFACE = os.environ.get("UNIGROK_SURFACE", "public").strip().lower() or "public"
+UI_ROOT_OVERRIDE = os.environ.get("UNIGROK_UI_ROOT", "").strip()
 _CATALOG_CACHE: tuple[float, dict[str, Any]] | None = None
 _SESSION_LOCKS: dict[str, asyncio.Lock] = {}
 _AGENT_JOBS: dict[str, tuple[float, asyncio.Task[dict[str, Any]]]] = {}
@@ -3503,16 +3510,27 @@ async def xai_delete_file(file_id: str, confirm_delete: bool = False) -> dict[st
     return await xai_api.delete_file(_validated_file_id(file_id))
 
 
-@mcp.custom_route("/ui/", methods=["GET"], include_in_schema=False)
-@mcp.custom_route("/ui", methods=["GET"], include_in_schema=False)
-async def control_center(_: Request) -> HTMLResponse:
-    # The dashboard is a single self-contained page with one inline <script>.
-    # Serve it under a per-response nonce so the CSP can forbid all other script
-    # execution (blocking injected-script exfiltration of the rendered telemetry)
-    # without moving to an external bundle. Dynamic style="width:.." bars still
-    # require 'unsafe-inline' for styles.
+def _client_is_loopback(request: Request) -> bool:
+    """True only when the direct TCP peer is loopback.
+
+    Deliberately ignores X-Forwarded-For and every other client-supplied header:
+    a spoofed header must never widen the loopback operator exemption. Callers
+    that sit behind a trusted proxy do not exist in this deployment shape (both
+    gateways bind 127.0.0.1), so the peer address is the only truth.
+    """
+    client = request.scope.get("client")
+    return bool(client) and client[0] in {"127.0.0.1", "::1"}
+
+
+def _ui_index_response(index_path: Path) -> HTMLResponse:
+    # The page is served under a per-response nonce so the CSP can forbid all
+    # other script execution (blocking injected-script exfiltration of the
+    # rendered telemetry) without moving to an external bundle. Dynamic
+    # style="width:.." bars still require 'unsafe-inline' for styles. The nonce
+    # replacement no-ops for pages with no inline script (the mounted forge
+    # console uses only same-origin external files, which 'self' covers).
     nonce = secrets.token_urlsafe(16)
-    html = (STATIC_ROOT / "dashboard.html").read_text(encoding="utf-8")
+    html = index_path.read_text(encoding="utf-8")
     html = html.replace("<script>", f'<script nonce="{nonce}">', 1)
     csp = (
         "default-src 'self'; "
@@ -3525,6 +3543,65 @@ async def control_center(_: Request) -> HTMLResponse:
         "form-action 'none'"
     )
     return HTMLResponse(html, headers={"content-security-policy": csp})
+
+
+@mcp.custom_route("/ui/", methods=["GET"], include_in_schema=False)
+@mcp.custom_route("/ui", methods=["GET"], include_in_schema=False)
+async def control_center(_: Request) -> HTMLResponse:
+    # /ui never consults Authorization or any identity state, on every surface:
+    # loopback operators always get the page, and public telemetry is identity-free.
+    if UI_ROOT_OVERRIDE:
+        index = Path(UI_ROOT_OVERRIDE) / "index.html"
+        if index.is_file():
+            return _ui_index_response(index)
+    return _ui_index_response(STATIC_ROOT / "dashboard.html")
+
+
+def _resolve_ui_asset(raw: str) -> Response:
+    """Resolve one mounted-console asset path with traversal safety (sync)."""
+    if not UI_ROOT_OVERRIDE:
+        return PlainTextResponse("Not Found", status_code=404)
+    if not raw or any(part in {"", ".", ".."} or part.startswith(".") for part in raw.split("/")):
+        return PlainTextResponse("Not Found", status_code=404)
+    root = Path(UI_ROOT_OVERRIDE).resolve()
+    try:
+        target = (root / raw).resolve()
+        target.relative_to(root)
+    except (OSError, ValueError):
+        return PlainTextResponse("Not Found", status_code=404)
+    if not target.is_file():
+        return PlainTextResponse("Not Found", status_code=404)
+    media_type = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
+    return Response(target.read_bytes(), media_type=media_type)
+
+
+@mcp.custom_route("/ui/{asset_path:path}", methods=["GET"], include_in_schema=False)
+async def ui_asset(request: Request) -> Response:
+    """Serve same-origin assets for a runtime-mounted console.
+
+    Only active when UNIGROK_UI_ROOT is set (forge deployments mount their
+    private console there). Without the override this returns 404 for every
+    subpath, exactly like the routeless default it replaces — the baked-in
+    public dashboard is a single self-contained page.
+    """
+    return _resolve_ui_asset(request.path_params.get("asset_path", ""))
+
+
+@mcp.custom_route("/control", methods=["GET"], include_in_schema=False)
+@mcp.custom_route("/auth/github", methods=["GET"], include_in_schema=False)
+@mcp.custom_route("/api/me", methods=["GET"], include_in_schema=False)
+async def forge_control_plane_stub(request: Request) -> Response:
+    """Contributor control-plane skeleton.
+
+    On the public surface these paths stay indistinguishable from unregistered
+    routes (identity-free 4765 contract). On the forge surface they exist but
+    answer 401 until the GitHub OAuth slice lands — no cookie, no bearer, no
+    body detail. The loopback helper is intentionally not consulted here: the
+    operator exemption applies to /ui, never to identity endpoints.
+    """
+    if SURFACE != "forge":
+        return PlainTextResponse("Not Found", status_code=404)
+    return JSONResponse({"error": "authentication_required"}, status_code=401)
 
 
 @mcp.custom_route("/.well-known/webmcp", methods=["GET"], include_in_schema=False)

--- a/tests/test_forge_surface.py
+++ b/tests/test_forge_surface.py
@@ -1,0 +1,189 @@
+"""P1 forge-surface hooks: default-unchanged, runtime UI mount, control-plane skeleton.
+
+Acceptance sheet: docs (private DoR) rows P1-P7 — surface flag defaulting,
+UNIGROK_UI_ROOT runtime mount with traversal safety, X-Forwarded-For never
+trusted for loopback, /ui never bearer-authed, forge skeleton 401s, telemetry
+contract parity.
+"""
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from starlette.requests import Request
+
+from unigrok_public import server
+
+
+def _request(
+    path: str = "/ui/",
+    *,
+    client: tuple[str, int] | None = ("127.0.0.1", 55001),
+    headers: list[tuple[bytes, bytes]] | None = None,
+    path_params: dict[str, str] | None = None,
+) -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": path,
+        "query_string": b"",
+        "headers": headers or [],
+        "client": client,
+        "path_params": path_params or {},
+    }
+    request = Request(scope)
+    if path_params:
+        request.scope["path_params"] = path_params
+    return request
+
+
+def test_surface_defaults_to_public() -> None:
+    # No env in the test run → the import-time default must be the public surface
+    # with no UI override: byte-for-byte today's 4765.
+    assert server.SURFACE == "public"
+    assert server.UI_ROOT_OVERRIDE == ""
+
+
+def test_ui_serves_baked_dashboard_by_default() -> None:
+    response = asyncio.run(server.control_center(_request()))
+    assert response.status_code == 200
+    assert b"<script nonce=" in response.body
+    assert "script-src 'self' 'nonce-" in response.headers["content-security-policy"]
+
+
+def test_ui_ignores_authorization_header() -> None:
+    # /ui is never bearer-authed on any surface: a bogus Authorization header
+    # must change nothing.
+    response = asyncio.run(
+        server.control_center(
+            _request(headers=[(b"authorization", b"Bearer forged-junk-token")])
+        )
+    )
+    assert response.status_code == 200
+
+
+def test_ui_root_override_serves_mounted_console(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    (tmp_path / "index.html").write_text("<html><body>forge console</body></html>")
+    (tmp_path / "app.js").write_text("console.log('forge')")
+    monkeypatch.setattr(server, "UI_ROOT_OVERRIDE", str(tmp_path))
+
+    index = asyncio.run(server.control_center(_request()))
+    assert index.status_code == 200
+    assert b"forge console" in index.body
+
+    asset = asyncio.run(
+        server.ui_asset(_request("/ui/app.js", path_params={"asset_path": "app.js"}))
+    )
+    assert asset.status_code == 200
+    assert b"forge" in asset.body
+    assert "javascript" in asset.headers["content-type"]
+
+
+def test_ui_root_override_missing_index_falls_back(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(server, "UI_ROOT_OVERRIDE", str(tmp_path))
+    response = asyncio.run(server.control_center(_request()))
+    assert response.status_code == 200
+    assert b"<script nonce=" in response.body  # baked dashboard, not a 500
+
+
+@pytest.mark.parametrize(
+    "asset_path",
+    ["../secrets.txt", "..", ".env", ".git/config", "a/../../escape", ""],
+)
+def test_ui_asset_blocks_traversal(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, asset_path: str
+) -> None:
+    (tmp_path / "index.html").write_text("ok")
+    outside = tmp_path.parent / "secrets.txt"
+    outside.write_text("secret")
+    monkeypatch.setattr(server, "UI_ROOT_OVERRIDE", str(tmp_path))
+    response = asyncio.run(
+        server.ui_asset(_request(f"/ui/{asset_path}", path_params={"asset_path": asset_path}))
+    )
+    assert response.status_code == 404
+
+
+def test_ui_asset_404_without_override() -> None:
+    # Default surface: every /ui subpath stays 404, identical to the routeless
+    # contract it replaces.
+    response = asyncio.run(
+        server.ui_asset(_request("/ui/app.js", path_params={"asset_path": "app.js"}))
+    )
+    assert response.status_code == 404
+
+
+def test_control_plane_404_on_public_surface() -> None:
+    response = asyncio.run(server.forge_control_plane_stub(_request("/api/me")))
+    assert response.status_code == 404
+
+
+def test_public_404_is_byte_identical_to_unregistered_routes() -> None:
+    # Anti-fingerprinting oracle: on the public surface the control-plane paths
+    # (and /ui subpaths) must be indistinguishable from paths that were never
+    # registered — same status, content-type, and body through the real app.
+    from starlette.testclient import TestClient
+
+    client = TestClient(server.mcp.streamable_http_app())
+    baseline = client.get("/definitely-not-registered")
+    for path in ("/api/me", "/control", "/auth/github", "/ui/app.js"):
+        probe = client.get(path)
+        assert probe.status_code == baseline.status_code == 404
+        assert probe.headers.get("content-type") == baseline.headers.get("content-type")
+        assert probe.content == baseline.content
+
+
+def test_ui_asset_blocks_symlink_escape(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # A symlink planted inside the mounted console must not read outside the
+    # jail: resolve() follows it and the relative_to() check fails closed.
+    root = tmp_path / "console"
+    root.mkdir()
+    (root / "index.html").write_text("ok")
+    secret = tmp_path / "outside-secret.txt"
+    secret.write_text("secret")
+    (root / "leak.txt").symlink_to(secret)
+    monkeypatch.setattr(server, "UI_ROOT_OVERRIDE", str(root))
+    response = asyncio.run(
+        server.ui_asset(_request("/ui/leak.txt", path_params={"asset_path": "leak.txt"}))
+    )
+    assert response.status_code == 404
+
+
+def test_control_plane_401_on_forge_surface(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(server, "SURFACE", "forge")
+    response = asyncio.run(server.forge_control_plane_stub(_request("/api/me")))
+    assert response.status_code == 401
+    assert "www-authenticate" not in {k.lower() for k in response.headers}
+
+
+def test_loopback_check_ignores_forwarded_for() -> None:
+    # A spoofed X-Forwarded-For must never widen the loopback exemption; only
+    # the direct TCP peer counts.
+    spoofed = _request(
+        client=("203.0.113.9", 40000),
+        headers=[(b"x-forwarded-for", b"127.0.0.1")],
+    )
+    assert server._client_is_loopback(spoofed) is False
+
+    genuine = _request(
+        client=("127.0.0.1", 40000),
+        headers=[(b"x-forwarded-for", b"203.0.113.9")],
+    )
+    assert server._client_is_loopback(genuine) is True
+
+    no_client = _request(client=None)
+    assert server._client_is_loopback(no_client) is False
+
+
+def test_telemetry_contract_identical_across_surfaces(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    public_health = asyncio.run(server.healthz(_request("/healthz")))
+    monkeypatch.setattr(server, "SURFACE", "forge")
+    forge_health = asyncio.run(server.healthz(_request("/healthz")))
+    assert public_health.body == forge_health.body


### PR DESCRIPTION
## What

The first P1 slice of the unified-UI plan: the public gateway gains two thin, default-off hooks so a private forge deployment can reuse this image without anything insider ever landing here.

- `UNIGROK_SURFACE` (default `public` — behavior byte-identical): on `forge`, skeleton control-plane routes `/control`, `/auth/github`, `/api/me` answer a bare `401` until the OAuth slice lands. On `public` they are byte-identical to unregistered paths (pinned by a parity test through the real app).
- `UNIGROK_UI_ROOT`: mounts a runtime console over `/ui` with a traversal- and symlink-jailed asset route. Unset → every `/ui` subpath stays 404 and the baked dashboard serves exactly as before.
- `/ui` never consults `Authorization` on any surface (pinned). Loopback helper uses the TCP peer only — `X-Forwarded-For` is ignored by construction (pinned).
- CI insider deny-list: tracked-path grep gate blocking forge UI trees, private overlays, and secret files.

## Tests

18 new tests (`tests/test_forge_surface.py`): default-unchanged, auth-ignored `/ui`, mount serve/fallback, traversal + symlink escape matrix, 404 anti-fingerprint oracle, XFF spoof, telemetry parity across surfaces. Full suite: 173 passed, ruff clean, deny-list green.

## Review guide

Walk the acceptance sheet rows P1–P11 (public PR section) in the private design-of-record (`unigrok-ui/docs/p1-dual-pr-acceptance-sheet.md`). Pairs with the private overlay PR; merge this side first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New HTTP surface for mounted UI assets and forge-only routes increases exposure if UNIGROK_UI_ROOT or SURFACE=forge is misconfigured; path-jail and anti-fingerprint tests mitigate but env mistakes matter.
> 
> **Overview**
> Adds **default-off** deployment hooks so the same public gateway image can run as a private forge without shipping insider assets in git.
> 
> **`UNIGROK_SURFACE`** (default `public`) registers skeleton contributor routes (`/control`, `/auth/github`, `/api/me`). On `public` they return **404** indistinguishable from unregistered paths; on `forge` they return a bare **401** until OAuth lands. **`UNIGROK_UI_ROOT`** optionally serves a runtime-mounted console at `/ui` plus a **jailed** `/ui/{asset_path}` asset route (traversal/symlink-safe); without it, behavior stays the baked-in dashboard and `/ui/*` subpaths stay **404**.
> 
> `/ui` does not use `Authorization`; loopback detection uses the **TCP peer only** (no `X-Forwarded-For`). CI runs **`scripts/ci-insider-denylist.sh`** to fail if tracked paths match forge UI trees, overlays, or secret patterns. **`tests/test_forge_surface.py`** pins the contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59a64f2c00f54c9cee26907aea80fc97c742d177. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->