### PR TITLE
fix(local): initialize failover concurrency slots

### DIFF
--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -458,6 +458,8 @@ def _layer_service_label() -> str:
 MCP_SERVER_NAME = _layer_service_label()
 _CATALOG_CACHE: dict[str, tuple[float, dict[str, Any]]] = {}
 _SESSION_LOCKS: dict[str, asyncio.Lock] = {}
+_LOCAL_SLOTS: asyncio.Semaphore | None = None
+_LOCAL_SLOTS_BUDGET: int | None = None
 # In-memory durable jobs for agent turns and slow xAI file/media calls. Completed
 # payloads are also persisted via STATE.save_agent_job so polls survive restarts.
 # Value: (created_monotonic, task, kind)

--- a/tests/test_local_plane_m1.py
+++ b/tests/test_local_plane_m1.py
@@ -85,6 +85,11 @@ def _reset_local_slots() -> None:
     server._LOCAL_SLOTS_BUDGET = None
 
 
+def test_local_concurrency_globals_exist_before_first_failover() -> None:
+    assert hasattr(server, "_LOCAL_SLOTS")
+    assert hasattr(server, "_LOCAL_SLOTS_BUDGET")
+
+
 def _local_catalog(ready: bool = True, model_id: str = "synth-model-1") -> dict:
     return {
         "cli": {


### PR DESCRIPTION
Fixes a real first-call crash in the local/offline failover path.

`_local_slot_acquire()` reads `_LOCAL_SLOTS` and `_LOCAL_SLOTS_BUDGET`, but neither global existed until tests explicitly created them. A production process with remote planes unavailable therefore raised `NameError` before Gemma inference even though `/readyz` reported the local plane ready.

The fix initializes both globals at module load and adds a regression assertion that they exist before first failover.

Verification:
- 93 local-plane tests pass, 7 intentionally skipped
- lint and diff checks pass
- isolated live smoke with CLI/API unavailable and the real Docker Model Runner succeeds through two Gemma calls (router + specialist)
- result: `resolved_plane=local`, `model=docker.io/ai/gemma4:latest`, `billing_class=local_runtime`, `cost_usd=0.0`, non-empty completion

This is the missing runtime correction behind the misleading state where readiness was green but an actual local serve crashed. It does not deploy or promote anything.