### PR TITLE
docs: release-contract CI gates for public-core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,6 @@ jobs:
       - run: uv sync --frozen
       - run: uv run ruff check .
       - run: bash scripts/ci-insider-denylist.sh
+      - run: uv run python scripts/check_release_contract.py
+      - run: uv run python scripts/check_docs.py
       - run: uv run pytest -q
-

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__/
 htmlcov/
 dist/
 build/
+local-backups/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,20 @@ All notable changes to the public UniGrok gateway.
   with behavioral contracts. Needle remains inactive by default.
 
 ### Fixed
+- Durable shutdown is monotonic: an atomic interrupted transition cannot overwrite a
+  terminal result, shutdown cancellation preserves the honest `lost`/unknown-provider
+  payload, explicit cancellation remains distinguishable, and first restart polls make
+  orphaned running rows terminal and retention-eligible.
+- Every direct xAI API tool now participates in the per-credential/model circuit breaker;
+  budget policy runs exactly once before admission, local bounded-download refusals do
+  not poison provider health, and the metered-API kill switch covers file reads and
+  mutations as documented.
+- Circuit-breaker half-open probes are generation-fenced and serialized. Exactly one
+  probe runs after cooldown; stale completion and caller cancellation cannot clear or
+  corrupt a newer breaker epoch. Threshold/cooldown controls are wired through Compose
+  and reported by discovery/runtime receipts.
+- Session locks are reference-counted and pruned only after the holder and every queued
+  waiter leave, preventing both the prior dual-lock race and unbounded session-key growth.
 - Mission ownership and poll truth are generation-fenced end to end: claims are atomic,
   active quanta heartbeat, envelope/artifact/event/evidence writes require the exact
   owner, stale sweeper snapshots cannot revoke renewed leases, and job/autonomy mirrors
@@ -119,6 +133,9 @@ All notable changes to the public UniGrok gateway.
   actual bounded 600-second service-token lifetime.
 
 ### Documentation
+- Add a current public architecture, a source/Docker/public/hosted readiness matrix, a
+  release evidence template, runtime source fingerprints, a read-only container-parity
+  checker, and CI-enforced release-version parity.
 - Restore and update the authenticated remote-deployment runbook with the current OAuth,
   secret-version, tenant, instance-local-state, atomic-cutover, smoke, and rollback
   contracts; link the hosted pilot from README, reference, security, development, known

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,11 @@
 
 ```bash
 uv sync --frozen
-uv run pytest -q
 uv run ruff check .
+bash scripts/ci-insider-denylist.sh
+uv run python scripts/check_release_contract.py
+uv run python scripts/check_docs.py
+uv run pytest -q
 docker compose config --quiet
 docker compose build grok-mcp
 ```
@@ -13,21 +16,27 @@ docker compose build grok-mcp
 ## Runtime smoke (manual)
 
 Compose uses one fixed container plus persistent auth/state volumes; it is not safe to
-run a second project against those same volumes. Stop and recreate the current local
-service on `4775` for a candidate smoke:
+run a second project against those same volumes. Drain active jobs, then stop and
+recreate the current local service on `4775` for a candidate smoke. Clients still pointed
+at `4765` are offline during this test. First follow the image-tag and stopped-state
+snapshot procedure in [Team readiness](docs/team-readiness.md):
 
 ```bash
-docker compose stop grok-mcp
-UNIGROK_PORT=4775 docker compose --env-file .env up --build -d grok-mcp
+UNIGROK_IMAGE=unigrok:team-ready-candidate UNIGROK_PORT=4775 \
+  docker compose --env-file .env up --build -d grok-mcp
 curl -fsS http://127.0.0.1:4775/healthz
 curl -fsS http://127.0.0.1:4775/readyz
 curl -fsS http://127.0.0.1:4775/runtimez
 uv run python scripts/smoke_mcp.py --url http://127.0.0.1:4775/mcp
+uv run python scripts/check_runtime_parity.py --container unigrok
 ```
 
 Compare MCP `tools/list` with `grok_mcp_discover_self`, then exercise both configured
 credential planes. Restore the normal port by recreating this same service on `4765`;
 do not point two containers at one state volume.
+
+Use [`docs/team-readiness.md`](docs/team-readiness.md) to distinguish source, local
+Docker, public GitHub, and hosted-service evidence before calling a change live.
 
 This local smoke does not deploy the authenticated hosted service. Maintainer-operated
 remote releases follow the digest, OAuth, public-smoke, and rollback gates in

--- a/LAUNCH.md
+++ b/LAUNCH.md
@@ -56,12 +56,12 @@ Status legend: [ ] open · [x] done · [~] partially proven
   optimization (forge loop for arbitrary files).
 - Function-path router; self-healing error messages; readability hive-vote
   layered on the mechanical gate.
-- Onboarding extraction (from internal donor research): dynamic settings plan (template +
-  deprecation map + classify-before-write, IDE executes) and reflex/synapse
+- Consent-first onboarding design: dynamic settings plan (template + deprecation map +
+  classify-before-write, IDE executes) and bounded fact routing
   memory (short auto-injected notes; per-turn relevance routing — maps onto
   the existing facts system). See docs/onboarding-extraction.md.
 - omlx eval discipline (fixed-seed stratified sampling, thinking-budget
   provenance) for the benchmark suite.
 - Structured micro-emit (silent-think full port) for short-answer hard tasks.
-- Needle tier: keep `needle_active: false` truthful; revive only behind the
-  promotion gates in the private design docs.
+- Needle tier: keep `needle_active: false` truthful; revive only after public promotion
+  gates, runtime code, and tests exist.

--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ See [SECURITY.md](SECURITY.md) for the complete public runtime boundary.
 
 | I want to… | Read |
 |---|---|
+| Understand the service and state machines | [Public architecture](docs/architecture.md) |
+| Prove source, Docker, and deployment readiness | [Team readiness](docs/team-readiness.md) |
 | See every tool and routing rule | [Technical reference](docs/reference.md) |
 | Understand or operate the authenticated hosted service | [Remote deployment](docs/remote-mcp-deployment.md) |
 | Run the explicit no-internet local helper | [Optional local-model helper](docs/offline-local-helper.md) |

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,16 +5,22 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: unigrok:1.1.0
+    image: ${UNIGROK_IMAGE:-unigrok:sky-layer-patch}
     container_name: unigrok
     ports:
       - "127.0.0.1:${UNIGROK_PORT:-4765}:8080"
     environment:
       UNIGROK_HOST: 0.0.0.0
       PORT: 8080
+      # Factory: all chat/agent tools on all the time
+      UNIGROK_CHAT_TOOLS: ${UNIGROK_CHAT_TOOLS:-always}
+      UNIGROK_SWARM: ${UNIGROK_SWARM:-active}
+      UNIGROK_DEFAULT_LEVEL: ${UNIGROK_DEFAULT_LEVEL:-max}
       UNIGROK_AUTH_PATH: /home/appuser/.grok/auth.json
       UNIGROK_BUILD_TIMEOUT: ${UNIGROK_BUILD_TIMEOUT:-120}
       UNIGROK_API_TIMEOUT: ${UNIGROK_API_TIMEOUT:-120}
