### PR TITLE
Test readiness credential gate

### DIFF
--- a/tests/test_public_boundary.py
+++ b/tests/test_public_boundary.py
@@ -219,6 +219,61 @@ async def test_api_only_capability_explicitly_selects_api(monkeypatch: pytest.Mo
 
 
 @pytest.mark.asyncio
+async def test_readyz_rejects_healthy_first_run_without_grok_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_catalogs(*, refresh: bool = False) -> dict:
+        return _catalogs(
+            cli_ready=False,
+            api_ready=False,
+            cli_models=[],
+            api_models=[],
+        )
+
+    class HealthyState:
+        async def health(self) -> bool:
+            return True
+
+    monkeypatch.setattr(server, "_catalogs", fake_catalogs)
+    monkeypatch.setattr(server, "STATE", HealthyState())
+    monkeypatch.setattr(server, "is_cloudrun_runtime", lambda: False)
+
+    response = await server.readyz(None)
+    payload = json.loads(response.body)
+
+    assert response.status_code == 503
+    assert payload["status"] == "not_ready"
+    assert payload["bootstrap"]["status"] == "BLOCKED"
+    assert payload["bootstrap"]["can_chat"] is False
+    assert payload["state"] == {"ready": True, "backend": "sqlite"}
+
+
+@pytest.mark.asyncio
+async def test_readyz_accepts_healthy_runtime_with_live_cli_credentials(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_catalogs(*, refresh: bool = False) -> dict:
+        return _catalogs(api_ready=False, api_models=[])
+
+    class HealthyState:
+        async def health(self) -> bool:
+            return True
+
+    monkeypatch.setattr(server, "_catalogs", fake_catalogs)
+    monkeypatch.setattr(server, "STATE", HealthyState())
+    monkeypatch.setattr(server, "is_cloudrun_runtime", lambda: False)
+
+    response = await server.readyz(None)
+    payload = json.loads(response.body)
+
+    assert response.status_code == 200
+    assert payload["status"] == "ready"
+    assert payload["bootstrap"]["status"] == "OK"
+    assert payload["bootstrap"]["can_chat"] is True
+    assert payload["state"] == {"ready": True, "backend": "sqlite"}
+
+
+@pytest.mark.asyncio
 async def test_self_description_is_generated_from_live_boundary(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## What changed

Adds direct regression coverage for the public `/readyz` contract:

- a healthy first-run instance with no Grok credentials returns `503 not_ready` and `bootstrap.can_chat=false`;
- a healthy local instance with live CLI credentials returns `200 ready`.

## Why

The runtime already behaves correctly, including in a clean no-credential container, but the route itself was not directly tested. These tests prevent a future change from making process health look like inference readiness.

## Impact

Test-only. No runtime, deployment, authentication, or healthcheck behavior changes.

## Validation

- `uv run --frozen pytest -q` — 384 passed
- `uv run --frozen ruff check .` — clean
- clean no-credential image smoke: `/healthz` 200; `/readyz` 503

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only additions with no runtime, auth, or healthcheck logic changes.
> 
> **Overview**
> Adds **direct regression tests** for the public `/readyz` endpoint so process health is not confused with inference readiness.
> 
> When the app state is healthy but **no Grok credentials** are available (CLI and API catalogs not ready), `/readyz` must return **503** with `not_ready`, `bootstrap.status` **BLOCKED**, and `can_chat` **false**, while still reporting healthy SQLite state.
> 
> When the runtime is healthy with **live CLI credentials** (API plane not required), `/readyz` must return **200** with `ready`, bootstrap **OK**, and `can_chat` **true**.
> 
> **Test-only** — no changes to the `readyz` handler or deployment behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 227e0d2133c748292ca95c0de416fdcfedebc811. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->