### PR TITLE
docs: engineering I/O safety and fair dual-plane benches

### DIFF
--- a/docs/ENGINEERING-IO-SAFETY.md
+++ b/docs/ENGINEERING-IO-SAFETY.md
@@ -1,0 +1,51 @@
+# Engineering · I/O safety & fair dual-plane benches
+
+**Audience:** UniGrok public core contributors  
+**Status:** Live
+
+## 1. Multi-writer state
+
+Prefer **one durable store with real concurrency control** (for example SQLite WAL,
+busy timeout, and explicit write serialization) over plain text files that many
+workers append and rewrite.
+
+If you must use a shared append-only text file across processes:
+
+1. **Exclusive lock** around the critical section
+2. **Hot path = append only**
+3. **Trim rarely** (amortized); re-read truth from the file — do not trust a sticky
+   in-process line counter across workers
+4. Keep a **fixed tail** (bounded memory)
+
+Anti-pattern: read the entire file and rewrite it on every line.
+
+## 2. Size-gate math
+
+If code says “when size > X, read the last Y bytes/window,” then **X and Y must be
+consistent** (window ≤ gate, units match). Mismatched gates cause silent logic bugs.
+
+## 3. Fair dual-plane benches
+
+When comparing behaviors, change **one** control at a time:
+
+- `depth` / shape **or**
+- `fallback_policy` (`same_plane` vs `cross_plane`)
+
+not both in the same comparison if you want a clean lesson.
+
+Do not treat editorial “architecture scores” as CI gates. Prefer executable tests for
+recovery and policy literals (already in-tree), for example:
+
+- cross-plane and same-plane recovery behavior in the team harness tests
+- fallback policy limited to `same_plane` | `cross_plane` (no third “local model”
+  policy value)
+- public tool surface that keeps normal callers on **intent**, not hidden plane knobs
+
+## 4. Operator routing (behavior, not deployment nicknames)
+
+Public UniGrok keeps **caller intent** — clients should not be taught to pass hidden
+model or plane knobs for normal use.
+
+For operators running **multiple deployments**, prefer deeper/safer paths for
+concurrent file and multi-writer work; lighter paths for simple short answers. That is
+operational guidance, not a public API change.

--- a/docs/development.md
+++ b/docs/development.md
@@ -3,6 +3,9 @@
 This guide is for contributors and release verification. Ordinary users only need the
 README. See also [CONTRIBUTING.md](../CONTRIBUTING.md).
 
+For multi-writer I/O rules and fair dual-plane bench protocol, see
+[ENGINEERING-IO-SAFETY.md](./ENGINEERING-IO-SAFETY.md).
+
 The authenticated Cloud Run service has a separate digest-pinned release and rollback
 gate. Do not infer a public deployment from a local Compose rebuild; operators must use
 the [remote deployment runbook](remote-mcp-deployment.md).


### PR DESCRIPTION
## Summary

- Add `docs/ENGINEERING-IO-SAFETY.md`: multi-writer text-file rules, size-gate math, one-knob dual-plane bench protocol, intent-first operator guidance.
- Link from `docs/development.md`.

## Why

Factory bake-off + audit: public core already uses SQLite WAL (no code port). Ship stranger-safe engineering law so contributors do not reintroduce full-file rewrite logs or mismatched size windows.

## Test plan

- [x] Docs-only PR (no runtime)
- [ ] Skim for secrets / private seat ports (none expected)
- [ ] Merge when green

PROMOTE GO (sponsor) · no train · no hooks package paste