### PR TITLE
test: harden public boundary against private trees

### DIFF
--- a/scripts/ci-insider-denylist.sh
+++ b/scripts/ci-insider-denylist.sh
@@ -10,13 +10,22 @@ set -euo pipefail
 
 deny_patterns=(
   '(^|/)\.DS_Store$'         # Finder metadata
+  '^\.agents/'               # private shared-agent canon and skills
   '^\.claude/'               # provider-local state
   '^\.a2a/'                  # private team relay
+  '^agentixos/'              # private control plane and courier runtime
+  '^architecture/agentixos/' # private control-plane contracts
   '^archives/'               # private historical material
+  '^campaigns/'              # private orchestration campaigns
+  '^codex/'                  # private provider workspace
+  '^cursor/'                 # private provider workspace
   '^evals/'                  # raw evaluation artifacts
   '^harvest/'                # private derived-work staging
   '^mcp_ui/'                 # private console tree
+  '^playbooks/'              # private orchestration methods
+  '^providers/'              # private provider profiles and adapters
   '^sites/'                  # private control-center app tree
+  '^tools/'                  # private experimental and training suites
   '(^|/)forge-console'       # private launch tooling
   '^docs/(AUTONOMY_INTEL|DEOVERFIT|OFFLINE_FREE_VARIANT|PUBLIC_STRANGER_SURFACE|SLEEP_PLANE|WASM_DOGFOOD)\.md$'
   '^docs/(design/ui-data-pipeline|github-copilot-mcp|onboarding-extraction|remote-mcp-deployment|team-readiness)\.md$'

--- a/scripts/ci-insider-denylist.sh
+++ b/scripts/ci-insider-denylist.sh
@@ -10,23 +10,23 @@ set -euo pipefail
 
 deny_patterns=(
   '(^|/)\.DS_Store$'         # Finder metadata
-  '^\.agents/'               # private shared-agent canon and skills
-  '^\.claude/'               # provider-local state
-  '^\.a2a/'                  # private team relay
-  '^agentixos/'              # private control plane and courier runtime
-  '^architecture/agentixos/' # private control-plane contracts
-  '^archives/'               # private historical material
-  '^campaigns/'              # private orchestration campaigns
-  '^codex/'                  # private provider workspace
-  '^cursor/'                 # private provider workspace
-  '^evals/'                  # raw evaluation artifacts
-  '^harvest/'                # private derived-work staging
-  '^mcp_ui/'                 # private console tree
-  '^playbooks/'              # private orchestration methods
-  '^providers/'              # private provider profiles and adapters
-  '^sites/'                  # private control-center app tree
-  '^tools/'                  # private experimental and training suites
-  '(^|/)forge-console'       # private launch tooling
+  '^\.agents($|/)'               # private shared-agent canon and skills
+  '^\.claude($|/)'               # provider-local state
+  '^\.a2a($|/)'                  # private team relay
+  '^agentixos($|/)'              # private control plane and courier runtime
+  '^architecture/agentixos($|/)' # private control-plane contracts
+  '^archives($|/)'               # private historical material
+  '^campaigns($|/)'              # private orchestration campaigns
+  '^codex($|/)'                  # private provider workspace
+  '^cursor($|/)'                 # private provider workspace
+  '^evals($|/)'                  # raw evaluation artifacts
+  '^harvest($|/)'                # private derived-work staging
+  '^mcp_ui($|/)'                 # private console tree
+  '^playbooks($|/)'              # private orchestration methods
+  '^providers($|/)'              # private provider profiles and adapters
+  '^sites($|/)'                  # private control-center app tree
+  '^tools($|/)'                  # private experimental and training suites
+  '(^|/)forge-console($|/)'      # private launch tooling
   '^docs/(AUTONOMY_INTEL|DEOVERFIT|OFFLINE_FREE_VARIANT|PUBLIC_STRANGER_SURFACE|SLEEP_PLANE|WASM_DOGFOOD)\.md$'
   '^docs/(design/ui-data-pipeline|github-copilot-mcp|onboarding-extraction|remote-mcp-deployment|team-readiness)\.md$'
   '^scripts/(bench_slim_preprompt|bench_stable_vs_slim|benchmark_deep|dogfood_optimize|parallel_probe|persona_bench|smoke_team_harness|soak_nokey|triage_optimize)\.py$'
@@ -58,27 +58,96 @@ provenance_patterns=(
   'metered cost of \$[0-9]'
 )
 
+print_path() {
+  local path="$1"
+  if (export LC_ALL=C; [[ "$path" =~ ^[[:print:]]+$ ]]); then
+    printf '%s' "$path"
+  else
+    printf 'hex:'
+    printf '%s' "$path" | LC_ALL=C od -An -v -tx1 | tr -d '[:space:]'
+  fi
+}
+
 fail=0
-repository_files="$(git ls-files --cached --others --exclude-standard)"
+
+# Git tree modes are authoritative for tracked symlinks and nested repositories.
+# Inspect them before content so a link can never make the scanner follow data
+# outside the public clone. NUL delimiters preserve tabs, newlines, and Unicode.
+while IFS= read -r -d '' entry; do
+  mode="${entry%% *}"
+  path="${entry#*$'\t'}"
+  case "$mode" in
+    100644|100755)
+      ;;
+    120000)
+      printf 'insider-denylist: FORBIDDEN tracked symlink: ' >&2
+      print_path "$path" >&2
+      printf '\n' >&2
+      fail=1
+      ;;
+    160000)
+      printf 'insider-denylist: FORBIDDEN tracked nested repository: ' >&2
+      print_path "$path" >&2
+      printf '\n' >&2
+      fail=1
+      ;;
+    *)
+      printf 'insider-denylist: FORBIDDEN tracked Git mode %s: ' "$mode" >&2
+      print_path "$path" >&2
+      printf '\n' >&2
+      fail=1
+      ;;
+  esac
+done < <(git ls-files --cached --stage -z)
+
+# Preserve the pre-staging guarantee too: an untracked link is still outside
+# the public clone contract even before it has a Git mode.
+while IFS= read -r -d '' path; do
+  if [ -L "$path" ]; then
+    printf 'insider-denylist: FORBIDDEN untracked symlink: ' >&2
+    print_path "$path" >&2
+    printf '\n' >&2
+    fail=1
+  fi
+done < <(git ls-files --others --exclude-standard -z)
+
 for pattern in "${deny_patterns[@]}"; do
