### PR TITLE
Keep zero-key local traffic on the operator machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,16 @@ docker compose build
 and start it locally:
 
 ```bash
-docker desktop enable model-runner --tcp 12434
+docker desktop enable model-runner
 docker model pull ai/gemma3:4B-Q4_K_M
 docker model run --detach ai/gemma3:4B-Q4_K_M
 ```
 
-This route uses Docker's loopback-only OpenAI-compatible endpoint and no API key.
-The pinned model supplies bounded local text assistance; UniGrok does not pretend
-that it provides cloud search, media generation, or a separately certified code role.
+This route uses Docker Desktop's private container endpoint and no API key. Leave
+host-side TCP support disabled: Docker Model Runner's API is unauthenticated, and
+enabling `--tcp` can expose it beyond localhost on some installations. The pinned
+model supplies bounded local text assistance; UniGrok does not pretend that it
+provides cloud search, media generation, or a separately certified code role.
 
 **Grok Build.** Log in once — the device login runs inside the container and stores
 the session in a private Docker volume:

--- a/docs/offline-local-helper.md
+++ b/docs/offline-local-helper.md
@@ -12,7 +12,7 @@ authority. Local results carry `billing_class: local_runtime` and `cost_usd: 0`.
 On Docker Desktop, enable Docker Model Runner and pull the pinned README model:
 
 ```bash
-docker desktop enable model-runner --tcp 12434
+docker desktop enable model-runner
 docker model pull ai/gemma3:4B-Q4_K_M
 docker model run --detach ai/gemma3:4B-Q4_K_M
 ```
