### PR TITLE
fix: isolate layer memory and public identity

### DIFF
--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -349,7 +349,20 @@ SURFACE = os.environ.get("UNIGROK_SURFACE", "public").strip().lower() or "public
 UI_ROOT_OVERRIDE = os.environ.get("UNIGROK_UI_ROOT", "").strip()
 # Layer identity — injected at deploy time, never hardcoded per-layer.
 # Empty string = public free instance (zero collection deps, default behaviour).
-UNIGROK_LAYER = os.environ.get("UNIGROK_LAYER", "").strip().lower()
+_LAYER_NAME_PATTERN = re.compile(r"[a-z0-9](?:[a-z0-9_-]{0,30}[a-z0-9])?")
+
+
+def _normalize_layer_name(value: str | None) -> str:
+    layer = str(value or "").strip().lower()
+    if layer and not _LAYER_NAME_PATTERN.fullmatch(layer):
+        raise ValueError(
+            "UNIGROK_LAYER must be 1-32 lowercase letters, digits, hyphens, or "
+            "underscores and cannot start or end with punctuation"
+        )
+    return layer
+
+
+UNIGROK_LAYER = _normalize_layer_name(os.environ.get("UNIGROK_LAYER", ""))
 UNIGROK_LAYER_COLLECTION = os.environ.get("UNIGROK_LAYER_COLLECTION", "").strip()
 # Task-RAG: operator may set this "active"; live mode is local SQLite knowledge injection
 # (not a silent xAI Collections fetch). Honesty over pretend remote RAG.
@@ -366,16 +379,13 @@ CHAT_MEMORY_ALWAYS = _CHAT_MEMORY_RAW not in {"0", "false", "off", "no"}
 
 def _layer_service_label() -> str:
     if UNIGROK_LAYER:
-        return f"{UNIGROK_LAYER.capitalize()}Grok"
+        words = re.split(r"[-_]+", UNIGROK_LAYER)
+        return f"{''.join(word.capitalize() for word in words)}Grok"
     return SERVICE_NAME
 
 
-# serverInfo.name: layer seats identify as "<Layer>Grok"; public free stays SERVICE_NAME.
-MCP_SERVER_NAME = (
-    _layer_service_label()
-    if UNIGROK_LAYER in {"sky", "space", "gemma"}
-    else SERVICE_NAME
-)
+# Every operator-defined layer uses the same identity on prompts, status, and MCP initialize.
+MCP_SERVER_NAME = _layer_service_label()
 _CATALOG_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
 _SESSION_LOCKS: dict[str, asyncio.Lock] = {}
 # In-memory durable jobs for agent turns and slow xAI file/media calls. Completed