-  if hits="$(grep -E "$pattern" <<<"$repository_files")"; then
-    echo "insider-denylist: FORBIDDEN repository path(s) matching '$pattern':" >&2
-    echo "$hits" >&2
+  pattern_failed=0
+  while IFS= read -r -d '' path; do
+    if [[ "$path" =~ $pattern ]]; then
+      if [ "$pattern_failed" -eq 0 ]; then
+        printf "insider-denylist: FORBIDDEN repository path(s) matching '%s':\n" \
+          "$pattern" >&2
+      fi
+      printf '  ' >&2
+      print_path "$path" >&2
+      printf '\n' >&2
+      pattern_failed=1
+    fi
+  done < <(git ls-files --cached --others --exclude-standard -z)
+  if [ "$pattern_failed" -ne 0 ]; then
     fail=1
   fi
 done
 
 for pattern in "${provenance_patterns[@]}"; do
-  hits="$({
-    while IFS= read -r file; do
-      [ -f "$file" ] || continue
-      [ "$file" = "scripts/ci-insider-denylist.sh" ] && continue
-      grep -I -H -n -E "$pattern" -- "$file" || true
-    done <<<"$repository_files"
-  } || true)"
-  if [ -n "$hits" ]; then
-    echo "insider-denylist: FORBIDDEN private provenance matching '$pattern':" >&2
-    echo "$hits" >&2
+  pattern_failed=0
+  while IFS= read -r -d '' path; do
+    [ -f "$path" ] || continue
+    [ -L "$path" ] && continue
+    [ "$path" = "scripts/ci-insider-denylist.sh" ] && continue
+    if matches="$(grep -I -n -E "$pattern" -- "$path")"; then
+      if [ "$pattern_failed" -eq 0 ]; then
+        printf "insider-denylist: FORBIDDEN private provenance matching '%s':\n" \
+          "$pattern" >&2
+      fi
+      printf '  file=' >&2
+      print_path "$path" >&2
+      printf '\n%s\n' "$matches" >&2
+      pattern_failed=1
+    fi
+  done < <(git ls-files --cached --others --exclude-standard -z)
+  if [ "$pattern_failed" -ne 0 ]; then
     fail=1
   fi
 done