+      UNIGROK_BREAKER_FAILURES: ${UNIGROK_BREAKER_FAILURES:-3}
+      UNIGROK_BREAKER_COOLDOWN: ${UNIGROK_BREAKER_COOLDOWN:-30}
       # Live Docker defaults: autonomy + mission v2 on (override via .env).
       UNIGROK_AUTONOMY: ${UNIGROK_AUTONOMY:-true}
       UNIGROK_MISSION_V2: ${UNIGROK_MISSION_V2:-true}
@@ -65,7 +71,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: unigrok:1.1.0
+    image: ${UNIGROK_IMAGE:-unigrok:1.1.0}
     profiles: ["auth"]
     command: ["grok", "login", "--device-auth"]
     environment:

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: ${UNIGROK_IMAGE:-unigrok:sky-layer-patch}
+    image: ${UNIGROK_IMAGE:-unigrok:1.1.0}
     container_name: unigrok
     ports:
       - "127.0.0.1:${UNIGROK_PORT:-4765}:8080"

--- a/docs/AUTONOMY_INTEL.md
+++ b/docs/AUTONOMY_INTEL.md
@@ -1,7 +1,9 @@
-# UniGrok Autonomy + Intelligence Plan (hive-merged)
+# UniGrok autonomy and intelligence design record
 
-**Hive verdict: REVISE → ship A0′/A0/A1/A1.5 first; hold A3–A4 until commit truth is green.**  
-Critique: high/direct, mission-committed (`telemetry_id` 396). Ultra critique job may still be in deadline quanta — treat this merge as authoritative for sequencing.
+Status: A0′, A0, and A1.5 informed the shipping Mission V2 implementation. Later phases
+remain design-only unless the technical reference and runtime tests say otherwise.
+
+**Design verdict: REVISE → ship A0′/A0/A1/A1.5 first; hold A3–A4 until commit truth is green.**
 
 Companions: `docs/DEOVERFIT.md`, **`docs/SLEEP_PLANE.md`** (idle consolidation —
 the hemisphere this plan originally missed). Goal: max useful autonomy in Docker
@@ -10,7 +12,7 @@ gates are class-conditional posteriors.
 
 ---
 
-## Proven anomaly (live)
+## Historical anomaly (resolved)
 
 | Fact | Detail |
 |---|---|
@@ -18,9 +20,10 @@ gates are class-conditional posteriors.
 | Model | Correct: `MCP_LIVE_OK` |
 | Mission V2 | `continue`, `committed=false` |
 | Gaps | `answer_too_short`, `token_echo`, `insufficient_evidence` |
-| Why stuck | No legal repair under that acceptance → continue has no progress |
+| Why stuck | No legal repair under that acceptance → continue had no progress |
+| Resolution | Literal task classification and exact-match CommitDone, covered by regression tests |
 
-**Root cause (hive):** class-mismatched verify — **substantial** gates fired on a **literal** mission. Not “model too short.”
+**Root cause:** class-mismatched verify — **substantial** gates fired on a **literal** mission. Not “model too short.”
 
 ---
 
@@ -175,9 +178,9 @@ Safest autonomy ≠ most rules. It means:
 
 | Item | State |
 |---|---|
-| Live anomaly | Confirmed |
-| Hive critique (awake) | Merged (REVISE sequencing) |
+| Literal false-continue anomaly | Resolved in task-class/verification code and regression tests |
+| Awake design review | Incorporated (REVISE sequencing) |
 | Sleep / consolidation plane | Specced in `docs/SLEEP_PLANE.md` (miss closed in docs) |
 | A0′ / A0 code | Implemented (`mission/task_class.py` + verify/autonomy) |
 | A1.5 unrepairable / same-state FailDone | Implemented (`should_terminal_fail` + epoch) |
-| S0 idle scheduler | After A0′/A0 ship gate |
+| S0 idle scheduler | Design only; not implemented |

--- a/docs/DEOVERFIT.md
+++ b/docs/DEOVERFIT.md
@@ -1,6 +1,6 @@
 # UniGrok de-overfitting plan
 
-Hive-merged (ultra, mission-committed, ~$0.034). Doctrine:
+Design-review doctrine:
 
 > Freeze only near-physics envelopes. Everything else is a posterior:
 > shadow-measured, budget-capped, promotion-receipted, kill-switchable.
@@ -95,7 +95,7 @@ zero semaphore identity checks.
 
 | Item | State |
 |---|---|
-| Phase 2 contract-test rewrite | In progress this change |
-| Governor weight bundle (demote literals) | In progress this change |
-| Physics envelope module | Stub this change |
+| Phase 2 contract-test rewrite | Implemented for the named mechanism-test patterns |
+| Governor weight bundle (demote literals) | Implemented as a versioned bundle |
+| Physics envelope module | Implemented as the current minimal envelope module |
 | Phases 3–5 | Not started |

--- a/docs/SLEEP_PLANE.md
+++ b/docs/SLEEP_PLANE.md
@@ -1,10 +1,10 @@
-# UniGrok Sleep / Consolidation Plane (hive-merged)
+# UniGrok sleep and consolidation design
 
 **Miss acknowledged:** the awake-only plan (A0′–A4) described cognition that
 starts when MCP arrives. Humans also consolidate while idle. Without a sleep
 plane, Docker is half-dead between chats and every live hit pays cold-start tax.
 
