### PR TITLE
feat(auth): service tokens for GitHub Copilot public MCP

### DIFF
--- a/docs/github-copilot-mcp.md
+++ b/docs/github-copilot-mcp.md
@@ -19,21 +19,93 @@ Service tokens are the automation path for GitHub (and similar bots).
 
 ## Operator: mint and deploy a token
 
-```bash
-# 1) Mint a long random secret (keep offline; never commit)
-TOKEN="$(openssl rand -hex 32)"
-echo "token (store in password manager): $TOKEN"
-echo "sha256 (optional for hashed deploy): $(printf '%s' "$TOKEN" | shasum -a 256 | awk '{print $1}')"
+**Do not use** short-lived `ugtoken.` review tokens (`scripts/mint_mcp_service_token.py`) for standing
+GitHub Copilot MCP config — those expire in ≤10 minutes and still need OAuth-style introspection.
+GitHub needs a **static** service token on the public gateway.
 
-# 2) Set on the public Cloud Run service (active region), e.g.:
-# UNIGROK_SERVICE_TOKENS=$TOKEN
-# or UNIGROK_SERVICE_TOKEN_SHA256=<sha256-hex>
-# UNIGROK_SERVICE_TOKEN_LABEL=github-copilot
-# optional scopes (default = full public MCP capability):
-# UNIGROK_SERVICE_TOKEN_SCOPES=unigrok:connect,unigrok:invoke,unigrok:review,unigrok:status,unigrok:chat
+### 1) Mint (local, once)
+
+```bash
+TOKEN="$(openssl rand -hex 32)"
+echo "token (password manager + Agents secret only): $TOKEN"
+echo "sha256 (optional hashed deploy): $(printf '%s' "$TOKEN" | shasum -a 256 | awk '{print $1}')"
 ```
 
-Redeploy / revise so the env is live. `GET /healthz` stays public; `/mcp` requires the bearer.
+Never commit the token. Never paste it into the PR.
+
+### 2) Cloud Run deploy (project `agentixai-inc`)
+
+Public MCP services (both regions share the same image/contract):
+
+| Service | Region |
+|---------|--------|
+| `unigrok-remote-mcp` | `us-east1` (active path for `mcp.grokmcp.org`) |
+| `unigrok-remote-mcp` | `us-central1` (warm standby) |
+
+**Preferred:** Secret Manager + new revision (plaintext never in shell history longer than needed).
+
+```bash
+# Project
+gcloud config set project agentixai-inc
+
+# Create or add a secret version (name is public; value is secret)
+printf '%s' "$TOKEN" | gcloud secrets create unigrok-copilot-service-token \
+  --data-file=- --replication-policy=automatic 2>/dev/null \
+  || printf '%s' "$TOKEN" | gcloud secrets versions add unigrok-copilot-service-token --data-file=-
+
+# Grant the Cloud Run runtime SA access (adjust SA if your service uses a custom one)
+PROJECT_NUMBER="$(gcloud projects describe agentixai-inc --format='value(projectNumber)')"
+gcloud secrets add-iam-policy-binding unigrok-copilot-service-token \
+  --member="serviceAccount:${PROJECT_NUMBER}-compute@developer.gserviceaccount.com" \
+  --role="roles/secretmanager.secretAccessor"
+
+# Active region — env from secret + label (atomic new revision)
+gcloud run services update unigrok-remote-mcp \
+  --region=us-east1 \
+  --update-secrets=UNIGROK_SERVICE_TOKENS=unigrok-copilot-service-token:latest \
+  --update-env-vars=UNIGROK_SERVICE_TOKEN_LABEL=github-copilot
+
+# Standby region — same digest/env contract
+gcloud run services update unigrok-remote-mcp \
+  --region=us-central1 \
+  --update-secrets=UNIGROK_SERVICE_TOKENS=unigrok-copilot-service-token:latest \
+  --update-env-vars=UNIGROK_SERVICE_TOKEN_LABEL=github-copilot
+```
+
+**Hashed-at-rest alternative** (gateway stores only SHA-256):
+
+```bash
+HASH="$(printf '%s' "$TOKEN" | shasum -a 256 | awk '{print $1}')"
+# Put HASH in Secret Manager as unigrok-copilot-service-token-sha256
+gcloud run services update unigrok-remote-mcp --region=us-east1 \
+  --update-secrets=UNIGROK_SERVICE_TOKEN_SHA256=unigrok-copilot-service-token-sha256:latest \
+  --update-env-vars=UNIGROK_SERVICE_TOKEN_LABEL=github-copilot
+# Repeat for us-central1. GitHub still gets the plaintext TOKEN in Agents secrets.
+```
+
+### 3) Smoke (after revision ready)
+
+```bash
+# Public health still open
+curl -fsS https://mcp.grokmcp.org/healthz
+
+# Anonymous /mcp must 401
+curl -sS -o /dev/null -w '%{http_code}\n' -X POST https://mcp.grokmcp.org/mcp \
+  -H 'Content-Type: application/json' -d '{}'
+
+# Service token must not 401 (may 406/400 on empty body — not 401)
+curl -sS -o /dev/null -w '%{http_code}\n' -X POST https://mcp.grokmcp.org/mcp \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' \
+  -H 'Accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}'
+```
+
+Optional scopes (default = full public MCP capability):
+
+```text
+UNIGROK_SERVICE_TOKEN_SCOPES=unigrok:connect,unigrok:invoke,unigrok:review,unigrok:status,unigrok:chat
+```
 
 ## GitHub: Agents secret
 

--- a/docs/github-copilot-mcp.md
+++ b/docs/github-copilot-mcp.md
@@ -1,0 +1,99 @@
+# GitHub Copilot cloud agent + UniGrok public MCP
+
+Connect **public** UniGrok (`https://mcp.grokmcp.org/mcp`) to **GitHub Copilot cloud agent**
+and **Copilot code review** without OAuth.
+
+## Why service tokens
+
+GitHub repository MCP settings support remote `http` servers with bearer headers, but
+**do not support remote OAuth**. UniGrok’s hosted public gateway is OAuth-first for IDEs.
+Service tokens are the automation path for GitHub (and similar bots).
+
+| Client | Auth |
+|--------|------|
+| Cursor / IDE OAuth | Control OAuth (unchanged) |
+| GitHub Copilot cloud agent / code review | Service token (`Authorization: Bearer …`) |
+| Local Docker loopback | No gateway auth (default) |
+
+**Never** point GitHub Copilot at Sky/Space/Ground private seats or `localhost`.
+
+## Operator: mint and deploy a token
+
+```bash
+# 1) Mint a long random secret (keep offline; never commit)
+TOKEN="$(openssl rand -hex 32)"
+echo "token (store in password manager): $TOKEN"
+echo "sha256 (optional for hashed deploy): $(printf '%s' "$TOKEN" | shasum -a 256 | awk '{print $1}')"
+
+# 2) Set on the public Cloud Run service (active region), e.g.:
+# UNIGROK_SERVICE_TOKENS=$TOKEN
+# or UNIGROK_SERVICE_TOKEN_SHA256=<sha256-hex>
+# UNIGROK_SERVICE_TOKEN_LABEL=github-copilot
+# optional scopes (default = full public MCP capability):
+# UNIGROK_SERVICE_TOKEN_SCOPES=unigrok:connect,unigrok:invoke,unigrok:review,unigrok:status,unigrok:chat
+```
+
+Redeploy / revise so the env is live. `GET /healthz` stays public; `/mcp` requires the bearer.
+
+## GitHub: Agents secret
+
+In the **public** product repo (`djtelicloud/grok-mcp-server`):
+
+1. **Settings → Secrets and variables → Agents**
+2. New secret: `COPILOT_MCP_UNIGROK_TOKEN` = the plaintext token (not the SHA-256)
+
+Only secrets/variables prefixed with `COPILOT_MCP_` are visible to MCP config.
+
+## GitHub: MCP configuration JSON
+
+**Settings → Copilot → MCP servers** — paste (no comments):
+
+```json
+{
+  "mcpServers": {
+    "unigrok-public": {
+      "type": "http",
+      "url": "https://mcp.grokmcp.org/mcp",
+      "headers": {
+        "Authorization": "Bearer ${COPILOT_MCP_UNIGROK_TOKEN}",
+        "X-Client-ID": "github-copilot-cloud"
+      },
+      "tools": [
+        "chat",
+        "agent",
+        "agent_result",
+        "review_pull_request",
+        "grok_mcp_status",
+        "grok_mcp_discover_self",
+        "list_models",
+        "benchmark_status",
+        "search_knowledge",
+        "remember_fact"
+      ]
+    }
+  }
+}
+```
+
+Start with the allowlist above. Expand only after you trust autonomous tool use
+(GitHub does **not** prompt for approval). Prefer read-only tools for code review.
+
+## Validate
+
+1. Save MCP configuration (JSON validates on save).
+2. Assign an issue to **Copilot** → open session logs → **Start MCP Servers**.
+3. Confirm `unigrok-public` tools appear.
+4. Optional: request Copilot code review on a PR and check environment setup logs.
+
+## Hard rules
+
+- Public product only — no Space/Sky secrets.
+- `PROMOTE` defaults stay product policy; this wire does not grant hierarchy promote.
+- Rotate tokens by minting a new value, updating Cloud Run + the Agents secret, then
+  revoking the old token from `UNIGROK_SERVICE_TOKENS` / hash list.
+- Provider keys (`XAI_API_KEY`, Grok Build OAuth) remain server-side only.
+
+## Related
+
+- [remote-mcp-deployment.md](./remote-mcp-deployment.md) — hosted OAuth + env contract
+- GitHub docs: [Configure MCP servers for your repository](https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/configure-mcp-servers)

