### PR TITLE
feat: stage explicit local GemmaGrok helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the public UniGrok gateway.
 
 ## [Unreleased]
 
+### Added
+- Experimental `gemmagrok-local` Compose profile and standalone MCP helper for an
+  explicitly selected, operator-owned local model runtime. The helper is loopback-only,
+  exposes `chat`/`status`, receives no Grok credentials, and is not part of automatic
+  `@grok` recovery.
+
 ### Changed
 - Runtime limits that formerly behaved as fixed constants are now clamped environment
   controls and are reported by discovery/runtime receipts: agent sync window and turn

--- a/README.md
+++ b/README.md
@@ -194,6 +194,11 @@ and a bounded diff. Six functions shipped this way (up to +52.8% measured). Sub-
 This routing section describes local Compose. The authenticated hosted pilot disables
 the CLI plane and uses the metered API only.
 
+Need an explicitly selected helper when the network is unavailable? The
+[optional local-model helper](docs/offline-local-helper.md) runs as a separate,
+default-off MCP server. It is not a third `@grok` plane and never activates on an
+authentication or provider failure.
+
 ```mermaid
 flowchart TD
     T["{ task: Your request }"] --> L["Live-discovered Grok lead"]
@@ -275,6 +280,7 @@ See [SECURITY.md](SECURITY.md) for the complete public runtime boundary.
 |---|---|
 | See every tool and routing rule | [Technical reference](docs/reference.md) |
 | Understand or operate the authenticated hosted service | [Remote deployment](docs/remote-mcp-deployment.md) |
+| Run the explicit no-internet local helper | [Optional local-model helper](docs/offline-local-helper.md) |
 | Drive `agent` from an IDE agent | [Technical reference](docs/reference.md#how-an-ide-agent-should-drive-agent) |
 | Develop or acceptance-test UniGrok | [Development guide](docs/development.md) |
 | See what has limited soak and how to report a miss | [Known limits](docs/known-limits.md) |

--- a/compose.yaml
+++ b/compose.yaml
@@ -81,6 +81,42 @@ services:
     security_opt:
       - no-new-privileges:true
 
+  # Explicit, default-off local-model helper. This is a separate MCP server and
+  # is never selected by the public @grok routing or credential recovery path.
+  gemmagrok-local:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: unigrok:1.1.0
+    profiles: ["offline"]
+    command: ["/app/.venv/bin/python", "-m", "unigrok_public.gemmagrok_peer"]
+    ports:
+      - "127.0.0.1:${GEMMAGROK_PORT:-4777}:8080"
+    environment:
+      GEMMAGROK_HOST: 0.0.0.0
+      GEMMAGROK_TRANSPORT: streamable-http
+      PORT: 8080
+      GEMMAGROK_RUNTIME_URL: http://host.docker.internal:${GEMMAGROK_RUNTIME_PORT:-8081}
+      GEMMAGROK_MODEL_ID: ${GEMMAGROK_MODEL_ID:-}
+      GEMMAGROK_TIMEOUT_SECONDS: ${GEMMAGROK_TIMEOUT_SECONDS:-120}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    tmpfs:
+      - /tmp:rw,noexec,nosuid,nodev,size=64m,uid=1000,gid=1000,mode=0700
+    read_only: true
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    init: true
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/healthz', timeout=5)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    restart: unless-stopped
+
 volumes:
   grok-cli-auth:
     name: unigrok-cli-auth

--- a/docs/offline-local-helper.md
+++ b/docs/offline-local-helper.md
@@ -1,0 +1,89 @@
+# Optional local-model helper
+
+UniGrok includes an experimental, default-off MCP helper for an operator-owned
+local model runtime. It is useful when a model and all of its runtime assets are
+already present on the machine and remote Grok planes are unavailable.
+
+This first stage is deliberately narrow:
+
+- it is a separate MCP server named `gemmagrok-local`, normally on
+  `http://127.0.0.1:4777/mcp`;
+- it exposes only `chat` and `status`;
+- it accepts only a loopback or Docker-host runtime origin and disables proxy
+  inheritance and redirects;
+- it receives no Grok login, xAI API key, workspace, shell, file, or web access;
+- it never becomes an automatic fallback for the public `@grok` server.
+
+The main `grok-mcp` service still uses only its documented CLI and API planes.
+An authentication failure remains a denial; it does not route into this helper.
+
+## Prerequisite: a staged local runtime
+
+Start an OpenAI-compatible local runtime that serves both:
+
+```text
+GET  /v1/models
+POST /v1/chat/completions
+```
+
+The runtime must be reachable on the same machine. The helper rejects remote
+hosts, URL credentials, redirects, and runtime URLs with extra paths. If the
+runtime advertises more than one model, select one exact live-discovered id with
+`GEMMAGROK_MODEL_ID`; the helper does not contain a model allowlist or download a
+replacement.
+
+For a real no-internet run, pre-stage the image, Python dependencies, model,
+tokenizer, and any adapters before disconnecting. This helper does not itself
+certify or seal those external assets.
+
+## Start the default-off Compose profile
+
+Assuming the local runtime listens on host port `8081`:
+
+```bash
+export GEMMAGROK_MODEL_ID='<exact id from the local /v1/models response>'
+docker compose --profile offline up -d gemmagrok-local
+curl --fail --silent http://127.0.0.1:4777/readyz
+```
+
+The service is not started by a normal `docker compose up -d grok-mcp`. Change
+the helper port with `GEMMAGROK_PORT` and the host runtime port with
+`GEMMAGROK_RUNTIME_PORT`.
+
+You can also run it directly without Docker:
+
+```bash
+GEMMAGROK_RUNTIME_URL=http://127.0.0.1:8081 \
+GEMMAGROK_MODEL_ID='<exact local model id>' \
+uv run python -m unigrok_public.gemmagrok_peer
+```
+
+## Connect an IDE explicitly
+
+Add a second MCP entry without credentials. For example:
+
+```json
+{
+  "mcpServers": {
+    "gemmagrok-local": {
+      "url": "http://127.0.0.1:4777/mcp",
+      "headers": {
+        "X-Client-ID": "cursor-gemmagrok-local"
+      }
+    }
+  }
+}
+```
+
+Use this named helper only when you explicitly want a local answer. Keep the
+normal `grok` entry on port `4765`; the two identities and their readiness are
+independent.
+
+## Current promotion boundary
+
+This stage proves a useful local MCP surface, not production failover routing.
+Before any future automatic or `failover=local` path can ship, it still needs a
+separate shadow-mode change with outage classification, an authorization-deny
+test, sealed-asset verification, bounded request eligibility, and rollback
+receipts. Hosted Cloud Run does not gain a local model from enabling this
+Compose-only helper.

