### PR TITLE
feat(agent): separate session and global memory

### DIFF
--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -3389,10 +3389,14 @@ async def _durable_mission_terminal_payload(mission: dict[str, Any]) -> dict[str
         )
         raw_scope = request.get("memory_scope")
         scope = normalize_scope(raw_scope) if raw_scope else session_name
-        use_memory = bool(request.get("use_memory", True))
+        use_session_history, use_global_memory = _resolve_memory_controls(
+            use_memory=bool(request.get("use_memory", True)),
+            use_session_history=bool(request.get("use_session_history", True)),
+            use_global_memory=request.get("use_global_memory"),
+        )
         facts = (
             await STATE.search_facts(prompt, scope=scope, limit=5)
-            if use_memory
+            if use_global_memory
             else []
         )
         message_count, context_pack_meta = await _persist_committed_session_turn(
@@ -3402,7 +3406,8 @@ async def _durable_mission_terminal_payload(mission: dict[str, Any]) -> dict[str
             model=None,
             mode="auto",
             facts=facts,
-            use_memory=use_memory,
+            use_session_history=use_session_history,
+            use_global_memory=use_global_memory,
             commit_key=str(mission["job_id"]),
         )
     except Exception:
@@ -4254,6 +4259,19 @@ async def _run_hive(
     return result
 
 
+def _resolve_memory_controls(
+    *,
+    use_memory: bool,
+    use_session_history: bool,
+    use_global_memory: bool | None,
+) -> tuple[bool, bool]:
+    """Resolve independent recall controls without collapsing explicit false."""
+    return (
+        bool(use_session_history),
+        bool(use_memory if use_global_memory is None else use_global_memory),
+    )
+
+
 async def _persist_committed_session_turn(
     *,
     session: str,
@@ -4262,11 +4280,16 @@ async def _persist_committed_session_turn(
     model: str | None,
     mode: str,
     facts: list[dict[str, Any]],
-    use_memory: bool,
+    use_session_history: bool,
+    use_global_memory: bool,
     commit_key: str | None = None,
 ) -> tuple[int, dict[str, Any] | None]:
     """Persist only a committed answer, then derive the next-turn context pack."""
-    prior_pack = ContextPack.from_dict(await STATE.load_context_pack(session))
+    prior_pack = (
+        ContextPack.from_dict(await STATE.load_context_pack(session))
+        if use_session_history and use_global_memory
+        else None
+    )
     append_kwargs = {
         "model": str(result.get("model") or model or "") or None,
         "plane": str(result.get("resolved_plane") or result.get("plane") or "") or None,
@@ -4297,13 +4320,17 @@ async def _persist_committed_session_turn(
         return message_count, None
     context_pack_meta: dict[str, Any] | None = None
     if context_pack_mode() != "off":
-        refreshed = await STATE.load_messages(session)
+        refreshed = (
+            await STATE.load_messages(session)
+            if use_session_history
+            else []
+        )
         prior_version = int(prior_pack.version) if prior_pack else 0
         pack = build_context_pack(
             session=session,
             history=refreshed,
             next_task=prompt,
-            facts=facts if use_memory else None,
+            facts=facts if use_global_memory else None,
             version=prior_version + 1,
         )
         if pack is not None:
@@ -4314,13 +4341,11 @@ async def _persist_committed_session_turn(
                 "keeps": len(pack.keeps),
                 "donts": len(pack.donts),
                 "dropped": pack.dropped,
-                "lead_notes": pack.lead_notes,
-                "prefrontal": pack.prefrontal,
+                "has_lead_notes": bool(pack.lead_notes),
+                "has_prefrontal": bool(pack.prefrontal),
                 "pfc_loops": pack.pfc_loops,
                 "pfc_points": pack.pfc_points,
-                "pfc_confidence": pack.pfc_confidence,
-                "pfc_absent": pack.pfc_absent,
-                "pfc_absent_confidence": pack.pfc_absent_confidence,
+                "has_pfc_absent": bool(pack.pfc_absent),
             }
     return message_count, context_pack_meta
 
@@ -4359,6 +4384,8 @@ async def _execute_team_turn(
     caller_instructions: str,
     memory_scope: str | None,
     use_memory: bool,
+    use_session_history: bool = True,
+    use_global_memory: bool | None = None,
     model: str | None,
     effort: str | None,
     mode: Literal["auto", "fast", "reasoning", "research"],
@@ -4373,9 +4400,26 @@ async def _execute_team_turn(
     persist_session: bool = True,
     prior_continue_count: int = 0,
 ) -> dict[str, Any]:
-    history = await STATE.load_messages(session) if session else []
+    (
+        effective_use_session_history,
+        effective_use_global_memory,
+    ) = _resolve_memory_controls(
+        use_memory=use_memory,
+        use_session_history=use_session_history,
+        use_global_memory=use_global_memory,
+    )
+    history = (
+        await STATE.load_messages(session)
+        if session and effective_use_session_history
+        else []
+    )
     prior_pack: ContextPack | None = None
-    if session and context_pack_mode() != "off":
+    if (
+        session
+        and effective_use_session_history
+        and effective_use_global_memory
+        and context_pack_mode() != "off"
+    ):
         prior_pack = ContextPack.from_dict(await STATE.load_context_pack(session))
     if prior_pack is not None and (
         prior_pack.keeps
@@ -4393,7 +4437,11 @@ async def _execute_team_turn(
         provider_prompt = apply_deep_harness(provider_prompt)
         effort = effort or "xhigh"
     scope = normalize_scope(memory_scope or session or "global")
-    facts = await STATE.search_facts(prompt, scope=scope, limit=5) if use_memory else []
+    facts = (
+        await STATE.search_facts(prompt, scope=scope, limit=5)
+        if effective_use_global_memory
+        else []
+    )
     context_parts: list[str] = []
     layer_block = _layer_context_block()
     if layer_block:
@@ -4416,7 +4464,7 @@ async def _execute_team_turn(
             for item in facts
         )
         context_parts.append("# Durable user-controlled knowledge (untrusted hints)\n" + rendered)
-    elif use_memory and UNIGROK_LAYER:
+    elif effective_use_global_memory and UNIGROK_LAYER:
         # Layer seats: if scoped search empty, still pull global seat law.
         extra = await _durable_knowledge_block(prompt, scope=scope, limit=5)
         if extra:
@@ -4734,7 +4782,8 @@ async def _execute_team_turn(
                 model=model,
                 mode=mode,
                 facts=facts,
-                use_memory=use_memory,
+                use_session_history=effective_use_session_history,
+                use_global_memory=effective_use_global_memory,
             )
     except Exception as exc:
         completed_attempts = _usage_attempts_for_result(
@@ -4752,8 +4801,20 @@ async def _execute_team_turn(
             "state_lifetime": runtime_contract["state_lifetime"],
             "workspace_attached": False,
             "workspace_context_supplied": bool(courier),
-            "memory_scope": public_state_name(scope) if use_memory else None,
-            "memory_fact_ids": fact_ids,
+            "memory_scope": (
+                public_state_name(scope)
+                if effective_use_global_memory
+                else None
+            ),
+            "memory_controls": {
+                "use_session_history": effective_use_session_history,
+                "use_global_memory": effective_use_global_memory,
+                "session_history_loaded": bool(
+                    session and effective_use_session_history
+                ),
+                "session_history_message_count": len(history),
+                "global_memory_fact_count": len(facts),
+            },
             "session_turn_persisted": persist_completed_session,
         }
     )
@@ -4855,6 +4916,8 @@ async def agent(
     system_prompt: str | None = None,
     memory_scope: str | None = None,
     use_memory: bool = True,
+    use_session_history: bool = True,
+    use_global_memory: bool | None = None,
     disable_tools: list[Literal["web", "x_search", "remote_code_execution"]] | None = None,
     depth: Literal["auto", "deep", "hive"] = "auto",
     level: Literal[
@@ -4889,6 +4952,10 @@ async def agent(
     `workspace_context` couriers explicitly selected text; it grants no direct
     filesystem, shell, Git, credential, or MCP authority. Stored facts are
     retrieved from `memory_scope` (the session name by default) plus global facts.
+    `use_session_history` independently controls named-session recall while
+    `use_global_memory` independently controls stored-fact retrieval. When
+    `use_global_memory` is omitted, it inherits legacy `use_memory`; disabling
+    recall never disables persistence of a committed current turn.
     Supplying an API key enables metered API execution by default; the service owner
     can disable it globally with `UNIGROK_ENABLE_METERED_API=false`.
     `prompt` is a compatibility alias for `task`; callers should supply only one.
@@ -5051,6 +5118,15 @@ async def agent(
             memory_scope = request_snapshot.get("memory_scope") or memory_scope
             if "use_memory" in request_snapshot:
                 use_memory = bool(request_snapshot.get("use_memory"))
+            use_session_history = bool(
+                request_snapshot.get("use_session_history", True)
+            )
+            raw_global_memory = request_snapshot.get("use_global_memory")
+            use_global_memory = (
+                None
+                if raw_global_memory is None
+                else bool(raw_global_memory)
+            )
             disable_tools = list(request_snapshot.get("disable_tools") or []) or None
             if request_snapshot.get("depth") in {"auto", "deep", "hive"}:
                 depth = request_snapshot["depth"]  # type: ignore[assignment]
@@ -5123,6 +5199,14 @@ async def agent(
     scope = normalize_scope(memory_scope) if memory_scope else None
     if get_active_principal() is not None:
         scope = normalize_scope(scoped_scope(scope or session_name or "global"))
+    (
+        effective_use_session_history,
+        effective_use_global_memory,
+    ) = _resolve_memory_controls(
+        use_memory=use_memory,
+        use_session_history=use_session_history,
+        use_global_memory=use_global_memory,
+    )
     disabled = set(disable_tools or [])
     allow_web = "web" not in disabled
     allow_x_search = "x_search" not in disabled
@@ -5229,6 +5313,8 @@ async def agent(
             caller_instructions=caller_instructions,
             memory_scope=scope,
             use_memory=bool(use_memory),
+            use_session_history=effective_use_session_history,
+            use_global_memory=effective_use_global_memory,
             model=None,
             effort=turn_effort,
             mode="auto",
@@ -5269,6 +5355,8 @@ async def agent(
                 "system_prompt": caller_instructions,
                 "memory_scope": scope,
                 "use_memory": bool(use_memory),
+                "use_session_history": effective_use_session_history,
+                "use_global_memory": use_global_memory,
                 "disable_tools": sorted(disabled),
                 "depth": depth,
                 "level": level,
@@ -5812,7 +5900,7 @@ async def agent(
             ):
                 persisted_facts = (
                     await STATE.search_facts(prompt, scope=scope or session_name, limit=5)
-                    if use_memory
+                    if effective_use_global_memory
                     else []
                 )
                 message_count, context_pack_meta = await _persist_committed_session_turn(
@@ -5822,7 +5910,8 @@ async def agent(
                     model=None,
                     mode="auto",
                     facts=persisted_facts,
-                    use_memory=bool(use_memory),
+                    use_session_history=effective_use_session_history,
+                    use_global_memory=effective_use_global_memory,
                     commit_key=job_id,
                 )
                 result["session_message_count"] = message_count

--- a/tests/test_autonomy.py
+++ b/tests/test_autonomy.py
@@ -260,7 +260,10 @@ async def test_continue_restores_original_task_not_acceptance(
     first = await server.agent(
         task="Ship the service carefully",
         acceptance="Return a checklist of deploy steps including healthz",
+        session="controls:preserve-false",
         workspace_context="## Diff\n+ critical path",
+        use_session_history=False,
+        use_global_memory=False,
         disable_tools=["web"],
     )
     assert first["status"] == "continue"
@@ -272,4 +275,6 @@ async def test_continue_restores_original_task_not_acceptance(
     assert captured.get("prompt") == "Ship the service carefully"
     assert "critical path" in str(captured.get("workspace_context") or "")
     assert captured.get("allow_web") is False
+    assert captured.get("use_session_history") is False
+    assert captured.get("use_global_memory") is False
     assert second["status"] in {"continue", "complete", "pending"}

--- a/tests/test_mission_server_integration.py
+++ b/tests/test_mission_server_integration.py
@@ -429,6 +429,101 @@ async def test_terminal_reattach_repairs_crash_before_session_commit(
 
 
 @pytest.mark.asyncio
+async def test_terminal_reattach_honors_explicit_memory_false_controls(
+    mission_server: PublicStateStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job_id = "6" * 32
+    token = "1" * 32
+    task = "Reply with exactly OK"
+    session = "recover-session-explicit-false"
+    await mission_server.append_turn(session, "PRIOR_SESSION_SENTINEL", "prior answer")
+    await mission_server.save_fact(
+        "GLOBAL_MEMORY_SENTINEL",
+        scope=session,
+        source="terminal-reattach-test",
+    )
+    captured_pack: dict[str, object] = {}
+
+    def capture_context_pack(**kwargs: object) -> None:
+        captured_pack.update(kwargs)
+        return None
+
+    monkeypatch.setattr(server, "context_pack_mode", lambda: "cpu")
+    monkeypatch.setattr(server, "build_context_pack", capture_context_pack)
+    mission_id = await _create_mission(
+        mission_server,
+        job_id=job_id,
+        token=token,
+        task=task,
+        request={
+            "task": task,
+            "acceptance": task,
+            "session": session,
+            "use_memory": True,
+            "use_session_history": False,
+            "use_global_memory": False,
+        },
+    )
+    projection_kind = f"candidate_projection:{mission_id}"
+    projection_hash = sealed_content_hash("OK", kind=projection_kind)
+    assert await mission_server.put_mission_artifact(
+        mission_id,
+        projection_hash,
+        kind=projection_kind,
+        sealed="OK",
+        projection="OK",
+        lease_token=OWNER_LEASE,
+        lease_generation=1,
+    )
+    assert await mission_server.cas_mission_status(
+        mission_id,
+        expect_status="running",
+        expect_version=0,
+        expect_lease_generation=1,
+        expect_lease_token=OWNER_LEASE,
+        new_status="verifying",
+    )
+    winner = {
+        "status": "complete",
+        "job_id": job_id,
+        "acceptance_hash": "acceptance-hash",
+        "text": "OK",
+        "mission": {"status": "complete", "committed": True},
+        "autonomy": {"committed": True},
+    }
+    await mission_server.save_agent_job(job_id, "complete", winner)
+    assert await mission_server.cas_mission_status(
+        mission_id,
+        expect_status="verifying",
+        expect_version=1,
+        expect_lease_generation=1,
+        expect_lease_token=OWNER_LEASE,
+        new_status="complete",
+        checkpoint_update={
+            "candidate_hash": sealed_content_hash("OK", kind="candidate"),
+            "candidate_projection_hash": projection_hash,
+        },
+        clear_lease=True,
+    )
+
+    first = await server.agent(continue_token=token)
+    second = await server.agent(continue_token=token)
+
+    assert first["session_turn_persisted"] is True
+    assert second["session_turn_persisted"] is True
+    assert captured_pack["history"] == []
+    assert captured_pack["facts"] is None
+    messages = await mission_server.load_messages(session)
+    assert [message["content"] for message in messages] == [
+        "PRIOR_SESSION_SENTINEL",
+        "prior answer",
+        task,
+        "OK",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_terminal_reattach_ignores_stale_running_job_projection(
     mission_server: PublicStateStore,
 ) -> None:

--- a/tests/test_public_boundary.py
+++ b/tests/test_public_boundary.py
@@ -137,6 +137,15 @@ def test_public_mcp_tool_contract_is_exact_and_self_checked() -> None:
     assert ".agents/skills/<skill-name>/SKILL.md" in server.INSTRUCTIONS
     agent_tool = next(tool for tool in tools if tool.name == "agent")
     assert "disable_tools" in agent_tool.inputSchema["properties"]
+    session_history = agent_tool.inputSchema["properties"]["use_session_history"]
+    global_memory = agent_tool.inputSchema["properties"]["use_global_memory"]
+    assert session_history["default"] is True
+    assert session_history["type"] == "boolean"
+    assert global_memory["default"] is None
+    assert {choice["type"] for choice in global_memory["anyOf"]} == {
+        "boolean",
+        "null",
+    }
     caller_evidence = agent_tool.inputSchema["properties"]["caller_evidence"]
     evidence_schema = agent_tool.inputSchema["$defs"]["CallerEvidenceInput"]
     assert caller_evidence["anyOf"][0]["items"]["$ref"].endswith(

--- a/tests/test_team_harness.py
+++ b/tests/test_team_harness.py
@@ -436,6 +436,23 @@ async def test_agent_session_couriers_context_and_reuses_history(
     assert first["workspace_context_supplied"] is True
     assert "hidden-value" not in str(captured[0]["system_context"])
 
+    await state.save_fact(
+        "GLOBAL_MEMORY_SHOULD_STAY_OFF",
+        scope="vscode:alpha",
+    )
+    await state.save_context_pack(
+        "vscode:alpha",
+        ContextPack(
+            session="vscode:alpha",
+            version=99,
+            mode="cpu",
+            keeps=["PRIOR_PACK_SHOULD_STAY_OFF"],
+            donts=[],
+            dropped=0,
+            item_count=1,
+        ).to_dict(),
+        version=99,
+    )
     second = await server.agent(
         "Continue the review",
         session="vscode:alpha",
@@ -444,8 +461,14 @@ async def test_agent_session_couriers_context_and_reuses_history(
     assert second["session_message_count"] == 4
     assert "Review the failure" in captured[1]["prompt"]
     assert "team response complete" in captured[1]["prompt"]
+    assert "PRIOR_PACK_SHOULD_STAY_OFF" not in captured[1]["prompt"]
+    assert "GLOBAL_MEMORY_SHOULD_STAY_OFF" not in str(
+        captured[1]["system_context"]
+    )
     assert second["memory_controls"]["use_session_history"] is True
     assert second["memory_controls"]["use_global_memory"] is False
+    assert second["memory_controls"]["session_history_message_count"] == 2
+    assert second["memory_controls"]["global_memory_fact_count"] == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/test_team_harness.py
+++ b/tests/test_team_harness.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from unigrok_public import server
+from unigrok_public.context_pack import ContextPack
 from unigrok_public.harness import (
     format_session_prompt,
     is_nonanswer_completion,
@@ -94,6 +95,28 @@ def test_history_format_and_nonanswer_contract() -> None:
     assert not is_nonanswer_completion(
         "Plan:\n1. Inspect files\n2. Run tests", prompt="Give me a plan"
     )
+
+
+@pytest.mark.parametrize(
+    ("use_memory", "use_session_history", "use_global_memory", "expected"),
+    [
+        (True, True, None, (True, True)),
+        (False, True, None, (True, False)),
+        (False, False, True, (False, True)),
+        (True, True, False, (True, False)),
+    ],
+)
+def test_memory_control_resolution_preserves_inheritance_and_false(
+    use_memory: bool,
+    use_session_history: bool,
+    use_global_memory: bool | None,
+    expected: tuple[bool, bool],
+) -> None:
+    assert server._resolve_memory_controls(
+        use_memory=use_memory,
+        use_session_history=use_session_history,
+        use_global_memory=use_global_memory,
+    ) == expected
 
 
 def test_nonanswer_catches_generic_promise_preambles() -> None:
@@ -421,6 +444,145 @@ async def test_agent_session_couriers_context_and_reuses_history(
     assert second["session_message_count"] == 4
     assert "Review the failure" in captured[1]["prompt"]
     assert "team response complete" in captured[1]["prompt"]
+    assert second["memory_controls"]["use_session_history"] is True
+    assert second["memory_controls"]["use_global_memory"] is False
+
+
+@pytest.mark.parametrize(
+    ("use_session_history", "use_global_memory", "session_name"),
+    [
+        (True, False, "memory:modes"),
+        (False, True, "memory:modes"),
+        (True, True, "memory:modes"),
+        (False, False, "memory:modes"),
+        (True, False, None),
+    ],
+)
+@pytest.mark.asyncio
+async def test_agent_memory_controls_select_inputs_independently(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    use_session_history: bool,
+    use_global_memory: bool,
+    session_name: str | None,
+) -> None:
+    state = PublicStateStore(tmp_path / "memory-controls.db")
+    await state.append_turn(
+        "memory:modes",
+        "SESSION_HISTORY_SENTINEL",
+        "prior answer",
+    )
+    await state.save_fact(
+        "GLOBAL_MEMORY_SENTINEL for current task",
+        scope="memory:modes",
+    )
+    await state.save_context_pack(
+        "memory:modes",
+        ContextPack(
+            session="memory:modes",
+            version=1,
+            mode="cpu",
+            keeps=["PRIOR_PACK_MAY_INCLUDE_GLOBAL_SENTINEL"],
+            donts=[],
+            dropped=0,
+            item_count=1,
+        ).to_dict(),
+        version=1,
+    )
+    captured_turn: dict[str, object] = {}
+    captured_pack: dict[str, object] = {}
+
+    async def fake_unified(prompt: str, **kwargs: object) -> dict:
+        captured_turn.update({"prompt": prompt, **kwargs})
+        return {
+            "text": "current answer",
+            "model": "grok-test",
+            "plane": "grok_cli_oauth",
+            "resolved_plane": "cli",
+            "cost_usd": 0.0,
+            "degraded": False,
+        }
+
+    async def fake_catalogs(*, refresh: bool = False) -> dict:
+        return {
+            "cli": {
+                "ready": True,
+                "models": ["grok-test"],
+                "default_model": "grok-test",
+            },
+            "api": {"ready": False, "models": [], "image_models": []},
+        }
+
+    async def fake_route(prompt: str, catalogs: dict) -> dict[str, str]:
+        return {"route": "direct", "specialist_prompt": prompt}
+
+    def fake_build_context_pack(**kwargs: object) -> ContextPack:
+        captured_pack.update(kwargs)
+        return ContextPack(
+            session=str(kwargs["session"]),
+            version=int(kwargs["version"]),
+            mode="cpu",
+            keeps=["PACK_BODY_SENTINEL"],
+            donts=[],
+            dropped=0,
+            item_count=1,
+            lead_notes="LEAD_NOTES_BODY_SENTINEL",
+            prefrontal="PREFRONTAL_BODY_SENTINEL",
+            pfc_loops=1,
+            pfc_points=1,
+            pfc_confidence=0.8,
+            pfc_absent="PFC_ABSENT_BODY_SENTINEL",
+            pfc_absent_confidence=0.7,
+        )
+
+    monkeypatch.setattr(server, "STATE", state)
+    monkeypatch.setattr(server, "_run_unified", fake_unified)
+    monkeypatch.setattr(server, "_catalogs", fake_catalogs)
+    monkeypatch.setattr(server, "_route_task", fake_route)
+    monkeypatch.setattr(server, "context_pack_mode", lambda: "cpu")
+    monkeypatch.setattr(server, "build_context_pack", fake_build_context_pack)
+    server._SESSION_LOCKS.clear()
+
+    result = await server.agent(
+        task="current task",
+        session=session_name,
+        use_session_history=use_session_history,
+        use_global_memory=use_global_memory,
+    )
+
+    effective_session_history = bool(session_name and use_session_history)
+    provider_prompt = str(captured_turn["prompt"])
+    system_context = str(captured_turn.get("system_context") or "")
+    assert (
+        "SESSION_HISTORY_SENTINEL" in provider_prompt
+    ) is effective_session_history
+    assert (
+        "PRIOR_PACK_MAY_INCLUDE_GLOBAL_SENTINEL" in provider_prompt
+    ) is bool(session_name and use_session_history and use_global_memory)
+    assert ("GLOBAL_MEMORY_SENTINEL" in system_context) is use_global_memory
+    if session_name:
+        assert bool(captured_pack["history"]) is use_session_history
+        assert bool(captured_pack["facts"]) is use_global_memory
+    else:
+        assert captured_pack == {}
+    assert len(await state.load_messages("memory:modes")) == (
+        4 if session_name else 2
+    )
+    assert result["memory_controls"] == {
+        "use_session_history": use_session_history,
+        "use_global_memory": use_global_memory,
+        "session_history_loaded": effective_session_history,
+        "session_history_message_count": 2 if effective_session_history else 0,
+        "global_memory_fact_count": 1 if use_global_memory else 0,
+    }
+    assert "GLOBAL_MEMORY_SENTINEL" not in str(result)
+    for memory_body in (
+        "PACK_BODY_SENTINEL",
+        "LEAD_NOTES_BODY_SENTINEL",
+        "PREFRONTAL_BODY_SENTINEL",
+        "PFC_ABSENT_BODY_SENTINEL",
+    ):
+        assert memory_body not in str(result)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add independent use_session_history and nullable use_global_memory controls
- preserve legacy use_memory behavior: `use_memory=False` disables global facts while named-session history remains available unless `use_session_history=False`
- preserve exact continuation values and prevent cross-mode context-pack leakage
- always persist committed turns while exposing only boolean/count memory telemetry
- cover Mission V2 terminal reattach and the legacy public entrypoint behavior

## Verification
- exact head `bb383e0e72c63b10c35c828a6390cf33fed1341e`
- focused memory/autonomy/public suites: 118 passed
- exact legacy-entrypoint proof: omitted granular flags plus `use_memory=False` retains named-session history, excludes global facts and prior context-pack contents, and reports session=true/global=false
- isolated live MCP acceptance used local `docker.io/ai/gemma4:latest`, cost $0
- session-only positive pair recalled `SES-4K9-MANGO`; a null session returned exactly `NULL`
- seeded unrelated global fact remained excluded; restart persistence was proved
- Goodall read-only audit returned PASS with no actionable defect

## Combined pre-integration
- merged PR #543 head `02da8280e8aa44987553b200ed3363cf5d276ed2` into this exact head without conflicts in an isolated worktree
- combined tree `ca00a7408ec49fe44381ca4de039a9cdc0d9e4e7`
- full combined suite: 627 passed, 7 skipped
- combined Ruff check: passed

## Landing order
PR #540 is merged. This branch intentionally remains draft until sibling PR #543 lands because both edit `server.py`. After #543 lands: merge current `main`, verify the resulting tree matches this pre-integration tree or explain the delta, rerun the public checks, then mark this PR ready for the protected gate.