### PR TITLE
fix(ui): make Forge navigation mobile-first

### DIFF
--- a/docs/design/ui-data-pipeline.md
+++ b/docs/design/ui-data-pipeline.md
@@ -255,7 +255,7 @@ exactly that truth:
 | --- | --- | --- |
 | 404 / absent | public surface, no identity exists | button links out to the control site (marketing) |
 | 401 | forge surface, signed out | "Continue with Cloud" reuses the existing Control OAuth registration; "Use device code" remains the explicit fallback |
-| 200 `{login, tier}` | gated session | "Signed in · login" pill (click = sign out); server-granted `tier` may raise the visible tier (never lower, never below the surface floor) |
+| 200 `{login, tier}` | gated session | username-only pill (click = sign out); server-granted `tier` may raise the visible tier (never lower, never below the surface floor) |
 
 **Preferred Cloud link** (`github_auth.py`, Forge only):
 `/auth/control/start` dynamically registers a loopback PKCE client with the

--- a/src/unigrok_public/static/dashboard.html
+++ b/src/unigrok_public/static/dashboard.html
@@ -54,12 +54,12 @@
     .footer{color:var(--muted);margin-top:18px;font-size:clamp(12px,0.26vw+10px,13.5px)}
     .tier-nav{display:flex;align-items:center;gap:10px;margin:0 0 18px;padding:9px 14px;border:1px solid var(--line);
       border-radius:14px;background:#0d132480;backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);flex-wrap:wrap}
-    .tier-label{color:var(--muted);font-size:clamp(11px,0.24vw+9.5px,12.5px);font-weight:750;letter-spacing:.12em;text-transform:uppercase}
     .tier-tab{display:inline-flex;align-items:center;gap:8px;border:1px solid var(--line);border-radius:99px;
-      padding:7px 15px;color:var(--muted);font-weight:650;font-size:clamp(13px,0.3vw+11px,15.5px);
-      text-decoration:none;transition:color .12s,border-color .12s}
+      min-height:42px;padding:7px 15px;color:var(--muted);font-weight:650;font-size:clamp(13px,0.3vw+11px,15.5px);
+      text-decoration:none;transition:color .12s,border-color .12s;white-space:nowrap}
     .menu-btn{border:1px solid var(--line);background:#0d1324cc;color:var(--text);border-radius:10px;
-      padding:6px 13px;font-size:clamp(15px,0.34vw+12px,18px);cursor:pointer;line-height:1;transition:border-color .12s}
+      min-width:42px;min-height:42px;padding:6px 13px;font-size:clamp(15px,0.34vw+12px,18px);cursor:pointer;
+      line-height:1;transition:border-color .12s}
     .menu-btn:hover{border-color:var(--cyan)}
     .signin{margin-left:auto;order:99;display:inline-flex;align-items:center;border:1px solid #1e5f5a;
       background:linear-gradient(90deg,#12302880,#15254180);color:#baf7c7;border-radius:99px;padding:7px 16px;
@@ -168,8 +168,30 @@
        so wide desktop/IDE panes keep the two-up layout as long as it fits. */
     @media(max-width:1150px){.card{grid-column:span 6}}
     @media(max-width:760px){.card.wide{grid-column:1/-1}}
+    @media(max-width:680px){
+      main{width:calc(100% - 16px);padding-top:12px}
+      .tier-nav{display:grid;grid-template-columns:44px repeat(3,minmax(0,1fr));align-items:stretch;gap:6px;
+        padding:8px;margin-bottom:14px}
+      .menu-btn{grid-column:1;grid-row:1;min-width:44px;min-height:44px;padding:6px}
+      .tier-tab{justify-content:center;min-width:0;min-height:44px;padding:7px 4px;
+        font-size:clamp(11.5px,3.4vw,13px)}
+      .tier-tab[data-tier="public"]{grid-column:2;grid-row:1}
+      .tier-tab[data-tier="sky"]{grid-column:3;grid-row:1}
+      .tier-tab[data-tier="space"]{grid-column:4;grid-row:1}
+      .signin{grid-column:1/-1;grid-row:2;width:100%;min-width:0;min-height:44px;margin-left:0;
+        justify-content:center;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+      .signin-alt{grid-column:1/-1;grid-row:3;min-height:44px;align-items:center;justify-content:center;
+        white-space:normal;text-align:center}
+      .ghflow{grid-column:1/-1;grid-row:4;min-width:0;margin-left:0;justify-content:center;
+        white-space:normal;text-align:center;overflow-wrap:anywhere}
+      .snip2{grid-template-columns:minmax(0,1fr)}
+    }
     @media(max-width:540px){header{display:block}
-      .status{justify-content:flex-start;margin-top:16px}.card,.card.wide{grid-column:1/-1}}
+      .status{justify-content:flex-start;margin-top:16px}.card,.card.wide{grid-column:1/-1}
+      .tiernote{min-width:0}.bar-row{grid-template-columns:minmax(68px,1fr) minmax(76px,3fr) 52px;gap:7px}
+      .kv{grid-template-columns:minmax(68px,auto) minmax(0,1fr);gap:9px 12px}
+      .kv b{min-width:0;overflow-wrap:anywhere}}
+    @media(max-width:360px){.tier-dot{display:none}.tier-tab{gap:0;padding-inline:3px}}
   </style>
 </head>
 <body><main>
@@ -179,7 +201,7 @@
     <nav id="ditems"></nav>
     <div class="drawer-foot">Drawer is an index of this deck — items scroll to their panel. Contributor actions live on the control site.</div>
   </aside>
-  <nav class="tier-nav" id="tiernav" aria-label="surface tier"><button id="dmenu" class="menu-btn" aria-label="open command drawer">☰</button><span class="tier-label">Surface</span><a class="signin" id="signin" href="https://control.grokmcp.org" title="sign-in happens on control.grokmcp.org — this deck never logs you in locally">Open contributor control</a><a class="signin-alt" id="deviceauth" href="#" title="Use GitHub's device-code flow on this Forge">Use device code</a></nav>
+  <nav class="tier-nav" id="tiernav" aria-label="UniGrok destinations"><button id="dmenu" class="menu-btn" aria-label="open command drawer">☰</button><a class="signin" id="signin" href="https://control.grokmcp.org" title="sign-in happens on control.grokmcp.org — this deck never logs you in locally">Open contributor control</a><a class="signin-alt" id="deviceauth" href="#" title="Use GitHub's device-code flow on this Forge">Use device code</a></nav>
   <div class="legend" aria-label="status color key"><span class="lg-label">Levels</span>
     <span class="lg"><i style="background:#3fa266"></i>great</span>
     <span class="lg"><i style="background:#81a1c1"></i>good</span>
@@ -295,7 +317,7 @@ const METERED_KINDS=new Set(['web_search','x_search','remote_code_execution','ch
 const KIND_COL=n=>METERED_KINDS.has(n)?lvHex.warning:'#4a5675';   // metered (costs) vs free (neutral)
 const ROUTE_COL=n=>n==='error'?lvHex.threat:GRADFILL;             // only error carries a level
 const MODEL_COL=()=>GRADFILL;                                     // model choice has no severity
-const UI_BUILD='unigrok-ui-v1.1.0-r28';
+const UI_BUILD='unigrok-ui-v1.1.0-r29';
 const CLOUD_AUTO_KEY='unigrok-cloud-auto-r25',CLOUD_RESUME_KEY='unigrok-cloud-resume-r25';
 const CONTROL_START_FAILED=new URLSearchParams(location.search).get('control')==='unavailable';
 // Unified 3-tier switcher: every tab is native navigation to that tier's own
@@ -587,7 +609,7 @@ $('connectcard').addEventListener('click',e=>{const btn=e.target.closest('.ctab,
 // forge until the GitHub OAuth slice answers, 200 {login,tier?} once gated.
 // The deck renders exactly that truth — signed-out is never dressed up.
 function applyIdentity(me){const el=$('signin'),fallback=$('deviceauth');if(!el)return;
-  if(me&&me.login){el.textContent=`Signed in · ${me.login}`;el.href='#';el.dataset.ghout='1';
+  if(me&&me.login){el.textContent=me.login;el.href='#';el.dataset.ghout='1';
     el.title='contributor session active — click to sign out';
     if(me.kind==='control')localStorage.removeItem(CLOUD_AUTO_KEY);
     sessionStorage.removeItem(CLOUD_RESUME_KEY);if(fallback)fallback.style.display='none';}

--- a/tests/test_control_center_ui.py
+++ b/tests/test_control_center_ui.py
@@ -233,7 +233,22 @@ def test_forge_nav_is_port_bound_and_space_is_advertised() -> None:
     assert "activeTier='sky'" not in html
     assert "function hydrateSkyLive(rt,b)" in html
     assert "No cross-port" in html or "no cross-port" in html
-    assert "UI_BUILD" in html and "r28" in html
+    assert "UI_BUILD" in html and "r29" in html
+
+
+def test_mobile_tier_nav_is_compact_and_overflow_safe() -> None:
+    html = DASHBOARD.read_text(encoding="utf-8")
+    assert '<nav class="tier-nav" id="tiernav" aria-label="UniGrok destinations">' in html
+    assert '<span class="tier-label">Surface</span>' not in html
+    assert ".tier-label{" not in html
+    assert "grid-template-columns:44px repeat(3,minmax(0,1fr))" in html
+    assert '.tier-tab[data-tier="public"]{grid-column:2;grid-row:1}' in html
+    assert '.tier-tab[data-tier="sky"]{grid-column:3;grid-row:1}' in html
+    assert '.tier-tab[data-tier="space"]{grid-column:4;grid-row:1}' in html
+    assert ".snip2{grid-template-columns:minmax(0,1fr)}" in html
+    assert ".kv{grid-template-columns:minmax(68px,auto) minmax(0,1fr)" in html
+    assert ".kv b{min-width:0;overflow-wrap:anywhere}" in html
+    assert "@media(max-width:360px){.tier-dot{display:none}" in html
 
 
 def test_explicit_non_forge_surface_bypasses_legacy_port_fallback() -> None:
@@ -433,7 +448,8 @@ def test_dashboard_identity_states_follow_gateway_truth() -> None:
     html = DASHBOARD.read_text(encoding="utf-8")
     assert "function applyIdentity(me)" in html
     assert "fetch('/api/me')" in html
-    assert "Signed in · ${me.login}" in html
+    assert "el.textContent=me.login" in html
+    assert "Signed in · ${me.login}" not in html
     assert "Continue with Cloud" in html
     assert "el.href='/auth/control/start'" in html
     assert "location.replace('/auth/control/start')" in html


### PR DESCRIPTION
## What changed

- makes the Forge top navigation responsive down to 320px with 44px touch targets
- keeps the destination buttons exactly `@grok`, `@skygrok`, and `@spacegrok`
- removes the visible `Surface` label
- shows only the GitHub username for an active session, without redundant `Signed in` text
- fixes mobile overflow in the policy and IDE-connect panels

## Why

The previous flex-wrap layout expanded the page beyond a phone viewport and made the primary controls cramped. Signed-in state also repeated information already conveyed by the visible username.

## Validation

- `583 passed, 7 skipped`
- Ruff, docs contract, release contract, insider denylist, and Compose validation passed
- Docker image `unigrok:forge-r29-codex-4c64d4d` is healthy on live Forge `:4766`
- browser checks at 320×700 and 390×844 show zero page overflow, exact destination links, and all visible nav controls at 44px
- existing auth/state volumes retained: 90 facts, 69 samples, latest receipt 138, recorded cost unchanged