### PR TITLE
fix(ui): switch Forge tabs to live tier origins

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -59,6 +59,9 @@ services:
       UNIGROK_SPACE_URL: ${UNIGROK_SPACE_URL:-}
       # Forge-surface GitHub sign-in (device flow): public client id, never a secret.
       UNIGROK_SURFACE: ${UNIGROK_SURFACE:-public}
+      # Forge's own loopback auth origin is independent from Public tier nav.
+      UNIGROK_FORGE_PORT: ${UNIGROK_FORGE_PORT:-4766}
+      UNIGROK_FORGE_URL: ${UNIGROK_FORGE_URL:-}
       UNIGROK_GITHUB_CLIENT_ID: ${UNIGROK_GITHUB_CLIENT_ID:-}
       UNIGROK_CONTRIBUTOR_LOGINS: ${UNIGROK_CONTRIBUTOR_LOGINS:-}
       UNIGROK_CONTRIBUTOR_TIER: ${UNIGROK_CONTRIBUTOR_TIER:-sky}

--- a/docs/design/ui-data-pipeline.md
+++ b/docs/design/ui-data-pipeline.md
@@ -48,6 +48,10 @@ native full navigation; the destination page reads only its own same-origin
 feeds. Forge is not a data proxy and never relabels its own feeds as Sky or
 Space.
 
+The top-tab labels stay deliberately terse: `@grok`, `@skygrok`, and
+`@spacegrok`. The destination page title and eyebrow carry the longer
+GroundCommand/SkyCommand/SpaceCommand description.
+
 **Hierarchical scoping:** each tier renders its own panels plus every lower
 tier's; panels above the active tier are `display:none`. Public visitors see only
 public panels. Higher tiers still enforce their own auth on arrival — the nav is
@@ -286,6 +290,10 @@ public. No password ever touches the deck; every failure keeps its honest name
 device session remains usable and the remembered Control token is retained.
 Forge auth mutations require a non-simple same-loopback request, preventing a
 foreign page from silently unlinking the machine.
+Forge's canonical auth/cookie origin comes from `UNIGROK_FORGE_URL` (or the
+`UNIGROK_FORGE_PORT` fallback) and is intentionally independent from
+`UNIGROK_PUBLIC_URL`/`UNIGROK_PUBLIC_PORT`. The switchboard can therefore send
+`@grok` to public core `:4765` without breaking Forge login on `:4766`.
 
 Signed-out is never dressed up; the granted tier is server truth, so the
 GitHub gate — not the client — controls what data shows.

--- a/example.env
+++ b/example.env
@@ -12,6 +12,9 @@ UNIGROK_PUBLIC_PORT=4765
 # Cloud OAuth/PKCE is the preferred path and needs no additional client id.
 # Contributor logins gain UNIGROK_CONTRIBUTOR_TIER (default sky) in the deck.
 # UNIGROK_SURFACE=forge
+# Forge auth/cookies stay on this origin even when @grok navigates to :4765.
+# UNIGROK_FORGE_PORT=4766
+# UNIGROK_FORGE_URL=http://127.0.0.1:4766
 # UNIGROK_GITHUB_CLIENT_ID=
 # UNIGROK_CONTRIBUTOR_LOGINS=
 # UNIGROK_CONTRIBUTOR_TIER=sky

--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -391,6 +391,9 @@ LOCAL_RUNTIME_URL = _resolve_local_runtime_url()
 PUBLIC_TIER_PORT = _bounded_int("UNIGROK_PUBLIC_PORT", 4765, 1, 65535)
 SKY_TIER_PORT = _bounded_int("UNIGROK_SKY_PORT", 4768, 1, 65535)
 SPACE_TIER_PORT = _bounded_int("UNIGROK_SPACE_PORT", 4769, 1, 65535)
+# Forge auth is intentionally separate from tier navigation. A Forge switchboard
+# may navigate Public to :4765 while its own cookie/PKCE origin remains :4766.
+FORGE_CONTROL_PORT = _bounded_int("UNIGROK_FORGE_PORT", 4766, 1, 65535)
 
 
 def _tier_url(name: str) -> str | None:
