### PR TITLE
fix(ui): bind tier navigation to live ports

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -49,7 +49,9 @@ services:
       UNIGROK_ENABLE_METERED_API: ${UNIGROK_ENABLE_METERED_API:-true}
       UNIGROK_API_MODEL: ${UNIGROK_API_MODEL:-}
       # Control Center tier nav: per-tier URLs win, host ports are the fallback.
-      UNIGROK_PUBLIC_PORT: ${UNIGROK_PORT:-4765}
+      # Public navigation stays bound to canonical core even when this
+      # container itself is a Forge rehearsal on another host port.
+      UNIGROK_PUBLIC_PORT: ${UNIGROK_PUBLIC_PORT:-4765}
       UNIGROK_SKY_PORT: ${UNIGROK_SKY_PORT:-4768}
       UNIGROK_SPACE_PORT: ${UNIGROK_SPACE_PORT:-4769}
       UNIGROK_PUBLIC_URL: ${UNIGROK_PUBLIC_URL:-}

--- a/docs/design/ui-data-pipeline.md
+++ b/docs/design/ui-data-pipeline.md
@@ -43,13 +43,17 @@ exactly one inline script.
 
 The same baked page serves all three surfaces. A unified switcher (`#tiernav`)
 links each tier to its own port on the current host — public `4765`, sky `4768`,
-space `4769` — and the active tier is derived from the port. `?preview=sky|space`
-lets one running container show a higher tier's panels for review.
+space `4769` — and the active tier is derived from the port. Every tier click is
+native full navigation; the destination page reads only its own same-origin
+feeds. Forge is not a data proxy and never relabels its own feeds as Sky or
+Space.
 
 **Hierarchical scoping:** each tier renders its own panels plus every lower
 tier's; panels above the active tier are `display:none`. Public visitors see only
 public panels. Higher tiers still enforce their own auth on arrival — the nav is
-navigation, not access.
+navigation, not access. The Space tab stays visible as an access-dependent
+upgrade advertisement. If its loopback port is absent, navigation fails
+honestly; there is no Sky fallback or sample-as-live replacement.
 
 | Tier | Port | Panels |
 | --- | --- | --- |
@@ -57,8 +61,9 @@ navigation, not access.
 | `@skygrok` Sky Observer | 4768 | 4-lane swarm grid, breakers + trip rates, P95 latency, GitHub reviews (Grok-score ring + PR standouts), live-run streaming |
 | `@spacegrok` Space Awareness | 4769 | claim-plane by-state + proof matrix, memory/RAG, SPACE=DARK security monitor, sealed report card, linked devices |
 
-Tier data on sky/space is **sample**, badged, and wires to live data only on the
-private-overlay surfaces — never on the public core (`AGENTS.md` boundary).
+Shared runtime fields on sky/space come from that selected origin. Unfinished
+private-overlay panels remain **sample** and badged; they are never hydrated
+from a lower tier (`AGENTS.md` boundary).
 
 ## Visual system
 
@@ -175,13 +180,13 @@ Downward-leak classes: **S** secret · **N** name/identity · **T** topology ·
 | Tool registry | code | `runtimez.tools[]`, `tool_count` | — | tool surface chart | — |
 | Memory / RAG | task-rag env + facts table | `task_rag.{configured,mode,chat_memory,collection_label_set}` + r19 `fact_count` | existence-only for collection label | memory panel (r19) | N → label presence bool, never name |
 | Connect config | `_configured_mcp_url()` | url + `X-Client-ID` | deliberate publication | connect card | non-secret by design |
-| Tier nav | `UNIGROK_PORT` + r19 `UNIGROK_SKY_PORT` / `UNIGROK_SPACE_PORT` (names-only) | r19 `runtimez.tier_nav` | **suppressed in cloud mode** | top nav | T → loopback-bound ports; hosted surface omits the block |
+| Tier nav | `UNIGROK_PUBLIC_PORT` / `UNIGROK_SKY_PORT` / `UNIGROK_SPACE_PORT` plus optional per-tier URLs (names-only) | r19 `runtimez.tier_nav` | **suppressed in cloud mode** | top nav | T → loopback-bound ports; hosted surface omits the block |
 
 ### Floor L1 — Sky (`@skygrok`, 4768) adds
 
 | Data feature | Source | Floor guard on lower tiers | UI panel |
 | --- | --- | --- | --- |
