### PR TITLE
fix: ruff E501 in offline min-role seed SQL

### DIFF
--- a/src/unigrok_public/local_plane_loader.py
+++ b/src/unigrok_public/local_plane_loader.py
@@ -945,7 +945,8 @@ def ensure_dogfood_min_roles(conn: sqlite3.Connection, *, family: str = "gemma")
             conn.execute(
                 """
                 INSERT INTO promote_gates
-                  (cert_id, role, metric_id, status, family, manifest_key, certified_at, payload_json)
+                  (cert_id, role, metric_id, status, family,
+                   manifest_key, certified_at, payload_json)
                 VALUES (?, ?, ?, 'certified', ?, 'promote_gates', ?, ?)
                 ON CONFLICT(cert_id) DO UPDATE SET
                   role=excluded.role,


### PR DESCRIPTION
## Summary
- Fix sole CI failure from #519 (ruff E501 line length in `ensure_dogfood_min_roles`).

## Test plan
- [x] `uv run ruff check src/unigrok_public/local_plane_loader.py`
- [ ] CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Whitespace-only SQL formatting in dogfood seed path; no logic or data changes.
> 
> **Overview**
> Resolves a **ruff E501** line-length violation in `ensure_dogfood_min_roles` by wrapping the `INSERT INTO promote_gates` column list onto two lines. **No SQL semantics or runtime behavior change**—CI lint only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c0ad81a95a0fd8c921df26bd19d81067052366d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->