@@ -6843,7 +6846,7 @@ async def ui_asset(request: Request) -> Response:
 
 def _forge_control_callback_url() -> str:
     """Canonical loopback callback; never trust a request Host header."""
-    configured = _tier_url("UNIGROK_PUBLIC_URL")
+    configured = _tier_url("UNIGROK_FORGE_URL")
     if configured:
         try:
             parsed = urlsplit(configured)
@@ -6860,7 +6863,7 @@ def _forge_control_callback_url() -> str:
                 return f"{configured.rstrip('/')}/auth/control/callback"
         except ValueError:
             pass
-    return f"http://127.0.0.1:{PUBLIC_TIER_PORT}/auth/control/callback"
+    return f"http://127.0.0.1:{FORGE_CONTROL_PORT}/auth/control/callback"
 
 
 def _forge_request_is_canonical(request: Request) -> bool:

--- a/src/unigrok_public/static/dashboard.html
+++ b/src/unigrok_public/static/dashboard.html
@@ -58,8 +58,6 @@
     .tier-tab{display:inline-flex;align-items:center;gap:8px;border:1px solid var(--line);border-radius:99px;
       padding:7px 15px;color:var(--muted);font-weight:650;font-size:clamp(13px,0.3vw+11px,15.5px);
       text-decoration:none;transition:color .12s,border-color .12s}