--- a/tests/test_insider_denylist.py
+++ b/tests/test_insider_denylist.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+DENYLIST = REPOSITORY_ROOT / "scripts" / "ci-insider-denylist.sh"
+
+PRIVATE_TREE_FIXTURES = (
+    ".agents/skills/private.md",
+    "agentixos/control_plane/private.py",
+    "architecture/agentixos/v1/private.json",
+    "campaigns/private.md",
+    "codex/private.md",
+    "cursor/private.md",
+    "harvest/private.json",
+    "playbooks/private.md",
+    "providers/private.md",
+    "tools/private/private.py",
+)
+
+
+def _run_denylist(repository: Path) -> subprocess.CompletedProcess[str]:
+    git = shutil.which("git")
+    bash = shutil.which("bash")
+    assert git is not None
+    assert bash is not None
+    subprocess.run(
+        [git, "init", "--quiet"],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return subprocess.run(
+        [bash, str(DENYLIST)],
+        cwd=repository,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize("relative_path", PRIVATE_TREE_FIXTURES)
+def test_private_tree_is_rejected_from_public_clone(
+    tmp_path: Path, relative_path: str
+) -> None:
+    fixture = tmp_path / relative_path
+    fixture.parent.mkdir(parents=True, exist_ok=True)
+    fixture.write_text("fixture\n", encoding="utf-8")
+
+    result = _run_denylist(tmp_path)
+
+    assert result.returncode == 1
+    assert relative_path in result.stderr
+
+
+def test_public_product_tree_remains_allowed(tmp_path: Path) -> None:
+    for relative_path in (
+        "src/unigrok_public/server.py",
+        "docs/reference.md",
+        "scripts/check_docs.py",
+        "tests/test_public_boundary.py",
+    ):
+        fixture = tmp_path / relative_path
+        fixture.parent.mkdir(parents=True, exist_ok=True)
+        fixture.write_text("public fixture\n", encoding="utf-8")
+
+    result = _run_denylist(tmp_path)
+
+    assert result.returncode == 0, result.stderr

--- a/tests/test_insider_denylist.py
+++ b/tests/test_insider_denylist.py
@@ -9,21 +9,27 @@ import pytest
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 DENYLIST = REPOSITORY_ROOT / "scripts" / "ci-insider-denylist.sh"
 
-PRIVATE_TREE_FIXTURES = (
-    ".agents/skills/private.md",
-    "agentixos/control_plane/private.py",
-    "architecture/agentixos/v1/private.json",
-    "campaigns/private.md",
-    "codex/private.md",
-    "cursor/private.md",
-    "harvest/private.json",
-    "playbooks/private.md",
-    "providers/private.md",
-    "tools/private/private.py",
+FORBIDDEN_FAMILY_PATHS = (
+    ".agents",
+    "agentixos",
+    "architecture/agentixos",
+    "campaigns",
+    "codex",
+    "cursor",
+    "harvest",
+    "playbooks",
+    "providers",
+    "tools",
+)
+
+FORBIDDEN_DESCENDANT_FIXTURES = tuple(
+    f"{family}/private.txt" for family in FORBIDDEN_FAMILY_PATHS
 )
 
 
-def _run_denylist(repository: Path) -> subprocess.CompletedProcess[str]:
+def _run_denylist(
+    repository: Path, *, track: bool = False
+) -> subprocess.CompletedProcess[str]:
     git = shutil.which("git")
     bash = shutil.which("bash")
     assert git is not None
@@ -35,6 +41,14 @@ def _run_denylist(repository: Path) -> subprocess.CompletedProcess[str]:
         capture_output=True,
         text=True,
     )
+    if track:
+        subprocess.run(
+            [git, "add", "--all"],
+            cwd=repository,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
     return subprocess.run(
         [bash, str(DENYLIST)],
         cwd=repository,
@@ -44,7 +58,7 @@ def _run_denylist(repository: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
-@pytest.mark.parametrize("relative_path", PRIVATE_TREE_FIXTURES)
+@pytest.mark.parametrize("relative_path", FORBIDDEN_DESCENDANT_FIXTURES)
 def test_private_tree_is_rejected_from_public_clone(
     tmp_path: Path, relative_path: str
 ) -> None:
@@ -58,17 +72,130 @@ def test_private_tree_is_rejected_from_public_clone(
     assert relative_path in result.stderr
 
 
-def test_public_product_tree_remains_allowed(tmp_path: Path) -> None:
+@pytest.mark.parametrize("relative_path", FORBIDDEN_FAMILY_PATHS)
+def test_exact_private_family_path_is_rejected(
+    tmp_path: Path, relative_path: str
+) -> None:
+    fixture = tmp_path / relative_path
+    fixture.parent.mkdir(parents=True, exist_ok=True)
+    fixture.write_text("fixture\n", encoding="utf-8")
+
+    result = _run_denylist(tmp_path)
+
+    assert result.returncode == 1
+    assert relative_path in result.stderr
+
+
+@pytest.mark.parametrize("relative_path", FORBIDDEN_FAMILY_PATHS)
+def test_exact_private_family_symlink_is_rejected(
+    tmp_path: Path, relative_path: str
+) -> None:
+    fixture = tmp_path / relative_path
+    fixture.parent.mkdir(parents=True, exist_ok=True)
+    fixture.symlink_to("not-inspected-target")
+
+    result = _run_denylist(tmp_path, track=True)
+
+    assert result.returncode == 1
+    assert "FORBIDDEN tracked symlink" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "relative_path",
+    (
+        "docs/nested-link",
+        "docs/内部-link",
+        "docs/control\nlink",
+    ),
+)
+def test_any_nested_tracked_symlink_is_rejected(
+    tmp_path: Path, relative_path: str
+) -> None:
+    fixture = tmp_path / relative_path
+    fixture.parent.mkdir(parents=True, exist_ok=True)
+    fixture.symlink_to("not-inspected-target")
+
+    result = _run_denylist(tmp_path, track=True)
+
+    assert result.returncode == 1
+    assert "FORBIDDEN tracked symlink" in result.stderr
+
+
+def test_untracked_symlink_is_rejected_before_staging(tmp_path: Path) -> None:
+    fixture = tmp_path / "docs/untracked-link"
+    fixture.parent.mkdir(parents=True, exist_ok=True)
+    fixture.symlink_to("not-inspected-target")
+
+    result = _run_denylist(tmp_path)
+
+    assert result.returncode == 1
+    assert "FORBIDDEN untracked symlink" in result.stderr
+
+
+def test_tracked_nested_repository_is_rejected(tmp_path: Path) -> None:
+    git = shutil.which("git")
+    assert git is not None
+    subprocess.run(
+        [git, "init", "--quiet"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        [
+            git,
+            "update-index",
+            "--add",
+            "--cacheinfo",
+            f"160000,{'1' * 40},docs/nested-repository",
+        ],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    result = _run_denylist(tmp_path)
+
+    assert result.returncode == 1
+    assert "FORBIDDEN tracked nested repository" in result.stderr
+
+
+def test_similarly_named_regular_public_files_remain_allowed(tmp_path: Path) -> None:
     for relative_path in (
         "src/unigrok_public/server.py",
         "docs/reference.md",
         "scripts/check_docs.py",
         "tests/test_public_boundary.py",
+        ".agents.md",
+        ".claude.md",
+        ".a2a.md",
+        "agentixos.md",
+        "architecture/agentixos.md",
+        "archives.md",
+        "campaigns.md",
+        "codex.md",
+        "cursor.md",
+        "evals.md",
+        "harvest.md",
+        "mcp_ui.md",
+        "playbooks.md",
+        "providers.md",
+        "sites.md",
+        "tools.md",
+        "docs/forge-console-notes.md",
+        "docs/内部.md",
+        "docs/control\nname.md",
     ):
         fixture = tmp_path / relative_path
         fixture.parent.mkdir(parents=True, exist_ok=True)
         fixture.write_text("public fixture\n", encoding="utf-8")
 
-    result = _run_denylist(tmp_path)
+    executable = tmp_path / "scripts/public-helper"
+    executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    executable.chmod(0o755)
+
+    result = _run_denylist(tmp_path, track=True)
 
     assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## What changed

- Hardened the public insider denylist for private agent/control-plane trees, orchestration trees, provider workspaces, and experimental tool suites.
- Made forbidden families match both the exact entry and descendants, added NUL-safe path handling, and reject tracked/untracked symlinks, nested repositories, and unsupported Git modes.
- Added 36 executable adversarial cases covering forbidden descendants, exact entries, symlinks, newline/Unicode paths, gitlinks, and allowed public near-matches.
- Left runtime source and the ordered 29-tool Core surface unchanged.

## Why

The prior path-only gate could accept an exact same-name symlink and Git-quoted filenames. The repaired gate checks Git modes first, never follows links, and preserves arbitrary valid Git path bytes while retaining narrow public near-matches.

## Independent public gate

- Head: `dbf93dc738ce0388e8023315265ee487d28babad`
- Base: `948dffaf44c7fa86490f636b5f93591d5cf42393`
- Scope: two public verification files only; 301 additions and 22 deletions
- Classification: PUBLIC; no personal names, local paths, private seat/repository names, credential shapes, corpora, receipts, or private operational content
- Frozen environment: `uv sync --frozen` with CPython 3.14.6
- Tests: 604 passed, 7 skipped; focused denylist suite 36/36
- Independent adversarial replay: 36/36 rejects across every intended family, newline path, symlink, and gitlink; allowed near-match control passed
- Static/contracts: Ruff, insider denylist, six-surface version contract, and 11-document link contract passed
- Repository safety: no symlinks, gitlinks, or special tracked modes; heuristic secret-shape scan clean; MIT project license and 54-package inventory with no GPL/AGPL or unknown third-party license
- Clean container: no-cache image `sha256:ce669b2d90d5f4a162fd68ee8e24b7b6260832ef0733fbd372c9f9b603d55cd4` built from a fresh clone and excluded Git metadata, docs, tests, scripts, private trees, and build state
- Hardened runtime: UID/GID 1000, read-only root, all capabilities dropped, no-new-privileges, writable state/tmpfs only, healthy `/healthz`, ready `/readyz`, version 1.1.0 `/runtimez`, and no workspace attached
- MCP parity: initialize, ordered 29-tool `tools/list`, self-discovery, status, and destructive-confirmation gate passed
- Configured routes: isolated zero-key local marker passed on `local` with `cost_usd=0`; configured live CLI and API markers passed
- GitHub: current-head CI, CodeQL Python, CodeQL Actions, and repository CodeQL checks passed; merge tree equals the reviewed head tree

## Risk and cost

No runtime behavior changed. The API marker used one metered call; the smoke harness does not expose its per-call cost. No deployment, release, repository-setting, or production-runtime change was performed.