### PR TITLE
Serialize half-open circuit-breaker probes

### DIFF
--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -17,6 +17,7 @@ import time
 import uuid
 from collections.abc import Awaitable, Callable, Iterator, Sequence
 from contextvars import ContextVar
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
 from urllib.parse import urlsplit
@@ -456,37 +457,125 @@ def _breaker_key(plane: str, model: str | None) -> str:
     return f"{plane}:{credential}:{model or 'default'}"
 
 
-def _breaker_before_call(plane: str, model: str | None) -> None:
+@dataclass(frozen=True, slots=True)
+class _BreakerAdmission:
+    key: str
+    plane: str
+    generation: int
+    probe: bool
+
+
+def _breaker_state(key: str) -> dict[str, Any]:
+    state = _CIRCUIT_BREAKERS.setdefault(
+        key,
+        {
+            "failures": 0,
+            "trips": 0,
+            "open_until": 0.0,
+            "half_open": False,
+            "generation": 0,
+        },
+    )
+    state.setdefault("generation", 0)
+    return state
+
+
+def _breaker_before_call(plane: str, model: str | None) -> _BreakerAdmission:
+    """Atomically admit a closed call or claim the single half-open probe."""
     key = _breaker_key(plane, model)
-    state = _CIRCUIT_BREAKERS.get(key)
-    if not state:
-        return
+    state = _breaker_state(key)
+    if bool(state.get("half_open")):
+        raise RuntimeError("circuit breaker open")
     open_until = float(state.get("open_until") or 0.0)
     if open_until > time.monotonic():
         raise RuntimeError("circuit breaker open")
+    generation = int(state.get("generation") or 0)
     if open_until:
-        state["open_until"] = 0.0
         state["half_open"] = True