-    .tier-access{font-size:.72em;letter-spacing:.05em;text-transform:uppercase;color:var(--purple);
-      border:1px solid #6e55a866;border-radius:99px;padding:1px 7px}
     .menu-btn{border:1px solid var(--line);background:#0d1324cc;color:var(--text);border-radius:10px;
       padding:6px 13px;font-size:clamp(15px,0.34vw+12px,18px);cursor:pointer;line-height:1;transition:border-color .12s}
     .menu-btn:hover{border-color:var(--cyan)}
@@ -297,7 +295,7 @@ const METERED_KINDS=new Set(['web_search','x_search','remote_code_execution','ch
 const KIND_COL=n=>METERED_KINDS.has(n)?lvHex.warning:'#4a5675';   // metered (costs) vs free (neutral)
 const ROUTE_COL=n=>n==='error'?lvHex.threat:GRADFILL;             // only error carries a level
 const MODEL_COL=()=>GRADFILL;                                     // model choice has no severity
-const UI_BUILD='unigrok-ui-v1.1.0-r27';
+const UI_BUILD='unigrok-ui-v1.1.0-r28';
 const CLOUD_AUTO_KEY='unigrok-cloud-auto-r25',CLOUD_RESUME_KEY='unigrok-cloud-resume-r25';
 const CONTROL_START_FAILED=new URLSearchParams(location.search).get('control')==='unavailable';
 // Unified 3-tier switcher: every tab is native navigation to that tier's own
@@ -307,9 +305,9 @@ const CONTROL_START_FAILED=new URLSearchParams(location.search).get('control')==
 // own reachability/auth on arrival — navigation advertises access, never
 // grants it. Space remains visible as an access-dependent upgrade.
 const TIERS=[
-  {id:'public',label:'@grok Public Core',port:'4765',name:'GroundCommand',eyebrow:'public core'},
-  {id:'sky',label:'@skygrok Sky Observer',port:'4768',name:'SkyCommand',eyebrow:'sky observer'},
-  {id:'space',label:'@spacegrok Space Awareness',port:'4769',name:'SpaceCommand',eyebrow:'space awareness'},
+  {id:'public',label:'@grok',port:'4765',name:'GroundCommand',eyebrow:'public core'},
+  {id:'sky',label:'@skygrok',port:'4768',name:'SkyCommand',eyebrow:'sky observer'},
+  {id:'space',label:'@spacegrok',port:'4769',name:'SpaceCommand',eyebrow:'space awareness'},
 ];
 const LEVEL={public:0,sky:1,space:2};
 const herePort=location.port||(location.protocol==='https:'?'443':'80');
@@ -323,9 +321,8 @@ document.getElementById('tiernav').insertAdjacentHTML('beforeend',TIERS.map(t=>{
   const tip=t.id==='public'?'opens the public core and its live data':
     t.id==='space'?'upgrade: opens SpaceCommand and its live data when that port is available':
     `opens the ${t.id} surface and its live data — requires that stack to be running`;
-  const access=t.id==='space'?'<span class="tier-access">upgrade</span>':'';
   return `<a class="tier-tab" data-tier="${t.id}" href="${href}" title="${tip}">`+
-    `<span class="tier-dot ${t.id}"></span>${t.label}${access}</a>`;
+    `<span class="tier-dot ${t.id}"></span>${t.label}</a>`;
 }).join(''));
 function isForgeSurface(rt){
   // Prefer server truth (/runtimez.surface). Factory fallback: public tier_nav

--- a/tests/test_control_center_ui.py
+++ b/tests/test_control_center_ui.py
@@ -201,33 +201,39 @@ def test_tier_nav_renders_all_three_surfaces() -> None:
     # Full tuples, not bare ports (a port can appear in unrelated sample data).
     # Each tier carries its command name + eyebrow for the dynamic page title.
     for tup in (
-        "{id:'public',label:'@grok Public Core',port:'4765',name:'GroundCommand'",
-        "{id:'sky',label:'@skygrok Sky Observer',port:'4768',name:'SkyCommand'",
-        "{id:'space',label:'@spacegrok Space Awareness',port:'4769',name:'SpaceCommand'",
+        "{id:'public',label:'@grok',port:'4765',name:'GroundCommand'",
+        "{id:'sky',label:'@skygrok',port:'4768',name:'SkyCommand'",
+        "{id:'space',label:'@spacegrok',port:'4769',name:'SpaceCommand'",
     ):
         assert tup in html
+    for verbose_label in (
+        "@grok Public Core",
+        "@skygrok Sky Observer",
+        "@spacegrok Space Awareness",
+    ):
+        assert f"label:'{verbose_label}'" not in html
     # applyTier drives title/eyebrow/tab state from the active tier
     assert "function applyTier(" in html and "$('pagetitle').textContent" in html
 
 
 def test_forge_nav_is_port_bound_and_space_is_advertised() -> None:
     # Forge uses the same native, per-origin navigation as every other surface.
-    # Space stays visible as an access-dependent upgrade; it is never replaced
-    # by a same-origin sample shell.
+    # Space stays visible as an access-dependent destination; the tab itself
+    # keeps the exact terse label and is never replaced by a sample shell.
     html = DASHBOARD.read_text(encoding="utf-8")
     assert "function bindForgeSurface(rt)" in html
     assert "function isForgeSurface(rt)" in html
     assert "if(surface)return surface==='forge'" in html
     assert "if(rt.tier_nav)" in html
     assert "if(rt.tier_nav&&!forgeSurface)" not in html
-    assert '<span class="tier-access">upgrade</span>' in html
+    assert "tier-access" not in html
     assert "upgrade: opens SpaceCommand and its live data" in html
     assert "dataset.inshell" not in html
     assert "a.hidden=true" not in html
     assert "activeTier='sky'" not in html
     assert "function hydrateSkyLive(rt,b)" in html
     assert "No cross-port" in html or "no cross-port" in html
-    assert "UI_BUILD" in html and "r27" in html
+    assert "UI_BUILD" in html and "r28" in html
 
 
 def test_explicit_non_forge_surface_bypasses_legacy_port_fallback() -> None:
@@ -394,6 +400,8 @@ def test_tier_nav_ports_are_bounded_env_values() -> None:
     compose = Path("compose.yaml").read_text(encoding="utf-8")
     assert "UNIGROK_PUBLIC_PORT: ${UNIGROK_PUBLIC_PORT:-4765}" in compose
     assert "UNIGROK_PUBLIC_PORT: ${UNIGROK_PORT:-4765}" not in compose
+    assert "UNIGROK_FORGE_PORT: ${UNIGROK_FORGE_PORT:-4766}" in compose
+    assert "UNIGROK_FORGE_URL: ${UNIGROK_FORGE_URL:-}" in compose
 
 
 def test_dashboard_consumes_server_tier_truth() -> None:

--- a/tests/test_control_oauth_bridge.py
+++ b/tests/test_control_oauth_bridge.py
@@ -42,7 +42,7 @@ def _request(
 ) -> server.Request:
     request_headers = list(headers or [])
     if not any(name.lower() == b"host" for name, _ in request_headers):
-        request_headers.insert(0, (b"host", b"127.0.0.1:4765"))
+        request_headers.insert(0, (b"host", b"127.0.0.1:4766"))
     return server.Request(
         {
             "type": "http",
@@ -51,7 +51,7 @@ def _request(
             "headers": request_headers,
             "query_string": query_string,
             "client": ("127.0.0.1", 40000),
-            "server": ("127.0.0.1", 4765),
+            "server": ("127.0.0.1", 4766),
             "scheme": "http",
         }
     )
@@ -297,7 +297,7 @@ def test_logout_requires_non_simple_same_loopback_request(
                 method="POST",
                 headers=[
                     (b"x-unigrok-csrf", b"1"),
-                    (b"origin", b"http://127.0.0.1:4765"),
+                    (b"origin", b"http://127.0.0.1:4766"),
                 ],
             )
         )

--- a/tests/test_forge_surface.py
+++ b/tests/test_forge_surface.py
@@ -24,7 +24,7 @@ def _request(
 ) -> Request:
     request_headers = list(headers or [])
     if not any(name.lower() == b"host" for name, _ in request_headers):
-        request_headers.insert(0, (b"host", b"127.0.0.1:4765"))
+        request_headers.insert(0, (b"host", b"127.0.0.1:4766"))
     scope = {
         "type": "http",
         "method": "GET",
@@ -183,10 +183,29 @@ def test_forge_auth_rejects_non_loopback_host(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(server, "SURFACE", "forge")
     response = asyncio.run(
         server.forge_identity(
-            _request("/api/me", headers=[(b"host", b"attacker.example:4765")])
+            _request("/api/me", headers=[(b"host", b"attacker.example:4766")])
         )
     )
     assert response.status_code == 403
+
+
+def test_forge_auth_origin_is_independent_from_public_nav(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(server, "SURFACE", "forge")
+    monkeypatch.setenv("UNIGROK_PUBLIC_URL", "http://127.0.0.1:4765")
+    monkeypatch.setenv("UNIGROK_FORGE_URL", "http://127.0.0.1:4766")
+
+    assert (
+        server._forge_control_callback_url()
+        == "http://127.0.0.1:4766/auth/control/callback"
+    )
+    assert server._forge_auth_guard(_request("/api/me")) is None
+    rejected = server._forge_auth_guard(
+        _request("/api/me", headers=[(b"host", b"127.0.0.1:4765")])
+    )
+    assert rejected is not None
+    assert rejected.status_code == 403
 
 
 def test_loopback_check_ignores_forwarded_for() -> None:

--- a/tests/test_github_device_auth.py
+++ b/tests/test_github_device_auth.py
@@ -183,7 +183,7 @@ def test_device_cookie_round_trip_survives_server_cache_reset(
     monkeypatch.setattr(server, "_client_is_loopback", lambda _request: True)
     with TestClient(
         server.mcp.streamable_http_app(),
-        base_url="http://127.0.0.1:4765",
+        base_url="http://127.0.0.1:4766",
     ) as client:
         response = client.post(
             "/auth/github/poll",


### PR DESCRIPTION
## What changed

- makes the Forge tabs exactly `@grok`, `@skygrok`, and `@spacegrok`
- keeps each tab as native full-page navigation to `:4765`, `:4768`, and `:4769`, so the destination owns the displayed data
- separates the Forge control/auth origin (`UNIGROK_FORGE_URL` / `UNIGROK_FORGE_PORT`) from the Public tier destination
- updates Compose, environment documentation, design documentation, and regression coverage

## Why

Forge runs on `:4766`, while `@grok` data belongs to Public Core on `:4765`. The prior configuration reused the Public destination as Forge's auth origin, so correcting navigation could break Forge host validation. The old live deployment also mounted a stale dashboard file over the image.

## Impact

Forge can now preserve its signed-in control session on `:4766` while the three terse tabs open the real Ground, Sky, and Space surfaces. No same-origin preview or data relabeling is used.

## Validation

- 582 tests passed, 7 skipped
- Ruff passed
- docs, release, insider-denylist, and Compose checks passed
- isolated Docker rehearsal passed
- live `:4766` cutover passed with auth/state continuity
- browser verification confirmed the three exact labels and native destinations
