### PR TITLE
fix: remove compose override file (insider denylist)

### DIFF
--- a/compose.local-failover.override.yml
+++ b/compose.local-failover.override.yml
@@ -1,8 +1,0 @@
-services:
-  grok-mcp:
-    image: ${UNIGROK_IMAGE:-unigrok:public-main-b796776}
-    environment:
-      UNIGROK_LOCAL_RUNTIME_URL: ${UNIGROK_LOCAL_RUNTIME_URL:-http://host.docker.internal:12434}
-      UNIGROK_LOCAL_PROBE_TIMEOUT: ${UNIGROK_LOCAL_PROBE_TIMEOUT:-5}
-    extra_hosts:
-      - "host.docker.internal:host-gateway"


### PR DESCRIPTION
## Summary
- Delete `compose.local-failover.override.yml` — public CI denylist forbids `*.override.yml`.
- Local auto defaults remain in product code + `compose.yaml` env cascade.
- Factory host-only overrides stay under `~/.docker/agentixos/` if needed.

## Test plan
- [ ] CI green (denylist + ruff)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/infra hygiene only—no runtime or application code changes.
> 
> **Overview**
> Removes **`compose.local-failover.override.yml`** from the repo because public CI’s insider denylist forbids **`*.override.yml`** filenames.
> 
> That file only layered Docker Compose overrides for **`grok-mcp`** (image tag, `UNIGROK_LOCAL_RUNTIME_URL` / `UNIGROK_LOCAL_PROBE_TIMEOUT`, and `host.docker.internal` via `extra_hosts`). Those local failover defaults are unchanged in product code and **`compose.yaml`** env cascade; factory-only host tweaks can still live under **`~/.docker/agentixos/`** when needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 030b3b78ce50df55add59dad2d580aa6b3762a35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->