### PR TITLE
fix: canonicalize remote auth claims

### DIFF
--- a/src/unigrok_public/remote_auth.py
+++ b/src/unigrok_public/remote_auth.py
@@ -400,9 +400,15 @@ async def introspect_oauth_token(token: str, required: str) -> dict[str, Any] | 
         return None
     if public_mcp_resource() not in audiences:
         return None
-    claims = dict(payload)
-    claims["unigrok_principal"] = principal
-    return claims
+    # Treat the introspection response as untrusted boundary data.  Only the
+    # fields required by the public gateway survive validation; arbitrary
+    # provider metadata must not flow into request state or logs.
+    return {
+        "active": True,
+        "scope": scopes,
+        "unigrok_principal": principal,
+        "unigrok_auth": "oauth",
+    }
 
 
 def _metadata_url(path: str, query_string: bytes) -> str | None:
@@ -441,6 +447,7 @@ class RemoteOAuthMiddleware:
 
         token = _extract_bearer(_scope_header(scope, b"authorization"))
         claims: dict[str, Any] | None = match_service_token(token)
+        auth_kind = "service_token" if claims is not None else "oauth"
         body = b""
         if path == "/mcp" and scope.get("method") == "POST":
             # Authenticate the connection before buffering a potentially large
@@ -499,14 +506,15 @@ class RemoteOAuthMiddleware:
         else:
             claims = match_service_token(token)
             if claims is not None:
+                auth_kind = "service_token"
                 granted_scopes = set(str(claims.get("scope") or "").split())
                 if not set(required.split()).issubset(granted_scopes):
                     claims = None
             else:
+                auth_kind = "oauth"
                 claims = await introspect_oauth_token(token or "", required)
         if claims is not None:
             scope["unigrok.oauth"] = claims
