### PR TITLE
docs(agents): add Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,3 +29,39 @@
 - Before claiming completion, run `uv run pytest -q`, `uv run ruff check .`, build the
   image, verify `/healthz`, `/readyz`, `/runtimez`, compare MCP `tools/list` with
   self-discovery, and exercise both configured credential planes.
+
+## Cursor Cloud specific instructions
+
+This is a single Python 3.12 service (`grok-mcp-server` / `unigrok_public`) managed by
+`uv`. Dependencies are refreshed by the startup update script (`uv sync --frozen`); the
+committed `.venv` is already present. The standard lint/test/build check suite lives in
+`docs/development.md` — reference it rather than re-deriving commands.
+
+- Run the server in dev mode directly (no Docker needed):
+  `UNIGROK_HOST=127.0.0.1 PORT=4765 uv run python -m unigrok_public.server`.
+  Non-obvious: the direct run defaults to `127.0.0.1:8080`, but `scripts/smoke_mcp.py`
+  and the docs assume `4765`, so set `PORT=4765` to match. Docker/compose is NOT
+  installed in this VM, and `docker compose build` downloads the `grok` CLI installer
+  from `x.ai`, so it needs network egress.
+- Credential planes gate live Grok answers, not the server itself. With no
+  `XAI_API_KEY` and no `grok` CLI OAuth login, the server still starts, `/healthz` is
+  `ok`, `/runtimez` works, MCP `tools/list` returns all 29 tools, and the local-state
+  tools (`remember_fact`, `search_knowledge`, `list_sessions`) work end-to-end. But
+  `/readyz` reports `not_ready`, `bootstrap.can_chat` is false, and the `@grok` `agent`
+  tool cannot reach a plane. `scripts/smoke_mcp.py` (no `--invoke-*` flags) therefore
+  stops at the `can_chat` assertion until a plane is configured; its `--invoke-cli/api/
+  research/code` flags require live credentials. Provide `XAI_API_KEY` (metered API
+  plane) or run `grok login --device-auth` to exercise the full `@grok` flow.
+- Durable state is embedded SQLite at `~/.local/share/unigrok/public-state.db` by
+  default (override with `UNIGROK_STATE_PATH` / `UNIGROK_STATE_DIR`); no external DB,
+  cache, or queue service exists.
+- Known pre-existing failures on `main` (independent of environment setup; do not treat
+  as regressions you introduced): `uv run python scripts/check_release_contract.py`
+  fails (`example.env` missing Compose vars `XAI_API_KEY_UNIGROK_GROUND`,
+  `XAI_PLANE_API`) — CI on `main` fails here, before pytest runs. `uv run pytest -q`
+  has ~26 failures in `tests/test_local_plane_m1.py`, `tests/test_local_plane_m3.py`
+  (test `seed_ready` raw-inserts `gate_manifest('promote_gates')` which
+  `PublicStateStore.initialize()` already dogfood-seeds → UNIQUE conflict) and
+  `tests/test_remote_boundary.py::test_principal_key_selection_never_crosses_oauth_tenants`
+  (expects source `owner_default`, code returns `owner_default:XAI_API_KEY`). Ruff and
+  the ~495 other tests pass.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for the UniGrok (`grok-mcp-server`) MCP service, and records durable, non-obvious startup/run caveats for future cloud agents in `AGENTS.md` under `## Cursor Cloud specific instructions`. No product code changed.

## Environment setup

- Runtime: Python 3.12, dependencies managed by `uv`. Startup update script: `uv sync --frozen`.
- Verified the dev workflow end-to-end (standard commands documented in `docs/development.md`).

## What was verified

| Step | Command | Result |
|---|---|---|
| Install deps | `uv sync --frozen` | OK |
| Lint | `uv run ruff check .` | OK (all pass) |
| Tests | `uv run pytest -q` | 495 passed, 7 skipped, 26 pre-existing failures |
| Run (dev) | `UNIGROK_HOST=127.0.0.1 PORT=4765 uv run python -m unigrok_public.server` | Serves `/healthz`, `/readyz`, `/runtimez`, `/ui/`, `/mcp` |
| Smoke (both planes) | `scripts/smoke_mcp.py --invoke-cli --invoke-api` | `plane=cli` → `SEQUENTIAL_TEST_GROK`, `api` → `DUAL_PLANE_API_OK` |
| Hello-world | MCP `agent` (`@grok`) real question | Answered via CLI plane (`grok-4.5`, `stop_reason=EndTurn`) |

## Full dual-plane end-to-end (`@grok`)

After adding `XAI_API_KEY` (metered API plane) and completing `grok login --device-auth` (Grok Build/CLI plane), `/readyz` reports `status: ready` with both planes armed. The canonical smoke test passes fully across both planes, and a real natural-language `@grok` question returned a correct answer with a working code example, routed Build-first through the CLI plane.

Dashboard with both planes armed (Service ready · CLI ready · API ready) and live receipts:

[Control Center dashboard with both planes ready](https://cursor.com/agents/bc-600876ba-7208-4dd7-95f1-7f50bf124bf2/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_both_planes_ready.webp)

## Pre-existing issues (not introduced here)

- `scripts/check_release_contract.py` fails (`example.env` missing Compose vars) — CI on `main` fails here, before pytest.
- 26 pytest failures in `test_local_plane_m1/m3` (dogfood seed vs `seed_ready` UNIQUE conflict on `gate_manifest`) and one `test_remote_boundary` principal-key label mismatch. Deterministic repo test/code drift, independent of the environment.

## Notes

- Without a Grok credential plane the server + local-state tools still work, but `/readyz` is `not_ready` and `can_chat` is false. Both planes are now live in this session.
- Docker is not installed in this VM; `docker compose build` needs network egress to `x.ai`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-600876ba-7208-4dd7-95f1-7f50bf124bf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-600876ba-7208-4dd7-95f1-7f50bf124bf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