+        return _BreakerAdmission(key, plane, generation, True)
+    return _BreakerAdmission(key, plane, generation, False)
 
 
-def _breaker_success(plane: str, model: str | None) -> None:
-    state = _CIRCUIT_BREAKERS.setdefault(
-        _breaker_key(plane, model),
-        {"failures": 0, "trips": 0, "open_until": 0.0, "half_open": False},
+def _breaker_abandon_delay_seconds(plane: str) -> float:
+    """Fence replacement probes through the longest configured provider deadline."""
+    provider_deadline = (
+        max(float(xai_api.API_TIMEOUT_SECONDS), float(xai_api.MEDIA_TIMEOUT_SECONDS))
+        if plane == "api"
+        else float(BUILD_TIMEOUT_SECONDS)
     )
-    state.update({"failures": 0, "open_until": 0.0, "half_open": False})
+    return max(float(BREAKER_COOLDOWN_SECONDS), provider_deadline)
 
 
-def _breaker_failure(plane: str, model: str | None) -> None:
-    state = _CIRCUIT_BREAKERS.setdefault(
-        _breaker_key(plane, model),
-        {"failures": 0, "trips": 0, "open_until": 0.0, "half_open": False},
+def _breaker_abandon_probe(admission: _BreakerAdmission) -> None:
+    """Fence a cancelled probe without treating cancellation as provider failure."""
+    if not admission.probe:
+        return
+    state = _CIRCUIT_BREAKERS.get(admission.key)
+    if (
+        state is None
+        or int(state.get("generation") or 0) != admission.generation
+        or not bool(state.get("half_open"))
+    ):
+        return
+    state["half_open"] = False
+    state["open_until"] = time.monotonic() + _breaker_abandon_delay_seconds(
+        admission.plane
     )
+    state["generation"] = admission.generation + 1
+
+
+def _breaker_success(admission: _BreakerAdmission) -> None:
+    state = _CIRCUIT_BREAKERS.get(admission.key)
+    if (
+        state is None
+        or int(state.get("generation") or 0) != admission.generation
+    ):
+        return
+    open_until = float(state.get("open_until") or 0.0)
+    half_open = bool(state.get("half_open"))
+    if admission.probe:
+        if not half_open or not open_until:
+            return
+        state.update(
+            {
+                "failures": 0,
+                "open_until": 0.0,
+                "half_open": False,
+                "generation": admission.generation + 1,
+            }
+        )
+        return
+    if half_open or open_until:
+        return
+    state["failures"] = 0
+
+
+def _breaker_failure(admission: _BreakerAdmission) -> None:
+    state = _CIRCUIT_BREAKERS.get(admission.key)
+    if (
+        state is None
+        or int(state.get("generation") or 0) != admission.generation
+    ):
+        return
+    open_until = float(state.get("open_until") or 0.0)
+    half_open = bool(state.get("half_open"))
+    if admission.probe:
+        if not half_open or not open_until:
+            return
+        state["failures"] = int(state.get("failures") or 0) + 1
+        state["trips"] = int(state.get("trips") or 0) + 1
+        state["open_until"] = time.monotonic() + BREAKER_COOLDOWN_SECONDS
+        state["half_open"] = False
+        state["generation"] = admission.generation + 1
+        return
+    if half_open or open_until:
+        return
     state["failures"] = int(state.get("failures") or 0) + 1
     if state["failures"] >= BREAKER_FAILURE_THRESHOLD:
         state["trips"] = int(state.get("trips") or 0) + 1
         state["open_until"] = time.monotonic() + BREAKER_COOLDOWN_SECONDS
         state["half_open"] = False
+        state["generation"] = admission.generation + 1
 
 
 def _breaker_snapshot() -> dict[str, Any]:
@@ -500,12 +589,13 @@ def _breaker_snapshot() -> dict[str, Any]:
         if plane == "api" and credential != api_credential:
             continue
         public_key = f"{plane}:{model}"
+        open_until = float(state.get("open_until") or 0.0)
         snapshot[public_key] = {
             "failures": int(state.get("failures") or 0),
             "trips": int(state.get("trips") or 0),
-            "open": float(state.get("open_until") or 0.0) > now,
+            "open": bool(open_until),
             "retry_after_seconds": max(
-                0, round(float(state.get("open_until") or 0.0) - now)
+                0, round(open_until - now)
             ),
             "half_open": bool(state.get("half_open")),
         }
@@ -520,13 +610,16 @@ async def _guarded_provider_call(
     """Run one provider operation through the shared circuit breaker."""
     if plane == "api":
         await enforce_caller_budget(STATE)
-    _breaker_before_call(plane, model)
+    admission = _breaker_before_call(plane, model)
     try:
         result = await operation()
-    except Exception:
-        _breaker_failure(plane, model)
+    except asyncio.CancelledError:
+        _breaker_abandon_probe(admission)
         raise
-    _breaker_success(plane, model)
+    except Exception:
+        _breaker_failure(admission)
+        raise
+    _breaker_success(admission)
     return result
 
 BUILD_AGENT_SYSTEM_PROMPT = (
@@ -2670,7 +2763,11 @@ async def _run_unified(
 
     async def _call(target: Literal["cli", "api"], call_prompt: str) -> dict[str, Any]:
         target_model = model or _lead_model(catalogs, target)
-        _breaker_before_call(target, target_model)
+        if target == "api":
+            _require_metered_api_enabled()
+            await enforce_caller_budget(STATE)
+        admission = _breaker_before_call(target, target_model)
+        capability_unavailable = False
         try:
             if target == "cli":
                 build_prompt = call_prompt
@@ -2692,15 +2789,10 @@ async def _run_unified(
                 )
                 if not result.get("model"):
                     result["model"] = target_model
-                if str(result.get("text") or "").strip().startswith(
+                capability_unavailable = str(result.get("text") or "").strip().startswith(
                     CAPABILITY_UNAVAILABLE_PREFIX
-                ):
-                    raise RuntimeError(
-                        "Grok Build reported a required capability unavailable"
-                    )
+                )
             else:
-                _require_metered_api_enabled()
-                await enforce_caller_budget(STATE)
                 # The API plane only accepts low/medium/high. Clamp the wider CLI
                 # ladder (none/minimal/xhigh/max) to the nearest API level so
                 # cross-plane recovery stays seamless instead of erroring.
@@ -2724,10 +2816,15 @@ async def _run_unified(
                     max_turns=max_turns if agentic else None,
                     max_tokens=max_output_tokens,
                 )
-        except Exception:
-            _breaker_failure(target, target_model)
+        except asyncio.CancelledError:
+            _breaker_abandon_probe(admission)
             raise
-        _breaker_success(target, target_model)
+        except Exception:
+            _breaker_failure(admission)
+            raise
+        _breaker_success(admission)
+        if capability_unavailable:
+            raise RuntimeError("Grok Build reported a required capability unavailable")
         return result
 
     async def _call_with_recovery(target: Literal["cli", "api"]) -> dict[str, Any]:

--- a/tests/test_public_boundary.py
+++ b/tests/test_public_boundary.py
@@ -514,9 +514,12 @@ async def test_all_tools_available_does_not_bypass_authenticated_cli(
 
 
 @pytest.mark.asyncio
-async def test_cli_unavailable_capability_gets_one_bounded_api_recovery(
+async def test_cli_unavailable_capability_recovers_without_tripping_breaker(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    breakers: dict[str, dict] = {}
+    build_calls = 0
+
     async def fake_resolve(
         requested: str, model: str | None, *, requires_api: bool
     ) -> tuple[str, dict]:
@@ -528,6 +531,8 @@ async def test_cli_unavailable_capability_gets_one_bounded_api_recovery(
         return "safe"
 
     async def fake_build(prompt: str, **kwargs: object) -> dict:
+        nonlocal build_calls
+        build_calls += 1
         return {"text": server.CAPABILITY_UNAVAILABLE_PREFIX + "remote sandbox"}
 
     async def fake_alternate(current: str, model: str | None, *, requires_api: bool) -> str:
@@ -543,23 +548,34 @@ async def test_cli_unavailable_capability_gets_one_bounded_api_recovery(
     monkeypatch.setattr(server.BUILD_ACP, "run", fake_build)
     monkeypatch.setattr(server, "_alternate_plane", fake_alternate)
     monkeypatch.setattr(server.xai_api, "chat", fake_api_chat)
-    result = await server._run_unified(
-        "Use a remote sandbox",
-        model=None,
-        effort=None,
-        plane="auto",
-        fallback_policy="cross_plane",
-        agentic=True,
-        max_turns=6,
-        allow_web=True,
-        allow_x_search=True,
-        allow_code=True,
-    )
+    monkeypatch.setattr(server, "_CIRCUIT_BREAKERS", breakers)
+    monkeypatch.setattr(server, "BREAKER_FAILURE_THRESHOLD", 2)
+    results = [
+        await server._run_unified(
+            "Use a remote sandbox",
+            model=None,
+            effort=None,
+            plane="auto",
+            fallback_policy="cross_plane",
+            agentic=True,
+            max_turns=6,
+            allow_web=True,
+            allow_x_search=True,
+            allow_code=True,
+        )
+        for _ in range(3)
+    ]
+    result = results[-1]
     assert result["text"] == "API_RECOVERY_OK"
     assert result["resolved_plane"] == "api"
     assert result["fallback_occurred"] is True
     assert result["fallback_from"] == "cli"
     assert result["fallback_reason"] == "cli_capability_unavailable"
+    assert build_calls == 3
+    cli_key = server._breaker_key("cli", "grok-cli-live")
+    assert breakers[cli_key]["failures"] == 0
+    assert breakers[cli_key]["trips"] == 0
+    assert breakers[cli_key]["open_until"] == 0.0
 
 
 def test_metered_api_requires_only_owner_enablement(
@@ -598,18 +614,293 @@ def test_fallback_reason_is_precise_and_plane_specific(
 
 
 def test_circuit_breaker_opens_and_recovers(monkeypatch: pytest.MonkeyPatch) -> None:
-    server._CIRCUIT_BREAKERS.clear()
+    breakers: dict[str, dict] = {}
+    monkeypatch.setattr(server, "_CIRCUIT_BREAKERS", breakers)
     monkeypatch.setattr(server, "BREAKER_FAILURE_THRESHOLD", 2)
     monkeypatch.setattr(server, "BREAKER_COOLDOWN_SECONDS", 5)
-    server._breaker_failure("cli", "grok-live")
-    server._breaker_failure("cli", "grok-live")
+    server._breaker_failure(server._breaker_before_call("cli", "grok-live"))
+    server._breaker_failure(server._breaker_before_call("cli", "grok-live"))
+    key = server._breaker_key("cli", "grok-live")
     snapshot = server._breaker_snapshot()["cli:grok-live"]
     assert snapshot["open"] is True
     assert snapshot["trips"] == 1
     with pytest.raises(RuntimeError, match="circuit breaker open"):
         server._breaker_before_call("cli", "grok-live")
-    server._breaker_success("cli", "grok-live")
+
+    breakers[key]["open_until"] = server.time.monotonic() - 1
+    expired = server._breaker_snapshot()["cli:grok-live"]
+    assert expired["open"] is True
+    assert expired["retry_after_seconds"] == 0
+    probe = server._breaker_before_call("cli", "grok-live")
+    assert probe.probe is True
+    server._breaker_success(probe)
     assert server._breaker_snapshot()["cli:grok-live"]["open"] is False
+    assert breakers[key]["generation"] == 2
+
+
+def test_stale_breaker_completions_cannot_clear_newer_epoch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    breakers: dict[str, dict] = {}
+    monkeypatch.setattr(server, "_CIRCUIT_BREAKERS", breakers)
+    monkeypatch.setattr(server, "BREAKER_FAILURE_THRESHOLD", 2)
+    stale_success = server._breaker_before_call("cli", "grok-live")
+    stale_failure = server._breaker_before_call("cli", "grok-live")
+    server._breaker_failure(server._breaker_before_call("cli", "grok-live"))
+    server._breaker_failure(server._breaker_before_call("cli", "grok-live"))
+    key = server._breaker_key("cli", "grok-live")
+    opened_generation = breakers[key]["generation"]
+    opened_until = breakers[key]["open_until"]
+
+    server._breaker_success(stale_success)
+    assert breakers[key]["generation"] == opened_generation
+    assert breakers[key]["open_until"] == opened_until
+
+    breakers[key]["open_until"] = server.time.monotonic() - 1
+    probe = server._breaker_before_call("cli", "grok-live")
+    server._breaker_success(stale_success)
+    server._breaker_failure(stale_failure)
+    assert breakers[key]["half_open"] is True
+    assert breakers[key]["generation"] == opened_generation
+    with pytest.raises(RuntimeError, match="circuit breaker open"):
+        server._breaker_before_call("cli", "grok-live")
+
+    server._breaker_success(probe)
+    closed_generation = breakers[key]["generation"]
+    server._breaker_failure(stale_failure)
+    assert breakers[key]["generation"] == closed_generation
+    assert breakers[key]["open_until"] == 0.0
+    assert breakers[key]["failures"] == 0
+
+
+def test_stale_probe_token_cannot_release_replacement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    breakers: dict[str, dict] = {}
+    monkeypatch.setattr(server, "_CIRCUIT_BREAKERS", breakers)
+    monkeypatch.setattr(server, "BREAKER_FAILURE_THRESHOLD", 2)
+    monkeypatch.setattr(server, "BUILD_TIMEOUT_SECONDS", 20)
+    server._breaker_failure(server._breaker_before_call("cli", "grok-live"))
+    server._breaker_failure(server._breaker_before_call("cli", "grok-live"))
+    key = server._breaker_key("cli", "grok-live")
+    breakers[key]["open_until"] = server.time.monotonic() - 1
+    abandoned = server._breaker_before_call("cli", "grok-live")
+    server._breaker_abandon_probe(abandoned)
+    replacement_generation = breakers[key]["generation"]
+    breakers[key]["open_until"] = server.time.monotonic() - 1
+    replacement = server._breaker_before_call("cli", "grok-live")
+
+    server._breaker_abandon_probe(abandoned)
+    server._breaker_success(abandoned)
+    server._breaker_failure(abandoned)
+    assert breakers[key]["generation"] == replacement_generation
+    assert breakers[key]["half_open"] is True
+    with pytest.raises(RuntimeError, match="circuit breaker open"):
+        server._breaker_before_call("cli", "grok-live")
+
+    server._breaker_success(replacement)
+    assert breakers[key]["half_open"] is False
+    assert breakers[key]["open_until"] == 0.0
+
+
+def test_failed_half_open_probe_reopens_breaker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    breakers: dict[str, dict] = {}
+    monkeypatch.setattr(server, "_CIRCUIT_BREAKERS", breakers)
+    monkeypatch.setattr(server, "BREAKER_FAILURE_THRESHOLD", 2)
+    server._breaker_failure(server._breaker_before_call("cli", "grok-live"))
+    server._breaker_failure(server._breaker_before_call("cli", "grok-live"))
+    key = server._breaker_key("cli", "grok-live")
+    breakers[key]["open_until"] = server.time.monotonic() - 1
+    probe = server._breaker_before_call("cli", "grok-live")
+    server._breaker_failure(probe)
+
+    assert breakers[key]["half_open"] is False
+    assert breakers[key]["open_until"] > server.time.monotonic()
+    assert breakers[key]["generation"] == 2
+    assert breakers[key]["trips"] == 2
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_allows_only_one_half_open_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    breakers: dict[str, dict] = {}
+    monkeypatch.setattr(server, "_CIRCUIT_BREAKERS", breakers)
+    monkeypatch.setattr(server, "BREAKER_FAILURE_THRESHOLD", 2)
+    server._breaker_failure(server._breaker_before_call("api", "grok-live"))
+    server._breaker_failure(server._breaker_before_call("api", "grok-live"))
+    key = server._breaker_key("api", "grok-live")
+    breakers[key]["open_until"] = server.time.monotonic() - 1
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def allow_budget(state: object) -> None:
+        return None
+
+    async def operation() -> dict:
+        nonlocal calls
+        calls += 1
+        entered.set()
+        await release.wait()
+        return {"text": "probe ok"}
+
+    monkeypatch.setattr(server, "enforce_caller_budget", allow_budget)
+    winner = asyncio.create_task(
+        server._guarded_provider_call("api", "grok-live", operation)
+    )
+    await asyncio.wait_for(entered.wait(), timeout=1)
+
+    with pytest.raises(RuntimeError, match="circuit breaker open"):
+        await server._guarded_provider_call("api", "grok-live", operation)
+    assert calls == 1
+    assert breakers[key]["half_open"] is True
+
+    release.set()
+    assert await winner == {"text": "probe ok"}
+    assert breakers[key] == {
+        "failures": 0,
+        "trips": 1,
+        "open_until": 0.0,
+        "half_open": False,
+        "generation": 2,
+    }
+
+    assert await server._guarded_provider_call(
+        "api", "grok-live", operation
+    ) == {"text": "probe ok"}
+    assert calls == 2
+
+
+@pytest.mark.asyncio
+async def test_cancelled_guarded_half_open_probe_fences_safe_replacement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    breakers: dict[str, dict] = {}
+    monkeypatch.setattr(server, "_CIRCUIT_BREAKERS", breakers)
+    monkeypatch.setattr(server, "BREAKER_FAILURE_THRESHOLD", 2)
+    monkeypatch.setattr(server, "BREAKER_COOLDOWN_SECONDS", 5)
+    monkeypatch.setattr(server.xai_api, "API_TIMEOUT_SECONDS", 10)
+    monkeypatch.setattr(server.xai_api, "MEDIA_TIMEOUT_SECONDS", 20)
+    server._breaker_failure(server._breaker_before_call("api", "grok-live"))
+    server._breaker_failure(server._breaker_before_call("api", "grok-live"))
+    key = server._breaker_key("api", "grok-live")
+    breakers[key]["open_until"] = server.time.monotonic() - 1
+    entered = asyncio.Event()
+    replacement_calls = 0
+
+    async def allow_budget(state: object) -> None:
+        return None
+
+    async def blocked_operation() -> dict:
+        entered.set()
+        await asyncio.Event().wait()
+        return {"text": "unreachable"}
+
+    monkeypatch.setattr(server, "enforce_caller_budget", allow_budget)
+    probe = asyncio.create_task(
+        server._guarded_provider_call("api", "grok-live", blocked_operation)
+    )
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    probe.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await probe
+
+    assert breakers[key]["failures"] == 2
+    assert breakers[key]["trips"] == 1
+    assert breakers[key]["half_open"] is False
+    assert breakers[key]["generation"] == 2
+    assert breakers[key]["open_until"] >= server.time.monotonic() + 19
+
+    async def replacement() -> dict:
+        nonlocal replacement_calls
+        replacement_calls += 1
+        return {"text": "replacement ok"}
+
+    with pytest.raises(RuntimeError, match="circuit breaker open"):
+        await server._guarded_provider_call("api", "grok-live", replacement)
+    assert replacement_calls == 0
+
+    breakers[key]["open_until"] = server.time.monotonic() - 1
+    assert await server._guarded_provider_call(
+        "api", "grok-live", replacement
+    ) == {"text": "replacement ok"}
+    assert breakers[key]["half_open"] is False
+    assert breakers[key]["open_until"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_cancelled_unified_half_open_probe_fences_safe_replacement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    breakers: dict[str, dict] = {}
+    monkeypatch.setattr(server, "_CIRCUIT_BREAKERS", breakers)
+    monkeypatch.setattr(server, "BREAKER_FAILURE_THRESHOLD", 2)
+    monkeypatch.setattr(server, "BREAKER_COOLDOWN_SECONDS", 5)
+    monkeypatch.setattr(server, "BUILD_TIMEOUT_SECONDS", 20)
+    key = server._breaker_key("cli", "grok-cli-live")
+    server._breaker_failure(server._breaker_before_call("cli", "grok-cli-live"))
+    server._breaker_failure(server._breaker_before_call("cli", "grok-cli-live"))
+    breakers[key]["open_until"] = server.time.monotonic() - 1
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def fake_resolve(
+        requested: str, model: str | None, *, requires_api: bool
+    ) -> tuple[str, dict]:
+        return "cli", _catalogs(api_ready=False, api_models=[])
+
+    async def fake_system_prompt(kind: str, extra_context: str | None = None) -> str:
+        return "safe"
+
+    async def fake_build(prompt: str, **kwargs: object) -> dict:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            entered.set()
+            await release.wait()
+        return {"text": "CLI_OK", "plane": "cli", "cost_usd": 0.0}
+
+    monkeypatch.setattr(server, "_resolve_plane", fake_resolve)
+    monkeypatch.setattr(server, "_system_prompt", fake_system_prompt)
+    monkeypatch.setattr(server.BUILD_ACP, "run", fake_build)
+    arguments = {
+        "model": None,
+        "effort": None,
+        "plane": "auto",
+        "fallback_policy": "same_plane",
+        "agentic": False,
+        "max_turns": 1,
+        "allow_web": False,
+        "allow_x_search": False,
+        "allow_code": False,
+        "nonanswer_recovery": False,
+    }
+
+    probe = asyncio.create_task(server._run_unified("probe", **arguments))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    probe.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await probe
+
+    assert breakers[key]["failures"] == 2
+    assert breakers[key]["trips"] == 1
+    assert breakers[key]["half_open"] is False
+    assert breakers[key]["generation"] == 2
+    assert breakers[key]["open_until"] >= server.time.monotonic() + 19
+
+    with pytest.raises(RuntimeError, match="circuit breaker open"):
+        await server._run_unified("too soon", **arguments)
+    assert calls == 1
+
+    breakers[key]["open_until"] = server.time.monotonic() - 1
+    assert (await server._run_unified("replacement", **arguments))["text"] == "CLI_OK"
+    assert calls == 2
+    assert breakers[key]["half_open"] is False
+    assert breakers[key]["open_until"] == 0.0
 
 
 @pytest.mark.asyncio
@@ -787,6 +1078,7 @@ async def test_unified_api_call_obeys_owner_policy_before_provider(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls = 0
+    breakers: dict[str, dict] = {}
 
     async def fake_resolve(*args, **kwargs):
         return "api", _catalogs()
@@ -802,6 +1094,7 @@ async def test_unified_api_call_obeys_owner_policy_before_provider(
     monkeypatch.setattr(server, "_resolve_plane", fake_resolve)
     monkeypatch.setattr(server, "_system_prompt", fake_system)
     monkeypatch.setattr(xai_api, "chat", fake_api_chat)
+    monkeypatch.setattr(server, "_CIRCUIT_BREAKERS", breakers)
     arguments = {
         "model": None,
         "effort": None,
@@ -817,11 +1110,53 @@ async def test_unified_api_call_obeys_owner_policy_before_provider(
     with pytest.raises(RuntimeError, match="disabled by server policy"):
         await server._run_unified("test", **arguments)
     assert calls == 0
+    assert breakers == {}
 
     monkeypatch.setattr(server, "METERED_API_ENABLED", True)
     result = await server._run_unified("test", **arguments)
     assert result["text"] == "API_OK"
     assert calls == 1
+
+
+@pytest.mark.asyncio
+async def test_unified_api_budget_denial_precedes_provider_breaker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    breakers: dict[str, dict] = {}
+
+    async def fake_resolve(*args: object, **kwargs: object) -> tuple[str, dict]:
+        return "api", _catalogs()
+
+    async def fake_system(*args: object, **kwargs: object) -> str:
+        return "system"
+
+    async def deny_budget(state: object) -> None:
+        raise RuntimeError("caller budget exhausted")
+
+    async def forbidden_provider(*args: object, **kwargs: object) -> dict:
+        raise AssertionError("provider must not run after a caller-budget denial")
+
+    monkeypatch.setattr(server, "_resolve_plane", fake_resolve)
+    monkeypatch.setattr(server, "_system_prompt", fake_system)
+    monkeypatch.setattr(server, "enforce_caller_budget", deny_budget)
+    monkeypatch.setattr(server.xai_api, "chat", forbidden_provider)
+    monkeypatch.setattr(server, "METERED_API_ENABLED", True)
+    monkeypatch.setattr(server, "_CIRCUIT_BREAKERS", breakers)
+
+    with pytest.raises(RuntimeError, match="caller budget exhausted"):
+        await server._run_unified(
+            "test",
+            model=None,
+            effort=None,
+            plane="api",
+            fallback_policy="same_plane",
+            agentic=False,
+            max_turns=1,
+            allow_web=False,
+            allow_x_search=False,
+            allow_code=False,
+        )
+    assert breakers == {}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- admits exactly one half-open provider probe per existing plane/credential/model breaker key;
- gives every admitted call a generation-scoped token so stale successes, failures, and cancellations cannot mutate a newer breaker epoch;
- fences replacement probes after cancellation through the longest relevant provider deadline, preventing overlap with work that may continue behind `asyncio.to_thread`;
- evaluates metered API policy and caller budget before breaker admission;
- treats a valid `UNIGROK_CAPABILITY_UNAVAILABLE:` response as provider success before bounded cross-plane fallback;
- reports an expired breaker as open until its owning recovery probe succeeds.

## Root cause

The original cooldown path set `half_open=true` but did not reject later callers, allowing a recovery stampede. A boolean-only fix was still unsafe: stale in-flight completions could clear a newer open state, and cancellation could release a probe while its underlying blocking provider call continued.

## Impact

Recovery is single-flight and epoch-safe without changing breaker keys, thresholds, cooldown configuration, fallback policy, or caller-budget contracts. Healthy capability negotiation no longer poisons provider health.

## Validation

- `uv run --frozen pytest -q` — 391 passed
- `uv run --frozen ruff check .` — clean
- targeted breaker, policy, budget, stale-completion, cancellation, and capability-fallback tests — 10 passed
- two independent adversarial reviews — clean