-| Swarm 4-lane grid, trip rates | private overlay | not rendered on L0; `?preview=sky` shows **sample-badged** shell, zero live fetch | swarm grid |
+| Swarm 4-lane grid, trip rates | private overlay | not rendered on L0; the visible Sky tab navigates to the Sky origin | swarm grid |
 | GitHub review ring + PR standouts | private overlay | same | reviews |
 | Live-run SSE stream | private overlay | same; Run trigger stays disabled until contributor surface (spend-capable POST is an operate feature, never faked) | live run |
 | Team assignment board | private overlay (Sky env home) | same | team board |
@@ -200,6 +205,11 @@ control.grokmcp.org, never local), review ops, run trigger, team assignment.
 
 **Access features added at L2:** device enrollment (one-time codes),
 sealed-report publication.
+
+`SPACE=DARK` still means zero-write awareness, no Ground-to-Space MCP wiring,
+and no public model promotion. The visible Space navigation tab is the narrow
+exception: it advertises the higher tier and relies on port reachability plus
+the destination's own controls; it does not grant Space authority.
 
 ### Credential inheritance — upward trickle
 
@@ -295,13 +305,17 @@ GitHub gate — not the client — controls what data shows.
 
 Residual risks (accepted, watched): local anonymous aggregate shows all
 callers on a shared box (by design, own store); r19 `tier_nav` advertises
-higher-tier loopback ports (names-only env, hosted-suppressed); `?preview=`
-must never gain live fetches.
+higher-tier loopback ports (names-only env, hosted-suppressed). Sky and Space
+must remain loopback-bound until those destinations enforce remote-user auth.
 
 ## Forge console fold
 
 The legacy 4766 console's features are absorbed into this design:
 