--- a/docs/remote-mcp-deployment.md
+++ b/docs/remote-mcp-deployment.md
@@ -43,6 +43,21 @@ Do not expose the local Compose port directly to a LAN or the internet. Cloud
 mode is the reviewed remote boundary; it is not enabled by changing only the
 bind address.
 
+## Service tokens (GitHub Copilot and non-OAuth bots)
+
+GitHub Copilot cloud agent and code review **cannot** complete remote OAuth.
+For those clients, mint an operator service token and set on the public gateway:
+
+| Variable | Purpose |
+|----------|---------|
+| `UNIGROK_SERVICE_TOKENS` | Comma-separated plaintext tokens (min 32 chars, URL-safe) |
+| `UNIGROK_SERVICE_TOKEN_SHA256` | Comma-separated SHA-256 hex digests (preferred at rest) |
+| `UNIGROK_SERVICE_TOKEN_LABEL` | Principal label (default `automation` → `service:<label>`) |
+| `UNIGROK_SERVICE_TOKEN_SCOPES` | Optional scope list (default: full public MCP scopes) |
+
+Clients send `Authorization: Bearer <token>`. OAuth and service tokens both work when
+configured together. See [github-copilot-mcp.md](./github-copilot-mcp.md).
+
 ## OAuth contract
 
 The gateway publishes RFC 9728 protected-resource metadata and WebMCP discovery