-**Hive verdict (telemetry 397):** Sleep is a **real miss as a hemisphere**, but
+**Design verdict:** Sleep is a **real miss as a hemisphere**, but
 **overreach as “fill Docker with a second brain.”** Ship it as a **preemptible,
 receipted, non-committing maintenance generator** that only decreases a measured
 `V_sleep`. Live path owns CommitDone forever. Default sleep **off** until awake

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,109 @@
+# UniGrok public architecture
+
+Status: shipping public-core architecture. Design-only work is explicitly labelled in
+its own documents. Runtime truth is reported by `grok_mcp_discover_self`, `/readyz`, and
+`/runtimez`; a source checkout is not proof of what a container is running.
+
+## System boundary
+
+```mermaid
+flowchart LR
+    IDE["IDE or coding agent"] -->|"MCP request"| GW["UniGrok gateway"]
+    GW --> AUTH["Auth, tenant, budget, and input policy"]
+    AUTH --> ROUTER["Grok-led router"]
+    ROUTER --> CLI["Isolated Grok Build CLI plane"]
+    ROUTER --> API["Metered xAI API plane"]
+    GW --> JOBS["Detached durable-job registry"]
+    JOBS --> DB["SQLite state and mission ledger"]
+    CLI --> CB1["Per model circuit breaker"]
+    API --> CB2["Per credential generation and model circuit breaker"]
+
+    IDE -. "bounded, explicit text courier" .-> GW
+    HOST["Workspace, Git, shell, IDE state, external MCP"] -. "not attached" .-> GW
+```
+
+The gateway has no ambient authority over the caller's files, Git repository, shell,
+credentials, other MCP servers, or IDE state. A caller may deliberately courier bounded,
+redacted text, but that does not become workspace attachment.
+
+## Execution planes
+
+| Plane | Credential | Typical role | Isolation |
+| --- | --- | --- | --- |
+| Grok Build CLI | Grok subscription OAuth stored in the server volume | Local lead, routing, and subscription-first work | Disposable workspace/config home; local file, shell, edit, and MCP capabilities removed |
+| xAI API | Server-owned or principal-bound API key | Metered specialists, files, media, search, remote code, or bounded recovery | Separate credential cache, concurrency pools, budgets, and circuit breakers |
+
+Models are discovered independently from each live credential plane. Callers choose
+intent and depth, not a hard-coded model allowlist. Cross-plane recovery is bounded and
+receipted.
+
+## Request and job lifecycle
+
+Fast work can finish inside the initial sync window. Slow work detaches from the MCP
+request. Generic durable tools return `pending` with a `job_id`; an autonomy-enabled
+`agent` returns `continue` with `poll=true`, the same `job_id`, and its durable
+`continue_token`. In either case the caller polls `agent_result` using the same ID.
+Request timeout or caller cancellation does not cancel detached work.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Running
+    Running --> PollView: sync window expires
+    PollView --> Running: pending or continue; same worker continues
+    Running --> Complete: result persisted
+    Running --> Error: terminal error persisted
+    Running --> Lost: service stops before provider outcome
+    Complete --> [*]
+    Error --> [*]
+    Lost --> [*]
+```
+
+`lost` is terminal durable truth with an unknown provider outcome. It must not be
+silently rewritten as caller cancellation, and it is unsafe to duplicate a metered or
+mutating request until the provider state has been inspected.
+
+Mission V2 adds a fenced mission ledger around agent quanta. Claims carry a lease token,
+lease generation, checkpoint version, immutable acceptance hash, sealed artifacts, and
+typed evidence. Only the current owner may advance mission truth.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Queued
+    Queued --> Running: claim lease
+    Running --> Verifying: propose done
+    Verifying --> Complete: CommitDone CAS
+    Verifying --> WaitingEvent: repairable gaps
+    WaitingEvent --> Running: same continue token
+    Running --> Failed
+    Running --> BudgetExhausted
+    Running --> Cancelled
+```
+
+Reattach is serial and uses the same `continue_token`. Terminal reattach reads canonical
+durable truth and never reruns the model. Mission truth is authoritative over the legacy
+job projection after restart.
+
+## State and deployment topology
+
+| Property | Local Compose | Hosted Cloud Run |
+| --- | --- | --- |
+| Source | Copied into the image at build time; no source bind mount | Same reviewed image, deployed by immutable digest |
+| SQLite | Named persistent Docker volume | Instance-local `/tmp` in the current deployment |
+| Restart continuity | Sessions, facts, terminal jobs, and mission ledger survive container recreation when volumes are retained | Instance replacement may lose sessions, facts, and jobs |
+| Rollout | One fixed local service and state volume | Atomic revision cutover; no fractional canary while state is instance-local |
+
+Every built source tree has a non-secret `source_fingerprint` reported by `/healthz`,
+discovery, and `/runtimez`. Use `scripts/check_runtime_parity.py` to compare all public
+runtime files in a checkout with a running local container. A version string, healthy
+process, Git branch, image tag, or public revision alone is not source-parity proof.
+
+## Safety ordering
+
+Local validation and budget policy run before provider admission. Provider failures
+advance the matching circuit breaker; local policy refusals do not. After cooldown,
+exactly one half-open probe is admitted. Probe cancellation is fenced through the
+longest provider deadline so an abandoned worker cannot overlap a replacement.
+
+The release and incident evidence gates are in [Team readiness](team-readiness.md).
+Detailed tool/status contracts are in the [Technical reference](reference.md), and the
+hosted boundary is in the [remote deployment runbook](remote-mcp-deployment.md).

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,8 +14,11 @@ trigger conditions; wasm is **not** in the shipping gateway today.
 
 ```bash
 uv sync --frozen
-uv run pytest -q
 uv run ruff check .
+bash scripts/ci-insider-denylist.sh
+uv run python scripts/check_release_contract.py
+uv run python scripts/check_docs.py
+uv run pytest -q
 docker compose config --quiet
 docker compose build grok-mcp
 ```
@@ -25,15 +28,19 @@ docker compose build grok-mcp
 The checked-in Compose file intentionally uses one fixed container and the persistent
 `unigrok-*` auth/state volumes. It is not a side-by-side deployment definition. Stop the
 current container, then recreate the same local service on `4775` if you want to keep an