@@ -26,19 +26,19 @@ curl --fail --silent http://127.0.0.1:4765/runtimez
 ```
 
 The container automatically probes Docker Model Runner through
-`host.docker.internal:12434`. When no remote route is ready, the discovered Gemma
-model supplies the bounded router and text path. Requests without a funded local role,
-including cloud-only media and search, fail closed instead of escaping to a paid service
-or fabricating a result.
+`model-runner.docker.internal`, Docker Desktop's private container endpoint. When no
+remote route is ready, the discovered Gemma model supplies the bounded router and text
+path. Requests without a funded local role, including cloud-only media and search, fail
+closed instead of escaping to a paid service or fabricating a result.
 
 Set `UNIGROK_LOCAL_AUTO=off` to disable automatic probing. For another
 OpenAI-compatible loopback runtime, set `UNIGROK_LOCAL_RUNTIME_URL` to its base URL.
 The runtime must expose model discovery and chat completions and must remain on the
-same machine.
+same machine; remote, credentialed, and non-HTTP URLs are refused.
 
-Docker Model Runner's endpoint is unauthenticated. Keep port `12434` on loopback.
-For a genuinely offline run, pre-stage the image, model, tokenizer, and dependencies
-before disconnecting.
+Docker Model Runner's endpoint is unauthenticated. Leave host-side TCP support
+disabled unless you separately secure it. For a genuinely offline run, pre-stage the
+image, model, tokenizer, and dependencies before disconnecting.
 
 ## Optional named helper
 

--- a/example.env
+++ b/example.env
@@ -73,7 +73,9 @@ UNIGROK_ENABLE_METERED_API=true
 # Prefer docker compose --env-file <private-env>. Never put this key in IDE MCP JSON.
 # XAI_API_KEY=
 # UNIGROK_LOCAL_AUTO=on
-# UNIGROK_LOCAL_RUNTIME_URL=http://host.docker.internal:12434
+# Defaults to Docker Desktop's private container endpoint:
+# UNIGROK_LOCAL_RUNTIME_URL=http://model-runner.docker.internal/engines/v1
+# Explicit overrides must use localhost, a loopback IP, or a Docker internal host.
 
 
 # The Docker service creates a persistent OAuth volume and uses this in-container path.

--- a/src/unigrok_public/local_plane_loader.py
+++ b/src/unigrok_public/local_plane_loader.py
@@ -1125,7 +1125,11 @@ class OpenAICompatProbe:
             return ProbeResult(runtime_up=False, errors=(f"openai_compat:httpx:{exc}",))
         try:
             api_base = openai_compat_api_base(base_url)
-            async with httpx.AsyncClient(timeout=timeout) as client:
+            async with httpx.AsyncClient(
+                timeout=timeout,
+                follow_redirects=False,
+                trust_env=False,
+            ) as client:
                 resp = await client.get(f"{api_base}/models")
                 resp.raise_for_status()
                 payload = resp.json()
@@ -1166,7 +1170,11 @@ class OllamaProbe:
             return ProbeResult(runtime_up=False, errors=(f"ollama:httpx:{exc}",))
         base = base_url.rstrip("/")
         try:
-            async with httpx.AsyncClient(timeout=timeout) as client:
+            async with httpx.AsyncClient(
+                timeout=timeout,
+                follow_redirects=False,
+                trust_env=False,
+            ) as client:
                 resp = await client.get(f"{base}/api/tags")
                 resp.raise_for_status()
                 payload = resp.json()
@@ -1210,7 +1218,11 @@ class MLXProbe:
             return ProbeResult(runtime_up=False, errors=(f"mlx:httpx:{exc}",))
         try:
             api_base = openai_compat_api_base(base_url)
-            async with httpx.AsyncClient(timeout=timeout) as client:
+            async with httpx.AsyncClient(
+                timeout=timeout,
+                follow_redirects=False,
+                trust_env=False,
+            ) as client:
                 resp = await client.get(f"{api_base}/models")
                 resp.raise_for_status()
                 payload = resp.json()

--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -355,6 +355,46 @@ UNIGROK_LAYER = _normalize_layer_name(os.environ.get("UNIGROK_LAYER", ""))
 UNIGROK_LAYER_COLLECTION = os.environ.get("UNIGROK_LAYER_COLLECTION", "").strip()
 
 # --- offline local plane constants ---
+_LOCAL_RUNTIME_HOSTS = frozenset(
+    {
+        "localhost",
+        "host.docker.internal",
+        "gateway.docker.internal",
+        "model-runner.docker.internal",
+    }
+)
+
+
+def _validated_local_runtime_url(value: str) -> str:
+    """Return a local HTTP runtime URL or refuse remote/credentialed routing."""
+
+    raw = str(value or "").strip().rstrip("/")
+    if not raw:
+        raise ValueError("local runtime URL is empty")
+    parsed = urlsplit(raw)
+    if parsed.scheme != "http":
+        raise ValueError("local runtime must use HTTP on the operator's machine")
+    if parsed.username or parsed.password:
+        raise ValueError("local runtime URL must not contain credentials")
+    if parsed.query or parsed.fragment:
+        raise ValueError("local runtime URL must not contain a query or fragment")
+    try:
+        _ = parsed.port
+    except ValueError as exc:
+        raise ValueError("local runtime URL has an invalid port") from exc
+
+    host = (parsed.hostname or "").lower()
+    local = host in _LOCAL_RUNTIME_HOSTS
+    if not local:
+        try:
+            local = ipaddress.ip_address(host).is_loopback
+        except ValueError:
+            local = False
+    if not local:
+        raise ValueError("local runtime must use an explicit local host")
+    return raw
+
+
 def _resolve_local_runtime_url() -> str:
     """Local plane is automatic: default Docker Model Runner unless disabled.
 
@@ -365,11 +405,11 @@ def _resolve_local_runtime_url() -> str:
     """
     explicit = os.environ.get("UNIGROK_LOCAL_RUNTIME_URL", "").strip()
     if explicit:
-        return explicit
+        return _validated_local_runtime_url(explicit)
     mode = os.environ.get("UNIGROK_LOCAL_AUTO", "on").strip().lower()
     if mode in {"0", "false", "off", "no"}:
         return ""
-    return "http://host.docker.internal:12434/engines/v1"
+    return "http://model-runner.docker.internal/engines/v1"
 
 
 LOCAL_RUNTIME_URL = _resolve_local_runtime_url()
@@ -7678,7 +7718,11 @@ async def _openai_compat_chat(
     if max_tokens is not None:
         body["max_tokens"] = int(max_tokens)
     api_base = local_plane_loader.openai_compat_api_base(base_url)
-    async with httpx.AsyncClient(timeout=timeout) as client:
+    async with httpx.AsyncClient(
+        timeout=timeout,
+        follow_redirects=False,
+        trust_env=False,
+    ) as client:
         resp = await client.post(f"{api_base}/chat/completions", json=body)
         resp.raise_for_status()
         payload = resp.json() if resp.content else {}

--- a/tests/test_local_direct_talk.py
+++ b/tests/test_local_direct_talk.py
@@ -53,7 +53,7 @@ def test_direct_talk_requires_full_combo(monkeypatch):
             {
                 "UNIGROK_LOCAL_DIRECT_TALK_MODE": "non_certified",
                 "UNIGROK_LOCAL_DIRECT_MODEL": "gemma4",
-                "UNIGROK_LOCAL_RUNTIME_URL": "http://rt.test",
+                "UNIGROK_LOCAL_RUNTIME_URL": "http://127.0.0.1:8081",
             },
         ).DIRECT_TALK_ACTIVE
         is False
@@ -67,7 +67,7 @@ def _active(monkeypatch):
             "UNIGROK_LAYER": "gemma",
             "UNIGROK_LOCAL_DIRECT_TALK_MODE": "non_certified",
             "UNIGROK_LOCAL_DIRECT_MODEL": "gemma4",
-            "UNIGROK_LOCAL_RUNTIME_URL": "http://rt.test",
+            "UNIGROK_LOCAL_RUNTIME_URL": "http://127.0.0.1:8081",
         },
     )
 
@@ -89,7 +89,7 @@ def test_run_unified_direct_talk_never_resolves_plane(monkeypatch):
     async def _fake_transport(
         base, model, messages, *, max_tokens, timeout  # noqa: ASYNC109
     ):
-        assert base == "http://rt.test"
+        assert base == "http://127.0.0.1:8081"
         assert model == "gemma4"
         return {"text": "hello from gemma", "stop_reason": "stop"}
 

--- a/tests/test_local_runtime_transport.py
+++ b/tests/test_local_runtime_transport.py
@@ -5,6 +5,7 @@ import json
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
+import httpx
 import pytest
 
 from unigrok_public import local_plane_loader, server
@@ -41,11 +42,113 @@ def test_default_local_runtime_is_dmr_openai_base(
 
     assert (
         server._resolve_local_runtime_url()
-        == "http://host.docker.internal:12434/engines/v1"
+        == "http://model-runner.docker.internal/engines/v1"
     )
 
-    monkeypatch.setenv("UNIGROK_LOCAL_RUNTIME_URL", "http://runtime.test/v1/")
-    assert server._resolve_local_runtime_url() == "http://runtime.test/v1/"
+    monkeypatch.setenv("UNIGROK_LOCAL_RUNTIME_URL", "http://127.0.0.1:8081/v1/")
+    assert server._resolve_local_runtime_url() == "http://127.0.0.1:8081/v1"
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    (
+        ("http://localhost:11434/", "http://localhost:11434"),
+        ("http://[::1]:8081/v1/", "http://[::1]:8081/v1"),
+        (
+            "http://host.docker.internal:12434/engines/v1",
+            "http://host.docker.internal:12434/engines/v1",
+        ),
+        (
+            "http://model-runner.docker.internal/engines/v1",
+            "http://model-runner.docker.internal/engines/v1",
+        ),
+    ),
+)
+def test_explicit_local_runtime_accepts_only_local_hosts(
+    monkeypatch: pytest.MonkeyPatch,
+    configured: str,
+    expected: str,
+) -> None:
+    monkeypatch.setenv("UNIGROK_LOCAL_RUNTIME_URL", configured)
+    assert server._resolve_local_runtime_url() == expected
+
+
+@pytest.mark.parametrize(
+    "configured",
+    (
+        "https://127.0.0.1:8081",
+        "http://example.com:8081",
+        "http://user:pass@127.0.0.1:8081",
+        "http://127.0.0.1:8081/v1?mode=unsafe",
+        "http://127.0.0.1:bad-port",
+    ),
+)
+def test_explicit_local_runtime_rejects_remote_or_credentialed_urls(
+    monkeypatch: pytest.MonkeyPatch,
+    configured: str,
+) -> None:
+    monkeypatch.setenv("UNIGROK_LOCAL_RUNTIME_URL", configured)
+    with pytest.raises(ValueError):
+        server._resolve_local_runtime_url()
+
+
+def test_local_http_clients_ignore_proxies_and_refuse_redirects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clients: list[dict[str, object]] = []
+
+    class Response:
+        content = b"{}"
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict:
+            return {
+                "data": [{"id": "local-model"}],
+                "models": [{"name": "local-model"}],
+                "choices": [
+                    {
+                        "message": {"content": "local answer"},
+                        "finish_reason": "stop",
+                    }
+                ],
+            }
+
+    class Client:
+        def __init__(self, **kwargs: object) -> None:
+            clients.append(kwargs)
+
+        async def __aenter__(self) -> Client:
+            return self
+
+        async def __aexit__(self, *args: object) -> None:
+            return None
+
+        async def get(self, url: str) -> Response:
+            return Response()
+
+        async def post(self, url: str, **kwargs: object) -> Response:
+            return Response()
+
+    monkeypatch.setattr(httpx, "AsyncClient", Client)
+    local = "http://127.0.0.1:8081"
+    asyncio.run(local_plane_loader.OpenAICompatProbe().list_models(local, 1.0))
+    asyncio.run(local_plane_loader.OllamaProbe().list_models(local, 1.0))
+    asyncio.run(local_plane_loader.MLXProbe().list_models(local, 1.0))
+    asyncio.run(
+        server._openai_compat_chat(
+            local,
+            "local-model",
+            [{"role": "user", "content": "hello"}],
+            max_tokens=32,
+            timeout=1.0,
+        )
+    )
+
+    assert len(clients) == 4
+    assert all(client["trust_env"] is False for client in clients)
+    assert all(client["follow_redirects"] is False for client in clients)
 
 
 class _OpenAIHandler(BaseHTTPRequestHandler):


### PR DESCRIPTION
## What changed

- Use Docker Desktop's private `model-runner.docker.internal` container endpoint by default and stop instructing users to enable unauthenticated host-side TCP.
- Refuse remote, credentialed, non-HTTP, query-bearing, or malformed `UNIGROK_LOCAL_RUNTIME_URL` values.
- Disable environment proxies and redirects for all local model discovery and prompt-carrying HTTP clients.
- Update the public README, offline helper guide, example configuration, and boundary tests.

## Why

Docker Model Runner's HTTP API is unauthenticated. The previous README enabled TCP and described it as loopback-only even though the measured endpoint was reachable from the LAN. Local probes and chat also inherited `*_PROXY`, and an arbitrary runtime URL could still be reported as the local plane.

## User impact

The documented no-key route stays inside the operator's Docker Desktop environment by default. Explicit local runtimes still work through localhost, loopback addresses, or Docker's internal hostnames; remote endpoints fail during configuration instead of being mislabeled local.

## Verification

- `uv run pytest -q`: 568 passed, 7 skipped
- `uv run ruff check .`: passed
- clean-clone public boundary/local transport suite: 73 passed
- image build: passed
- `/healthz`, `/readyz`, `/runtimez`: HTTP 200
- local route: ready with live Docker Model Runner discovery
- MCP `tools/list` and self-discovery: 29/29 matched
- zero-key model call: `LOCAL_ROUTE_OK`, `plane=local`, `cost_usd=0`
