### PR TITLE
fix(ui): preserve explicit forge tier selection

### DIFF
--- a/src/unigrok_public/static/dashboard.html
+++ b/src/unigrok_public/static/dashboard.html
@@ -328,7 +328,10 @@ document.getElementById('tiernav').insertAdjacentHTML('beforeend',TIERS.map(t=>{
 function selectTier(id){
   if(LEVEL[id]==null)return;
   if(forgeSurface&&id==='space')return;
-  preview=(id===runtimeTier)?null:id;
+  // An explicit forge selection must survive the 10-second runtime refresh.
+  // Keep even the public tier in the URL; otherwise a remembered Sky login
+  // silently wins reconcileTier() and flips the page back after the click.
+  preview=forgeSurface?id:(id===runtimeTier)?null:id;
   activeTier=id;
   const u=new URL(location.href);
   if(preview)u.searchParams.set('preview',preview);else u.searchParams.delete('preview');
@@ -357,7 +360,7 @@ function bindForgeOmniaware(rt){
     const id=a.dataset.tier;
     if(id==='space'){a.hidden=true;a.style.display='none';a.setAttribute('aria-hidden','true');return;}
     a.dataset.inshell='1';
-    a.href=id==='public'||id===runtimeTier?'/ui/':`/ui/?preview=${id}`;
+    a.href=`/ui/?preview=${id}`;
     a.title=`switch to ${id} Surface in-shell — stay on forge`;
   });
   const note=document.querySelector('#sky-tier .tiernote');

--- a/tests/test_control_center_ui.py
+++ b/tests/test_control_center_ui.py
@@ -218,6 +218,8 @@ def test_forge_omniaware_inshell_surface() -> None:
     assert "function bindForgeOmniaware(rt)" in html
     assert "function selectTier(id)" in html
     assert "function isForgeSurface(rt)" in html
+    assert "preview=forgeSurface?id:(id===runtimeTier)?null:id" in html
+    assert "a.href=`/ui/?preview=${id}`" in html
     assert "rt.surface==='forge'" in html
     assert "dataset.inshell" in html
     assert "if(forgeSurface)$('space-tier').style.display='none'" in html


### PR DESCRIPTION
Fixes the r26 forge tier-switch acceptance bug reproduced in the live `:4766` overlay: for a signed-in Sky user, clicking Public briefly showed GroundCommand, then the 10-second runtime refresh silently switched back to Sky because the explicit Public choice was not encoded.

This change encodes every explicit forge tier selection as `?preview=<tier>`, so Public and Sky remain stable across telemetry refreshes and hard reloads. Non-forge navigation is unchanged because the in-shell click path only runs when `forgeSurface` is true.

Evidence:
- exact base: `f63cc8e57c10ab1eaf23f2d976218b048dc2094a`
- before: Public reverted to Sky after the 10-second refresh
- target route verified live: `?preview=public` remains GroundCommand after refresh; `?preview=sky` remains SkyCommand; Space stays hidden
- 45 targeted tests pass; Python lint and diff checks pass

This is a bounded fix for PR #524, not a promotion or deployment action.