-IDE's `4765` configuration untouched while testing:
+IDE's `4765` configuration file untouched while testing. Clients still pointed at
+`4765` are offline until the service is restored. Drain active jobs first, because this
+recreates the only local runtime. Before the candidate touches SQLite, create the image
+tag and stopped-volume snapshot in [Team readiness](team-readiness.md):
 
 ```bash
-docker compose stop grok-mcp
-UNIGROK_PORT=4775 docker compose --env-file .env up --build -d grok-mcp
+UNIGROK_IMAGE=unigrok:team-ready-candidate UNIGROK_PORT=4775 \
+  docker compose --env-file .env up --build -d grok-mcp
 curl -fsS http://127.0.0.1:4775/healthz
 curl -fsS http://127.0.0.1:4775/readyz
 curl -fsS http://127.0.0.1:4775/runtimez
 uv run python scripts/smoke_mcp.py --url http://127.0.0.1:4775/mcp
+uv run python scripts/check_runtime_parity.py --container unigrok
 ```
 
 Then open a real IDE MCP client against `http://127.0.0.1:4775/mcp` (header
@@ -41,8 +48,14 @@ Then open a real IDE MCP client against `http://127.0.0.1:4775/mcp` (header
 `grok_mcp_discover_self`, exercise both configured credential planes, and confirm
 host sources match the running container for `src/` and static UI files.
 
+The parity command is read-only and compares a content fingerprint plus every public
+runtime path. Treat `DRIFT` as a stop signal; do not assume the checkout should overwrite
+an active container. See [Team readiness](team-readiness.md) for the evidence matrix and
+handoff format.
+
 Restore the normal port by recreating the same service with `UNIGROK_PORT=4765`.
-Do not point two containers at the same SQLite state volume.
+Use `UNIGROK_IMAGE` to select the reviewed candidate or recorded rollback image. Do not
+point two containers at the same SQLite state volume.
 
 To verify team-state persistence across a restart, create a named `agent` session,
 restart the container, and confirm the same session still resolves through the MCP
@@ -50,11 +63,12 @@ tools (facts / session history).
 
 ## Cutting a release
 
-One version bump commit, then tag and publish — the version string lives in three
-places that must move together:
+One version bump commit, then tag and publish. The release-contract check keeps the
+package metadata, lockfile root package, README badge, Compose image tags, and smoke
+expectation aligned:
 
-1. Bump the version in `pyproject.toml`, `src/unigrok_public/__init__.py`, and the
-   README version badge. Promote the `[Unreleased]` section of `CHANGELOG.md` to
+1. Bump the version across the surfaces checked by
+   `uv run python scripts/check_release_contract.py`. Promote the `[Unreleased]` section of `CHANGELOG.md` to
    `## [X.Y.Z] — <date>`, leaving an empty `[Unreleased]` above it. Commit as
    `chore(release): X.Y.Z` and push (or merge via PR).
 2. Tag and publish the GitHub release:

--- a/docs/known-limits.md
+++ b/docs/known-limits.md
@@ -50,6 +50,15 @@ selected specialists and bounded recovery. Every result carries
 those receipts show a fallback to the API plane that you did not expect, file
 a bug with those fields — they tell most of the story.
 
+### Circuit-breaker states are intentionally conservative
+
+Breakers are isolated by plane, credential generation, and model. After the cooldown,
+only one half-open probe is admitted; other calls fail fast. A cancelled probe is fenced
+through the longest configured provider deadline because its underlying worker may still
+be stopping. This can look like an extended cooldown, but admitting an overlapping
+replacement could duplicate provider work. `/runtimez` and `benchmark_status` distinguish
+cooldown, probe-ready, and half-open states. See the [technical reference](reference.md#runtime-limits).
+
 ### Expected behavior, not bugs
 
 - **`xhigh` on the API plane auto-downgrades to `high`** instead of erroring.

--- a/docs/onboarding-extraction.md
+++ b/docs/onboarding-extraction.md
@@ -1,20 +1,20 @@
-# Onboarding extraction design (post-launch)
+# Consent-first onboarding and fact-routing design
 
-Harvest of internal donor-research ideas into UniGrok's onboarding plan and facts
-system. Two tracks. Server writes nothing — the IDE executes plans with its
-own permissions (existing `grok_mcp_onboard_client` contract).
+Public design for extending UniGrok's onboarding plan and facts system. Two tracks.
+The server writes nothing — the IDE executes plans with its own permissions under the
+existing `grok_mcp_onboard_client` contract. This is design-only unless a behavior is
+also documented in the technical reference and covered by runtime tests.
 
 ## Track A — dynamic IDE settings in the onboarding plan
 
-Donor scripts (`ide_hijack.py`, `settings_sync.py`) generate settings from
-templates but clobber user edits. We keep the good mechanics, drop the harm.
+Settings plans need template-driven updates without clobbering user edits.
 
 **Portable algorithm (plan emits instructions, never file writes):**
 
 ```
 INPUTS (server-side, read-only):
   T = template of MANAGED keys -> desired values (namespaced under "unigrok")
-  D = deprecation map {oldKey -> newKey | null}     # the piece donors lacked
+  D = deprecation map {oldKey -> newKey | null}
   targets = [{path, format}]  # global/workspace settings.json (JSONC), .gemini (JSON)
 
 PLAN PER TARGET (instructions for the IDE):
@@ -31,35 +31,32 @@ PLAN PER TARGET (instructions for the IDE):
   7. OUTPUT: merged preview + diff + conflict list + .bak instruction
 ```
 
-**Non-negotiables (fix the donor's trust traps):**
+**Non-negotiables:**
 - Never overwrite a key outside `T∪D`; always emit a diff for keys inside it.
 - Global user settings is a separate, explicitly-consented target.
-- Do NOT port `hunt_extension_friction`'s guess-by-name value synthesis (it
-  disabled safety confirmations). Discover keys from manifests only as
+- Do not synthesize settings values from extension names or disable safety
+  confirmations. Discover keys from manifests only as
   *suggestions*, never auto-applied.
-- Keep from donor: JSONC tolerance, `.bak` backup, classify-before-write
-  accounting, dedupe-by-id, and the `settings.local.json` manifest-of-pointers
-  shape (`rules.autoLoad` + `agents.systemPromptFile`) — this is exactly our
-  "return a plan of pointers, don't write content" model.
+- Preserve JSONC tolerance, `.bak` backup instructions, classify-before-write
+  accounting, dedupe-by-id, and a namespaced manifest of pointers. This matches the
+  "return a plan, never write content" model.
 
 ## Track B — reflex/synapse memory onto the facts system
 
-Donor `omni_router.py` does per-turn TF-IDF selection of short notes;
-`synapse_recorder`/`decay` weight them by outcome.
+The future route may select a small set of short, relevant notes per turn and adjust
+their ranking only from explicit outcomes.
 
 **What UniGrok already covers (do NOT rebuild):**
 - Auto-appearing short notes → `remember_fact` + per-turn `search_facts(prompt,
   limit=5)` injected as "Durable user-controlled knowledge". This is the DB
-  analog of reflex files, and the `limit=5` top-k is *better* than the donor's
-  "inject every reflex every turn" default (their main context-bloat trap).
+  analog of reflex files. The `limit=5` top-k avoids injecting every note on every turn.
 
 **Small, high-value additions (server-side, schema tweaks):**
-1. Relevance floor on fact injection (mirror donor `T_REFLEX≈0.40`) so weak
-   matches aren't injected.
+1. A measured relevance floor on fact injection so weak matches are not injected.
 2. Fact `category` tag (`reflex` vs plain user fact) to distinguish procedural
    scars from preferences.
-3. Outcome-weighted facts: `weight` column, +reinforce/−penalize on outcome,
-   prune at ≤0 (donor's UCB loop; hook Forge's `record_landed_outcome`).
+3. Outcome-weighted facts: reinforce or penalize only from explicit feedback, retain the
+   evidence receipt, and prune at a reviewed floor.
 4. Dedup on `remember_fact` (content-aware slug) to avoid near-duplicates.
 
 **IDE-side only (can't live in the DB):** if file-based reflexes are wanted,
@@ -67,7 +64,7 @@ the onboarding plan emits the `.md` files plus the
 `chat.instructionsFilesLocations` config; the IDE writes them. Bound the count
 (don't inherit "inject all").
 
-**Traps to avoid from the donor:** append-only log with no dedupe (stale-weight
+**Traps to avoid:** append-only logs with no dedupe (stale-weight
 duplicates win argmax); filename-only novelty (reflex written once, never
 updated/expired); toxic entries with empty golden path winning selection. Our
 DB + top-k + relevance floor sidesteps most of these by construction.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -154,6 +154,10 @@ http://localhost:4765/mcp
 
 Transport: Streamable HTTP. The MCP handshake, `/healthz`, `/readyz`, `/runtimez`,
 `grok_mcp_status`, and `grok_mcp_discover_self` all report version `1.1.0`.
+`/healthz`, `/runtimez`, and discovery also expose a non-secret
+`source_fingerprint`, which identifies the byte content and relative paths of the baked
+public runtime tree. For local Docker, compare it with the checkout using
+`uv run python scripts/check_runtime_parity.py --container unigrok`.
 
 The owner-operated hosted pilot uses `https://mcp.grokmcp.org/mcp`. It publishes
 OAuth protected-resource metadata and requires an active, correctly scoped Control
@@ -263,12 +267,23 @@ Environment values outside their range are clamped. `grok_mcp_discover_self` and
 | `UNIGROK_FILE_CONTENT_MAX_BYTES` | 2,000,000 | 1,024–10,000,000 |
 | `UNIGROK_API_MAX_INFLIGHT` | 4 | 1–16 |
 | `UNIGROK_API_MAX_FILE_INFLIGHT` | 2 | 1–4 |
+| `UNIGROK_BREAKER_FAILURES` | 3 | 2–20 |
+| `UNIGROK_BREAKER_COOLDOWN` | 30 s | 5–600 s |
 | `UNIGROK_CATALOG_TTL` | 60 s | 5–600 s |
 | `UNIGROK_STATE_RETENTION_HOURS` | 24 h | 1–720 h |
 
 `agent_result(wait_seconds)` is a separate per-poll argument: default 16 seconds,
 clamped to 1–20. `xai_get_file_content(max_bytes)` defaults to 500,000 and clamps to
 1,024–1,000,000 bytes, then remains bounded by the environment hard cap above.
+
+Circuit breakers are isolated by plane, credential generation, and model. `open=true`
+with a positive retry time means calls fail fast during cooldown; `open=true` with
+`retry_after_seconds=0` means the breaker is probe-ready, not closed. Exactly one
+half-open probe is admitted. Cancellation does not count as provider failure, but a
+replacement probe remains fenced through the longest configured provider deadline so a
+cancelled worker cannot overlap its replacement. Local policy or unavailable-capability
+decisions do not poison provider health. Inspect `/benchmarkz` or `/runtimez` before
+restarting merely to clear a breaker, because a restart can interrupt durable work.
 
 ## Local Compose team continuity
 

--- a/docs/remote-mcp-deployment.md
+++ b/docs/remote-mcp-deployment.md
@@ -82,6 +82,7 @@ Deploy the repository image to a dedicated service and set:
 | `UNIGROK_ALLOWED_ORIGINS` | Optional exact browser origins; omit when no browser client is approved |
 | `UNIGROK_REMOTE_BODY_MAX_BYTES` | Optional MCP body cap; defaults to 28 MB and clamps to 64 KB-32 MB |
 | `UNIGROK_CALLER_BUDGETS` | Optional JSON daily USD stop thresholds keyed by full canonical OAuth principal |
+| `UNIGROK_BREAKER_FAILURES` / `UNIGROK_BREAKER_COOLDOWN` | Optional provider breaker threshold/cooldown; defaults 3 failures / 30 seconds |
 | `UNIGROK_STATE_DIR` | `/tmp/unigrok` for the current instance-local deployment |
 | `XAI_API_KEY` | Owner-default xAI credential from a version-pinned secret |
 | `UNIGROK_PRINCIPAL_XAI_KEYS_JSON` | Optional secret JSON map from canonical OAuth principal to xAI key |
@@ -159,7 +160,8 @@ restarts as documented in the technical reference.
    - `/healthz` and `/readyz` return `200`;
    - unauthenticated `/mcp` returns `401`;
    - protected-resource and authorization-server metadata return `200`;
-   - the revision header identifies the candidate;
+   - `X-UniGrok-Revision` identifies the candidate and `source_fingerprint` matches the
+     tested image;
    - OAuth initialization, all-tools discovery, destructive-action rejection,
      and a real API invocation succeed.
 7. Run a bounded latency soak and inspect candidate logs for errors and 5xx

--- a/docs/team-readiness.md
+++ b/docs/team-readiness.md
@@ -1,0 +1,197 @@
+# Team readiness and handoff
+
+This is the shared evidence path for contributors and release operators. It does not
+claim that a checkout, image, public branch, or hosted revision is current; each claim
+must be proved independently.
+
+## Four separate truths
+
+| Question | Authority | What is not enough |
+| --- | --- | --- |
+| What code are we editing? | Current folder contents plus `git status` | A PR page or running container |
+| What code is local Docker running? | Runtime `source_fingerprint` plus `scripts/check_runtime_parity.py` | Image tag, container age, or Docker “healthy” |
+| What is public source? | Protected public `main` commit | Local branch or unpushed commit |
+| What serves remote users? | Public health/readiness, revision header, image digest, authenticated MCP smoke | GitHub merge or control-plane deployment status alone |
+
+Never collapse these into one “deployed” status.
+
+## Source candidate gate
+
+Run from the repository root:
+
+```bash
+uv sync --frozen
+uv run ruff check .
+bash scripts/ci-insider-denylist.sh
+uv run python scripts/check_release_contract.py
+uv run python scripts/check_docs.py
+uv run pytest -q
+docker compose config --quiet
+```
+
+The candidate is source-ready only when all seven pass and the intended diff has been
+reviewed. A passing source gate does not modify Docker or deploy Cloud Run.
+
+## Local Docker gate
+
+Compose copies `src/` into the image. It has no source bind mount, so editing or
+committing the folder never changes the running service. Every local IDE configured for
+port `4765` reaches the same container.
+
+Before any rebuild or recreation:
+
+1. Check `/runtimez` for runtime controls, breaker state, the current
+   `source_fingerprint`, and both worker counters. Drain requires
+   `grok_build.in_flight=0` and `durable_jobs.active=0`.
+2. Record the current image ID and identify the rollback image.
+3. Drain or explicitly accept interruption of active jobs. A generic provider operation
+   interrupted before its outcome is persisted becomes `lost`.
+4. Preserve the `unigrok-cli-auth` and `unigrok-public-state` volumes unless data loss is
+   an explicit decision.
+
+Prove checkout/container parity without copying or changing runtime files:
+
+```bash
+uv run python scripts/check_runtime_parity.py --container unigrok
+```
+
+`MATCH` proves byte identity for the public runtime tree. `DRIFT` is a stop signal: decide
+which source is authoritative before rebuilding. The command never changes the
+container.
+
+After an intentional rebuild, require:
+
+```bash
+curl -fsS http://127.0.0.1:4765/healthz
+curl -fsS http://127.0.0.1:4765/readyz
+curl -fsS http://127.0.0.1:4765/runtimez
+uv run python scripts/smoke_mcp.py --url http://127.0.0.1:4765/mcp
+uv run python scripts/check_runtime_parity.py --container unigrok
+```
+
+`/healthz` proves process liveness. `/readyz` additionally requires SQLite plus a usable
+credential plane. Docker's health label alone is not application readiness.
+
+## Local application and state rollback
+
+Application rollback and SQLite rollback are separate decisions. Before a candidate
+touches the persistent volume, stop the drained service, record its image ID, give that
+image an explicit rollback tag, and copy the stopped state directory into the ignored,
+Finder-visible `local-backups/` folder. Include the database plus any `-wal` and `-shm`
+files as one set:
+
+```bash
+docker compose stop grok-mcp
+docker inspect unigrok --format '{{.Image}}'
+docker image tag <recorded-image-id> unigrok:rollback-before-candidate
+mkdir -p local-backups/before-candidate/state
+docker cp unigrok:/state/. local-backups/before-candidate/state/
+```
+
+Replace `<recorded-image-id>` with the exact value printed by the preceding command.
+The Compose image is selectable without retagging the release default:
+
+```bash
+UNIGROK_IMAGE=unigrok:team-ready-candidate UNIGROK_PORT=4775 \
+  docker compose --env-file .env up --build -d grok-mcp
+```
+
+Roll back the application first while retaining current state:
+
+```bash
+docker compose stop grok-mcp
+UNIGROK_IMAGE=unigrok:rollback-before-candidate UNIGROK_PORT=4765 \
+  docker compose --env-file .env up --no-build --force-recreate -d grok-mcp
+```
+
+Then repeat health, readiness, runtime, MCP smoke, and source-fingerprint checks. Restore
+the SQLite snapshot only if the old application cannot safely use the post-candidate
+schema or the candidate damaged state. State restoration discards newer sessions, jobs,
+and receipts, so stop the service and retain a second copy first:
+
+```bash
+docker compose stop grok-mcp
+mkdir -p local-backups/post-candidate/state
+docker cp unigrok:/state/. local-backups/post-candidate/state/
+docker run --rm --user 1000:1000 \
+  --mount type=volume,src=unigrok-public-state,dst=/state \
+  --mount type=bind,src="$PWD/local-backups/before-candidate/state",dst=/backup,readonly \
+  --mount type=bind,src="$PWD/scripts/restore_local_state.py",dst=/restore.py,readonly \
+  --entrypoint /app/.venv/bin/python unigrok:rollback-before-candidate \
+  /restore.py --state-dir /state --backup-dir /backup \
+  --confirm stopped-service-state-rollback
+```
+
+The helper validates the backup, restores the database and sidecars as one set, and
+keeps the displaced state in a timestamped directory inside the volume. Start the
+rollback image only after it reports `OK`. Never restore or replace the OAuth volume as
+part of an application rollback.
+
+## Durable-job and Mission V2 acceptance
+
+| Observation | Meaning | Operator action |
+| --- | --- | --- |
+| `pending` | Worker outlived the sync window | Poll `agent_result` with the same `job_id`; do not duplicate work |
+| Generic `complete` or `error` | Terminal result is persisted | Consume the stored payload |
+| Generic `lost` | Service stopped before a provider outcome was recorded | Inspect provider state before retrying metered or mutating work |
+| Mission `continue` | Durable mission is waiting or has repairable gaps | Reattach serially with the same `continue_token` |
+| Mission terminal | Canonical mission truth is sealed | Reattach is read-only; no model rerun |
+| Repeated `cas_verifying_failed` | Fenced commit did not advance | Stop blind polling, capture the mission receipt, and escalate |
+
+Do not fire concurrent reattach calls for one token. Do not change the Mission V2
+envelope version or disable Mission V2 while missions are active unless degraded recovery
+is an explicit team decision.
+
+The pre-release reliability suite must cover: pending-to-terminal polling, explicit
+cancel, shutdown during a generic mutation, completion/shutdown races, restart polling,
+rapid serial Mission V2 reattach, and final `committed=true`.
+
+## Circuit-breaker incident matrix
+
+| Runtime state | Interpretation | Action |
+| --- | --- | --- |
+| `open=false`, `half_open=false` | Closed | Normal operation |
+| `open=true`, retry time positive | Cooldown | Wait; investigate provider failures |
+| `open=true`, retry time zero | Probe-ready | Allow the runtime's single probe; do not stampede it manually |
+| `half_open=true` | One probe owns admission | Concurrent calls should fail fast |
+
+Cancellation does not count as a provider failure, but a cancelled half-open probe is
+fenced through the longest configured provider deadline. Local budget, hard-cap, and
+capability-policy refusals must not poison provider health. Prefer observation over a
+restart: restarting to clear a breaker can turn active work into `lost`.
+
+## Hosted release evidence
+
+Use the full [remote deployment runbook](remote-mcp-deployment.md). A public-safe handoff
+contains:
+
+```text
+Source commit:
+Immutable image digest:
+Candidate active / standby revisions:
+Previous known-good revision:
+Non-secret effective runtime settings:
+Source tests / lint / boundary gate:
+Candidate readiness + authenticated MCP smoke:
+Public hostname smoke and X-UniGrok-Revision:
+Cutover time:
+Observation-window end:
+Errors, 5xx, breaker trips, lost jobs:
+Rollback decision and owner:
+```
+
+Filled records containing infrastructure identifiers, OAuth principals, secret versions,
+credentials, job tokens, or private research stay in the operator-private system. Public
+Core receives only scrubbed product behavior and reproducible tests.
+
+## Handoff vocabulary
+
+- **Ready:** candidate gates pass; not yet serving users.
+- **Live:** authoritative endpoint proves the intended revision and smoke contract.
+- **Blocked:** one named gate failed with evidence.
+- **Rolled back:** traffic returned to the recorded known-good revision and public smoke
+  passed.
+- **Monitor-only:** healthy state with no evidence-backed mutation to make.
+
+Architecture is documented in [Public architecture](architecture.md). Known limitations
+remain in [Known limits](known-limits.md).

--- a/evals/python_codegen_comparison/RESULTS.md
+++ b/evals/python_codegen_comparison/RESULTS.md
@@ -36,7 +36,7 @@ direct route, and reported $0 metered API cost. Its verified telemetry receipt i
 
 For the second pass, Grok used the `ultra` hive route with five votes and a merge pass
 across the CLI and API planes. The receipt reports five personas (`critic`, `gate`,
-`bounty`, `spec`, and `failures`), a metered cost of $0.0370508, and telemetry ID 381.
+`bounty`, `spec`, and `failures`), a session telemetry recorded.
 That receipt is recorded as a verified success. The known `xai_list_files` timeout was
 not involved in either round; no file-list tool was used.
 

--- a/example.env
+++ b/example.env
@@ -1,5 +1,7 @@
 # Local MCP port. The checked-in Compose definition runs one local instance at a time.
 UNIGROK_PORT=4765
+# Select an explicit candidate or rollback image without retagging the default.
+UNIGROK_IMAGE=unigrok:1.1.0
 
 # Hosted OAuth/Cloud Run settings are intentionally absent from this local template.
 # Operators use docs/remote-mcp-deployment.md and inject versioned secrets server-side.
@@ -8,6 +10,11 @@ UNIGROK_PORT=4765
 # Provider deadlines: 30-600 seconds.
 UNIGROK_BUILD_TIMEOUT=120
 UNIGROK_API_TIMEOUT=120
+# Provider circuit breaker: consecutive failures 2-20; cooldown 5-600 seconds.
+# After cooldown, exactly one half-open probe is admitted for each
+# plane/credential/model key.
+UNIGROK_BREAKER_FAILURES=3
+UNIGROK_BREAKER_COOLDOWN=30
 # Long-running autonomy + mission v2. Docker compose defaults these on for live.
 UNIGROK_AUTONOMY=true
 UNIGROK_MISSION_V2=true

--- a/example.env
+++ b/example.env
@@ -2,6 +2,9 @@
 UNIGROK_PORT=4765
 # Select an explicit candidate or rollback image without retagging the default.
 UNIGROK_IMAGE=unigrok:1.1.0
+UNIGROK_CHAT_TOOLS=always
+UNIGROK_SWARM=active
+UNIGROK_DEFAULT_LEVEL=max
 
 # Hosted OAuth/Cloud Run settings are intentionally absent from this local template.
 # Operators use docs/remote-mcp-deployment.md and inject versioned secrets server-side.

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Validate relative links in tracked Markdown without making network requests."""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from urllib.parse import unquote
+
+ROOT = Path(__file__).resolve().parents[1]
+LINK = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
+
+
+def _tracked_markdown() -> list[Path]:
+    git = shutil.which("git")
+    if git is None:
+        raise RuntimeError("git executable was not found")
+    completed = subprocess.run(
+        [git, "ls-files", "--cached", "--others", "--exclude-standard", "--", "*.md"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [ROOT / line for line in completed.stdout.splitlines() if line]
+
+
+def main() -> int:
+    failures: list[str] = []
+    try:
+        files = _tracked_markdown()
+    except (OSError, RuntimeError, subprocess.SubprocessError) as exc:
+        print(f"docs-contract: ERROR: {exc}", file=sys.stderr)
+        return 2
+    for document in files:
+        for line_number, line in enumerate(
+            document.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            for raw_target in LINK.findall(line):
+                target = raw_target.strip().strip("<>").split(maxsplit=1)[0]
+                if not target or target.startswith(
+                    ("#", "http://", "https://", "mailto:")
+                ):
+                    continue
+                relative = unquote(target.split("#", 1)[0])
+                if not relative:
+                    continue
+                if Path(relative).is_absolute():
+                    failures.append(
+                        f"{document.relative_to(ROOT)}:{line_number}: "
+                        f"absolute filesystem link is not allowed: {relative}"
+                    )
+                    continue
+                resolved = (document.parent / relative).resolve()
+                if not resolved.is_relative_to(ROOT.resolve()):
+                    failures.append(
+                        f"{document.relative_to(ROOT)}:{line_number}: "
+                        f"link escapes repository: {relative}"
+                    )
+                elif not resolved.exists():
+                    failures.append(
+                        f"{document.relative_to(ROOT)}:{line_number}: missing {relative}"
+                    )
+    if failures:
+        print("docs-contract: FAILED", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        return 1
+    print(f"docs-contract: OK ({len(files)} repository Markdown files)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_release_contract.py
+++ b/scripts/check_release_contract.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Fail when the public release version drifts across shipping surfaces."""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _text(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def _match(path: str, pattern: str) -> str | None:
+    found = re.search(pattern, _text(path), flags=re.MULTILINE)
+    return found.group(1) if found else None
+
+
+def main() -> int:
+    project = tomllib.loads(_text("pyproject.toml"))
+    expected = str(project["project"]["version"])
+    observed: dict[str, list[str | None]] = {
+        "src/unigrok_public/__init__.py": [
+            _match("src/unigrok_public/__init__.py", r'^__version__\s*=\s*"([^"]+)"')
+        ],
+        "README.md badge": [
+            _match("README.md", r"shields\.io/badge/version-([0-9][0-9A-Za-z.-]*)-")
+        ],
+        "compose.yaml images": re.findall(
+            r"^\s*image:\s*(?:\$\{UNIGROK_IMAGE:-)?unigrok:([^}\s]+)\}?",
+            _text("compose.yaml"),
+            flags=re.MULTILINE,
+        ),
+        "docs/reference.md": [
+            _match("docs/reference.md", r"all report version `([^`]+)`")
+        ],
+        "scripts/smoke_mcp.py": [
+            _match("scripts/smoke_mcp.py", r'^EXPECTED_VERSION\s*=\s*"([^"]+)"')
+        ],
+    }
+
+    lock = tomllib.loads(_text("uv.lock"))
+    root_versions = [
+        str(package.get("version"))
+        for package in lock.get("package", [])
+        if package.get("name") == project["project"]["name"]
+    ]
+    observed["uv.lock root package"] = root_versions
+
+    failures: list[str] = []
+    for surface, versions in observed.items():
+        if not versions:
+            failures.append(f"{surface}: version marker missing")
+            continue
+        mismatches = [version for version in versions if version != expected]
+        if mismatches:
+            failures.append(f"{surface}: expected {expected}, found {versions}")
+
+    compose_variables = set(re.findall(r"\$\{([A-Z][A-Z0-9_]*)", _text("compose.yaml")))
+    example_variables = set(
+        re.findall(
+            r"^\s*#?\s*([A-Z][A-Z0-9_]*)=",
+            _text("example.env"),
+            flags=re.MULTILINE,
+        )
+    )
+    missing_examples = sorted(compose_variables - example_variables)
+    if missing_examples:
+        failures.append(
+            "example.env: missing Compose variables " + ", ".join(missing_examples)
+        )
+
+    if failures:
+        print("release-contract: FAILED", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        return 1
+    print(f"release-contract: OK ({expected}; {len(observed)} surfaces)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_runtime_parity.py
+++ b/scripts/check_runtime_parity.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Compare the checkout's public runtime source with a running Docker container."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from unigrok_public.build_identity import manifest_fingerprint, source_manifest
+
+_CONTAINER_MANIFEST_PROGRAM = r"""
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1]).resolve()
+if not root.is_dir():
+    print(f"source root is not a directory: {root}", file=sys.stderr)
+    raise SystemExit(2)
+
+manifest = {}
+for path in sorted(root.rglob("*")):
+    relative = path.relative_to(root)
+    if (
+        not path.is_file()
+        or "__pycache__" in relative.parts
+        or path.name == ".DS_Store"
+        or path.suffix in {".pyc", ".pyo"}
+    ):
+        continue
+    manifest[relative.as_posix()] = hashlib.sha256(path.read_bytes()).hexdigest()
+print(json.dumps(manifest, sort_keys=True))
+"""
+
+
+def compare_manifests(host: dict[str, str], runtime: dict[str, str]) -> dict[str, Any]:
+    """Return a stable, machine-readable source comparison."""
+    host_paths = set(host)
+    runtime_paths = set(runtime)
+    return {
+        "status": "match" if host == runtime else "drift",
+        "host_fingerprint": manifest_fingerprint(host),
+        "runtime_fingerprint": manifest_fingerprint(runtime),
+        "changed": sorted(
+            path for path in host_paths & runtime_paths if host[path] != runtime[path]
+        ),
+        "missing_in_runtime": sorted(host_paths - runtime_paths),
+        "extra_in_runtime": sorted(runtime_paths - host_paths),
+    }
+
+
+def _runtime_manifest(container: str, root: str) -> dict[str, str]:
+    docker = shutil.which("docker")
+    if docker is None:
+        raise RuntimeError("docker executable was not found")
+    completed = subprocess.run(
+        [docker, "exec", container, "python", "-c", _CONTAINER_MANIFEST_PROGRAM, root],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or "docker exec failed"
+        raise RuntimeError(detail[:500])
+    payload = json.loads(completed.stdout)
+    if not isinstance(payload, dict) or not all(
+        isinstance(path, str) and isinstance(digest, str)
+        for path, digest in payload.items()
+    ):
+        raise RuntimeError("container returned an invalid source manifest")
+    return payload
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Prove whether the current checkout and a running UniGrok container "
+            "contain byte-identical public runtime sources."
+        )
+    )
+    parser.add_argument("--container", default="unigrok")
+    parser.add_argument(
+        "--host-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1] / "src" / "unigrok_public",
+    )
+    parser.add_argument("--container-root", default="/app/src/unigrok_public")
+    parser.add_argument("--json", action="store_true", dest="json_output")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        report = compare_manifests(
+            source_manifest(args.host_root),
+            _runtime_manifest(args.container, args.container_root),
+        )
+    except (OSError, RuntimeError, subprocess.SubprocessError, json.JSONDecodeError) as exc:
+        print(f"runtime-parity: ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json_output:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(f"runtime-parity: {report['status'].upper()}")
+        print(f"  checkout: {report['host_fingerprint']}")
+        print(f"  container: {report['runtime_fingerprint']}")
+        for label in ("changed", "missing_in_runtime", "extra_in_runtime"):
+            paths = report[label]
+            if paths:
+                print(f"  {label.replace('_', ' ')} ({len(paths)}):")
+                for path in paths:
+                    print(f"    {path}")
+    return 0 if report["status"] == "match" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci-insider-denylist.sh
+++ b/scripts/ci-insider-denylist.sh
@@ -4,7 +4,8 @@
 # The public gateway image must never ship contributor/forge UI assets, private
 # deploy overlays, or secret material. Forge deployments mount their private
 # console at runtime (UNIGROK_UI_ROOT); nothing insider is ever committed here.
-# This checks TRACKED PATHS, so the deny-list itself can be documented freely.
+# This checks tracked plus untracked, non-ignored repository files so a local gate
+# catches provenance before staging. The deny-list itself is excluded from text scans.
 set -euo pipefail
 
 deny_patterns=(
@@ -18,11 +19,37 @@ deny_patterns=(
   '\.pem$'
 )
 
+# Public prose may explain the boundary, but it must not preserve private review
+# receipts or name internal donor artifacts. Keep these narrow so ordinary uses of
+# words such as "private" and the public telemetry_id field remain valid.
+provenance_patterns=(
+  'internal donor'
+  'donor-research'
+  'private DoR'
+  'telemetry([ _-]?(ID|id))?[` )=:#-]*[0-9]{2,}'
+  'metered cost of \$[0-9]'
+)
+
 fail=0
-tracked="$(git ls-files)"
+repository_files="$(git ls-files --cached --others --exclude-standard)"
 for pattern in "${deny_patterns[@]}"; do
-  if hits="$(grep -E "$pattern" <<<"$tracked")"; then
-    echo "insider-denylist: FORBIDDEN tracked path(s) matching '$pattern':" >&2
+  if hits="$(grep -E "$pattern" <<<"$repository_files")"; then
+    echo "insider-denylist: FORBIDDEN repository path(s) matching '$pattern':" >&2
+    echo "$hits" >&2
+    fail=1
+  fi
+done
+
+for pattern in "${provenance_patterns[@]}"; do
+  hits="$({
+    while IFS= read -r file; do
+      [ -f "$file" ] || continue
+      [ "$file" = "scripts/ci-insider-denylist.sh" ] && continue
+      grep -I -H -n -E "$pattern" -- "$file" || true
+    done <<<"$repository_files"
+  } || true)"
+  if [ -n "$hits" ]; then
+    echo "insider-denylist: FORBIDDEN private provenance matching '$pattern':" >&2
     echo "$hits" >&2
     fail=1
   fi

--- a/src/unigrok_public/harness.py
+++ b/src/unigrok_public/harness.py
@@ -192,7 +192,7 @@ _HIVE_VOTE_JSON_RE = re.compile(r"\{[^{}]*\"v\"\s*:\s*\"(?:pass|fail|risk)\"[^{}
 
 def number_draft_lines(draft: str) -> str:
     """Diff-style index: number every draft line so votes can anchor precisely."""
-    # Hive-optimized via dogfood_optimize.py (telemetry 111): +22.6% measured.
+    # Hive-optimized via dogfood_optimize.py: +22.6% measured.
     return "\n".join(
         f"L{i}: {line}" for i, line in enumerate(str(draft or "").splitlines(), 1)
     )
@@ -211,7 +211,7 @@ def build_vote_prompt(task: str, draft: str, persona: dict[str, str]) -> str:
 
 
 def parse_hive_vote(text: str) -> dict[str, Any] | None:
-    # Hive-optimized via dogfood_optimize.py (telemetry 134): +18.0% measured.
+    # Hive-optimized via dogfood_optimize.py: +18.0% measured.
     match = _HIVE_VOTE_JSON_RE.search(str(text or ""))
     if not match:
         return None
@@ -350,7 +350,7 @@ def parse_done_vote(text: str) -> bool | None:
 
 def majority(values: list[str], default: str) -> str:
     """Plain-code vote count; ties break toward the first-seen most common value."""
-    # Hive-optimized via dogfood_optimize.py (telemetry 132): +20.8% measured.
+    # Hive-optimized via dogfood_optimize.py: +20.8% measured.
     if not values:
         return default
     counts: dict[str, int] = {}
@@ -505,7 +505,7 @@ def _looks_like_plan(text: str) -> bool:
 def is_nonanswer_completion(content: Any, *, prompt: str = "") -> bool:
     """Reject an empty promise or unsolicited plan that delivers no result."""
 
-    # Hive-optimized via dogfood_optimize.py (telemetry 122): +18.0% measured.
+    # Hive-optimized via dogfood_optimize.py: +18.0% measured.
     if not isinstance(content, str):
         return True
     stripped = content.strip()

--- a/tests/test_forge_surface.py
+++ b/tests/test_forge_surface.py
@@ -1,6 +1,6 @@
 """P1 forge-surface hooks: default-unchanged, runtime UI mount, control-plane skeleton.
 
-Acceptance sheet: docs (private DoR) rows P1-P7 — surface flag defaulting,
+Acceptance sheet: docs acceptance sheet rows P1-P7 — surface flag defaulting,
 UNIGROK_UI_ROOT runtime mount with traversal safety, X-Forwarded-For never
 trusted for loopback, /ui never bearer-authed, forge skeleton 401s, telemetry
 contract parity.


### PR DESCRIPTION
## Summary
Adds docs and release-contract CI gates for public UniGrok core.

## Authority
- Sponsor (David) PROMOTE YES
- @skygrok / Sky-Command PROMOTE YES (dual authority)
- Pre-beta flow: public core gym · DEFAULT_FAILOVER=OFF · READY=false honest

## Notes
- Base: current `main` tip `#514` helper (`20d8e31`) already Live
- Does **not** enable Gemma default failover
- Does **not** publish private intelligence corpus

## Test plan
- [ ] CI green on this PR
- [ ] No secrets / private paths in diff

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly documentation, CI scripts, and Compose/env templates; runtime code touch is limited to comment/provenance scrubbing with no behavioral logic in the diff.
> 
> **Overview**
> Adds **CI-enforced release and docs contracts**: `check_release_contract.py` keeps version strings aligned across `pyproject.toml`, lockfile, README, Compose, reference, and smoke; `check_docs.py` validates relative Markdown links. Contributor and development guides run these before `pytest`.
> 
> Introduces a **team readiness** path: new `docs/architecture.md` and `docs/team-readiness.md` (four-way evidence: source vs Docker vs public `main` vs hosted), plus `scripts/check_runtime_parity.py` for read-only checkout↔container `source_fingerprint` comparison. README links the new docs; remote deployment smoke now expects revision header and fingerprint parity.
> 
> **Compose / local ops**: `UNIGROK_IMAGE` override, default factory env (`CHAT_TOOLS`, `SWARM`, `DEFAULT_LEVEL`), and breaker threshold/cooldown wired through Compose and `example.env` (release contract also requires every Compose `${VAR}` appear in `example.env`). `local-backups/` is gitignored for documented SQLite rollback snapshots.
> 
> **Public-repo hygiene**: insider denylist scans untracked files and blocks private provenance strings (telemetry IDs, metered cost lines, donor references); design docs reframed as public design records; eval RESULTS and harness comments scrub similar IDs. `CHANGELOG` documents recent runtime fixes (shutdown, breakers, session locks) alongside the new documentation gates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58f3bc6e0235b4693e639001563940b359cfeb60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->