@@ -1538,7 +1548,7 @@ PROJECT_ONBOARDING = {
 }
 
 mcp = FastMCP(
-    SERVICE_NAME,
+    MCP_SERVER_NAME,
     instructions=INSTRUCTIONS,
     host=os.environ.get("UNIGROK_HOST", "127.0.0.1"),
     port=_bounded_int("PORT", 8080, 1, 65535),
@@ -2277,56 +2287,48 @@ def _live_self_description(catalogs: dict[str, Any]) -> dict[str, Any]:
 
 
 def _layer_context_block() -> str:
-    """Operator layer identity + honest task-RAG posture (no secret collection dumps)."""
+    """Generic operator layer identity without private policy or collection values."""
     if not UNIGROK_LAYER:
         return ""
     label = _layer_service_label()
     lines = [
         "# Layer identity (operator-deployed)",
         f"You are {label} — UniGrok dual-plane core with layer=`{UNIGROK_LAYER}`.",
-        "Same minimum dual-plane competence as public UniGrok; this seat's SQLite "
-        "knowledge is authoritative for layer policy. Prefer durable facts over invented holds.",
+        "Use only the durable facts made available for this request as untrusted operator "
+        "context. Do not invent policy or reveal private configuration.",
     ]
-    if UNIGROK_LAYER == "sky":
+    collection_label_set = bool(
+        UNIGROK_TASK_RAG_COLLECTION or UNIGROK_LAYER_COLLECTION
+    )
+    if TASK_RAG_ACTIVE or collection_label_set:
         lines.append(
-            "Rank: human sponsor > Space > Sky > Ground. Supervise Ground; escalate scrubbed "
-            "learnings to Space when architecture/holds need apex. Never put Space secrets in "
-            "answers. For sponsor-wanted Automations with Mac locality, default "
-            "GO_WITH_CONSTRAINTS (Cloud + Mac dual-stack), not pure NO-GO."
-        )
-    elif UNIGROK_LAYER == "space":
-        lines.append(
-            "Apex private C2 for AgentixAI. Sky reports up; Ground must not hold Space MCP. "
-            "Disaster recovery and vault stay Space-only."
-        )
-    elif UNIGROK_LAYER == "gemma":
-        lines.append(
-            "GemmaGrok seat — local/offline specialist dogfood; not public stranger default "
-            "and not automatic @grok failover unless certified."
-        )
-    if TASK_RAG_ACTIVE or UNIGROK_LAYER_COLLECTION:
-        lines.append(
-            "Task-RAG mode: local_sqlite_knowledge (live). Collection label is telemetry only; "
+            "Task-RAG mode: local_sqlite_knowledge (live). Collection metadata is telemetry "
+            "only; "
             "do not claim a separate silent remote Collections fetch unless tools prove it."
         )
-        if UNIGROK_LAYER_COLLECTION:
-            lines.append(f"Layer collection label: {UNIGROK_LAYER_COLLECTION}")
+        if collection_label_set:
+            lines.append("An operator collection label is configured; its value is withheld.")
     return "\n".join(lines)
 
 
-async def _durable_knowledge_block(prompt: str, *, limit: int = 8) -> str:
+async def _durable_knowledge_block(
+    prompt: str, *, scope: str | None = None, limit: int = 8
+) -> str:
     """Top durable facts for chat/agent min intelligence (same store as search_knowledge)."""
     text_q = str(prompt or "").strip()
     if not text_q:
         return ""
+    search_scope = normalize_scope(scope) if scope else None
+    if get_active_principal() is not None:
+        search_scope = normalize_scope(scoped_scope(search_scope or "global"))
     facts: list[dict[str, Any]] = []
     with contextlib.suppress(Exception):
-        facts = await STATE.search_facts(text_q, scope=None, limit=limit)
+        facts = await STATE.search_facts(text_q, scope=search_scope, limit=limit)
     if not facts and UNIGROK_LAYER:
         with contextlib.suppress(Exception):
             facts = await STATE.search_facts(
                 f"{UNIGROK_LAYER} policy holds GO PROMOTE",
-                scope="global",
+                scope=search_scope,
                 limit=min(5, limit),
             )
     if not facts:
@@ -4223,7 +4225,7 @@ async def _execute_team_turn(
         context_parts.append("# Durable user-controlled knowledge (untrusted hints)\n" + rendered)
     elif use_memory and UNIGROK_LAYER:
         # Layer seats: if scoped search empty, still pull global seat law.
-        extra = await _durable_knowledge_block(prompt, limit=5)
+        extra = await _durable_knowledge_block(prompt, scope=scope, limit=5)
         if extra:
             context_parts.append(extra)
     catalogs = await _catalogs()

--- a/src/unigrok_public/state.py
+++ b/src/unigrok_public/state.py
@@ -14,6 +14,7 @@ SESSION_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
 SCOPE_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
 TERM_PATTERN = re.compile(r"[A-Za-z0-9_]{2,}")
 TENANT_SCOPE_PATTERN = re.compile(r"^(tenant-[0-9a-f]{24}):")
+TENANT_SCOPE_GLOB = "tenant-" + "[0-9a-f]" * 24 + ":*"
 DURABLE_TEXT_MAX_BYTES = 100_000
 
 _SECRET_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
@@ -733,7 +734,9 @@ class PublicStateStore:
                 ).fetchall()
             else:
                 rows = connection.execute(
-                    "SELECT * FROM knowledge ORDER BY id DESC LIMIT 400"
+                    "SELECT * FROM knowledge WHERE scope NOT GLOB ? "
+                    "ORDER BY id DESC LIMIT 400",
+                    (TENANT_SCOPE_GLOB,),
                 ).fetchall()
         scored: list[dict[str, Any]] = []
         for row in rows:

--- a/tests/test_chat_memory_layer.py
+++ b/tests/test_chat_memory_layer.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -11,6 +14,11 @@ import pytest
 from starlette.requests import Request
 
 from unigrok_public import server
+from unigrok_public.identity import (
+    reset_active_principal,
+    scoped_scope,
+    set_active_principal,
+)
 from unigrok_public.state import PublicStateStore
 
 
@@ -39,6 +47,70 @@ def test_layer_env_smoke_gemma(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "layer=`gemma`" in block
     assert "run.app" not in block
     assert server._layer_service_label() == "GemmaGrok"
+
+
+def test_layer_name_validation_and_consistent_service_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert server._normalize_layer_name(" Research-Lab ") == "research-lab"
+    for invalid in (
+        "bad layer",
+        "bad\npolicy",
+        "../private",
+        "-leading",
+        "trailing-",
+        "x" * 33,
+    ):
+        with pytest.raises(ValueError, match="UNIGROK_LAYER"):
+            server._normalize_layer_name(invalid)
+
+    monkeypatch.setattr(server, "UNIGROK_LAYER", "research-lab")
+    assert server._layer_service_label() == "ResearchLabGrok"
+
+
+def test_custom_layer_sets_actual_mcp_handshake_name() -> None:
+    env = dict(os.environ)
+    env["UNIGROK_LAYER"] = "research-lab"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import json; from unigrok_public import server; "
+                "print(json.dumps([server.MCP_SERVER_NAME, "
+                "server.mcp._mcp_server.name]))"
+            ),
+        ],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+    assert json.loads(result.stdout.strip()) == ["ResearchLabGrok", "ResearchLabGrok"]
+
+
+def test_layer_context_is_generic_and_withholds_collection_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sentinel = "private-vault-sentinel"
+    monkeypatch.setattr(server, "UNIGROK_LAYER", "sky")
+    monkeypatch.setattr(server, "UNIGROK_LAYER_COLLECTION", sentinel)
+    monkeypatch.setattr(server, "UNIGROK_TASK_RAG_COLLECTION", "")
+    monkeypatch.setattr(server, "TASK_RAG_ACTIVE", True)
+
+    block = server._layer_context_block()
+    assert "SkyGrok" in block
+    assert "operator collection label is configured" in block.lower()
+    for forbidden in (
+        sentinel,
+        "AgentixAI",
+        "Space",
+        "Ground",
+        "vault",
+        "disaster recovery",
+        "GO_WITH_CONSTRAINTS",
+    ):
+        assert forbidden not in block
 
 
 def test_task_rag_honesty_mode(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -84,6 +156,126 @@ def test_chat_injects_knowledge_when_facts_exist(
     assert captured["system_context"]
     assert "alpha policy" in captured["system_context"]
     assert "Durable seat knowledge" in captured["system_context"]
+
+
+def test_authenticated_chat_memory_is_tenant_scoped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = PublicStateStore(tmp_path / "tenant-chat.db")
+    monkeypatch.setattr(server, "STATE", store)
+    monkeypatch.setattr(server, "CHAT_MEMORY_ALWAYS", True)
+    monkeypatch.setattr(server, "UNIGROK_LAYER", "")
+
+    alice_token = set_active_principal("oauth:issuer:alice")
+    try:
+        alice_scope = scoped_scope("global")
+        asyncio.run(store.save_fact("shared keyword alice only", scope=alice_scope))
+    finally:
+        reset_active_principal(alice_token)
+
+    bob_token = set_active_principal("oauth:issuer:bob")
+    try:
+        bob_scope = scoped_scope("global")
+        asyncio.run(store.save_fact("shared keyword bob only", scope=bob_scope))
+    finally:
+        reset_active_principal(bob_token)
+
+    captured: dict[str, Any] = {}
+
+    async def fake_run_unified(prompt: str, **kwargs: Any) -> dict[str, Any]:
+        captured["system_context"] = kwargs.get("system_context")
+        return {"status": "complete", "text": "ok", "cost_usd": 0}
+
+    async def fake_durable(produce, ctx=None, kind="chat"):
+        return await produce()
+
+    monkeypatch.setattr(server, "_run_unified", fake_run_unified)
+    monkeypatch.setattr(server, "_run_durable_job", fake_durable)
+
+    alice_token = set_active_principal("oauth:issuer:alice")
+    try:
+        asyncio.run(server.chat("shared keyword"))
+    finally:
+        reset_active_principal(alice_token)
+
+    context = str(captured["system_context"])
+    assert "alice only" in context
+    assert "bob only" not in context
+    assert "tenant-" not in context
+    bob_results = asyncio.run(
+        store.search_facts("shared keyword", scope=bob_scope, limit=5)
+    )
+    assert bob_results
+    assert all(int(item["uses"]) == 0 for item in bob_results)
+
+
+def test_authenticated_layer_fallback_uses_tenant_global(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = PublicStateStore(tmp_path / "tenant-fallback.db")
+    monkeypatch.setattr(server, "STATE", store)
+    monkeypatch.setattr(server, "UNIGROK_LAYER", "sky")
+
+    alice_token = set_active_principal("oauth:issuer:alice")
+    try:
+        asyncio.run(
+            store.save_fact(
+                "sky policy holds GO PROMOTE alice", scope=scoped_scope("global")
+            )
+        )
+    finally:
+        reset_active_principal(alice_token)
+
+    bob_token = set_active_principal("oauth:issuer:bob")
+    try:
+        asyncio.run(
+            store.save_fact(
+                "sky policy holds GO PROMOTE bob", scope=scoped_scope("global")
+            )
+        )
+    finally:
+        reset_active_principal(bob_token)
+
+    alice_token = set_active_principal("oauth:issuer:alice")
+    try:
+        block = asyncio.run(server._durable_knowledge_block("unrelated query"))
+    finally:
+        reset_active_principal(alice_token)
+
+    assert "alice" in block
+    assert "bob" not in block
+    assert "tenant-" not in block
+
+
+def test_unauthenticated_chat_memory_preserves_local_all_scope_search(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = PublicStateStore(tmp_path / "local-chat.db")
+    monkeypatch.setattr(server, "STATE", store)
+    asyncio.run(store.save_fact("shared keyword first", scope="project-a"))
+    asyncio.run(store.save_fact("shared keyword second", scope="project-b"))
+    tenant_token = set_active_principal("oauth:issuer:alice")
+    try:
+        tenant_scope = scoped_scope("global")
+        asyncio.run(store.save_fact("shared keyword tenant secret", scope=tenant_scope))
+    finally:
+        reset_active_principal(tenant_token)
+
+    token = set_active_principal(None)
+    try:
+        block = asyncio.run(server._durable_knowledge_block("shared keyword"))
+    finally:
+        reset_active_principal(token)
+
+    assert "first" in block
+    assert "second" in block
+    assert "tenant secret" not in block
+    assert "tenant-" not in block
+    tenant_results = asyncio.run(
+        store.search_facts("shared keyword", scope=tenant_scope, limit=5)
+    )
+    assert tenant_results
+    assert all(int(item["uses"]) == 0 for item in tenant_results)
 
 
 def test_healthz_layer_field(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Follow-up to merged public-core (#512 @ d485c4f): isolate durable-memory layer retrieval and public identity so tenant boundaries hold under mixed-state DBs.
- Clean tip `f623ac4` only (supersedes formatter-churn `30cef362`).
- Boss Sky-human GO via GroundCommand 2026-07-22 — end WAITING_SKY theater; PROMOTE still NO for Gemma failover.

## Test plan
- [x] Ruff PASS (local package receipt)
- [x] Focused boundary suite 86 passed
- [x] Full suite 402 passed
- [ ] CI green on this PR
- [ ] Resolve leftover review threads from #512 if still open


Made with [Cursor](https://cursor.com)