--- a/example.env
+++ b/example.env
@@ -26,6 +26,8 @@ UNIGROK_DEFAULT_LEVEL=max
 
 # Hosted OAuth/Cloud Run settings are intentionally absent from this local template.
 # Operators use docs/remote-mcp-deployment.md and inject versioned secrets server-side.
+# GitHub Copilot (non-OAuth): docs/github-copilot-mcp.md — UNIGROK_SERVICE_TOKENS or
+# UNIGROK_SERVICE_TOKEN_SHA256 on the public Cloud Run service only.
 
 # Shared public harness controls (values outside each range are clamped).
 # Provider deadlines: 30-600 seconds.

--- a/src/unigrok_public/remote_auth.py
+++ b/src/unigrok_public/remote_auth.py
@@ -1,18 +1,27 @@
-"""Fail-closed OAuth edge for the owner-operated remote MCP deployment.
+"""Fail-closed auth edge for the owner-operated remote MCP deployment.
 
 Local Docker remains loopback-first and credential-free at the gateway layer.
-When ``UNIGROK_RUNTIME=cloudrun``, every protected request is authenticated by
-the existing Control service through token introspection.  Provider keys stay
-server-side and are never accepted as gateway bearer credentials.
+When ``UNIGROK_RUNTIME=cloudrun``, protected requests require either:
+
+1. Control OAuth bearer tokens validated by remote introspection, or
+2. Operator-minted **service tokens** (``UNIGROK_SERVICE_TOKENS`` /
+   ``UNIGROK_SERVICE_TOKEN_SHA256``) for non-OAuth automation such as
+   GitHub Copilot cloud agent / code review.
+
+Provider keys stay server-side and are never accepted as gateway bearer
+credentials. Service tokens are not OAuth and never unlock private Sky/Space
+seats — this module only gates the public MCP resource.
 """
 
 from __future__ import annotations
 
+import hashlib
 import ipaddress
 import json
 import logging
 import os
 import re
+import secrets
 from collections.abc import Mapping
 from typing import Any
 from urllib.parse import quote, urlsplit
@@ -123,6 +132,105 @@ def oauth_scopes() -> list[str]:
     return list(dict.fromkeys(values))
 
 
+
+_DEFAULT_SERVICE_SCOPES = (
+    "unigrok:connect",
+    "unigrok:invoke",
+    "unigrok:review",
+    "unigrok:status",
+    "unigrok:chat",
+)
+_SERVICE_TOKEN_MIN = 32
+_SERVICE_TOKEN_MAX = 256
+_SERVICE_TOKEN_RE = re.compile(r"^[A-Za-z0-9._~+/=\-]{32,256}$")
+
+
+def service_token_scopes() -> list[str]:
+    """Scopes granted to every valid service token (default = full MCP capability)."""
+    values = [
+        item.strip()
+        for item in os.environ.get(
+            "UNIGROK_SERVICE_TOKEN_SCOPES", " ".join(_DEFAULT_SERVICE_SCOPES)
+        ).replace(",", " ").split()
+        if item.strip()
+    ]
+    if not values or any(_OAUTH_SCOPE_RE.fullmatch(item) is None for item in values):
+        return list(_DEFAULT_SERVICE_SCOPES)
+    return list(dict.fromkeys(values))
+
+
+def service_token_label() -> str:
+    raw = os.environ.get("UNIGROK_SERVICE_TOKEN_LABEL", "automation").strip() or "automation"
+    # Stable principal segment: keep it URL-safe and short.
+    cleaned = re.sub(r"[^A-Za-z0-9._-]{1,64}", "-", raw)[:64].strip("-._")
+    return cleaned or "automation"
+
+
+def _digest_token(token: str) -> bytes:
+    return hashlib.sha256(token.encode("utf-8")).digest()
+
+
+def _configured_service_digests() -> frozenset[bytes]:
+    digests: set[bytes] = set()
+    for raw in os.environ.get("UNIGROK_SERVICE_TOKENS", "").split(","):
+        token = raw.strip()
+        if not token:
+            continue
+        if _SERVICE_TOKEN_RE.fullmatch(token) is None:
+            logger.warning("ignoring malformed UNIGROK_SERVICE_TOKENS entry")
+            continue
+        digests.add(_digest_token(token))
+    for raw in os.environ.get("UNIGROK_SERVICE_TOKEN_SHA256", "").split(","):
+        digest_hex = raw.strip().lower()
+        if not digest_hex:
+            continue
+        if re.fullmatch(r"[0-9a-f]{64}", digest_hex) is None:
+            logger.warning("ignoring malformed UNIGROK_SERVICE_TOKEN_SHA256 entry")
+            continue
+        digests.add(bytes.fromhex(digest_hex))
+    return frozenset(digests)
+
+
+def service_tokens_configured() -> bool:
+    return bool(_configured_service_digests())
+
+
+def auth_enforcement_active() -> bool:
+    """True when the remote edge must reject anonymous protected traffic."""
+    return bool(introspection_url()) or service_tokens_configured()
+
+
+def match_service_token(token: str | None) -> dict[str, Any] | None:
+    """Return synthetic auth claims for a valid service token, else None."""
+    if not token or len(token) > _SERVICE_TOKEN_MAX:
+        return None
+    allowed = _configured_service_digests()
+    if not allowed:
+        return None
+    candidate = _digest_token(token)
+    matched = False
+    for digest in allowed:
+        if secrets.compare_digest(candidate, digest):
+            matched = True
+            break
+    if not matched:
+        return None
+    scopes = " ".join(service_token_scopes())
+    label = service_token_label()
+    resource = public_mcp_resource() or "service-token"
+    principal = f"service:{label}"
+    return {
+        "active": True,
+        "token_type": "service",
+        "scope": scopes,
+        "iss": "unigrok:service-token",
+        "sub": label,
+        "aud": resource,
+        "unigrok_principal": principal,
+        "unigrok_auth": "service_token",
+    }
+
+
 def canonical_oauth_principal(issuer: Any, subject: Any) -> str | None:
     if not isinstance(issuer, str) or issuer not in authorization_servers():
         return None
@@ -178,15 +286,22 @@ def oauth_metadata() -> tuple[dict[str, Any], int, dict[str, str]]:
             503,
             {"Cache-Control": "no-store"},
         )
+    validation = "remote-introspection"
+    if service_tokens_configured():
+        validation = "remote-introspection-or-service-token"
+    payload: dict[str, Any] = {
+        "resource": resource,
+        "authorization_servers": servers,
+        "scopes_supported": scopes,
+        "bearer_methods_supported": ["header"],
+        "x_unigrok_authorization_status": "active",
+        "x_unigrok_access_token_validation": validation,
+    }
+    if service_tokens_configured():
+        payload["x_unigrok_service_token"] = True
+        payload["x_unigrok_service_token_scopes"] = service_token_scopes()
     return (
-        {
-            "resource": resource,
-            "authorization_servers": servers,
-            "scopes_supported": scopes,
-            "bearer_methods_supported": ["header"],
-            "x_unigrok_authorization_status": "active",
-            "x_unigrok_access_token_validation": "remote-introspection",
-        },
+        payload,
         200,
         {"Cache-Control": "public, max-age=300"},
     )
@@ -319,19 +434,20 @@ class RemoteOAuthMiddleware:
             await self.app(scope, receive, send)
             return
         path = str(scope.get("path") or "")
-        active = bool(introspection_url())
+        active = auth_enforcement_active()
         if path in _PUBLIC_PATHS or not active:
             await self.app(scope, receive, send)
             return
 
         token = _extract_bearer(_scope_header(scope, b"authorization"))
-        claims: dict[str, Any] | None = None
+        claims: dict[str, Any] | None = match_service_token(token)
         body = b""
         if path == "/mcp" and scope.get("method") == "POST":
             # Authenticate the connection before buffering a potentially large
-            # base64 file request. The returned token scope is then checked
-            # locally once the exact tools/call capability is known.
-            claims = await introspect_oauth_token(token or "", "unigrok:connect")
+            # base64 file request. Service tokens resolve locally; OAuth uses
+            # Control introspection. Scope is re-checked once tools/call is known.
+            if claims is None:
+                claims = await introspect_oauth_token(token or "", "unigrok:connect")
             if claims is None:
                 required = "unigrok:connect"
                 logger.warning("oauth access_denied path=%s scope=%s", path, required)
@@ -377,13 +493,23 @@ class RemoteOAuthMiddleware:
             granted = claims.get("scope")
             granted_scopes = set(granted.split()) if isinstance(granted, str) else set()
             if not set(required.split()).issubset(granted_scopes):
+                # Token already authenticated (connect phase or service match) but
+                # lacks the tool scope — hard deny, do not re-introspect.
                 claims = None
         else:
-            claims = await introspect_oauth_token(token or "", required)
+            claims = match_service_token(token)
+            if claims is not None:
+                granted_scopes = set(str(claims.get("scope") or "").split())
+                if not set(required.split()).issubset(granted_scopes):
+                    claims = None
+            else:
+                claims = await introspect_oauth_token(token or "", required)
         if claims is not None:
             scope["unigrok.oauth"] = claims
+            auth_kind = str(claims.get("unigrok_auth") or "oauth")
             logger.info(
-                "oauth access_allowed path=%s scope=%s principal=%s",
+                "%s access_allowed path=%s scope=%s principal=%s",
+                auth_kind,
                 path,
                 required,
                 principal_label(str(claims.get("unigrok_principal") or "")),

--- a/tests/test_remote_boundary.py
+++ b/tests/test_remote_boundary.py
@@ -642,17 +642,10 @@ async def test_agent_job_owner_column_migrates_existing_state(tmp_path: Path) ->
 # --- Service tokens (GitHub Copilot / non-OAuth automation) ---
 
 
-SERVICE_TOKEN = "copilot-test-token-aaaaaaaaaaaaaaaaaaaaaaaa"
-SERVICE_TOKEN_SHA256 = (
-    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"  # placeholder replaced
-)
-
-
 @pytest.fixture
 def service_token_env(monkeypatch: pytest.MonkeyPatch) -> str:
-    import hashlib
-
-    token = "copilot-test-token-bbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    # Synthetic fixture secret (not a production credential).
+    token = "copilot-test-token-bbbbbbbbbbbbbbbbbbbbbbbbbbbb"  # noqa: S105
     monkeypatch.setenv("UNIGROK_SERVICE_TOKENS", token)
     monkeypatch.setenv("UNIGROK_SERVICE_TOKEN_LABEL", "github-copilot")
     monkeypatch.setenv(
@@ -683,7 +676,7 @@ def test_service_token_sha256_env_matches_without_plaintext(
 ) -> None:
     import hashlib
 
-    token = "copilot-hash-token-cccccccccccccccccccccccccccc"
+    token = "copilot-hash-token-cccccccccccccccccccccccccccc"  # noqa: S105
     digest = hashlib.sha256(token.encode("utf-8")).hexdigest()
     monkeypatch.delenv("UNIGROK_SERVICE_TOKENS", raising=False)
     monkeypatch.setenv("UNIGROK_SERVICE_TOKEN_SHA256", digest)
@@ -756,7 +749,7 @@ async def test_service_token_middleware_denies_anonymous(
 async def test_service_token_works_alongside_oauth(
     remote_oauth_env: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    token = "copilot-dual-token-dddddddddddddddddddddddddddd"
+    token = "copilot-dual-token-dddddddddddddddddddddddddddd"  # noqa: S105
     monkeypatch.setenv("UNIGROK_SERVICE_TOKENS", token)
     monkeypatch.setenv("UNIGROK_SERVICE_TOKEN_LABEL", "github-copilot")
 

--- a/tests/test_remote_boundary.py
+++ b/tests/test_remote_boundary.py
@@ -637,3 +637,147 @@ async def test_agent_job_owner_column_migrates_existing_state(tmp_path: Path) ->
     assert "owner" in columns
     assert "agent_jobs_owner" in indexes
     assert await store.load_agent_job("b" * 32, owner="some-owner") is None
+
+
+# --- Service tokens (GitHub Copilot / non-OAuth automation) ---
+
+
+SERVICE_TOKEN = "copilot-test-token-aaaaaaaaaaaaaaaaaaaaaaaa"
+SERVICE_TOKEN_SHA256 = (
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"  # placeholder replaced
+)
+
+
+@pytest.fixture
+def service_token_env(monkeypatch: pytest.MonkeyPatch) -> str:
+    import hashlib
+
+    token = "copilot-test-token-bbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    monkeypatch.setenv("UNIGROK_SERVICE_TOKENS", token)
+    monkeypatch.setenv("UNIGROK_SERVICE_TOKEN_LABEL", "github-copilot")
+    monkeypatch.setenv(
+        "UNIGROK_SERVICE_TOKEN_SCOPES",
+        "unigrok:connect,unigrok:invoke,unigrok:review,unigrok:status,unigrok:chat",
+    )
+    # Local-style enforcement without OAuth introspection.
+    monkeypatch.delenv("UNIGROK_OAUTH_INTROSPECTION_URL", raising=False)
+    monkeypatch.delenv("UNIGROK_RUNTIME", raising=False)
+    return token
+
+
+def test_service_token_match_is_constant_time_and_labeled(
+    service_token_env: str,
+) -> None:
+    claims = remote_auth.match_service_token(service_token_env)
+    assert claims is not None
+    assert claims["unigrok_auth"] == "service_token"
+    assert claims["unigrok_principal"] == "service:github-copilot"
+    assert "unigrok:connect" in claims["scope"]
+    assert "unigrok:invoke" in claims["scope"]
+    assert remote_auth.match_service_token("wrong-token-xxxxxxxxxxxxxxxxxxxxxxxx") is None
+    assert remote_auth.match_service_token(None) is None
+
+
+def test_service_token_sha256_env_matches_without_plaintext(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import hashlib
+
+    token = "copilot-hash-token-cccccccccccccccccccccccccccc"
+    digest = hashlib.sha256(token.encode("utf-8")).hexdigest()
+    monkeypatch.delenv("UNIGROK_SERVICE_TOKENS", raising=False)
+    monkeypatch.setenv("UNIGROK_SERVICE_TOKEN_SHA256", digest)
+    monkeypatch.setenv("UNIGROK_SERVICE_TOKEN_LABEL", "ci")
+    claims = remote_auth.match_service_token(token)
+    assert claims is not None
+    assert claims["unigrok_principal"] == "service:ci"
+    assert remote_auth.match_service_token(token + "x") is None
+
+
+def test_auth_enforcement_active_with_service_tokens_only(
+    service_token_env: str,
+) -> None:
+    assert remote_auth.service_tokens_configured() is True
+    assert remote_auth.auth_enforcement_active() is True
+    assert remote_auth.introspection_url() is None
+
+
+@pytest.mark.asyncio
+async def test_service_token_middleware_allows_tools_call(
+    service_token_env: str,
+) -> None:
+    seen: dict[str, Any] = {}
+
+    async def app(scope: dict[str, Any], receive: Any, send: Any) -> None:
+        seen["claims"] = scope.get("unigrok.oauth")
+        response = JSONResponse({"ok": True})
+        await response(scope, receive, send)
+
+    body = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": {"name": "chat", "arguments": {"prompt": "hi"}},
+        }
+    ).encode()
+    status, headers, response_body = await _asgi_exchange(
+        remote_auth.RemoteOAuthMiddleware(app),
+        path="/mcp",
+        method="POST",
+        body_chunks=(body,),
+        headers=((b"authorization", f"Bearer {service_token_env}".encode()),),
+    )
+    assert status == 200
+    assert seen["claims"]["unigrok_auth"] == "service_token"
+    assert json.loads(response_body)["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_service_token_middleware_denies_anonymous(
+    service_token_env: str,
+) -> None:
+    async def app(scope: dict[str, Any], receive: Any, send: Any) -> None:
+        response = JSONResponse({"ok": True})
+        await response(scope, receive, send)
+
+    status, headers, response_body = await _asgi_exchange(
+        remote_auth.RemoteOAuthMiddleware(app),
+        path="/mcp",
+        method="POST",
+        body_chunks=(b'{"jsonrpc":"2.0","id":1,"method":"tools/list"}',),
+        headers=(),
+    )
+    assert status == 401
+    assert json.loads(response_body)["error"] == "unauthorized"
+
+
+@pytest.mark.asyncio
+async def test_service_token_works_alongside_oauth(
+    remote_oauth_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    token = "copilot-dual-token-dddddddddddddddddddddddddddd"
+    monkeypatch.setenv("UNIGROK_SERVICE_TOKENS", token)
+    monkeypatch.setenv("UNIGROK_SERVICE_TOKEN_LABEL", "github-copilot")
+
+    async def app(scope: dict[str, Any], receive: Any, send: Any) -> None:
+        response = JSONResponse(
+            {
+                "principal": (scope.get("unigrok.oauth") or {}).get("unigrok_principal"),
+                "auth": (scope.get("unigrok.oauth") or {}).get("unigrok_auth"),
+            }
+        )
+        await response(scope, receive, send)
+
+    body = b'{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+    status, _headers, response_body = await _asgi_exchange(
+        remote_auth.RemoteOAuthMiddleware(app),
+        path="/mcp",
+        method="POST",
+        body_chunks=(body,),
+        headers=((b"authorization", f"Bearer {token}".encode()),),
+    )
+    assert status == 200
+    payload = json.loads(response_body)
+    assert payload["auth"] == "service_token"
+    assert payload["principal"] == "service:github-copilot"


### PR DESCRIPTION
## Summary

GitHub Copilot **cloud agent** and **code review** cannot complete remote OAuth. This PR adds a fail-closed **service token** bearer path on the public UniGrok gateway so those clients can call `https://mcp.grokmcp.org/mcp` without OAuth, while IDE OAuth + Control introspection stay primary.

## Changes

- `remote_auth.py`: accept `UNIGROK_SERVICE_TOKENS` and/or `UNIGROK_SERVICE_TOKEN_SHA256` (SHA-256 compare); optional label/scopes; enforce when tokens **or** OAuth introspection is configured
- Tests for match, deny anonymous, allow tools/call, coexist with OAuth
- Docs: `docs/github-copilot-mcp.md` (mint, Cloud Run, GitHub Agents secret, MCP JSON), deployment note, `example.env` pointer

## Non-goals

- No Sky/Space/private seats
- No provider keys as gateway credentials
- Not a substitute for short-lived `ugtoken.` review broker tokens (`scripts/mint_mcp_service_token.py`)

## Verify

```bash
uv run pytest tests/test_remote_boundary.py -q
```

(29 passed on author machine.)

## Operator after merge

1. Deploy image digest to `unigrok-remote-mcp` (us-east1 + us-central1)
2. Mint token + Secret Manager + `UNIGROK_SERVICE_TOKENS` / hash env (see `docs/github-copilot-mcp.md`)
3. GitHub repo Agents secret `COPILOT_MCP_UNIGROK_TOKEN` + Copilot MCP JSON allowlist
4. Smoke: anonymous `/mcp` → 401; bearer initialize → not 401

## PROMOTE

Public product path only. Hierarchy PROMOTE unchanged.