### PR TITLE
fix: restore public main gate after SRP merge

### DIFF
--- a/src/unigrok_public/remote_auth.py
+++ b/src/unigrok_public/remote_auth.py
@@ -400,9 +400,15 @@ async def introspect_oauth_token(token: str, required: str) -> dict[str, Any] | 
         return None
     if public_mcp_resource() not in audiences:
         return None
-    claims = dict(payload)
-    claims["unigrok_principal"] = principal
-    return claims
+    # Treat the introspection response as untrusted boundary data.  Only the
+    # fields required by the public gateway survive validation; arbitrary
+    # provider metadata must not flow into request state or logs.
+    return {
+        "active": True,
+        "scope": scopes,
+        "unigrok_principal": principal,
+        "unigrok_auth": "oauth",
+    }
 
 
 def _metadata_url(path: str, query_string: bytes) -> str | None:
@@ -441,6 +447,7 @@ class RemoteOAuthMiddleware:
 
         token = _extract_bearer(_scope_header(scope, b"authorization"))
         claims: dict[str, Any] | None = match_service_token(token)
+        auth_kind = "service_token" if claims is not None else "oauth"
         body = b""
         if path == "/mcp" and scope.get("method") == "POST":
             # Authenticate the connection before buffering a potentially large
@@ -499,14 +506,15 @@ class RemoteOAuthMiddleware:
         else:
             claims = match_service_token(token)
             if claims is not None:
+                auth_kind = "service_token"
                 granted_scopes = set(str(claims.get("scope") or "").split())
                 if not set(required.split()).issubset(granted_scopes):
                     claims = None
             else:
+                auth_kind = "oauth"
                 claims = await introspect_oauth_token(token or "", required)
         if claims is not None:
             scope["unigrok.oauth"] = claims