+- **Port-bound tier navigation**: Forge defaults its Public target to canonical
+  core `4765`; Sky and Space use the authoritative `runtimez.tier_nav` targets.
+  Native navigation rebinds every relative feed and MCP snippet to the selected
+  origin while preserving CSP `connect-src 'self'`.
 - **Live on public**: per-plane usage (calls + recorded cost on the routing
   card), connect-an-IDE (known clients cross-referenced with live caller
   telemetry, copy-to-clipboard **non-secret** MCP config — url + `X-Client-ID`

--- a/example.env
+++ b/example.env
@@ -2,6 +2,7 @@
 UNIGROK_PORT=4765
 # Control Center tier nav (optional): each tier may live on its own origin.
 # Full URLs win; ports are the same-host fallback. Hosted runtime serves neither.
+UNIGROK_PUBLIC_PORT=4765
 # UNIGROK_PUBLIC_URL=
 # UNIGROK_SKY_URL=
 # UNIGROK_SPACE_URL=

--- a/src/unigrok_public/static/dashboard.html
+++ b/src/unigrok_public/static/dashboard.html
@@ -58,6 +58,8 @@
     .tier-tab{display:inline-flex;align-items:center;gap:8px;border:1px solid var(--line);border-radius:99px;
       padding:7px 15px;color:var(--muted);font-weight:650;font-size:clamp(13px,0.3vw+11px,15.5px);
       text-decoration:none;transition:color .12s,border-color .12s}
+    .tier-access{font-size:.72em;letter-spacing:.05em;text-transform:uppercase;color:var(--purple);
+      border:1px solid #6e55a866;border-radius:99px;padding:1px 7px}
     .menu-btn{border:1px solid var(--line);background:#0d1324cc;color:var(--text);border-radius:10px;
       padding:6px 13px;font-size:clamp(15px,0.34vw+12px,18px);cursor:pointer;line-height:1;transition:border-color .12s}
     .menu-btn:hover{border-color:var(--cyan)}
@@ -295,17 +297,15 @@ const METERED_KINDS=new Set(['web_search','x_search','remote_code_execution','ch
 const KIND_COL=n=>METERED_KINDS.has(n)?lvHex.warning:'#4a5675';   // metered (costs) vs free (neutral)
 const ROUTE_COL=n=>n==='error'?lvHex.threat:GRADFILL;             // only error carries a level
 const MODEL_COL=()=>GRADFILL;                                     // model choice has no severity
-const UI_BUILD='unigrok-ui-v1.1.0-r26';
+const UI_BUILD='unigrok-ui-v1.1.0-r27';
 const CLOUD_AUTO_KEY='unigrok-cloud-auto-r25',CLOUD_RESUME_KEY='unigrok-cloud-resume-r25';
 const CONTROL_START_FAILED=new URLSearchParams(location.search).get('control')==='unavailable';
-// Unified 3-tier switcher: each tab links to its own surface on the same host.
-// The active tier is the current port; ?preview=sky|space lets one running
-// container show a higher tier's panels for review. Hierarchical scoping:
-// each tier renders its own panels plus every lower tier's. Higher tiers still
-// enforce their own auth on arrival — this is navigation, not access.
-// Forge omniaware (r26): when /runtimez.surface==='forge', tabs switch
-// in-shell (activeTier + ?preview=) instead of full-nav to deprecated
-// per-port /ui/; Space tab stays hidden (SPACE=DARK).
+// Unified 3-tier switcher: every tab is native navigation to that tier's own
+// origin. The page then reads only same-origin feeds, so the active tier and
+// displayed data can never drift apart. Hierarchical scoping: each tier
+// renders its own panels plus every lower tier's. Higher tiers enforce their
+// own reachability/auth on arrival — navigation advertises access, never
+// grants it. Space remains visible as an access-dependent upgrade.
 const TIERS=[
   {id:'public',label:'@grok Public Core',port:'4765',name:'GroundCommand',eyebrow:'public core'},
   {id:'sky',label:'@skygrok Sky Observer',port:'4768',name:'SkyCommand',eyebrow:'sky observer'},
@@ -313,36 +313,20 @@ const TIERS=[
 ];
 const LEVEL={public:0,sky:1,space:2};
 const herePort=location.port||(location.protocol==='https:'?'443':'80');
-let preview=new URLSearchParams(location.search).get('preview');
 const portTier=(TIERS.find(t=>t.port===herePort)||{}).id||'public';
-let runtimeTier=portTier,sessionTier=null;
+let runtimeTier=portTier;
 let forgeSurface=false;
-let activeTier=(preview&&LEVEL[preview]!=null)?preview:runtimeTier;
+let activeTier=runtimeTier;
 let tierLevel=LEVEL[activeTier];
 document.getElementById('tiernav').insertAdjacentHTML('beforeend',TIERS.map(t=>{
   const href=`${location.protocol}//${location.hostname}:${t.port}/ui/`;
-  const tip=t.id==='public'?'the public core surface':`opens the ${t.id} surface — requires that stack to be running`;
+  const tip=t.id==='public'?'opens the public core and its live data':
+    t.id==='space'?'upgrade: opens SpaceCommand and its live data when that port is available':
+    `opens the ${t.id} surface and its live data — requires that stack to be running`;
+  const access=t.id==='space'?'<span class="tier-access">upgrade</span>':'';
   return `<a class="tier-tab" data-tier="${t.id}" href="${href}" title="${tip}">`+
-    `<span class="tier-dot ${t.id}"></span>${t.label}</a>`;
+    `<span class="tier-dot ${t.id}"></span>${t.label}${access}</a>`;
 }).join(''));
-function syncPreviewUrl(){
-  const u=new URL(location.href);
-  if(preview)u.searchParams.set('preview',preview);else u.searchParams.delete('preview');
-  history.replaceState(history.state,'',u.pathname+u.search+u.hash);
-}
-function selectTier(id){
-  if(LEVEL[id]==null)return;
-  if(forgeSurface&&id==='space')return;
-  // An explicit forge selection must survive the 10-second runtime refresh.
-  // Keep even the public tier in the URL; otherwise a remembered Sky login
-  // silently wins reconcileTier() and flips the page back after the click.
-  preview=forgeSurface?id:(id===runtimeTier)?null:id;
-  activeTier=id;
-  syncPreviewUrl();
-  applyTier();
-  if(tierLevel>=1)renderSky();
-  if(tierLevel>=2)renderSpace(LAST_RT);
-}
 function isForgeSurface(rt){
   // Prefer server truth (/runtimez.surface). Factory fallback: public tier_nav
   // remapped onto this origin (forge :4766 / r25 :4776) — never treat :4765 core
@@ -355,23 +339,10 @@ function isForgeSurface(rt){
   if(pub.url&&String(pub.url).replace(/\/$/,'')===self)return true;
   return String(pub.port||'')===String(herePort);
 }
-function bindForgeOmniaware(rt){
+function bindForgeSurface(rt){
   if(!isForgeSurface(rt))return;
   forgeSurface=true;
   document.body.dataset.surface='forge';
-  if(preview==='space'){preview='sky';activeTier='sky';syncPreviewUrl();}
-  document.querySelectorAll('.tier-tab').forEach(a=>{
-    const id=a.dataset.tier;
-    if(id==='space'){a.hidden=true;a.style.display='none';a.setAttribute('aria-hidden','true');return;}
-    a.dataset.inshell='1';
-    a.href=`/ui/?preview=${id}`;
-    a.title=`switch to ${id} Surface in-shell — stay on forge`;
-  });
-  const note=document.querySelector('#sky-tier .tiernote');
-  if(note)note.textContent='same-origin feeds pending on forge · panels remain sample';
-  const badge=document.querySelector('#sky-tier .tierhead .sample');
-  if(badge){badge.textContent='SAMPLE';badge.dataset.skyState='sample';
-    badge.title='same-origin feeds not hydrated';}
 }
 // Command Drawer: an index of this deck mirroring the control-site groups.
 // Items anchor-scroll to their panel; contributor items are hidden on the
@@ -407,52 +378,40 @@ function renderDrawer(){
 }
 // Tier identity: title, eyebrow, tab highlight, and hierarchical panel reveal.
 function applyTier(){
-  if(forgeSurface&&activeTier==='space')activeTier='sky';
   const ti=TIERS.find(x=>x.id===activeTier)||TIERS[0];
   tierLevel=LEVEL[activeTier];
-  if(forgeSurface)tierLevel=Math.min(tierLevel,1);
   $('pagetitle').textContent=ti.name;document.title=`${ti.name} · UniGrok`;
   $('eyebrow').textContent=`UniGrok 1.1 · ${ti.eyebrow}${forgeSurface?' · forge':''}`;
   document.querySelectorAll('.tier-tab').forEach(a=>a.classList.toggle('active',a.dataset.tier===activeTier));
   $('sky-tier').style.display=tierLevel>=1?'':'none';
   $('space-tier').style.display=tierLevel>=2?'':'none';
-  if(forgeSurface)$('space-tier').style.display='none';
   renderDrawer();
 }
 function reconcileTier(){
-  if(forgeSurface&&preview==='space')preview='sky';
-  if(preview&&LEVEL[preview]!=null)activeTier=preview;
-  else activeTier=sessionTier&&LEVEL[sessionTier]>LEVEL[runtimeTier]?sessionTier:runtimeTier;
+  activeTier=runtimeTier;
   applyTier();
 }
 applyTier();
 // Server truth wins over port-sniffing: /runtimez.layer names the tier this
 // instance actually serves, and tier_nav carries the Docker-configured host
-// ports (loopback-bound; the hosted runtime omits the block). ?preview= keeps
-// review priority; absent feeds change nothing.
-let LAST_RT=null;
+// ports (loopback-bound; the hosted runtime omits the block). Every surface,
+// including Forge, uses those targets for native navigation.
 function applyRuntimeTier(rt){
   if(!rt)return;
-  LAST_RT=rt;
-  bindForgeOmniaware(rt);
+  bindForgeSurface(rt);
   // Each tier may live on its own origin (factory URLs from the env); the
   // port is only the same-host fallback when no URL is configured.
-  // On forge, keep in-shell hrefs — do not rewrite tabs back to foreign ports.
-  if(rt.tier_nav&&!forgeSurface){TIERS.forEach(ti=>{const nav=rt.tier_nav[ti.id];if(!nav)return;
+  if(rt.tier_nav){TIERS.forEach(ti=>{const nav=rt.tier_nav[ti.id];if(!nav)return;
     const a=document.querySelector(`.tier-tab[data-tier="${ti.id}"]`);if(!a)return;
     if(nav.url){a.href=`${nav.url}/ui/`;}
     else if(nav.port){ti.port=String(nav.port);a.href=`${location.protocol}//${location.hostname}:${ti.port}/ui/`;}});}
   if(LEVEL[rt.layer]!=null)runtimeTier=rt.layer;
   reconcileTier();
 }
-// One delegated click handler for the drawer (open/close/navigate) + Esc.
-function isPrimaryUnmodifiedClick(e){
-  return !e.defaultPrevented&&e.button===0&&!e.metaKey&&!e.ctrlKey&&!e.shiftKey&&!e.altKey;
-}
+// One delegated click handler for the drawer + auth controls. Tier anchors
+// deliberately stay browser-native so primary and modified clicks both open
+// the real target origin.
 document.addEventListener('click',e=>{
-  const tab=e.target.closest('.tier-tab');
-  if(tab&&forgeSurface&&tab.dataset.inshell&&isPrimaryUnmodifiedClick(e)){
-    e.preventDefault();selectTier(tab.dataset.tier);return;}
   const gh=e.target.closest('#signin');
   if(e.target.closest('#deviceauth')){e.preventDefault();ghStart();return;}
   if(gh&&gh.dataset.ghout){e.preventDefault();ghOut();return;}
@@ -513,7 +472,7 @@ const SPACE={
   devices:[{name:'MacBook Pro — this machine',linked:'Jul 19',status:'linked'}],
 };
 function setSkyHydrationState(hasBreakers,hasLatency){
-  if(!forgeSurface)return;
+  if(tierLevel<1)return;
   const live=[];if(hasBreakers)live.push('breakers');if(hasLatency)live.push('latency');
   const sample=['lanes','reviews','run'];
   if(!hasBreakers)sample.unshift('breakers');
@@ -633,19 +592,19 @@ $('connectcard').addEventListener('click',e=>{const btn=e.target.closest('.ctab,
 function applyIdentity(me){const el=$('signin'),fallback=$('deviceauth');if(!el)return;
   if(me&&me.login){el.textContent=`Signed in · ${me.login}`;el.href='#';el.dataset.ghout='1';
     el.title='contributor session active — click to sign out';
-    sessionTier=LEVEL[me.tier]!=null?me.tier:null;if(me.kind==='control')localStorage.removeItem(CLOUD_AUTO_KEY);
+    if(me.kind==='control')localStorage.removeItem(CLOUD_AUTO_KEY);
     sessionStorage.removeItem(CLOUD_RESUME_KEY);if(fallback)fallback.style.display='none';}
   else if(me&&me.unavailable){el.textContent='Cloud link reconnecting';el.href='#';delete el.dataset.ghout;
-    el.title='your remembered login is retained; use device code if Cloud is temporarily unavailable';sessionTier=null;
+    el.title='your remembered login is retained; use device code if Cloud is temporarily unavailable';
     if(fallback)fallback.style.display='inline-flex';}
   else if(me&&me.surface==='forge'){
     if(!CONTROL_START_FAILED&&localStorage.getItem(CLOUD_AUTO_KEY)!=='off'&&sessionStorage.getItem(CLOUD_RESUME_KEY)!=='1'){
       sessionStorage.setItem(CLOUD_RESUME_KEY,'1');location.replace('/auth/control/start');return;}
     el.textContent=CONTROL_START_FAILED?'Cloud temporarily unavailable':'Continue with Cloud';el.href='/auth/control/start';delete el.dataset.ghout;
-    el.title='reuse your remembered control.grokmcp.org GitHub session';sessionTier=null;
+    el.title='reuse your remembered control.grokmcp.org GitHub session';
     if(fallback)fallback.style.display='inline-flex';}
   else{el.textContent='Open contributor control';el.href='https://control.grokmcp.org';delete el.dataset.ghout;
-    el.title='sign-in happens on control.grokmcp.org';sessionTier=null;
+    el.title='sign-in happens on control.grokmcp.org';
     if(fallback)fallback.style.display='none';}
   reconcileTier();}
 // Device-flow driver: start -> show the one-time code + github link -> poll
@@ -672,10 +631,11 @@ async function ghStart(){if(GHFLOW)return;
 async function ghOut(){localStorage.setItem(CLOUD_AUTO_KEY,'off');sessionStorage.setItem(CLOUD_RESUME_KEY,'1');
   await fetch('/auth/logout',{method:'POST',headers:{'X-UniGrok-CSRF':'1'}}).catch(()=>null);
   document.getElementById('ghflow')?.remove();applyIdentity({surface:'forge'});}
+const feedJson=r=>r.ok?r.json():Promise.reject(new Error(`feed HTTP ${r.status}`));
 async function refresh(){if(refresh.busy)return;refresh.busy=true;try{const [ready,b,rt,me]=await Promise.all([
-  fetch('/readyz').then(r=>r.json()).catch(()=>null),
-  fetch('/benchmarkz').then(r=>r.json()).catch(()=>null),
-  fetch('/runtimez').then(r=>r.json()).catch(()=>null),
+  fetch('/readyz').then(feedJson).catch(()=>null),
+  fetch('/benchmarkz').then(feedJson).catch(()=>null),
+  fetch('/runtimez').then(feedJson).catch(()=>null),
   fetch('/api/me').then(r=>r.status===200?r.json():(r.status===503?{surface:'forge',unavailable:true}:(r.status===401?{surface:'forge'}:null))).catch(()=>null)]);
   applyIdentity(me);
   // Each feed is guarded independently: a missing feed reads "unreachable"/"—",

--- a/tests/test_control_center_ui.py
+++ b/tests/test_control_center_ui.py
@@ -153,7 +153,7 @@ def test_tier_gating_reveal_is_pinned() -> None:
     # verbatim so deleting or inverting it fails.
     html = DASHBOARD.read_text(encoding="utf-8")
     assert "{public:0,sky:1,space:2}" in html
-    assert ".get('preview')" in html
+    assert "activeTier=runtimeTier" in html
     assert "$('sky-tier').style.display=tierLevel>=1?'':'none'" in html
     assert "$('space-tier').style.display=tierLevel>=2?'':'none'" in html
     assert "if(tierLevel>=1)renderSky()" in html
@@ -210,30 +210,31 @@ def test_tier_nav_renders_all_three_surfaces() -> None:
     assert "function applyTier(" in html and "$('pagetitle').textContent" in html
 
 
-def test_forge_omniaware_inshell_surface() -> None:
-    # Forge leftover: Surface tabs switch in-shell (no full-nav to deprecated
-    # per-port /ui/), Space stays hidden, sky panels hydrate from same-origin
-    # feeds only (CSP connect-src 'self').
+def test_forge_nav_is_port_bound_and_space_is_advertised() -> None:
+    # Forge uses the same native, per-origin navigation as every other surface.
+    # Space stays visible as an access-dependent upgrade; it is never replaced
+    # by a same-origin sample shell.
     html = DASHBOARD.read_text(encoding="utf-8")
-    assert "function bindForgeOmniaware(rt)" in html
-    assert "function selectTier(id)" in html
+    assert "function bindForgeSurface(rt)" in html
     assert "function isForgeSurface(rt)" in html
-    assert "preview=forgeSurface?id:(id===runtimeTier)?null:id" in html
-    assert "a.href=`/ui/?preview=${id}`" in html
     assert "if(surface)return surface==='forge'" in html
-    assert "dataset.inshell" in html
-    assert "if(forgeSurface)$('space-tier').style.display='none'" in html
-    assert "history.replaceState" in html
+    assert "if(rt.tier_nav)" in html
+    assert "if(rt.tier_nav&&!forgeSurface)" not in html
+    assert '<span class="tier-access">upgrade</span>' in html
+    assert "upgrade: opens SpaceCommand and its live data" in html
+    assert "dataset.inshell" not in html
+    assert "a.hidden=true" not in html
+    assert "activeTier='sky'" not in html
     assert "function hydrateSkyLive(rt,b)" in html
     assert "No cross-port" in html or "no cross-port" in html
-    assert "UI_BUILD" in html and "r26" in html
+    assert "UI_BUILD" in html and "r27" in html
 
 
 def test_explicit_non_forge_surface_bypasses_legacy_port_fallback() -> None:
     html = DASHBOARD.read_text(encoding="utf-8")
     detect = html[
         html.index("function isForgeSurface(rt)")
-        : html.index("function bindForgeOmniaware(rt)")
+        : html.index("function bindForgeSurface(rt)")
     ]
     surface_truth = detect.index("if(surface)return surface==='forge'")
     legacy_fallback = detect.index("const pub=rt&&rt.tier_nav&&rt.tier_nav.public")
@@ -241,50 +242,31 @@ def test_explicit_non_forge_surface_bypasses_legacy_port_fallback() -> None:
     assert "String(rt?.surface||'').trim().toLowerCase()" in detect
 
 
-def test_forge_tier_links_preserve_modified_clicks() -> None:
+def test_tier_tabs_use_native_navigation() -> None:
     html = DASHBOARD.read_text(encoding="utf-8")
     click = html[
-        html.index("function isPrimaryUnmodifiedClick(e)")
+        html.index("document.addEventListener('click'")
         : html.index("document.addEventListener('keydown'")
     ]
-    for guard in (
-        "!e.defaultPrevented",
-        "e.button===0",
-        "!e.metaKey",
-        "!e.ctrlKey",
-        "!e.shiftKey",
-        "!e.altKey",
-    ):
-        assert guard in click
-    assert "tab.dataset.inshell&&isPrimaryUnmodifiedClick(e)" in click
-    assert "e.preventDefault();selectTier(tab.dataset.tier)" in click
-    assert "if(tab&&forgeSurface&&tab.dataset.inshell){e.preventDefault()" not in click
-    assert "a.href=`/ui/?preview=${id}`" in html
+    assert "tier-tab" not in click
+    assert "selectTier(" not in html
+    assert "syncPreviewUrl(" not in html
+    assert "history.replaceState" not in html
+    assert "if(nav.url){a.href=`${nav.url}/ui/`;}" in html
+    assert "else if(nav.port)" in html
 
 
-def test_forge_space_preview_normalizes_the_address_bar() -> None:
+def test_space_unavailable_never_falls_back_to_same_origin_preview() -> None:
     html = DASHBOARD.read_text(encoding="utf-8")
-    sync = html[html.index("function syncPreviewUrl()") : html.index("function selectTier(id)")]
-    select = html[html.index("function selectTier(id)") : html.index("function isForgeSurface(rt)")]
-    bind = html[
-        html.index("function bindForgeOmniaware(rt)")
-        : html.index("// Command Drawer:")
-    ]
-    assert "u.searchParams.set('preview',preview)" in sync
-    assert "u.searchParams.delete('preview')" in sync
-    assert "history.replaceState(history.state,'',u.pathname+u.search+u.hash)" in sync
-    assert "syncPreviewUrl();" in select
-    assert "preview='space'" not in bind
-    assert "if(preview==='space'){preview='sky';activeTier='sky';syncPreviewUrl();}" in bind
-    assert "if(preview==='space'){preview='sky';activeTier='sky';}" not in bind
+    assert ".get('preview')" not in html
+    assert "?preview=" not in html
+    assert "id==='space'?'upgrade: opens SpaceCommand" in html
+    assert "feedJson=r=>r.ok?r.json():Promise.reject" in html
+    assert "connect-src 'self'" not in html  # CSP is server-owned, never widened here.
 
 
 def test_sky_badge_tracks_live_payloads_without_hiding_samples() -> None:
     html = DASHBOARD.read_text(encoding="utf-8")
-    bind = html[
-        html.index("function bindForgeOmniaware(rt)")
-        : html.index("// Command Drawer:")
-    ]
     state = html[
         html.index("function setSkyHydrationState(")
         : html.index("function hydrateSkyLive(")
@@ -293,8 +275,7 @@ def test_sky_badge_tracks_live_payloads_without_hiding_samples() -> None:
         html.index("function hydrateSkyLive(")
         : html.index("function renderSky(")
     ]
-    assert "badge.textContent='LIVE'" not in bind
-    assert "badge.textContent='SAMPLE'" in bind
+    assert "if(tierLevel<1)return" in state
     assert "live.length?'MIXED':'SAMPLE'" in state
     assert "lanes','reviews','run" in state
     assert "hasBreakers=false,hasLatency=false" in hydrate
@@ -410,6 +391,9 @@ def test_tier_nav_ports_are_bounded_env_values() -> None:
     # /runtimez surfaces the tier feeds the deck consumes.
     for key in ('"layer"', '"surface"', '"task_rag"', '"credential_planes"', '"fact_count"'):
         assert key in gate
+    compose = Path("compose.yaml").read_text(encoding="utf-8")
+    assert "UNIGROK_PUBLIC_PORT: ${UNIGROK_PUBLIC_PORT:-4765}" in compose
+    assert "UNIGROK_PUBLIC_PORT: ${UNIGROK_PORT:-4765}" not in compose
 
 
 def test_dashboard_consumes_server_tier_truth() -> None:
@@ -420,7 +404,7 @@ def test_dashboard_consumes_server_tier_truth() -> None:
     assert "rt.tier_nav" in html
     assert "nav.url" in html and "nav.port" in html
     assert "LEVEL[rt.layer]" in html
-    assert "bindForgeOmniaware(rt)" in html
+    assert "bindForgeSurface(rt)" in html
     assert "applyRuntimeTier(rt);" in html
     # Credential-planes posture renders server truth, threat when no plane.
     assert "rt?.credential_planes" in html
@@ -464,18 +448,25 @@ def test_dashboard_identity_states_follow_gateway_truth() -> None:
     assert "el.href='https://control.grokmcp.org'" in html
 
 
-def test_authenticated_tier_survives_runtime_refresh_and_logout_relocks() -> None:
+def test_identity_never_relabels_same_origin_data_as_another_tier() -> None:
     html = DASHBOARD.read_text(encoding="utf-8")
     runtime = html[html.index("function applyRuntimeTier(rt)") :]
     runtime = runtime[: runtime.index("// One delegated click handler")]
     identity = html[html.index("function applyIdentity(me)") :]
     identity = identity[: identity.index("// Device-flow driver")]
 
-    assert "let runtimeTier=portTier,sessionTier=null;" in html
+    assert "let runtimeTier=portTier;" in html
     assert "function reconcileTier()" in html
     assert "runtimeTier=rt.layer" in runtime
-    assert "activeTier=rt.layer" not in runtime
-    assert "sessionTier=LEVEL[me.tier]!=null?me.tier:null" in identity
-    assert identity.count("sessionTier=null") == 3
+    assert "activeTier=runtimeTier" in html
+    assert "sessionTier" not in html
+    assert "me.tier" not in identity
     assert "reconcileTier();" in runtime
     assert "reconcileTier();" in identity
+
+
+def test_non_2xx_live_feeds_degrade_honestly() -> None:
+    html = DASHBOARD.read_text(encoding="utf-8")
+    assert "const feedJson=r=>r.ok?r.json():Promise.reject" in html
+    for endpoint in ("readyz", "benchmarkz", "runtimez"):
+        assert f"fetch('/{endpoint}').then(feedJson).catch(()=>null)" in html

--- a/tests/test_forge_surface.py
+++ b/tests/test_forge_surface.py
@@ -51,7 +51,11 @@ def test_ui_serves_baked_dashboard_by_default() -> None:
     response = asyncio.run(server.control_center(_request()))
     assert response.status_code == 200
     assert b"<script nonce=" in response.body
-    assert "script-src 'self' 'nonce-" in response.headers["content-security-policy"]
+    csp = response.headers["content-security-policy"]
+    assert "script-src 'self' 'nonce-" in csp
+    assert "connect-src 'self'" in csp
+    assert "127.0.0.1:4768" not in csp
+    assert "127.0.0.1:4769" not in csp
 
 
 def test_ui_ignores_authorization_header() -> None:
@@ -165,7 +169,11 @@ def test_ui_asset_blocks_symlink_escape(
 
 
 def test_control_plane_401_on_forge_surface(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def no_control_session(_: object) -> None:
+        return None
+
     monkeypatch.setattr(server, "SURFACE", "forge")
+    monkeypatch.setattr(server.github_auth, "control_session_info", no_control_session)
     response = asyncio.run(server.forge_identity(_request("/api/me")))
     assert response.status_code == 401
     assert "www-authenticate" not in {k.lower() for k in response.headers}

--- a/tests/test_github_device_auth.py
+++ b/tests/test_github_device_auth.py
@@ -172,8 +172,14 @@ def test_device_cookie_round_trip_survives_server_cache_reset(
     async def completed(_flow: str) -> dict:
         return {"session": sid, "login": "djtelicloud", "tier": "sky"}
 
+    async def no_control_session(_: object) -> None:
+        return None
+
     monkeypatch.setattr(server, "SURFACE", "forge")
     monkeypatch.setattr(github_auth, "poll_flow", completed)
+    # Keep the device-cookie round trip hermetic on developer machines that
+    # already have a valid Control OAuth token in their Forge state volume.
+    monkeypatch.setattr(github_auth, "control_session_info", no_control_session)
     monkeypatch.setattr(server, "_client_is_loopback", lambda _request: True)
     with TestClient(
         server.mcp.streamable_http_app(),


### PR DESCRIPTION
## What changed

- restore native Public/Sky/Space navigation from the server-authored `runtimez.tier_nav` map on every surface, including Forge
- keep Space visible as an access-dependent upgrade instead of hiding or coercing it to Sky
- bind the rendered tier to the current runtime origin, not login state or a same-origin preview
- reject non-2xx dashboard feeds as unavailable
- keep Forge's Public target on canonical core `:4765`
- preserve the GitHub Control OAuth flow and device-code fallback; make their tests hermetic when a developer already has Control auth

## Why

The r26 Forge switch changed the page chrome in-shell while every live feed still came from Forge. The tier buttons need to be real port switches so the selected origin supplies its own `/readyz`, `/runtimez`, and `/benchmarkz`. Native navigation preserves `connect-src 'self'` and fails honestly when a higher-tier port is unavailable.

Space remains zero-write and unconnected from lower planes; this is only a visible upgrade/navigation exception. No model promotion or parent merge is included.

## Validation

- `uv run pytest -q` — 581 passed, 7 skipped
- `uv run ruff check .`
- docs and release contract checks
- insider denylist and Compose validation
- Docker rehearsal `unigrok:forge-r27-codex` healthy on `:4788`, reporting Forge with tier targets `:4765`, `:4768`, `:4769`
- CSP still contains `connect-src 'self'`
- @grok ultra architecture review: clear; Sky ultra gate: CLEAR YES to push into PR #524, PROMOTE NO

This PR targets the open PR #524 branch so the parent can absorb the correction without rewriting its history.