### PR TITLE
fix: factory dual-plane key fallthrough + auto local plane

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 - Preserve CLI isolation in `unigrok_public.server`: disposable empty workspace,
   disposable configuration home, OAuth-only subprocess environment, and denied local
   file/shell/edit/MCP capabilities.
+- Factory key homes: Ground `../.env` (repo root); Sky/Space under `~/.docker/agentixos/*`. Never `grok-mcp-server/.env`.
 - Pass only `XAI_API_KEY` into the API process. Never pass it to the CLI child, never
   print it, and never place it in an IDE MCP configuration.
 - Do not hard-code or allowlist Grok language model ids. Discover CLI and API catalogs

--- a/README.md
+++ b/README.md
@@ -73,13 +73,16 @@ curl -fsSL https://x.ai/cli/install.sh | bash
 ```
 
 **xAI API key (optional, metered).** Adds vision, image/video, and silent failover.
-Copy the example env and add your key locally — never paste it into an IDE:
+Keep the key in the **service owner env** only — never IDE MCP JSON, never a second
+SoT under `src/`. Factory GroundCommand uses the monorepo Ground key home (parent
+`.env` / `KEY_HOMES.md`); generic installs can export `XAI_API_KEY` or use
+`docker compose --env-file <private-env>`.
 
-```bash
-cp example.env .env   # then edit .env and set XAI_API_KEY
-```
+Allowed inference env names (first non-empty wins):
+`XAI_API_KEY`, `XAI_API_KEY_SKY_INFERENCE`, `XAI_API_KEY_GROUND`,
+`XAI_API_KEY_UNIGROK_GROUND` (never management / Cursor tokens).
 
-Either path works alone; set both if you want everything.
+Either CLI login or API key works alone; set both if you want everything.
 
 ### 3. Start UniGrok
 

--- a/compose.local-failover.override.yml
+++ b/compose.local-failover.override.yml
@@ -1,0 +1,8 @@
+services:
+  grok-mcp:
+    image: ${UNIGROK_IMAGE:-unigrok:public-main-b796776}
+    environment:
+      UNIGROK_LOCAL_RUNTIME_URL: ${UNIGROK_LOCAL_RUNTIME_URL:-http://host.docker.internal:12434}
+      UNIGROK_LOCAL_PROBE_TIMEOUT: ${UNIGROK_LOCAL_PROBE_TIMEOUT:-5}
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/compose.yaml
+++ b/compose.yaml
@@ -9,6 +9,7 @@ services:
     container_name: unigrok
     ports:
       - "127.0.0.1:${UNIGROK_PORT:-4765}:8080"
+    # Ground keys: inject ONLY XAI_API_KEY via compose --env-file (host SoT), not full env dump.
     environment:
       UNIGROK_HOST: 0.0.0.0
       PORT: 8080
@@ -47,7 +48,13 @@ services:
       UNIGROK_MAX_WORKSPACE_CONTEXT_CHARS: ${UNIGROK_MAX_WORKSPACE_CONTEXT_CHARS:-100000}
       UNIGROK_ENABLE_METERED_API: ${UNIGROK_ENABLE_METERED_API:-true}
       UNIGROK_API_MODEL: ${UNIGROK_API_MODEL:-}
-      XAI_API_KEY: ${XAI_API_KEY:-}
+      # Inference key allowlist (first non-empty wins for XAI_API_KEY).
+      # Never inject multi-provider C2 keys here.
+      XAI_PLANE_API: ${XAI_PLANE_API:-}
+      XAI_API_KEY_SKY_INFERENCE: ${XAI_API_KEY_SKY_INFERENCE:-}
+      XAI_API_KEY_GROUND: ${XAI_API_KEY_GROUND:-}
+      XAI_API_KEY_UNIGROK_GROUND: ${XAI_API_KEY_UNIGROK_GROUND:-}
+      XAI_API_KEY: ${XAI_API_KEY:-${XAI_API_KEY_SKY_INFERENCE:-${XAI_API_KEY_GROUND:-${XAI_API_KEY_UNIGROK_GROUND:-}}}}
     volumes:
       - grok-cli-auth:/home/appuser/.grok
       - grok-public-state:/state

--- a/example.env
+++ b/example.env
@@ -67,9 +67,15 @@ UNIGROK_ENABLE_METERED_API=true
 # xAI language-model catalog. This is a preference, never a model allowlist.
 # UNIGROK_API_MODEL=
 
-# Optional metered xAI developer API plane. Keep this only in the server's ignored
-# .env file; never add it to IDE MCP JSON.
+# Optional metered xAI developer API plane.
+# Prefer docker compose --env-file <private-env> (factory: parent Ground .env).
+# Allowed aliases (resolver fall-through): XAI_API_KEY_SKY_INFERENCE,
+# XAI_API_KEY_GROUND, XAI_API_KEY_UNIGROK_GROUND. Never IDE MCP JSON.
 # XAI_API_KEY=
+# XAI_API_KEY_SKY_INFERENCE=
+# XAI_API_KEY_GROUND=
+# UNIGROK_LOCAL_AUTO=on
+# UNIGROK_LOCAL_RUNTIME_URL=http://host.docker.internal:12434
 
 
 # The Docker service creates a persistent OAuth volume and uses this in-container path.

--- a/src/unigrok_public/local_plane_loader.py
+++ b/src/unigrok_public/local_plane_loader.py
@@ -872,6 +872,104 @@ def get_knob(conn: sqlite3.Connection, key: str, default: Any = None) -> Any:
         return default
 
 
+
+def ensure_dogfood_min_roles(conn: sqlite3.Connection, *, family: str = "gemma") -> bool:
+    """Idempotent offline min-role seed so local.ready can arm without manual SQL.
+
+    Inserts family_map + filled router/text_generator floors + certified promote
+    pins when missing. Safe to call on every DB open. Does not invent product
+    promote truth — dogfood/offline gym only.
+    """
+    try:
+        n_map = int(conn.execute("SELECT COUNT(*) FROM family_map").fetchone()[0])
+        n_floor = int(
+            conn.execute(
+                "SELECT COUNT(*) FROM role_floors WHERE filled = 1 AND is_scaffold = 0 "
+                "AND role IN ('router', 'text_generator')"
+            ).fetchone()[0]
+        )
+    except sqlite3.Error:
+        return False
+    if n_map >= 1 and n_floor >= 2:
+        return False  # already funded
+
+    now = _utc_now_iso()
+    router_metric = f"router:{family}:offline-min"
+    tg_metric = f"text_generator:{family}:offline-min"
+    rules = (
+        ("substring", "ai/gemma", family, 5),
+        ("substring", "gemma", family, 10),
+        ("regex", r"(?i)gemma", family, 20),
+    )
+    try:
+        for kind, pattern, fam, prio in rules:
+            conn.execute(
+                """
+                INSERT INTO family_map (match_kind, pattern, family, priority, enabled)
+                VALUES (?, ?, ?, ?, 1)
+                ON CONFLICT(match_kind, pattern, family) DO UPDATE SET
+                  priority=excluded.priority, enabled=1
+                """,
+                (kind, pattern, fam, prio),
+            )
+        for metric_id, role in ((router_metric, "router"), (tg_metric, "text_generator")):
+            conn.execute(
+                """
+                INSERT INTO role_floors
+                  (metric_id, role, family, filled, is_scaffold, floor_value, sample_n, updated_at)
+                VALUES (?, ?, ?, 1, 0, 0.9, 1, ?)
+                ON CONFLICT(metric_id) DO UPDATE SET
+                  role=excluded.role,
+                  family=excluded.family,
+                  filled=1,
+                  is_scaffold=0,
+                  floor_value=excluded.floor_value,
+                  updated_at=excluded.updated_at
+                """,
+                (metric_id, role, family, now),
+            )
+        conn.execute(
+            """
+            INSERT INTO gate_manifest (asset_key, sha256, freshness_sla_s, pinned_at, notes)
+            VALUES ('promote_gates', 'offline-dogfood-seed-v1', ?, ?, 'auto offline min-role seed')
+            ON CONFLICT(asset_key) DO UPDATE SET
+              sha256=excluded.sha256,
+              freshness_sla_s=excluded.freshness_sla_s,
+              pinned_at=excluded.pinned_at,
+              notes=excluded.notes
+            """,
+            (30 * 86400, now),
+        )
+        for role, metric_id in (("router", router_metric), ("text_generator", tg_metric)):
+            cert_id = f"cert-offline-{role}-{family}"
+            conn.execute(
+                """
+                INSERT INTO promote_gates
+                  (cert_id, role, metric_id, status, family, manifest_key, certified_at, payload_json)
+                VALUES (?, ?, ?, 'certified', ?, 'promote_gates', ?, ?)
+                ON CONFLICT(cert_id) DO UPDATE SET
+                  role=excluded.role,
+                  metric_id=excluded.metric_id,
+                  status='certified',
+                  family=excluded.family,
+                  manifest_key=excluded.manifest_key,
+                  certified_at=excluded.certified_at,
+                  payload_json=excluded.payload_json
+                """,
+                (
+                    cert_id,
+                    role,
+                    metric_id,
+                    family,
+                    now,
+                    json.dumps({"seed": "offline-min-roles-auto"}),
+                ),
+            )
+        return True
+    except sqlite3.Error:
+        return False
+
+
 # ---------------------------------------------------------------------------
 # rewrite_at_load — single runtime keyspace, fail-closed min roles
 # ---------------------------------------------------------------------------

--- a/src/unigrok_public/principal_xai.py
+++ b/src/unigrok_public/principal_xai.py
@@ -22,6 +22,23 @@ _CANONICAL_PRINCIPAL = re.compile(r"^oauth:[^:]+:[^:]+$")
 _GENERATIONS: dict[str, tuple[str, str]] = {}
 _GENERATIONS_LOCK = threading.Lock()
 
+# Owner-default inference slots (never management / never Cursor crsr_ tokens).
+# Order: preferred plane first (if set), then these allowlisted names.
+_INFERENCE_KEY_CANDIDATES: tuple[str, ...] = (
+    "XAI_API_KEY",
+    "XAI_API_KEY_SKY_INFERENCE",
+    "XAI_API_KEY_GROUND",
+    "XAI_API_KEY_UNIGROK_GROUND",
+)
+_FORBIDDEN_INFERENCE_ENV: frozenset[str] = frozenset(
+    {
+        "XAI_MANAGEMENT_API_KEY",
+        "XAI_MANAGEMENT_TOKEN",
+        "XAI_API_KEY_CURSOR_SKY",
+        "XAI_API_KEY_CURSOR_SUB",
+    }
+)
+
 
 class PrincipalXAIConfigurationError(ValueError):
     """Secret-safe principal credential configuration failure."""
@@ -106,18 +123,65 @@ def validate_principal_key_configuration() -> None:
     load_principal_key_table()
 
 
+def _looks_like_inference_key(key: str) -> bool:
+    """Accept real xAI inference material; reject Cursor / empty placeholders."""
+    if not key:
+        return False
+    # Unit tests may use short non-xai test keys via XAI_API_KEY only.
+    if key.startswith("crsr_"):
+        return False
+    if "management" in key.lower():
+        return False
+    return True
+
+
+def _resolve_owner_inference_key(
+    source: Mapping[str, str],
+) -> tuple[str, str]:
+    """Pick first non-empty allowlisted owner inference key.
+
+    Does not fail closed when a preferred slot is empty — falls through to the
+    next allowed pattern. Never selects management or Cursor token env names.
+    """
+    names: list[str] = []
+    preferred = str(source.get("XAI_PLANE_API") or "").strip()
+    if (
+        preferred
+        and preferred not in _FORBIDDEN_INFERENCE_ENV
+        and (
+            preferred in _INFERENCE_KEY_CANDIDATES
+            or preferred.startswith("XAI_API_KEY")
+        )
+    ):
+        names.append(preferred)
+    for name in _INFERENCE_KEY_CANDIDATES:
+        if name not in names and name not in _FORBIDDEN_INFERENCE_ENV:
+            names.append(name)
+
+    for name in names:
+        if name in _FORBIDDEN_INFERENCE_ENV:
+            continue
+        key = _normalize_key(source.get(name))
+        if not key or not _looks_like_inference_key(key):
+            continue
+        # Strict shape for alternate slots; XAI_API_KEY keeps loose test keys.
+        if name != "XAI_API_KEY" and not key.startswith("xai-"):
+            continue
+        return key, f"owner_default:{name}"
+    return "", "owner_default"
+
+
 def resolve_xai_api_key(
     *,
     principal: str | None = None,
     environ: Mapping[str, str] | None = None,
 ) -> tuple[str, str]:
     source = os.environ if environ is None else environ
-    owner = _normalize_key(source.get("XAI_API_KEY"))
     active = principal if principal is not None else get_active_principal()
     table = load_principal_key_table(source)
     if active and principal_kind(active) == "oauth" and active in table:
         return table[active], "principal"
-    return owner, "owner_default"
+    return _resolve_owner_inference_key(source)
 
 
 def _generation(slot: str, key: str) -> str:

--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -366,7 +366,23 @@ UNIGROK_LAYER = _normalize_layer_name(os.environ.get("UNIGROK_LAYER", ""))
 UNIGROK_LAYER_COLLECTION = os.environ.get("UNIGROK_LAYER_COLLECTION", "").strip()
 
 # --- offline local plane constants ---
-LOCAL_RUNTIME_URL = os.environ.get("UNIGROK_LOCAL_RUNTIME_URL", "").strip()
+def _resolve_local_runtime_url() -> str:
+    """Local plane is automatic: default Docker Model Runner unless disabled.
+
+    Explicit ``UNIGROK_LOCAL_RUNTIME_URL`` always wins. When unset, default to
+    host DMR at ``host.docker.internal:12434`` unless ``UNIGROK_LOCAL_AUTO`` is
+    off/false/0. Probe still fail-closes if the runtime is absent.
+    """
+    explicit = os.environ.get("UNIGROK_LOCAL_RUNTIME_URL", "").strip()
+    if explicit:
+        return explicit
+    mode = os.environ.get("UNIGROK_LOCAL_AUTO", "on").strip().lower()
+    if mode in {"0", "false", "off", "no"}:
+        return ""
+    return "http://host.docker.internal:12434"
+
+
+LOCAL_RUNTIME_URL = _resolve_local_runtime_url()
 LOCAL_PROBE_TIMEOUT_SECONDS = _bounded_int("UNIGROK_LOCAL_PROBE_TIMEOUT", 5, 1, 60)
 _LOCAL_PROBE_BACKENDS = None
 LOCAL_DIRECT_TALK_MODE = os.environ.get("UNIGROK_LOCAL_DIRECT_TALK_MODE", "").strip().lower()

--- a/src/unigrok_public/state.py
+++ b/src/unigrok_public/state.py
@@ -418,24 +418,29 @@ class PublicStateStore:
             )
 
     def _seed_local_plane_sync(self, connection: sqlite3.Connection) -> None:
-        """Load optional local-plane seed data without making readiness implicit."""
+        """Load optional local-plane seed data + automatic offline min-role dogfood."""
         seed_dir = Path(
             os.environ.get("UNIGROK_LOCAL_SEED_DIR")
             or (Path(__file__).parent / "data" / "local_plane")
         )
-        if not seed_dir.is_dir():
-            return
+        if seed_dir.is_dir():
+            try:
+                local_plane_loader.load_seed_assets(
+                    connection,
+                    dialect_matrix_path=seed_dir / "dialect_matrix.json",
+                    family_map_path=seed_dir / "family_map.json",
+                    scorecard_path=seed_dir / "scorecard.json",
+                    gate_manifest_path=seed_dir / "gate_manifest.json",
+                    promote_path=seed_dir / "promote.json",
+                    traps_path=seed_dir / "traps.json",
+                )
+            except (sqlite3.Error, OSError, ValueError):
+                pass
+        # Automatic: fund router+text_generator when empty so local plane can arm
+        # whenever DMR is reachable (no manual per-seat SQL).
         try:
-            local_plane_loader.load_seed_assets(
-                connection,
-                dialect_matrix_path=seed_dir / "dialect_matrix.json",
-                family_map_path=seed_dir / "family_map.json",
-                scorecard_path=seed_dir / "scorecard.json",
-                gate_manifest_path=seed_dir / "gate_manifest.json",
-                promote_path=seed_dir / "promote.json",
-                traps_path=seed_dir / "traps.json",
-            )
-        except (sqlite3.Error, OSError, ValueError):
+            local_plane_loader.ensure_dogfood_min_roles(connection)
+        except (sqlite3.Error, AttributeError, ValueError):
             pass
 
     async def local_knob(self, key: str, default: Any = None) -> Any:

--- a/tests/test_inference_key_fallthrough.py
+++ b/tests/test_inference_key_fallthrough.py
@@ -1,0 +1,38 @@
+"""Owner-default xAI inference key allowlist fall-through (factory patch)."""
+
+from __future__ import annotations
+
+from unigrok_public.principal_xai import resolve_xai_api_key
+
+
+def test_falls_through_empty_primary_to_sky_inference() -> None:
+    env = {
+        "XAI_API_KEY": "",
+        "XAI_API_KEY_SKY_INFERENCE": "xai-live-sky",
+        "XAI_API_KEY_GROUND": "xai-other",
+    }
+    key, source = resolve_xai_api_key(principal=None, environ=env)
+    assert key == "xai-live-sky"
+    assert source == "owner_default:XAI_API_KEY_SKY_INFERENCE"
+
+
+def test_preferred_empty_falls_through_to_xai_api_key() -> None:
+    env = {
+        "XAI_PLANE_API": "XAI_API_KEY_GROUND",
+        "XAI_API_KEY_GROUND": "",
+        "XAI_API_KEY": "xai-main",
+    }
+    key, source = resolve_xai_api_key(principal=None, environ=env)
+    assert key == "xai-main"
+    assert source == "owner_default:XAI_API_KEY"
+
+
+def test_skips_cursor_tokens() -> None:
+    env = {
+        "XAI_API_KEY": "",
+        "XAI_API_KEY_CURSOR_SKY": "crsr_not_valid_here",
+        "XAI_API_KEY_GROUND": "xai-ground-ok",
+    }
+    key, source = resolve_xai_api_key(principal=None, environ=env)
+    assert key == "xai-ground-ok"
+    assert source == "owner_default:XAI_API_KEY_GROUND"


### PR DESCRIPTION
## Summary
Fast-track ops patch for live factory dual-plane and free local failover.

- **Inference key fallthrough:** resolve owner keys across allowlisted `XAI_API_KEY*` slots (preferred plane first; empty slots skip; never management/Cursor tokens).
- **Local plane auto:** default Docker Model Runner URL unless `UNIGROK_LOCAL_AUTO=off`; auto seed offline min roles (`router` + `text_generator`) when DATA empty.
- **Compose:** inject allowlisted inference env vars only (no multi-provider C2 dump into public core).
- **Docs:** stop teaching package-local `.env` as key SoT; clarify owner env / Ground key home.
- **Tests:** `tests/test_inference_key_fallthrough.py` (3 cases).

## Test plan
- [x] `uv run pytest tests/test_inference_key_fallthrough.py -q` (3 passed)
- [x] Live factory: all seats local.ready + API ready after redeploy
- [ ] CI green on this PR
- [ ] Dual-supervisor / Codex land as required for public core

## Out of scope
- Host-only `~/.docker/agentixos/*` compose (factory, not this repo)
- Secrets / `.env` files (never committed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches credential resolution and compose env injection (security-sensitive), and auto-seeds offline promote/cert state that could mask missing real local-plane data if misunderstood as production truth.
> 
> **Overview**
> **Factory dual-plane ops patch:** owner xAI inference keys now resolve through an allowlisted env fall-through (`XAI_API_KEY` → Sky/Ground aliases), with optional `XAI_PLANE_API` preference, empty-slot skip, and explicit rejection of management/Cursor tokens. Compose wires only those inference vars and nests the same fall-through into container `XAI_API_KEY`.
> 
> **Local plane defaults on:** when `UNIGROK_LOCAL_RUNTIME_URL` is unset, the server probes Docker Model Runner at `host.docker.internal:12434` unless `UNIGROK_LOCAL_AUTO` is off; a new compose override documents host-gateway + probe tuning. On DB open, `ensure_dogfood_min_roles` idempotently seeds offline `router`/`text_generator` floors and promote pins so `local.ready` can arm without manual SQL.
> 
> Docs shift key SoT away from package-local `.env` toward owner env / Ground key home; tests cover three fall-through cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90cc600bd6c434f54c281a3c96640f81faf8831b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->