-            auth_kind = str(claims.get("unigrok_auth") or "oauth")
             logger.info(
                 "%s access_allowed path=%s scope=%s principal=%s",
                 auth_kind,

--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 import contextlib
 import hashlib
 import ipaddress
@@ -49,9 +48,6 @@ from .context_pack import (
     context_pack_mode,
     format_session_with_pack,
 )
-from .tools import chats as chat_tools
-from .tools import media as media_tools
-from .tools import system as system_tools
 from .grok_build import GrokBuildACPManager
 from .harness import (
     HIVE_PERSONAS,
@@ -96,6 +92,9 @@ from .remote_auth import (
     validate_remote_configuration,
 )
 from .state import PublicStateStore, normalize_scope, normalize_session, redact_secrets
+from .tools import chats as chat_tools
+from .tools import media as media_tools
+from .tools import system as system_tools
 
 SERVICE_NAME = "UniGrok xAI Gateway"
 STATIC_ROOT = Path(__file__).with_name("static")
@@ -6887,15 +6886,18 @@ async def runtimez(_: Request) -> JSONResponse:
     )
     runtime_contract = _runtime_state_contract()
     description = _live_self_description(catalogs)
+    expected_layer = UNIGROK_LAYER or "public"
     core = system_tools.runtimez_core(
         service=SERVICE_NAME,
         version=__version__,
-        layer=UNIGROK_LAYER or "public",
+        layer=expected_layer,
         tool_count=len(PUBLIC_TOOLS),
         state_persistence=runtime_contract["state_persistence"],
         state_lifetime=runtime_contract["state_lifetime"],
         completion_recovery=runtime_contract["completion_recovery"],
     )
+    if core.get("layer") != expected_layer:
+        raise RuntimeError("runtimez core omitted the public layer identity")
     payload: dict[str, Any] = system_tools.runtimez_merge(core, {
             "request_limits": {
                 "build_concurrency": "provider_managed",
@@ -7886,7 +7888,6 @@ async def _serve_local_offline(
         return {
             "text": "",
             "error": err,
-            "status": "error",
             "model": None,
             "plane": "local",
             "billing_class": "local_runtime",
@@ -7941,12 +7942,29 @@ async def _serve_local_offline(
                 env = _degraded(
                     "local_router_floor_unfunded", "local_router_floor_unfunded"
                 )
+                env["status"] = "error"
                 return _stamp_latency(env)
-            direct["requested_plane"] = "auto"
-            direct["resolved_plane"] = "local"
-            direct["fallback_occurred"] = False
-            direct["degraded"] = False
-            direct["router_source"] = "direct_local_no_floor"
+            direct.update(
+                {
+                    "requested_plane": "auto",
+                    "resolved_plane": "local",
+                    "fallback_policy": "cross_plane",
+                    "fallback_occurred": False,
+                    "fallback_from": None,
+                    "fallback_reason": "local_router_floor_unfunded",
+                    "degraded": True,
+                    "trigger": "no_floor",
+                    "continue_count": int(prior_continue_count or 0),
+                    "orchestration": {
+                        "lead": None,
+                        "route": "direct",
+                        "specialist_model": direct.get("model"),
+                        "brief_authored_by_lead": False,
+                        "router_source": "direct_local_no_floor",
+                        "brief_source": None,
+                    },
+                }
+            )
             _stamp_router_receipt_fields(
                 direct,
                 router_source="direct_local_no_floor",

--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -3629,10 +3629,10 @@ async def _seal_autonomy_done(
 
 
 def _durable_store_status(payload: dict[str, Any]) -> str:
-    status = str(payload.get("status") or "")
+    status = str(payload.get("status") or "").strip().casefold()
     if status == "error":
         return JOB_ERROR
-    if status == "continue":
+    if status not in {"", "complete"}:
         return JOB_NEEDS_CONTINUATION
     return JOB_COMPLETE
 
@@ -4718,10 +4718,15 @@ async def _execute_team_turn(
     fact_ids = [int(item["id"]) for item in facts]
     message_count = len(history)
     context_pack_meta: dict[str, Any] | None = None
+    turn_status = str(result.get("status") or "").strip().casefold()
+    turn_completed = turn_status in {"", "complete"}
+    persist_completed_session = bool(
+        session and persist_session and turn_completed
+    )
     try:
-        if fact_ids:
+        if fact_ids and turn_completed:
             await STATE.touch_facts(fact_ids)
-        if session and persist_session:
+        if persist_completed_session:
             message_count, context_pack_meta = await _persist_committed_session_turn(
                 session=session,
                 prompt=prompt,
@@ -4749,7 +4754,7 @@ async def _execute_team_turn(
             "workspace_context_supplied": bool(courier),
             "memory_scope": public_state_name(scope) if use_memory else None,
             "memory_fact_ids": fact_ids,
-            "session_turn_persisted": bool(session and persist_session),
+            "session_turn_persisted": persist_completed_session,
         }
     )
     if context_pack_meta is not None:
@@ -5598,9 +5603,10 @@ async def agent(
             with contextlib.suppress(Exception):
                 await STATE.save_agent_job(job_id, JOB_ERROR, payload, owner=caller)
             return payload
+        turn_status = str(result.get("status") or "").strip().casefold()
         result.update(
             {
-                "status": "complete",
+                "status": turn_status or "complete",
                 "job_id": job_id,
                 "requested_mode": depth,
                 "level": level,
@@ -5630,7 +5636,7 @@ async def agent(
         if governor_execution is not None:
             result["governor_execution"] = governor_execution
         shadow_done: dict[str, Any] | None = None
-        if SHADOW_DONE_VOTE:
+        if SHADOW_DONE_VOTE and result["status"] == "complete":
             shadow_done = await _shadow_done_vote(prompt, str(result.get("text") or ""))
             if shadow_done is not None:
                 result["shadow_done_vote"] = shadow_done

--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -6896,8 +6896,12 @@ async def runtimez(_: Request) -> JSONResponse:
         state_lifetime=runtime_contract["state_lifetime"],
         completion_recovery=runtime_contract["completion_recovery"],
     )
-    if core.get("layer") != expected_layer:
-        raise RuntimeError("runtimez core omitted the public layer identity")
+    actual_layer = core.get("layer")
+    if actual_layer != expected_layer:
+        raise RuntimeError(
+            f"runtimez core layer mismatch: expected {expected_layer!r}, "
+            f"got {actual_layer!r}"
+        )
     payload: dict[str, Any] = system_tools.runtimez_merge(core, {
             "request_limits": {
                 "build_concurrency": "provider_managed",

--- a/src/unigrok_public/tools/media.py
+++ b/src/unigrok_public/tools/media.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 import base64
 import ipaddress
 import re
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Sequence
+from typing import Any
 from urllib.parse import urlsplit
 
 FILE_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,199}$")

--- a/tests/test_local_plane_m1.py
+++ b/tests/test_local_plane_m1.py
@@ -588,8 +588,10 @@ def test_offline_serve_receipts(
         _reset_local_slots()
         monkeypatch.setattr(server, "_CATALOG_CACHE", None)
         degraded = asyncio.run(server._serve_local_offline("What is a WAL?"))
+        assert degraded.get("text") == "WAL is a write-ahead log used for durability."
         assert degraded.get("degraded") is True
         assert degraded.get("fallback_reason") == "local_router_floor_unfunded"
+        assert degraded.get("router_source") == "direct_local_no_floor"
         assert degraded.get("billing_class") == "local_runtime"
         assert float(degraded.get("cost_usd") or 0.0) == 0.0
     finally:

--- a/tests/test_remote_boundary.py
+++ b/tests/test_remote_boundary.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 from collections.abc import Callable
 from pathlib import Path
@@ -9,7 +10,7 @@ from typing import Any
 import pytest
 from starlette.responses import JSONResponse
 
-from unigrok_public import remote_auth, server
+from unigrok_public import remote_auth, server, xai_api
 from unigrok_public.identity import (
     principal_label,
     public_state_name,
@@ -456,6 +457,108 @@ async def test_oauth_middleware_replays_body_and_propagates_canonical_claims(
     assert observed["introspection"] == ("opaque-token", "unigrok:connect")
     assert observed["body"] == body
     assert observed["claims"]["unigrok_principal"] == principal
+
+
+async def test_oauth_introspection_allowlists_claims_from_hostile_payload(
+    remote_oauth_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    marker = "hostile-secret-marker"
+    original_scope = "unigrok:status unigrok:connect"
+    payload = {
+        "active": True,
+        "scope": original_scope,
+        "iss": AUTHORIZATION_SERVER,
+        "sub": "reviewer:42",
+        "aud": [PUBLIC_RESOURCE],
+        "unigrok_auth": marker,
+        "access_token": marker,
+        "client_secret": marker,
+        "provider_metadata": {"private": marker},
+    }
+
+    class Response:
+        status_code = 200
+        content = b"{}"
+
+        def json(self) -> dict[str, Any]:
+            return payload
+
+    class Client:
+        async def __aenter__(self) -> Client:
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            return None
+
+        async def post(self, *_args: Any, **_kwargs: Any) -> Response:
+            return Response()
+
+    monkeypatch.setattr(remote_auth.httpx, "AsyncClient", lambda **_kwargs: Client())
+
+    claims = await remote_auth.introspect_oauth_token(
+        "opaque-token", "unigrok:connect"
+    )
+
+    assert claims == {
+        "active": True,
+        "scope": original_scope,
+        "unigrok_principal": _canonical_principal("reviewer:42"),
+        "unigrok_auth": "oauth",
+    }
+    assert marker not in json.dumps(claims, sort_keys=True)
+
+
+async def test_oauth_middleware_logs_constant_route_provenance(
+    remote_oauth_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    marker = "hostile-auth-kind-marker"
+    principal = _canonical_principal("reviewer:42")
+
+    async def hostile_claims(_token: str, required: str) -> dict[str, Any]:
+        return {
+            "active": True,
+            "scope": required,
+            "unigrok_principal": principal,
+            "unigrok_auth": marker,
+        }
+
+    monkeypatch.setattr(remote_auth, "introspect_oauth_token", hostile_claims)
+    caplog.set_level(logging.INFO, logger=remote_auth.__name__)
+
+    async def downstream(scope: dict[str, Any], receive: Any, send: Any) -> None:
+        await JSONResponse({"ok": True})(scope, receive, send)
+
+    status, _, response_body = await _asgi_exchange(
+        remote_auth.RemoteOAuthMiddleware(downstream),
+        path="/v1/models",
+        headers=((b"authorization", b"Bearer opaque-token"),),
+    )
+
+    assert status == 200
+    assert json.loads(response_body) == {"ok": True}
+    assert "oauth access_allowed" in caplog.text
+    assert marker not in caplog.text
+
+
+def test_observability_identifiers_exclude_raw_auth_material(
+    remote_oauth_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    principal = _canonical_principal("privacy-marker-subject")
+    label = principal_label(principal)
+    assert label == principal_label(principal)
+    assert label is not None
+    assert principal not in label
+    assert "privacy-marker-subject" not in label
+    assert AUTHORIZATION_SERVER not in label
+
+    credential_marker = "synthetic-credential-marker-xxxxxxxxxxxxxxxx"
+    monkeypatch.setenv("XAI_API_KEY", credential_marker)
+    monkeypatch.delenv("UNIGROK_PRINCIPAL_XAI_KEYS_JSON", raising=False)
+    cache_key = xai_api.credential_cache_key()
+    assert credential_marker not in cache_key
+    assert cache_key.startswith("owner_default:")
 
 
 def test_principal_key_selection_never_crosses_oauth_tenants(

--- a/tests/test_team_harness.py
+++ b/tests/test_team_harness.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -420,6 +421,89 @@ async def test_agent_session_couriers_context_and_reuses_history(
     assert second["session_message_count"] == 4
     assert "Review the failure" in captured[1]["prompt"]
     assert "team response complete" in captured[1]["prompt"]
+
+
+@pytest.mark.parametrize(
+    ("status", "stop_reason", "durable_status"),
+    [
+        ("continue", "local_capacity_exhausted", server.JOB_NEEDS_CONTINUATION),
+        ("error", "local_skill_no_floor", server.JOB_ERROR),
+    ],
+)
+@pytest.mark.asyncio
+async def test_agent_preserves_noncomplete_status_without_persisting_session_turn(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    status: str,
+    stop_reason: str,
+    durable_status: str,
+) -> None:
+    state = PublicStateStore(tmp_path / f"agent-{status}.db")
+
+    async def fake_unified(prompt: str, **kwargs) -> dict:
+        return {
+            "status": status,
+            "text": "",
+            "error": "Local serve did not complete.",
+            "model": None,
+            "plane": "local",
+            "requested_plane": "auto",
+            "resolved_plane": "local",
+            "fallback_occurred": False,
+            "cost_usd": 0.0,
+            "degraded": True,
+            "stop_reason": stop_reason,
+            "orchestration": {
+                "lead": None,
+                "route": "direct",
+                "specialist_model": None,
+                "brief_authored_by_lead": False,
+                "router_source": "heuristic",
+                "brief_source": None,
+            },
+        }
+
+    async def fake_local_offline(prompt: str, **kwargs) -> dict:
+        return await fake_unified(prompt, **kwargs)
+
+    async def fake_catalogs(*, refresh: bool = False) -> dict:
+        return {
+            "cli": {"ready": False, "models": [], "default_model": None},
+            "api": {"ready": False, "models": [], "image_models": []},
+            "local": {
+                "ready": True,
+                "models": ["local-test"],
+                "default_model": "local-test",
+            },
+        }
+
+    async def fake_route(prompt: str, catalogs: dict) -> dict[str, str]:
+        return {"route": "direct", "specialist_prompt": prompt}
+
+    shadow_done = AsyncMock()
+    monkeypatch.setattr(server, "STATE", state)
+    monkeypatch.setattr(server, "AUTONOMY_ENABLED", False)
+    monkeypatch.setattr(server, "SHADOW_DONE_VOTE", True)
+    monkeypatch.setattr(server, "_shadow_done_vote", shadow_done)
+    monkeypatch.setattr(server, "_run_unified", fake_unified)
+    monkeypatch.setattr(server, "_serve_local_offline", fake_local_offline)
+    monkeypatch.setattr(server, "_catalogs", fake_catalogs)
+    monkeypatch.setattr(server, "_route_task", fake_route)
+    server._SESSION_LOCKS.clear()
+
+    result = await server.agent(
+        "Use the local plane",
+        session=f"vscode:{status}",
+        use_memory=False,
+    )
+
+    assert result["status"] == status, result
+    assert result["session_turn_persisted"] is False
+    assert await state.load_messages(f"vscode:{status}") == []
+    stored = await state.load_agent_job(result["job_id"])
+    assert stored is not None
+    assert stored["status"] == durable_status
+    shadow_done.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Current public main b99f88e (#539) landed with its required CI test failing and seven full-suite behavior regressions.

This is a forward repair, not a rollback. It:
- fixes the Ruff import failures;
- restores bounded continue semantics for local capacity shedding;
- preserves explicit `continue` and `error` outcomes through the public `agent()` surface instead of overwriting them as `complete`;
- prevents non-complete turns from entering named-session history, touching committed fact use, or starting the optional shadow completion vote;
- preserves #539 SRP chats/system/media modules and its real direct local answer when the router floor is missing, while labeling that answer honestly as degraded/no-floor;
- asserts that the SRP runtime builder preserves the selected layer identity and reports expected/actual values on mismatch;
- leaves #538 denylist code and adversarial tests byte-for-byte unchanged.

Verified from an isolated worktree based exactly on b99f88e49928a69ffb477a518d1928017bd8ef8d at current head cb81a7650b538e0a92289e78acaacbfba94d6124:
- `uv sync --frozen`
- Ruff, insider denylist, release contract, and docs contract clean
- 613 passed, 7 skipped
- focused local-plane and team-agent regressions: 67 passed
- adversarial symlink and gitlink boundary cases included
- explicit `continue` stores as `needs_continuation`; explicit `error` stores as `error`; neither persists a session turn
- Antigravity independently matched both changed-file hashes and reproduced the focused suite and quality checks

The isolated image/health/tool smoke evidence was produced at the prior head b377ed2e026dda762eccae5b31efe597dc295072 and is retained only as historical evidence; it has not been represented as current-head image verification after the status-semantics repair.

Independent approval has been requested from eligible repository collaborators. No merge, release, deployment, branch-protection setting, or unrelated checkout was changed.