-            auth_kind = str(claims.get("unigrok_auth") or "oauth")
             logger.info(
                 "%s access_allowed path=%s scope=%s principal=%s",
                 auth_kind,

--- a/tests/test_remote_boundary.py
+++ b/tests/test_remote_boundary.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 from collections.abc import Callable
 from pathlib import Path
@@ -9,7 +10,7 @@ from typing import Any
 import pytest
 from starlette.responses import JSONResponse
 
-from unigrok_public import remote_auth, server
+from unigrok_public import remote_auth, server, xai_api
 from unigrok_public.identity import (
     principal_label,
     public_state_name,
@@ -456,6 +457,108 @@ async def test_oauth_middleware_replays_body_and_propagates_canonical_claims(
     assert observed["introspection"] == ("opaque-token", "unigrok:connect")
     assert observed["body"] == body
     assert observed["claims"]["unigrok_principal"] == principal
+
+
+async def test_oauth_introspection_allowlists_claims_from_hostile_payload(
+    remote_oauth_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    marker = "hostile-secret-marker"
+    original_scope = "unigrok:status unigrok:connect"
+    payload = {
+        "active": True,
+        "scope": original_scope,
+        "iss": AUTHORIZATION_SERVER,
+        "sub": "reviewer:42",
+        "aud": [PUBLIC_RESOURCE],
+        "unigrok_auth": marker,
+        "access_token": marker,
+        "client_secret": marker,
+        "provider_metadata": {"private": marker},
+    }
+
+    class Response:
+        status_code = 200
+        content = b"{}"
+
+        def json(self) -> dict[str, Any]:
+            return payload
+
+    class Client:
+        async def __aenter__(self) -> Client:
+            return self
+
+        async def __aexit__(self, *_args: Any) -> None:
+            return None
+
+        async def post(self, *_args: Any, **_kwargs: Any) -> Response:
+            return Response()
+
+    monkeypatch.setattr(remote_auth.httpx, "AsyncClient", lambda **_kwargs: Client())
+
+    claims = await remote_auth.introspect_oauth_token(
+        "opaque-token", "unigrok:connect"
+    )
+
+    assert claims == {
+        "active": True,
+        "scope": original_scope,
+        "unigrok_principal": _canonical_principal("reviewer:42"),
+        "unigrok_auth": "oauth",
+    }
+    assert marker not in json.dumps(claims, sort_keys=True)
+
+
+async def test_oauth_middleware_logs_constant_route_provenance(
+    remote_oauth_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    marker = "hostile-auth-kind-marker"
+    principal = _canonical_principal("reviewer:42")
+
+    async def hostile_claims(_token: str, required: str) -> dict[str, Any]:
+        return {
+            "active": True,
+            "scope": required,
+            "unigrok_principal": principal,
+            "unigrok_auth": marker,
+        }
+
+    monkeypatch.setattr(remote_auth, "introspect_oauth_token", hostile_claims)
+    caplog.set_level(logging.INFO, logger=remote_auth.__name__)
+
+    async def downstream(scope: dict[str, Any], receive: Any, send: Any) -> None:
+        await JSONResponse({"ok": True})(scope, receive, send)
+
+    status, _, response_body = await _asgi_exchange(
+        remote_auth.RemoteOAuthMiddleware(downstream),
+        path="/v1/models",
+        headers=((b"authorization", b"Bearer opaque-token"),),
+    )
+
+    assert status == 200
+    assert json.loads(response_body) == {"ok": True}
+    assert "oauth access_allowed" in caplog.text
+    assert marker not in caplog.text
+
+
+def test_observability_identifiers_exclude_raw_auth_material(
+    remote_oauth_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    principal = _canonical_principal("privacy-marker-subject")
+    label = principal_label(principal)
+    assert label == principal_label(principal)
+    assert label is not None
+    assert principal not in label
+    assert "privacy-marker-subject" not in label
+    assert AUTHORIZATION_SERVER not in label
+
+    credential_marker = "synthetic-credential-marker-xxxxxxxxxxxxxxxx"
+    monkeypatch.setenv("XAI_API_KEY", credential_marker)
+    monkeypatch.delenv("UNIGROK_PRINCIPAL_XAI_KEYS_JSON", raising=False)
+    cache_key = xai_api.credential_cache_key()
+    assert credential_marker not in cache_key
+    assert cache_key.startswith("owner_default:")
 
 
 def test_principal_key_selection_never_crosses_oauth_tenants(


### PR DESCRIPTION
## Summary

- Canonicalize successful OAuth introspection into an allowlisted claim set.
- Derive access-log route provenance from the locally verified service-token path; never from provider-controlled claims.
- Add hostile-marker regressions proving arbitrary introspection metadata neither survives canonicalization nor reaches logs.
- Add focused evidence that observability identifiers exclude raw principal and credential material.

## Root cause

The remote boundary copied the full introspection payload into request state, and the middleware later trusted `unigrok_auth` from those claims while formatting an access log. A malicious or misconfigured introspection server could therefore supply attacker-controlled sensitive text to the log path.

## Impact

Validated scope and canonical principal behavior are preserved. Provider-specific metadata is dropped, OAuth provenance is constant, and `service_token` provenance is used only after a local token match.

## Validation on PR head aa8853a83f469d4aec8b97d88943a79441e366ae

- `uv run pytest -q tests/test_remote_boundary.py` — 32 passed
- `uv run pytest -q tests/test_insider_denylist.py tests/test_remote_boundary.py` — 68 passed
- `uv run pytest -q` — 614 passed, 7 skipped
- `uv run ruff check .` — passed
- `bash scripts/ci-insider-denylist.sh` — passed
- Docker image build — passed
- Ephemeral image `/healthz`, `/readyz`, `/runtimez`, and MCP `tools/list` smoke — passed; 29 tools matched self-discovery

## Current stack relationship

This PR was created on #540's prior head b377ed2e026dda762eccae5b31efe597dc295072. #540 has since advanced to repaired head cb81a7650b538e0a92289e78acaacbfba94d6124, so GitHub's existing #541 checks do not constitute combined-head CI evidence.

A temporary, unpushed cherry-pick of aa8853 onto cb81a765 is conflict-free. The combined remote-boundary/local-agent surface passed 99 focused tests plus Ruff and `git diff --check`. No retarget, rebase, or branch update will occur during Ground's land hold.

After #540 lands, #541 must be rebased/cherry-picked onto landed `main` if #540 uses squash/rebase, or simply retargeted if ancestry is preserved. Protected-main CI and CODEOWNER approval must then run fresh.