### PR TITLE
feat(telemetry): record session outcome join key

### DIFF
--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -5424,6 +5424,7 @@ async def agent(
                     await STATE.save_telemetry(
                         {
                         "caller": caller,
+                        "session_name": session_name,
                         "request_kind": "agent",
                         "route": "error",
                         "requested_plane": "auto",
@@ -5616,15 +5617,29 @@ async def agent(
                 result["shadow_done_vote"] = shadow_done
         telemetry_id: int | None = None
         with contextlib.suppress(Exception):
+            turn_success: bool | None
+            try:
+                normalized_stop = re.sub(
+                    r"[^a-z0-9]+",
+                    "",
+                    str(result.get("stop_reason") or "").casefold(),
+                )
+                turn_success = bool(
+                    normalized_stop in {"", "endturn", "stop"}
+                    and not is_nonanswer_completion(result.get("text"), prompt=prompt)
+                )
+            except Exception:
+                turn_success = None
             telemetry_id = await STATE.save_telemetry(
                 {
                 "caller": caller,
+                "session_name": session_name,
                 "request_kind": "agent",
                 "route": result.get("orchestration", {}).get("route") or result.get("route"),
                 "requested_plane": result.get("requested_plane") or "auto",
                 "resolved_plane": result.get("resolved_plane") or result.get("plane"),
                 "model": result.get("model"),
-                "success": None,
+                "success": turn_success,
                 "verified": False,
                 "latency_ms": round((time.monotonic() - operation_started) * 1000),
                 "cost_usd": result.get("cost_usd"),

--- a/src/unigrok_public/state.py
+++ b/src/unigrok_public/state.py
@@ -260,6 +260,7 @@ class PublicStateStore:
                 CREATE TABLE IF NOT EXISTS telemetry (
                     id INTEGER PRIMARY KEY AUTOINCREMENT,
                     created_at TEXT NOT NULL,
+                    session_name TEXT,
                     caller TEXT NOT NULL,
                     request_kind TEXT NOT NULL,
                     route TEXT,
@@ -386,6 +387,16 @@ class PublicStateStore:
                 connection.execute(
                     "ALTER TABLE autonomy_jobs ADD COLUMN request_json TEXT"
                 )
+            telemetry_columns = {
+                str(row[1])
+                for row in connection.execute("PRAGMA table_info(telemetry)").fetchall()
+            }
+            if telemetry_columns and "session_name" not in telemetry_columns:
+                connection.execute("ALTER TABLE telemetry ADD COLUMN session_name TEXT")
+            connection.execute(
+                "CREATE INDEX IF NOT EXISTS telemetry_session_created "
+                "ON telemetry(session_name, created_at DESC)"
+            )
             agent_job_columns = {
                 str(row[1])
                 for row in connection.execute("PRAGMA table_info(agent_jobs)").fetchall()
@@ -833,7 +844,12 @@ class PublicStateStore:
 
     def _delete_session_sync(self, session: str) -> bool:
         with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
             cursor = connection.execute("DELETE FROM sessions WHERE name=?", (session,))
+            connection.execute(
+                "UPDATE telemetry SET session_name=NULL WHERE session_name=?",
+                (session,),
+            )
             connection.commit()
         return bool(cursor.rowcount)
 
@@ -986,13 +1002,14 @@ class PublicStateStore:
             cursor = connection.execute(
                 """
                 INSERT INTO telemetry(
-                    created_at, caller, request_kind, route, requested_plane,
+                    created_at, session_name, caller, request_kind, route, requested_plane,
                     resolved_plane, model, success, verified, latency_ms,
                     cost_usd, fallback_reason, stop_reason, metadata
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     utc_now(),
+                    str(row.get("session_name") or "")[:160] or None,
                     str(row.get("caller") or "anonymous")[:160],
                     str(row.get("request_kind") or "agent")[:80],
                     str(row.get("route") or "")[:80] or None,

--- a/tests/test_telemetry_outcome_session.py
+++ b/tests/test_telemetry_outcome_session.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from unigrok_public import server
+from unigrok_public.state import PublicStateStore, utc_now
+
+
+def _create_legacy_telemetry(path: Path) -> None:
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            """
+            CREATE TABLE telemetry (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                created_at TEXT NOT NULL,
+                caller TEXT NOT NULL,
+                request_kind TEXT NOT NULL,
+                route TEXT,
+                requested_plane TEXT,
+                resolved_plane TEXT,
+                model TEXT,
+                success INTEGER,
+                verified INTEGER NOT NULL DEFAULT 0,
+                latency_ms INTEGER NOT NULL DEFAULT 0,
+                cost_usd REAL NOT NULL DEFAULT 0,
+                fallback_reason TEXT,
+                stop_reason TEXT,
+                metadata TEXT
+            )
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO telemetry(
+                created_at, caller, request_kind, success, verified,
+                latency_ms, cost_usd, metadata
+            ) VALUES (?, 'legacy', 'agent', NULL, 0, 1, 0, '{}')
+            """,
+            (utc_now(),),
+        )
+        connection.commit()
+
+
+@pytest.mark.asyncio
+async def test_telemetry_session_migration_preserves_rows_and_adds_index(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "legacy.db"
+    _create_legacy_telemetry(path)
+
+    store = PublicStateStore(path)
+    await store.initialize()
+    new_id = await store.save_telemetry(
+        {
+            "session_name": "forge:verification",
+            "caller": "codex",
+            "request_kind": "agent",
+            "success": True,
+        }
+    )
+
+    with sqlite3.connect(path) as connection:
+        columns = {
+            str(row[1])
+            for row in connection.execute("PRAGMA table_info(telemetry)").fetchall()
+        }
+        indexes = {
+            str(row[1])
+            for row in connection.execute("PRAGMA index_list(telemetry)").fetchall()
+        }
+        rows = connection.execute(
+            "SELECT id, session_name, success FROM telemetry ORDER BY id"
+        ).fetchall()
+
+    assert "session_name" in columns
+    assert "telemetry_session_created" in indexes
+    assert rows == [(1, None, None), (new_id, "forge:verification", 1)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stop_reason", ["", "EndTurn", "end_turn", "stop"])
+async def test_agent_records_session_and_success_for_completed_stop_reasons(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    stop_reason: str,
+) -> None:
+    state = PublicStateStore(tmp_path / f"agent-{stop_reason or 'empty'}.db")
+
+    async def completed_turn(**_kwargs: object) -> dict:
+        return {
+            "text": "A complete provider answer.",
+            "model": "test-model",
+            "resolved_plane": "local",
+            "stop_reason": stop_reason,
+            "cost_usd": 0.0,
+            "orchestration": {"route": "direct"},
+        }
+
+    monkeypatch.setattr(server, "STATE", state)
+    monkeypatch.setattr(server, "_execute_team_turn", completed_turn)
+    monkeypatch.setattr(server, "AUTONOMY_ENABLED", False)
+    monkeypatch.setattr(server, "MISSION_V2_ENABLED", False)
+    monkeypatch.setattr(server, "SHADOW_DONE_VOTE", False)
+    monkeypatch.setattr(server, "_DURABLE_JOBS", {})
+
+    result = await server.agent(task="Answer this", session="forge:verification")
+
+    assert result["status"] == "complete"
+    with sqlite3.connect(state.path) as connection:
+        row = connection.execute(
+            "SELECT session_name, success, verified FROM telemetry ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+    assert row == ("forge:verification", 1, 0)
+
+
+@pytest.mark.asyncio
+async def test_agent_still_records_telemetry_when_outcome_classifier_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    state = PublicStateStore(tmp_path / "classifier-error.db")
+
+    async def completed_turn(**_kwargs: object) -> dict:
+        return {
+            "text": "A complete provider answer.",
+            "model": "test-model",
+            "resolved_plane": "cli",
+            "stop_reason": "EndTurn",
+            "cost_usd": 0.0,
+            "orchestration": {"route": "direct"},
+        }
+
+    def classifier_error(*_args: object, **_kwargs: object) -> bool:
+        raise RuntimeError("classifier unavailable")
+
+    monkeypatch.setattr(server, "STATE", state)
+    monkeypatch.setattr(server, "_execute_team_turn", completed_turn)
+    monkeypatch.setattr(server, "is_nonanswer_completion", classifier_error)
+    monkeypatch.setattr(server, "AUTONOMY_ENABLED", False)
+    monkeypatch.setattr(server, "MISSION_V2_ENABLED", False)
+    monkeypatch.setattr(server, "SHADOW_DONE_VOTE", False)
+    monkeypatch.setattr(server, "_DURABLE_JOBS", {})
+
+    result = await server.agent(task="Answer this", session="forge:verification")
+
+    assert result["status"] == "complete"
+    with sqlite3.connect(state.path) as connection:
+        row = connection.execute(
+            "SELECT session_name, success FROM telemetry ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+    assert row == ("forge:verification", None)
+
+
+@pytest.mark.asyncio
+async def test_agent_records_failed_stop_and_forget_session_clears_join_key(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    state = PublicStateStore(tmp_path / "failed-stop.db")
+    await state.append_turn("forge:forget-me", "Question", "Prior answer")
+
+    async def incomplete_turn(**_kwargs: object) -> dict:
+        return {
+            "text": "A partial provider answer.",
+            "model": "test-model",
+            "resolved_plane": "api",
+            "stop_reason": "length",
+            "cost_usd": 0.0,
+            "orchestration": {"route": "direct"},
+        }
+
+    monkeypatch.setattr(server, "STATE", state)
+    monkeypatch.setattr(server, "_execute_team_turn", incomplete_turn)
+    monkeypatch.setattr(server, "AUTONOMY_ENABLED", False)
+    monkeypatch.setattr(server, "MISSION_V2_ENABLED", False)
+    monkeypatch.setattr(server, "SHADOW_DONE_VOTE", False)
+    monkeypatch.setattr(server, "_DURABLE_JOBS", {})
+
+    result = await server.agent(task="Answer this", session="forge:forget-me")
+    assert result["status"] == "complete"
+
+    with sqlite3.connect(state.path) as connection:
+        row = connection.execute(
+            "SELECT session_name, success FROM telemetry ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+    assert row == ("forge:forget-me", 0)
+
+    assert await state.delete_session("forge:forget-me") is True
+    with sqlite3.connect(state.path) as connection:
+        cleared = connection.execute(
+            "SELECT session_name, success FROM telemetry ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+    assert cleared == (None, 0)


### PR DESCRIPTION
## Summary

- add a nullable, bounded `session_name` join key to agent telemetry with an additive SQLite migration and index
- record a coarse outcome for every normal agent turn (`1` when a complete, non-empty answer is returned; `0` for incomplete terminal reasons; `NULL` if classification itself is unavailable)
- preserve forget-session privacy by atomically clearing the telemetry join label while retaining aggregate operational measurements
- cover legacy migration, terminal-reason normalization, classifier failure, and forget-session behavior with regression tests

This is the current-`main` implementation of Claude's telemetry upgrade (`29b104c`), with Codex review fixes for the public core's `stop` terminal reason and session-deletion privacy.

## Why

Direct and hive turns previously could not be compared reliably: the normal agent path hardcoded `success=None`, and telemetry had no durable key linking a turn to its named session. This patch supplies the minimum outcome and join signals needed for honest gym measurement without storing prompt text in telemetry or exposing session labels through public telemetry projections.

## Validation

- `uv run ruff check .`
- `uv run pytest -q` — **582 passed, 7 skipped**
- release contract — PASS
- insider/secret denylist — PASS
- Docker image build — PASS
- isolated Docker smoke — `/healthz`, `/readyz`, `/runtimez`, MCP initialization, 29-tool list/self-discovery parity, destructive confirmation gate, and a real CLI agent turn all PASS
- isolated database proof — named session telemetry row recorded with `success=1`

The live `:4765` service was not changed. The existing xAI API readiness incident is outside this telemetry-only patch; the configured CLI plane was exercised end-to-end.
