### PR TITLE
Preserve hive orchestration on zero-key local fallback

### DIFF
--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -4446,7 +4446,7 @@ async def _execute_team_turn(
             "router_model": None,
             "router_cost_usd": 0.0,
         }
-    elif offline_local:
+    elif offline_local and depth != "hive":
         result = await _serve_local_offline(
             provider_prompt,
             system_context="\n\n".join(context_parts) or None,
@@ -4553,7 +4553,7 @@ async def _execute_team_turn(
     router_attempts = _routing_usage_attempts(routing)
     if media_block is not None:
         pass  # honest capability message already set as result
-    elif offline_local:
+    elif offline_local and depth != "hive":
         pass  # full offline serve already produced the result
     elif depth == "hive":
         try:

--- a/tests/test_local_plane_m3.py
+++ b/tests/test_local_plane_m3.py
@@ -382,6 +382,73 @@ def test_execute_team_turn_offline_via_resolve_no_hive_route(monkeypatch):
     assert out["cost_usd"] == 0.0
 
 
+def test_execute_team_turn_offline_explicit_hive_is_not_swallowed(monkeypatch):
+    """Explicit hive still runs its orchestration when auto resolves local."""
+    cats = _catalogs_fixture(local_ready=True)
+    offline_calls: list[str] = []
+    hive_calls: list[str] = []
+
+    async def _cats():
+        return cats
+
+    async def _offline(
+        prompt: str, *, system_context=None, prior_continue_count=0
+    ) -> dict[str, Any]:
+        offline_calls.append(prompt)
+        return {}
+
+    async def _hive(prompt: str, **kwargs: Any) -> dict[str, Any]:
+        hive_calls.append(prompt)
+        return {
+            "text": "hive answer",
+            "model": "local-synth",
+            "resolved_plane": "local",
+            "billing_class": "local_runtime",
+            "cost_usd": 0.0,
+            "hive": {
+                "stages": {
+                    "draft": {
+                        "route": "direct",
+                        "model": "local-synth",
+                    }
+                }
+            },
+        }
+
+    monkeypatch.setattr(server, "_catalogs", _cats)
+    monkeypatch.setattr(server, "_wants_media_generation", lambda p: None)
+    monkeypatch.setattr(server, "_serve_local_offline", _offline)
+    monkeypatch.setattr(server, "_run_hive", _hive)
+
+    out = asyncio.run(
+        server._execute_team_turn(
+            prompt="review offline",
+            session=None,
+            workspace_context="",
+            workspace_label="",
+            caller_instructions="",
+            memory_scope=None,
+            use_memory=False,
+            model=None,
+            effort=None,
+            mode="auto",
+            plane="auto",
+            fallback_policy="cross_plane",
+            turns=1,
+            allow_web=False,
+            allow_x_search=False,
+            allow_code=False,
+            depth="hive",
+        )
+    )
+
+    assert offline_calls == []
+    assert hive_calls == ["review offline"]
+    assert out["depth_engaged"] == "hive"
+    assert out["orchestration"]["route"] == "hive"
+    assert out["resolved_plane"] == "local"
+
+
 def test_run_unified_local_primary_serves_offline_envelope(monkeypatch):
     """_run_unified with resolve=local returns _serve_local_offline envelope as-is."""
     cats = _catalogs_fixture(local_ready=True)


### PR DESCRIPTION
## What changed

- Narrowed the zero-key local short-circuit so explicit or governor-resolved `depth="hive"` reaches `_run_hive`.
- Added a regression test proving local auto resolution does not swallow hive, while the existing direct-offline test remains unchanged.

## Root cause

`offline_local` was checked before the depth dispatch and then checked again as a no-op. Both branches masked the hive path while the result later reported `depth_engaged="hive"`.

## Validation

- exact ready head `02da8280e8aa44987553b200ed3363cf5d276ed2` on current `main`
- `pytest -q`: 617 passed, 7 skipped
- focused local-plane and routing-governor suites: 75 passed, 7 skipped
- `ruff check .`: passed
- clean Docker image built
- `/healthz`, `/readyz`, `/runtimez`: 200
- MCP handshake, 29-tool list, status, and self-discovery: matched
- zero-key direct local smoke: passed, cost $0
- zero-key explicit hive smoke (`voters=1`): `depth_engaged=hive`, `orchestration.route=hive`, local plane, cost $0
- CI, security, and CodeQL checks: passed
- Copilot reviewed all changed files with no comments
- Grok adversarial review: PASS

## Landing order

PR #540 is merged and this branch has reconciled current `main` without changing the feature tree. Auto-merge is armed with squash and will land after the protected branch receives one independent approval. PR #542 remains the sibling draft and will be reconciled after this PR lands.