--- a/example.env
+++ b/example.env
@@ -64,3 +64,10 @@ UNIGROK_ENABLE_METERED_API=true
 
 # The Docker service creates a persistent OAuth volume and uses this in-container path.
 UNIGROK_AUTH_PATH=/home/appuser/.grok/auth.json
+
+# Optional, default-off local-model helper (`docker compose --profile offline ...`).
+# It is a separate MCP server and never an automatic fallback for @grok.
+# GEMMAGROK_PORT=4777
+# GEMMAGROK_RUNTIME_PORT=8081
+# GEMMAGROK_MODEL_ID=<exact id returned by the already-running local runtime>
+# GEMMAGROK_TIMEOUT_SECONDS=120

--- a/src/unigrok_public/gemmagrok_peer.py
+++ b/src/unigrok_public/gemmagrok_peer.py
@@ -1,0 +1,276 @@
+"""Optional loopback-only MCP helper for an operator-owned local model runtime.
+
+This server is intentionally separate from UniGrok's public ``@grok`` server.
+It never receives Grok credentials, never selects a remote provider, and is not
+registered as an automatic fallback. Operators start it explicitly after they
+have staged an OpenAI-compatible model runtime on the same machine.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+from typing import Any, Literal
+from urllib.parse import urlsplit
+
+import httpx
+from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
+from mcp.types import ToolAnnotations
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from . import __version__
+
+SERVICE_NAME = "GemmaGrok local helper"
+MAX_PROMPT_CHARS = 20_000
+MAX_SYSTEM_PROMPT_CHARS = 8_000
+MAX_TOKENS = 2_048
+_LOCAL_RUNTIME_HOSTS = {
+    "localhost",
+    "host.docker.internal",
+    "gateway.docker.internal",
+}
+_READ_ONLY = ToolAnnotations(
+    readOnlyHint=True,
+    destructiveHint=False,
+    idempotentHint=True,
+)
+_TRANSPORT_SECURITY = TransportSecuritySettings(
+    enable_dns_rebinding_protection=True,
+    allowed_hosts=[
+        "127.0.0.1",
+        "127.0.0.1:*",
+        "localhost",
+        "localhost:*",
+        "[::1]",
+        "[::1]:*",
+        "gemmagrok-local:*",
+    ],
+    allowed_origins=[
+        "http://127.0.0.1:*",
+        "http://localhost:*",
+        "http://[::1]:*",
+        "http://gemmagrok-local:*",
+    ],
+)
+
+
+def _bounded_int(name: str, default: int, minimum: int, maximum: int) -> int:
+    try:
+        value = int(os.environ.get(name, str(default)))
+    except ValueError:
+        return default
+    return max(minimum, min(value, maximum))
+
+
+def _runtime_url(value: str | None = None) -> str:
+    raw = value if value is not None else os.environ.get("GEMMAGROK_RUNTIME_URL", "")
+    raw = raw.strip().rstrip("/")
+    if not raw:
+        raise RuntimeError("GemmaGrok local runtime URL is not configured")
+
+    parsed = urlsplit(raw)
+    if parsed.scheme != "http":
+        raise RuntimeError("GemmaGrok runtime must use local HTTP")
+    if parsed.username or parsed.password:
+        raise RuntimeError("GemmaGrok runtime URL must not contain credentials")
+    if parsed.path not in {"", "/"} or parsed.query or parsed.fragment:
+        raise RuntimeError("GemmaGrok runtime URL must contain only a local origin")
+    try:
+        port = parsed.port
+    except ValueError as exc:
+        raise RuntimeError("GemmaGrok runtime URL has an invalid port") from exc
+    if port is None:
+        raise RuntimeError("GemmaGrok runtime URL must include an explicit port")
+
+    host = (parsed.hostname or "").lower()
+    local = host in _LOCAL_RUNTIME_HOSTS
+    if not local:
+        try:
+            local = ipaddress.ip_address(host).is_loopback
+        except ValueError:
+            local = False
+    if not local:
+        raise RuntimeError("GemmaGrok runtime must resolve through an explicit local host")
+    return raw
+
+
+def _valid_text(value: str, field: str, limit: int) -> str:
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError(f"{field} must not be empty")
+    if len(text) > limit:
+        raise ValueError(f"{field} exceeds the {limit} character limit")
+    return text
+
+
+async def _runtime_request(
+    method: Literal["GET", "POST"],
+    path: str,
+    *,
+    payload: dict[str, Any] | None = None,
+) -> Any:
+    async with httpx.AsyncClient(
+        timeout=_bounded_int("GEMMAGROK_TIMEOUT_SECONDS", 120, 5, 600),
+        follow_redirects=False,
+        trust_env=False,
+    ) as client:
+        request_kwargs: dict[str, Any] = {"json": payload} if payload is not None else {}
+        response = await client.request(method, f"{_runtime_url()}{path}", **request_kwargs)
+        response.raise_for_status()
+    try:
+        return response.json()
+    except ValueError as exc:
+        raise RuntimeError("GemmaGrok local runtime returned invalid JSON") from exc
+
+
+async def _served_models() -> list[str]:
+    payload = await _runtime_request("GET", "/v1/models")
+    rows = payload.get("data") if isinstance(payload, dict) else None
+    if not isinstance(rows, list):
+        raise RuntimeError("GemmaGrok local runtime returned an invalid model catalog")
+    models = [
+        str(row.get("id") or "").strip()
+        for row in rows
+        if isinstance(row, dict) and str(row.get("id") or "").strip()
+    ]
+    return list(dict.fromkeys(models))
+
+
+async def _resolve_model() -> str:
+    models = await _served_models()
+    configured = os.environ.get("GEMMAGROK_MODEL_ID", "").strip()
+    if configured:
+        if configured not in models:
+            raise RuntimeError("configured GemmaGrok model is not served by the local runtime")
+        return configured
+    if len(models) == 1:
+        return models[0]
+    raise RuntimeError("GemmaGrok requires one served model or an explicit local model id")
+
+
+def _completion(payload: Any) -> tuple[str, str]:
+    choices = payload.get("choices") if isinstance(payload, dict) else None
+    if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+        raise RuntimeError("GemmaGrok local runtime returned an invalid completion")
+    choice = choices[0]
+    message = choice.get("message")
+    content = message.get("content") if isinstance(message, dict) else None
+    text = content.strip() if isinstance(content, str) else ""
+    if not text:
+        raise RuntimeError("GemmaGrok local runtime returned an empty final completion")
+    return text, str(choice.get("finish_reason") or "unknown")
+
+
+mcp = FastMCP(
+    SERVICE_NAME,
+    instructions=(
+        "Optional local GemmaGrok helper. Use chat for direct local-model answers. "
+        "This separate server has no web, shell, file, credential, or remote-provider access "
+        "and is never an automatic fallback for @grok."
+    ),
+    host=os.environ.get("GEMMAGROK_HOST", "127.0.0.1"),
+    port=_bounded_int("PORT", 4777, 1, 65535),
+    streamable_http_path="/mcp",
+    stateless_http=False,
+    json_response=False,
+    transport_security=_TRANSPORT_SECURITY,
+)
+mcp._mcp_server.version = __version__
+
+
+@mcp.tool(annotations=_READ_ONLY)
+async def chat(
+    prompt: str,
+    system_prompt: str | None = None,
+    max_tokens: int = 512,
+) -> dict[str, Any]:
+    """Ask the explicitly configured local model; remote fallback is impossible."""
+    user_prompt = _valid_text(prompt, "prompt", MAX_PROMPT_CHARS)
+    system = None
+    if system_prompt is not None and str(system_prompt).strip():
+        system = _valid_text(str(system_prompt), "system_prompt", MAX_SYSTEM_PROMPT_CHARS)
+    token_limit = max(1, min(int(max_tokens), MAX_TOKENS))
+    model = await _resolve_model()
+    messages: list[dict[str, str]] = []
+    if system:
+        messages.append({"role": "system", "content": system})
+    messages.append({"role": "user", "content": user_prompt})
+    payload = await _runtime_request(
+        "POST",
+        "/v1/chat/completions",
+        payload={
+            "model": model,
+            "messages": messages,
+            "max_tokens": token_limit,
+            "stream": False,
+        },
+    )
+    text, finish_reason = _completion(payload)
+    return {
+        "text": text,
+        "model": model,
+        "source": "gemmagrok",
+        "plane": "local",
+        "degraded": True,
+        "billing_class": "local_runtime",
+        "cost_usd": 0.0,
+        "finish_reason": finish_reason,
+        "remote_fallback": False,
+    }
+
+
+@mcp.tool(annotations=_READ_ONLY)
+async def status() -> dict[str, Any]:
+    """Return non-secret readiness for the optional local-only helper."""
+    try:
+        model = await _resolve_model()
+    except Exception:
+        return {
+            "service": SERVICE_NAME,
+            "runtime": "local",
+            "ready": False,
+            "model": None,
+            "remote_fallback": False,
+        }
+    return {
+        "service": SERVICE_NAME,
+        "runtime": "local",
+        "ready": True,
+        "model": model,
+        "remote_fallback": False,
+    }
+
+
+@mcp.custom_route("/healthz", methods=["GET"], include_in_schema=False)
+async def healthz(_: Request) -> JSONResponse:
+    return JSONResponse({"status": "healthy", "service": SERVICE_NAME})
+
+
+@mcp.custom_route("/readyz", methods=["GET"], include_in_schema=False)
+async def readyz(_: Request) -> JSONResponse:
+    result = await status()
+    if not result["ready"]:
+        return JSONResponse(
+            {"status": "not_ready", "service": SERVICE_NAME},
+            status_code=503,
+        )
+    return JSONResponse({"status": "ready", "service": SERVICE_NAME, "model": result["model"]})
+
+
+def main() -> None:
+    transport = os.environ.get("GEMMAGROK_TRANSPORT", "streamable-http").strip().lower()
+    if transport == "stdio":
+        mcp.run(transport="stdio")
+        return
+    if transport != "streamable-http":
+        raise ValueError("GEMMAGROK_TRANSPORT must be 'stdio' or 'streamable-http'")
+
+    import uvicorn
+
+    uvicorn.run(mcp.streamable_http_app(), host=mcp.settings.host, port=mcp.settings.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_gemmagrok_peer.py
+++ b/tests/test_gemmagrok_peer.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+from unigrok_public import gemmagrok_peer, server
+
+
+@pytest.mark.parametrize(
+    "url",
+    (
+        "http://127.0.0.1:8081",
+        "http://localhost:8081",
+        "http://[::1]:8081",
+        "http://host.docker.internal:8081",
+    ),
+)
+def test_runtime_url_accepts_only_explicit_local_origins(url: str) -> None:
+    assert gemmagrok_peer._runtime_url(url) == url
+
+
+@pytest.mark.parametrize(
+    "url",
+    (
+        "https://127.0.0.1:8081",
+        "http://example.com:8081",
+        "http://user:pass@127.0.0.1:8081",
+        "http://127.0.0.1:8081/v1",
+        "http://127.0.0.1",
+    ),
+)
+def test_runtime_url_rejects_remote_credentialed_or_ambiguous_origins(url: str) -> None:
+    with pytest.raises(RuntimeError):
+        gemmagrok_peer._runtime_url(url)
+
+
+@pytest.mark.asyncio
+async def test_runtime_client_ignores_proxies_and_refuses_redirects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict = {}
+
+    class Response:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {"data": []}
+
+    class Client:
+        def __init__(self, **kwargs: object) -> None:
+            captured["client"] = kwargs
+
+        async def __aenter__(self) -> Client:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def request(self, method: str, url: str, **kwargs: object) -> Response:
+            captured["request"] = (method, url, kwargs)
+            return Response()
+
+    monkeypatch.setattr(gemmagrok_peer.httpx, "AsyncClient", Client)
+    monkeypatch.setenv("GEMMAGROK_RUNTIME_URL", "http://127.0.0.1:8081")
+    await gemmagrok_peer._runtime_request("GET", "/v1/models")
+
+    assert captured["client"]["trust_env"] is False
+    assert captured["client"]["follow_redirects"] is False
+    assert captured["request"] == (
+        "GET",
+        "http://127.0.0.1:8081/v1/models",
+        {},
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_selection_is_live_discovered_and_explicit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def models() -> list[str]:
+        return ["local-a", "local-b"]
+
+    monkeypatch.setattr(gemmagrok_peer, "_served_models", models)
+    monkeypatch.setenv("GEMMAGROK_MODEL_ID", "local-b")
+    assert await gemmagrok_peer._resolve_model() == "local-b"
+
+    monkeypatch.setenv("GEMMAGROK_MODEL_ID", "not-served")
+    with pytest.raises(RuntimeError, match="not served"):
+        await gemmagrok_peer._resolve_model()
+
+    monkeypatch.delenv("GEMMAGROK_MODEL_ID", raising=False)
+    with pytest.raises(RuntimeError, match="one served model"):
+        await gemmagrok_peer._resolve_model()
+
+
+@pytest.mark.asyncio
+async def test_chat_calls_only_local_runtime_and_returns_honest_receipt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, str, dict | None]] = []
+
+    async def request(method: str, path: str, *, payload: dict | None = None) -> dict:
+        calls.append((method, path, payload))
+        if path == "/v1/models":
+            return {"data": [{"id": "local-model"}]}
+        return {
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "LOCAL_OK"},
+                    "finish_reason": "stop",
+                }
+            ]
+        }
+
+    monkeypatch.setattr(gemmagrok_peer, "_runtime_request", request)
+    monkeypatch.delenv("GEMMAGROK_MODEL_ID", raising=False)
+    result = await gemmagrok_peer.chat(
+        "Reply locally",
+        system_prompt="Stay concise",
+        max_tokens=64,
+    )
+
+    assert calls[0] == ("GET", "/v1/models", None)
+    assert calls[1][0:2] == ("POST", "/v1/chat/completions")
+    assert calls[1][2] == {
+        "model": "local-model",
+        "messages": [
+            {"role": "system", "content": "Stay concise"},
+            {"role": "user", "content": "Reply locally"},
+        ],
+        "max_tokens": 64,
+        "stream": False,
+    }
+    assert result == {
+        "text": "LOCAL_OK",
+        "model": "local-model",
+        "source": "gemmagrok",
+        "plane": "local",
+        "degraded": True,
+        "billing_class": "local_runtime",
+        "cost_usd": 0.0,
+        "finish_reason": "stop",
+        "remote_fallback": False,
+    }
+
+
+def test_reasoning_only_response_is_not_exposed_as_a_final_answer() -> None:
+    with pytest.raises(RuntimeError, match="empty final completion"):
+        gemmagrok_peer._completion(
+            {
+                "choices": [
+                    {
+                        "message": {"role": "assistant", "reasoning": "private reasoning"},
+                        "finish_reason": "length",
+                    }
+                ]
+            }
+        )
+
+
+@pytest.mark.asyncio
+async def test_status_fails_closed_without_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def unavailable() -> str:
+        raise RuntimeError("down")
+
+    monkeypatch.setattr(gemmagrok_peer, "_resolve_model", unavailable)
+    assert await gemmagrok_peer.status() == {
+        "service": gemmagrok_peer.SERVICE_NAME,
+        "runtime": "local",
+        "ready": False,
+        "model": None,
+        "remote_fallback": False,
+    }
+
+
+@pytest.mark.asyncio
+async def test_peer_surface_is_two_read_only_tools() -> None:
+    tools = await gemmagrok_peer.mcp.list_tools()
+    assert [tool.name for tool in tools] == ["chat", "status"]
+    assert all(tool.annotations is not None for tool in tools)
+    assert all(tool.annotations.readOnlyHint is True for tool in tools)
+
+
+def test_mcp_transport_rejects_host_and_origin_rebinding() -> None:
+    initialize = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-03-26",
+            "capabilities": {},
+            "clientInfo": {"name": "boundary-test", "version": "1"},
+        },
+    }
+    base_headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+    }
+    with TestClient(gemmagrok_peer.mcp.streamable_http_app()) as client:
+        hostile_host = client.post(
+            "/mcp",
+            headers={**base_headers, "Host": "attacker.invalid"},
+            json=initialize,
+        )
+        hostile_origin = client.post(
+            "/mcp",
+            headers={
+                **base_headers,
+                "Host": "127.0.0.1:4777",
+                "Origin": "https://attacker.invalid",
+            },
+            json=initialize,
+        )
+        local = client.post(
+            "/mcp",
+            headers={
+                **base_headers,
+                "Host": "127.0.0.1:4777",
+                "Origin": "http://127.0.0.1:4777",
+            },
+            json=initialize,
+        )
+
+    assert hostile_host.status_code == 421
+    assert hostile_origin.status_code == 403
+    assert local.status_code == 200
+    assert f'"version":"{gemmagrok_peer.__version__}"' in local.text
+
+
+def test_public_grok_server_does_not_import_or_route_to_gemmagrok() -> None:
+    source = inspect.getsource(server)
+    assert "gemmagrok_peer" not in source
+    assert "GEMMAGROK" not in source
+    assert "gemmagrok" not in server.PUBLIC_TOOL_NAMES
+
+
+@pytest.mark.asyncio
+async def test_public_grok_no_credentials_remains_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def no_credentials(*, refresh: bool = False) -> dict:
+        assert refresh is False
+        return {
+            "cli": {"ready": False, "models": []},
+            "api": {"ready": False, "models": []},
+        }
+
+    monkeypatch.setattr(server, "_catalogs", no_credentials)
+    with pytest.raises(RuntimeError, match="Neither Grok credential plane is ready"):
+        await server._resolve_plane("auto", None, requires_api=False)
+
+
+def test_compose_helper_is_default_off_loopback_only_and_has_no_credentials() -> None:
+    compose = (Path(__file__).parents[1] / "compose.yaml").read_text(encoding="utf-8")
+    helper = compose.split("  gemmagrok-local:", maxsplit=1)[1].split("\nvolumes:", maxsplit=1)[0]
+    assert 'profiles: ["offline"]' in helper
+    assert '"127.0.0.1:${GEMMAGROK_PORT:-4777}:8080"' in helper
+    assert "XAI_API_KEY" not in helper
+    assert "grok-cli-auth" not in helper
+    assert "GEMMAGROK_RUNTIME_URL" in helper


### PR DESCRIPTION
## What changed

- Adds a default-off `gemmagrok-local` Compose profile and separate MCP helper with only `chat` and `status`.
- Uses an operator-supplied local OpenAI-compatible runtime with live model discovery; no model weights, training data, Grok credentials, or remote-provider fallback ship here.
- Documents the prototype boundary and keeps the normal `@grok` CLI/API routing unchanged.

## Why

Ship the useful standalone prototype now so we can learn from real use before attempting automatic failover or a deeper in-core local plane.

## Verification

- Exact head: `d2f0ac4c46c1a4322cb82c4b3f91bef1a6b154ae`
- `uv sync --frozen`
- `uv run pytest -q` — 415 passed
- Ruff, Compose validation, diff checks, and public insider denylist passed
- Native and linux/amd64 images built successfully
- Final image completed real local MLX `chat`/`status` smoke with `remote_fallback=false`
- No-egress Docker proof completed `chat`, reported MCP version 1.1.0, and rejected a hostile Host header
- Independent review: clear after DNS-rebinding and handshake-version fixes

## Prototype boundary

This does **not** enable automatic `@grok → GemmaGrok` failover, hosted Cloud Run failover, or a GemmaGrok sub-agent route. Those remain later learning stages. PR #513 is a separate identity/memory hardening change and is not part of this packet.

Cost: $0 provider/API spend. Ready for review: yes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new local HTTP/MCP surface and outbound calls to a configured runtime, but it is loopback-scoped, credential-free, and explicitly isolated from main Grok auth and automatic fallback paths.
> 
> **Overview**
> Adds an **experimental, default-off** `gemmagrok-local` MCP server for operators who explicitly want answers from a **local OpenAI-compatible runtime** when remote Grok is unavailable. It is **not** wired into `@grok` routing or credential recovery.
> 
> The new `unigrok_public.gemmagrok_peer` module exposes only **`chat`** and **`status`**, talks to loopback/Docker-host runtimes with strict URL checks (no creds, redirects, or proxies), resolves models via live `/v1/models` discovery, and returns receipts that mark **`plane: local`**, **`degraded: true`**, and **`remote_fallback: false`**. Compose gains an **`offline`** profile binding **`127.0.0.1:4777`**, with no Grok OAuth/API volumes.
> 
> Docs and `example.env` describe opt-in IDE wiring; tests assert DNS-rebinding protections, runtime boundaries, and that the public **`server`** never imports or routes to GemmaGrok.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 311cac9e299eb2b2fe9da61080e57e86f9bd4fb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->