### PR TITLE
fix: activate GemmaGrok direct-talk route

### DIFF
--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -2908,6 +2908,15 @@ async def _run_unified(
     max_output_tokens: int | None = None,
     nonanswer_recovery: bool = True,
 ) -> dict[str, Any]:
+    if DIRECT_TALK_ACTIVE:
+        return await _serve_local_direct_noncertified(
+            prompt,
+            system_context=system_context,
+            allow_web=allow_web,
+            allow_x_search=allow_x_search,
+            allow_code=allow_code,
+        )
+
     # Silent-think doctrine (compute != print): reasoning effort stays high while a
     # tiny output cap is applied to KNOWN-SMALL emits (votes) so metered API output
     # tokens do not balloon. CLI is flat-rate and has no output cap, so this only
@@ -7033,10 +7042,6 @@ def main() -> None:
     uvicorn.run(app, host=mcp.settings.host, port=mcp.settings.port)
 
 
-if __name__ == "__main__":
-    main()
-
-
 async def _apply_continue_bound(result: dict[str, Any]) -> dict[str, Any]:
     """§5.5: shed/non_answer → status=continue with bounded continue_count.
 
@@ -7720,7 +7725,7 @@ async def _serve_local_direct_noncertified(
         )
     messages.append({"role": "user", "content": prompt})
 
-    _breaker_before_call("local", LOCAL_DIRECT_MODEL)
+    admission = _breaker_before_call("local", LOCAL_DIRECT_MODEL)
     try:
         got = await _openai_compat_chat(
             LOCAL_RUNTIME_URL,
@@ -7729,9 +7734,12 @@ async def _serve_local_direct_noncertified(
             max_tokens=None,
             timeout=BUILD_TIMEOUT_SECONDS,
         )
-        _breaker_success("local", LOCAL_DIRECT_MODEL)
+        _breaker_success(admission)
+    except asyncio.CancelledError:
+        _breaker_abandon_probe(admission)
+        raise
     except Exception:
-        _breaker_failure("local", LOCAL_DIRECT_MODEL)
+        _breaker_failure(admission)
         env = _stamp(
             {
                 "text": "The local model runtime did not answer; direct talk is degraded.",
@@ -8061,3 +8069,5 @@ def _storm_route_tiers_gated() -> bool:
     return bool(_STORM_429.get("half_open"))
 
 
+if __name__ == "__main__":
+    main()

--- a/tests/test_local_direct_talk.py
+++ b/tests/test_local_direct_talk.py
@@ -1,0 +1,151 @@
+"""Non-certified named-peer direct-talk mode."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+
+import pytest
+
+from unigrok_public import server
+
+
+def _reload_with(monkeypatch, env: dict[str, str]):
+    for key in (
+        "UNIGROK_LAYER",
+        "UNIGROK_LOCAL_DIRECT_TALK_MODE",
+        "UNIGROK_LOCAL_DIRECT_MODEL",
+        "UNIGROK_LOCAL_RUNTIME_URL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    return importlib.reload(server)
+
+
+@pytest.fixture(autouse=True)
+def _restore_server():
+    yield
+    importlib.reload(server)
+
+
+def test_direct_talk_off_by_default(monkeypatch):
+    current = _reload_with(monkeypatch, {})
+    assert current.DIRECT_TALK_ACTIVE is False
+    assert current.MCP_SERVER_NAME == current.SERVICE_NAME
+
+
+def test_direct_talk_requires_full_combo(monkeypatch):
+    assert _reload_with(monkeypatch, {"UNIGROK_LAYER": "gemma"}).DIRECT_TALK_ACTIVE is False
+    assert (
+        _reload_with(
+            monkeypatch,
+            {
+                "UNIGROK_LAYER": "gemma",
+                "UNIGROK_LOCAL_DIRECT_TALK_MODE": "non_certified",
+            },
+        ).DIRECT_TALK_ACTIVE
+        is False
+    )
+    assert (
+        _reload_with(
+            monkeypatch,
+            {
+                "UNIGROK_LAYER": "sky",
+                "UNIGROK_LOCAL_DIRECT_TALK_MODE": "non_certified",
+                "UNIGROK_LOCAL_DIRECT_MODEL": "gemma4",
+                "UNIGROK_LOCAL_RUNTIME_URL": "http://rt.test",
+            },
+        ).DIRECT_TALK_ACTIVE
+        is False
+    )
+
+
+def _active(monkeypatch):
+    return _reload_with(
+        monkeypatch,
+        {
+            "UNIGROK_LAYER": "gemma",
+            "UNIGROK_LOCAL_DIRECT_TALK_MODE": "non_certified",
+            "UNIGROK_LOCAL_DIRECT_MODEL": "gemma4",
+            "UNIGROK_LOCAL_RUNTIME_URL": "http://rt.test",
+        },
+    )
+
+
+def test_direct_talk_active_names_peer_from_layer(monkeypatch):
+    current = _active(monkeypatch)
+    assert current.DIRECT_TALK_ACTIVE is True
+    assert current.MCP_SERVER_NAME == "GemmaGrok"
+
+
+def test_run_unified_direct_talk_never_resolves_plane(monkeypatch):
+    current = _active(monkeypatch)
+
+    async def _boom(*args, **kwargs):
+        raise AssertionError("_resolve_plane must not run in direct-talk mode")
+
+    monkeypatch.setattr(current, "_resolve_plane", _boom)
+
+    async def _fake_transport(
+        base, model, messages, *, max_tokens, timeout  # noqa: ASYNC109
+    ):
+        assert base == "http://rt.test"
+        assert model == "gemma4"
+        return {"text": "hello from gemma", "stop_reason": "stop"}
+
+    monkeypatch.setattr(current, "_openai_compat_chat", _fake_transport)
+    result = asyncio.run(
+        current._run_unified(
+            "hi",
+            model=None,
+            effort=None,
+            plane="auto",
+            fallback_policy="cross_plane",
+            agentic=False,
+            max_turns=1,
+            allow_web=False,
+            allow_x_search=False,
+            allow_code=False,
+        )
+    )
+    assert result["text"] == "hello from gemma"
+    assert result["certification_status"] == "NON_CERTIFIED"
+    assert result["failover_eligible"] is False
+    assert result["gate_id"] is None
+    assert result["all_traffic_abstain"] == "OPEN"
+    assert result["plane"] == "local"
+    assert result["resolved_plane"] == "local"
+    assert result["route_mode"] == "direct_talk"
+    assert result["floor_role"] is None
+    assert result["floor_metric_ids"] == []
+    assert result["cost_usd"] == 0.0
+
+
+def test_direct_talk_capabilities_fail_closed(monkeypatch):
+    current = _active(monkeypatch)
+
+    async def _boom(*args, **kwargs):
+        raise AssertionError("transport must not run for a capability request")
+
+    monkeypatch.setattr(current, "_openai_compat_chat", _boom)
+    result = asyncio.run(
+        current._serve_local_direct_noncertified("do a thing", allow_web=True)
+    )
+    assert result["status"] == "error"
+    assert result["stop_reason"] == "direct_talk_unsupported_capability"
+    assert result["certification_status"] == "NON_CERTIFIED"
+    assert result["model"] is None
+
+
+def test_direct_talk_runtime_error_fails_closed(monkeypatch):
+    current = _active(monkeypatch)
+
+    async def _explode(*args, **kwargs):
+        raise RuntimeError("runtime down")
+
+    monkeypatch.setattr(current, "_openai_compat_chat", _explode)
+    result = asyncio.run(current._serve_local_direct_noncertified("hi"))
+    assert result["status"] == "error"
+    assert result["stop_reason"] == "local_runtime_unavailable"
+    assert result["failover_eligible"] is False


### PR DESCRIPTION
## What changed

- Routes the explicitly configured GemmaGrok non-certified direct-talk mode into `_run_unified` before remote-plane resolution.
- Updates that existing helper to the current circuit-breaker admission API.
- Moves module startup to the end of `server.py` so Docker `python -m unigrok_public.server` loads the offline helper definitions before serving.
- Adds focused tests for default-off behavior, exact activation, no remote-plane escape, capability rejection, and runtime failure.

## Why

PR #516 shipped the offline/local-plane stack but left this named-peer helper disconnected. This is the smallest public follow-up that makes the existing GemmaGrok direct-talk surface actually reachable without enabling default failover.

## Safety / defaults

- `DEFAULT_FAILOVER=OFF`
- Activation still requires the full explicit Gemma layer + non-certified direct-talk mode + local model + local runtime combination.
- No private intelligence files or credentials.

## Validation

- `6 passed` — direct-talk suite
- `76 passed` — public-boundary + forge-surface + direct-talk regression set
- Ruff: clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the main unified request entry point routing when a rare env combo is set; behavior is gated and fail-closed, but misconfiguration could surprise operators expecting certified/remote planes.
> 
> **Overview**
> **GemmaGrok direct-talk** is now reachable: when `DIRECT_TALK_ACTIVE` (full Gemma layer + `non_certified` mode + local model/runtime), `_run_unified` returns early via `_serve_local_direct_noncertified` and **never** runs `_resolve_plane` or remote failover.
> 
> The local direct-talk path’s circuit breaker calls were aligned with the admission-based API (`_breaker_before_call` → success/failure/abandon on cancel), matching `_guarded_provider_call`.
> 
> `if __name__ == "__main__"` was moved to the **end** of `server.py` so `python -m unigrok_public.server` loads offline helper definitions before startup.
> 
> New tests cover default-off activation rules, unified routing semantics (`NON_CERTIFIED`, `route_mode=direct_talk`, no gate/failover), capability rejection, and runtime errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0341b1dc9b85d77d6e2d9e0b055ad1306057b71e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->