### PR TITLE
fix(ui): treat zero p95 as no telemetry

### DIFF
--- a/src/unigrok_public/static/dashboard.html
+++ b/src/unigrok_public/static/dashboard.html
@@ -541,7 +541,7 @@ function hydrateSkyLive(rt,b){
   try{
     const rawP95=rt?.benchmark_summary?.latency_ms?.p95??b?.latency_ms?.p95;
     const p95=Number(rawP95);
-    if(rawP95!==null&&rawP95!==undefined&&rawP95!==''&&Number.isFinite(p95)&&p95>=0){
+    if(rawP95!==null&&rawP95!==undefined&&rawP95!==''&&Number.isFinite(p95)&&p95>0){
       const port=herePort||TIERS.find(t=>t.id==='public')?.port||'4766';
       SKY.latency=[{port:String(port),surface:forgeSurface?'forge console':'this origin',p95}];
       hasLatency=true;}

--- a/tests/test_control_center_ui.py
+++ b/tests/test_control_center_ui.py
@@ -300,7 +300,7 @@ def test_sky_badge_tracks_live_payloads_without_hiding_samples() -> None:
     assert "hasBreakers=false,hasLatency=false" in hydrate
     assert "SKY_SAMPLE_BREAKERS.map" in hydrate
     assert "SKY_SAMPLE_LATENCY.map" in hydrate
-    assert "Number.isFinite(p95)&&p95>=0" in hydrate
+    assert "Number.isFinite(p95)&&p95>0" in hydrate
     assert "setSkyHydrationState(hasBreakers,hasLatency)" in hydrate
     assert "return {breakers:hasBreakers,latency:hasLatency}" in hydrate
 


### PR DESCRIPTION
Follow-up for #524 after review of #527.

- Keep the Sky latency channel in SAMPLE state when p95 is zero, matching the dashboard gauge sentinel.
- Update the regression assertion accordingly.

Verification: 30 control-center tests pass; lint, JavaScript syntax, and diff checks pass.

PROMOTE=NO. Space remains dark.