### PR TITLE
[Donor research credited] Security analysis and hardening ideas

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,13 @@ the instructions and templates but remains workspace-neutral.
 - Ask for an image or video without an API key and UniGrok says so plainly — it never
   fabricates a media link.
 
-See [SECURITY.md](SECURITY.md) for the complete public runtime boundary.
+Optional local hardening (see [SECURITY.md](SECURITY.md) and `example.env`):
+
+- `UNIGROK_LOCAL_MCP_TOKEN` / `_SHA256` — require Bearer auth on `/mcp` while keeping health probes public
+- `UNIGROK_LOCAL_DAILY_BUDGET_USD` — fail-closed aggregate daily metered spend ceiling
+- `grok_mcp_onboard_client(safe_mode=true)` — install plan without auto-approve hooks / whole-server trust
+
+See [SECURITY.md](SECURITY.md) for the complete public runtime boundary and local IDE threat model.
 
 ## Go deeper when you need it
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,28 @@
 # Security Policy
 
+## Local IDE threat model
+
+Local Compose publishes only on loopback (`127.0.0.1`). By default the gateway
+treats that loopback TCB as trusted: any process that can reach `:4765` may call
+MCP tools. That is intentional for single-operator machines.
+
+Operators who want a tighter local edge can set `UNIGROK_LOCAL_MCP_TOKEN` (or
+`UNIGROK_LOCAL_MCP_TOKEN_SHA256`). When configured, protected surfaces require a
+matching `Authorization: Bearer` header; `/healthz` and `/readyz` stay public for
+probes. Put the same Bearer value in Cursor's `~/.cursor/mcp.json` headers — never
+commit it.
+
+Optional `UNIGROK_LOCAL_DAILY_BUDGET_USD` fails closed against aggregate telemetry
+spend for the UTC day. Host header DNS-rebinding protection is enabled on the main
+FastMCP transport (same class of control as GemmaGrok). Media URLs must be public
+HTTPS and reject `.internal` / `.local` names; resolved non-global addresses are
+rejected when DNS answers are available.
+
+Onboarding may emit a Cursor `beforeMCPExecution` hook that auto-allows only
+`agent` / `agent_result` (empty tool names ask). Gemini CLI's `trust:true`
+alternative trusts the whole server — prefer per-tool grants, or call
+`grok_mcp_onboard_client` with `safe_mode=true` to omit auto-approve hooks.
+
 ## Public runtime boundary
 
 The default Docker deployment binds to `127.0.0.1`. Grok Build ACP runs inside a
@@ -14,15 +37,15 @@ Provider credentials are isolated:
 - The API SDK receives `XAI_API_KEY` from the server environment. The key is never
   returned by status, discovery, model lists, errors, or tool results.
 
-Public media inputs must be HTTPS URLs. File upload accepts caller-supplied base64
-bytes and a plain filename; it never accepts a local path. Remote code execution runs
-only in xAI's server-side sandbox.
+Public media inputs must be HTTPS URLs (no `.internal` / private literals). File
+upload accepts caller-supplied base64 bytes and a plain filename; it never accepts a
+local path. Remote code execution runs only in xAI's server-side sandbox.
 
 API calls are metered. In local Compose, automatic routing prefers the Grok Build
 subscription, but supplying `XAI_API_KEY` and leaving
 `UNIGROK_ENABLE_METERED_API=true` authorizes bounded API routing fallback, specialists,
 and recovery. Every attempt is receipted; set the kill switch false to prevent metered
-execution. Failed/rejected attempt receipts contain only bounded billing metadata, and
+execution. Prefer `UNIGROK_LOCAL_DAILY_BUDGET_USD` for a hard local ceiling. Failed/rejected attempt receipts contain only bounded billing metadata, and
 Mission V2 checkpoints them by fenced lease generation so retries and restarts neither
 erase nor double-count known spend.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,9 +8,13 @@ MCP tools. That is intentional for single-operator machines.
 
 Operators who want a tighter local edge can set `UNIGROK_LOCAL_MCP_TOKEN` (or
 `UNIGROK_LOCAL_MCP_TOKEN_SHA256`). When configured, protected surfaces require a
-matching `Authorization: Bearer` header; `/healthz` and `/readyz` stay public for
-probes. Put the same Bearer value in Cursor's `~/.cursor/mcp.json` headers — never
-commit it.
+matching `Authorization: Bearer` header from loopback-shaped traffic (direct
+loopback peer, or Docker bridge/private peer with `Host: localhost` /
+`127.0.0.1`). Forwarded-proxy headers are rejected unless `UNIGROK_TRUST_PROXY=true`.
+Failed local-token auth is rate-limited per peer. `/healthz` and `/readyz` stay
+public for probes. Put the same Bearer value in Cursor's `~/.cursor/mcp.json`
+headers — never commit it. Tokens are compared via SHA-256 digests with
+constant-time equality; bearer values are never logged.
 
 Optional `UNIGROK_LOCAL_DAILY_BUDGET_USD` fails closed against aggregate telemetry
 spend for the UTC day. Host header DNS-rebinding protection is enabled on the main

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,7 +16,12 @@ services:
       # Public defaults: all chat/agent tools available.
       UNIGROK_CHAT_TOOLS: ${UNIGROK_CHAT_TOOLS:-always}
       UNIGROK_SWARM: ${UNIGROK_SWARM:-active}
-      UNIGROK_DEFAULT_LEVEL: ${UNIGROK_DEFAULT_LEVEL:-max}
+      UNIGROK_DEFAULT_LEVEL: ${UNIGROK_DEFAULT_LEVEL:-high}
+      # Optional local spend ceiling (USD/day, aggregate telemetry). Unset = uncapped.
+      UNIGROK_LOCAL_DAILY_BUDGET_USD: ${UNIGROK_LOCAL_DAILY_BUDGET_USD:-}
+      # Optional local MCP shared secret. When set, Cursor must send Authorization: Bearer …
+      UNIGROK_LOCAL_MCP_TOKEN: ${UNIGROK_LOCAL_MCP_TOKEN:-}
+      UNIGROK_LOCAL_MCP_TOKEN_SHA256: ${UNIGROK_LOCAL_MCP_TOKEN_SHA256:-}
       UNIGROK_AUTH_PATH: /home/appuser/.grok/auth.json
       UNIGROK_BUILD_TIMEOUT: ${UNIGROK_BUILD_TIMEOUT:-120}
       UNIGROK_API_TIMEOUT: ${UNIGROK_API_TIMEOUT:-120}

--- a/example.env
+++ b/example.env
@@ -4,7 +4,17 @@ UNIGROK_PORT=4765
 UNIGROK_IMAGE=unigrok:1.1.0
 UNIGROK_CHAT_TOOLS=always
 UNIGROK_SWARM=active
-UNIGROK_DEFAULT_LEVEL=max
+UNIGROK_DEFAULT_LEVEL=high
+
+# Optional local gateway shared secret (32-256 url-safe chars). When set, Cursor must
+# send Authorization: Bearer <token> in ~/.cursor/mcp.json. Prefer the sha256 form in
+# shared shells: UNIGROK_LOCAL_MCP_TOKEN_SHA256=<hex>.
+# UNIGROK_LOCAL_MCP_TOKEN=
+# UNIGROK_LOCAL_MCP_TOKEN_SHA256=
+
+# Optional aggregate daily metered spend ceiling for local Compose (USD). Fail-closed
+# when the telemetry ledger is unavailable. Unset = uncapped (provider account limits).
+# UNIGROK_LOCAL_DAILY_BUDGET_USD=5
 
 # Hosted OAuth/Cloud Run settings are intentionally absent from this local template.
 # Operators use docs/remote-mcp-deployment.md and inject versioned secrets server-side.

--- a/src/unigrok_public/caller_budget.py
+++ b/src/unigrok_public/caller_budget.py
@@ -1,4 +1,4 @@
-"""Fail-closed daily spend caps for authenticated hosted callers."""
+"""Fail-closed daily spend caps for authenticated hosted callers and local Compose."""
 
 from __future__ import annotations
 
@@ -9,12 +9,17 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import unquote
 
 from .identity import get_active_principal, principal_kind, principal_label
-from .remote_auth import authorization_servers, canonical_oauth_principal
+from .remote_auth import (
+    authorization_servers,
+    canonical_oauth_principal,
+    is_cloudrun_runtime,
+)
 
 if TYPE_CHECKING:
     from .state import PublicStateStore
 
 _BUDGET_ENV = "UNIGROK_CALLER_BUDGETS"
+_LOCAL_BUDGET_ENV = "UNIGROK_LOCAL_DAILY_BUDGET_USD"
 _MAX_BUDGET_BYTES = 65_536
 _MAX_BUDGET_ENTRIES = 256
 _MAX_PRINCIPAL_CHARS = 160
@@ -102,19 +107,56 @@ def load_caller_budgets() -> dict[str, float]:
     return budgets
 
 
+def load_local_daily_budget() -> float | None:
+    """Parse optional local Compose daily USD cap; None means uncapped."""
+    raw = str(os.environ.get(_LOCAL_BUDGET_ENV, "") or "").strip()
+    if not raw:
+        return None
+    try:
+        limit = float(raw)
+    except ValueError as exc:
+        raise CallerBudgetConfigurationError("invalid_local_limit") from exc
+    if not math.isfinite(limit) or limit < 0:
+        raise CallerBudgetConfigurationError("invalid_local_limit")
+    return limit
+
+
 def validate_caller_budget_configuration() -> None:
-    """Startup validation hook for the hosted runtime."""
+    """Startup validation hook for hosted and local budget env vars."""
     load_caller_budgets()
+    load_local_daily_budget()
+
+
+async def enforce_local_daily_budget(store: PublicStateStore) -> None:
+    """Reject local metered spend when the aggregate daily USD cap is hit."""
+    if is_cloudrun_runtime():
+        return
+    limit = load_local_daily_budget()
+    if limit is None:
+        return
+    try:
+        spent = float(await store.get_total_cost_today())
+    except Exception:
+        raise CallerBudgetUnavailable(
+            "Local daily budget ledger is unavailable; provider spend was denied."
+        ) from None
+    if not math.isfinite(spent) or spent < 0:
+        raise CallerBudgetUnavailable(
+            "Local daily budget ledger is invalid; provider spend was denied."
+        )
+    if spent >= limit:
+        raise CallerBudgetExceeded(
+            f"Local daily budget exhausted (${spent:.6f}/${limit:.6f})."
+        )
 
 
 async def enforce_caller_budget(store: PublicStateStore) -> None:
     """Reject provider spend when the active principal is at its daily cap.
 
-    The hot path is a no-op when the environment variable is absent. If caps
-    are configured, missing authenticated context and ledger failures deny the
-    request rather than silently re-enabling owner spend. Principals omitted
-    from a valid map retain the historical uncapped behavior.
+    Local Compose also honors ``UNIGROK_LOCAL_DAILY_BUDGET_USD`` against aggregate
+    telemetry spend. Hosted OAuth maps remain opt-in via ``UNIGROK_CALLER_BUDGETS``.
     """
+    await enforce_local_daily_budget(store)
     if not os.environ.get(_BUDGET_ENV, "").strip():
         return
     budgets = load_caller_budgets()

--- a/src/unigrok_public/remote_auth.py
+++ b/src/unigrok_public/remote_auth.py
@@ -26,6 +26,7 @@ import logging
 import os
 import re
 import secrets
+import time
 from collections.abc import Mapping
 from typing import Any
 from urllib.parse import quote, urlsplit
@@ -36,6 +37,17 @@ from starlette.responses import JSONResponse
 from .identity import principal_label
 
 logger = logging.getLogger(__name__)
+
+# Local-token auth abuse controls (in-process; resets on restart).
+_AUTH_FAIL_WINDOW_SECONDS = 60.0
+_AUTH_FAIL_MAX = 30
+_auth_failures: dict[str, list[float]] = {}
+_FORWARDED_HEADERS = (
+    b"x-forwarded-for",
+    b"x-forwarded-host",
+    b"x-forwarded-proto",
+    b"forwarded",
+)
 
 _PUBLIC_PATHS = frozenset(
     {
@@ -225,8 +237,109 @@ def local_mcp_token_configured() -> bool:
     return bool(_configured_local_mcp_digests())
 
 
+def _peer_address(scope: Mapping[str, Any]) -> str | None:
+    client = scope.get("client")
+    if not isinstance(client, (list, tuple)) or not client:
+        return None
+    host = str(client[0] or "").strip()
+    return host or None
+
+
+def _is_loopback_peer(scope: Mapping[str, Any]) -> bool:
+    host = _peer_address(scope)
+    if not host:
+        return False
+    try:
+        return bool(ipaddress.ip_address(host).is_loopback)
+    except ValueError:
+        return host.lower() in {"localhost"}
+
+
+def _host_header_is_loopback(scope: Mapping[str, Any]) -> bool:
+    raw = _scope_header(scope, b"host")
+    if not raw:
+        return False
+    host = raw.split(":", 1)[0].strip().strip("[]").lower()
+    return host in {"localhost", "127.0.0.1", "::1"}
+
+
+def _has_forwarded_headers(scope: Mapping[str, Any]) -> bool:
+    for key, _value in scope.get("headers") or []:
+        if key.lower() in _FORWARDED_HEADERS:
+            return True
+    return False
+
+
+def _trust_proxy_enabled() -> bool:
+    return os.environ.get("UNIGROK_TRUST_PROXY", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
+_DOCKER_LOCAL_NETWORKS = (
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("fc00::/7"),
+)
+
+
+def _is_compose_bridge_peer(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """True for typical Docker/LAN private peers (not documentation TEST-NET ranges)."""
+    if address.is_loopback or address.is_link_local:
+        return True
+    return any(address in network for network in _DOCKER_LOCAL_NETWORKS)
+
+
+def local_mcp_request_allowed(scope: Mapping[str, Any]) -> bool:
+    """Allow local tokens only from loopback-shaped traffic.
+
+    Direct loopback peers always pass. Docker Compose port-publish usually shows a
+    bridge peer IP, so RFC1918/ULA peers are accepted only when the Host header is
+    localhost/127.0.0.1 and no untrusted forwarded headers are present.
+    """
+    if _has_forwarded_headers(scope) and not _trust_proxy_enabled():
+        return False
+    if _is_loopback_peer(scope):
+        return True
+    peer = _peer_address(scope)
+    if not peer:
+        return False
+    try:
+        address = ipaddress.ip_address(peer)
+    except ValueError:
+        return False
+    return bool(_is_compose_bridge_peer(address) and _host_header_is_loopback(scope))
+
+
+def _auth_failure_key(scope: Mapping[str, Any]) -> str:
+    return _peer_address(scope) or "unknown"
+
+
+def _auth_failures_limited(scope: Mapping[str, Any]) -> bool:
+    now = time.monotonic()
+    key = _auth_failure_key(scope)
+    stamps = [stamp for stamp in _auth_failures.get(key, []) if now - stamp < _AUTH_FAIL_WINDOW_SECONDS]
+    _auth_failures[key] = stamps
+    return len(stamps) >= _AUTH_FAIL_MAX
+
+
+def _record_auth_failure(scope: Mapping[str, Any]) -> None:
+    now = time.monotonic()
+    key = _auth_failure_key(scope)
+    stamps = [stamp for stamp in _auth_failures.get(key, []) if now - stamp < _AUTH_FAIL_WINDOW_SECONDS]
+    stamps.append(now)
+    _auth_failures[key] = stamps
+
+
 def match_local_mcp_token(token: str | None) -> dict[str, Any] | None:
-    """Return synthetic auth claims for a valid local MCP token, else None."""
+    """Return synthetic auth claims for a valid local MCP token, else None.
+
+    Uses constant-time digest compares. Callers must also enforce
+    :func:`local_mcp_request_allowed` so tokens never authorize non-loopback peers.
+    """
     if is_cloudrun_runtime():
         return None
     if not token or len(token) > _SERVICE_TOKEN_MAX:
@@ -242,6 +355,7 @@ def match_local_mcp_token(token: str | None) -> dict[str, Any] | None:
             break
     if not matched:
         return None
+    # Local operator token: full public MCP capability set (not hosted admin).
     scopes = " ".join(_DEFAULT_SERVICE_SCOPES)
     return {
         "active": True,
@@ -509,8 +623,26 @@ class RemoteOAuthMiddleware:
             await self.app(scope, receive, send)
             return
 
+        if local_mcp_token_configured() and _auth_failures_limited(scope):
+            logger.warning(
+                "local_mcp_token access_denied path=%s reason=rate_limited peer=%s",
+                path,
+                _auth_failure_key(scope),
+            )
+            response = JSONResponse({"error": "too_many_auth_failures"}, status_code=429)
+            await response(scope, receive, send)
+            return
+
         token = _extract_bearer(_scope_header(scope, b"authorization"))
         claims: dict[str, Any] | None = match_local_mcp_token(token)
+        if claims is not None and not local_mcp_request_allowed(scope):
+            # Valid secret presented from a non-loopback / proxied peer — hard deny.
+            claims = None
+            logger.warning(
+                "local_mcp_token access_denied path=%s reason=non_loopback_or_forwarded peer=%s",
+                path,
+                _auth_failure_key(scope),
+            )
         if claims is None:
             claims = match_service_token(token)
         if claims is not None and claims.get("unigrok_auth") == "local_mcp_token":
@@ -528,7 +660,14 @@ class RemoteOAuthMiddleware:
                 claims = await introspect_oauth_token(token or "", "unigrok:connect")
             if claims is None:
                 required = "unigrok:connect"
-                logger.warning("oauth access_denied path=%s scope=%s", path, required)
+                if local_mcp_token_configured():
+                    _record_auth_failure(scope)
+                logger.warning(
+                    "oauth access_denied path=%s scope=%s peer=%s",
+                    path,
+                    required,
+                    _auth_failure_key(scope),
+                )
                 response = JSONResponse({"error": "unauthorized"}, status_code=401)
                 metadata = _metadata_url(path, scope.get("query_string", b""))
                 response.headers["WWW-Authenticate"] = (
@@ -576,6 +715,8 @@ class RemoteOAuthMiddleware:
                 claims = None
         else:
             claims = match_local_mcp_token(token)
+            if claims is not None and not local_mcp_request_allowed(scope):
+                claims = None
             if claims is not None:
                 auth_kind = "local_mcp_token"
                 granted_scopes = set(str(claims.get("scope") or "").split())
@@ -603,7 +744,14 @@ class RemoteOAuthMiddleware:
             await self.app(scope, receive, send)
             return
 
-        logger.warning("oauth access_denied path=%s scope=%s", path, required)
+        if local_mcp_token_configured():
+            _record_auth_failure(scope)
+        logger.warning(
+            "oauth access_denied path=%s scope=%s peer=%s",
+            path,
+            required,
+            _auth_failure_key(scope),
+        )
         response = JSONResponse({"error": "unauthorized"}, status_code=401)
         metadata = _metadata_url(path, scope.get("query_string", b""))
         if metadata:

--- a/src/unigrok_public/remote_auth.py
+++ b/src/unigrok_public/remote_auth.py
@@ -1,6 +1,10 @@
 """Fail-closed auth edge for a generic remote MCP deployment.
 
-Local Docker remains loopback-first and credential-free at the gateway layer.
+Local Docker remains loopback-first. By default the gateway stays credential-free
+for trusted loopback clients. Operators may opt in to a local shared secret with
+``UNIGROK_LOCAL_MCP_TOKEN`` / ``UNIGROK_LOCAL_MCP_TOKEN_SHA256``; when set, protected
+surfaces require a matching Bearer token (same middleware path as service tokens).
+
 When ``UNIGROK_RUNTIME=cloudrun``, protected requests require either:
 
 1. Control OAuth bearer tokens validated by remote introspection, or
@@ -9,7 +13,7 @@ When ``UNIGROK_RUNTIME=cloudrun``, protected requests require either:
    GitHub Copilot cloud agent / code review.
 
 Provider keys stay server-side and are never accepted as gateway bearer
-credentials. Service tokens are not OAuth and never expand authority beyond
+credentials. Service/local tokens are not OAuth and never expand authority beyond
 this public MCP resource.
 """
 
@@ -195,9 +199,69 @@ def service_tokens_configured() -> bool:
     return bool(_configured_service_digests())
 
 
+def _configured_local_mcp_digests() -> frozenset[bytes]:
+    """Digests for optional local Compose shared secrets."""
+    digests: set[bytes] = set()
+    for raw in os.environ.get("UNIGROK_LOCAL_MCP_TOKEN", "").split(","):
+        token = raw.strip()
+        if not token:
+            continue
+        if _SERVICE_TOKEN_RE.fullmatch(token) is None:
+            logger.warning("ignoring malformed UNIGROK_LOCAL_MCP_TOKEN entry")
+            continue
+        digests.add(_digest_token(token))
+    for raw in os.environ.get("UNIGROK_LOCAL_MCP_TOKEN_SHA256", "").split(","):
+        digest_hex = raw.strip().lower()
+        if not digest_hex:
+            continue
+        if re.fullmatch(r"[0-9a-f]{64}", digest_hex) is None:
+            logger.warning("ignoring malformed UNIGROK_LOCAL_MCP_TOKEN_SHA256 entry")
+            continue
+        digests.add(bytes.fromhex(digest_hex))
+    return frozenset(digests)
+
+
+def local_mcp_token_configured() -> bool:
+    return bool(_configured_local_mcp_digests())
+
+
+def match_local_mcp_token(token: str | None) -> dict[str, Any] | None:
+    """Return synthetic auth claims for a valid local MCP token, else None."""
+    if is_cloudrun_runtime():
+        return None
+    if not token or len(token) > _SERVICE_TOKEN_MAX:
+        return None
+    allowed = _configured_local_mcp_digests()
+    if not allowed:
+        return None
+    candidate = _digest_token(token)
+    matched = False
+    for digest in allowed:
+        if secrets.compare_digest(candidate, digest):
+            matched = True
+            break
+    if not matched:
+        return None
+    scopes = " ".join(_DEFAULT_SERVICE_SCOPES)
+    return {
+        "active": True,
+        "token_type": "local_mcp",
+        "scope": scopes,
+        "iss": "unigrok:local-mcp-token",
+        "sub": "operator",
+        "aud": "local-loopback",
+        "unigrok_principal": "local:operator",
+        "unigrok_auth": "local_mcp_token",
+    }
+
+
 def auth_enforcement_active() -> bool:
-    """True when the remote edge must reject anonymous protected traffic."""
-    return bool(introspection_url()) or service_tokens_configured()
+    """True when the edge must reject anonymous protected traffic."""
+    return (
+        bool(introspection_url())
+        or service_tokens_configured()
+        or local_mcp_token_configured()
+    )
 
 
 def match_service_token(token: str | None) -> dict[str, Any] | None:
@@ -446,12 +510,19 @@ class RemoteOAuthMiddleware:
             return
 
         token = _extract_bearer(_scope_header(scope, b"authorization"))
-        claims: dict[str, Any] | None = match_service_token(token)
-        auth_kind = "service_token" if claims is not None else "oauth"
+        claims: dict[str, Any] | None = match_local_mcp_token(token)
+        if claims is None:
+            claims = match_service_token(token)
+        if claims is not None and claims.get("unigrok_auth") == "local_mcp_token":
+            auth_kind = "local_mcp_token"
+        elif claims is not None:
+            auth_kind = "service_token"
+        else:
+            auth_kind = "oauth"
         body = b""
         if path == "/mcp" and scope.get("method") == "POST":
             # Authenticate the connection before buffering a potentially large
-            # base64 file request. Service tokens resolve locally; OAuth uses
+            # base64 file request. Local/service tokens resolve locally; OAuth uses
             # Control introspection. Scope is re-checked once tools/call is known.
             if claims is None:
                 claims = await introspect_oauth_token(token or "", "unigrok:connect")
@@ -504,15 +575,22 @@ class RemoteOAuthMiddleware:
                 # lacks the tool scope — hard deny, do not re-introspect.
                 claims = None
         else:
-            claims = match_service_token(token)
+            claims = match_local_mcp_token(token)
             if claims is not None:
-                auth_kind = "service_token"
+                auth_kind = "local_mcp_token"
                 granted_scopes = set(str(claims.get("scope") or "").split())
                 if not set(required.split()).issubset(granted_scopes):
                     claims = None
             else:
-                auth_kind = "oauth"
-                claims = await introspect_oauth_token(token or "", required)
+                claims = match_service_token(token)
+                if claims is not None:
+                    auth_kind = "service_token"
+                    granted_scopes = set(str(claims.get("scope") or "").split())
+                    if not set(required.split()).issubset(granted_scopes):
+                        claims = None
+                else:
+                    auth_kind = "oauth"
+                    claims = await introspect_oauth_token(token or "", required)
         if claims is not None:
             scope["unigrok.oauth"] = claims
             logger.info(

--- a/src/unigrok_public/remote_auth.py
+++ b/src/unigrok_public/remote_auth.py
@@ -318,10 +318,15 @@ def _auth_failure_key(scope: Mapping[str, Any]) -> str:
     return _peer_address(scope) or "unknown"
 
 
+def _fresh_auth_failure_stamps(key: str, now: float) -> list[float]:
+    window = _AUTH_FAIL_WINDOW_SECONDS
+    return [stamp for stamp in _auth_failures.get(key, []) if now - stamp < window]
+
+
 def _auth_failures_limited(scope: Mapping[str, Any]) -> bool:
     now = time.monotonic()
     key = _auth_failure_key(scope)
-    stamps = [stamp for stamp in _auth_failures.get(key, []) if now - stamp < _AUTH_FAIL_WINDOW_SECONDS]
+    stamps = _fresh_auth_failure_stamps(key, now)
     _auth_failures[key] = stamps
     return len(stamps) >= _AUTH_FAIL_MAX
 
@@ -329,7 +334,7 @@ def _auth_failures_limited(scope: Mapping[str, Any]) -> bool:
 def _record_auth_failure(scope: Mapping[str, Any]) -> None:
     now = time.monotonic()
     key = _auth_failure_key(scope)
-    stamps = [stamp for stamp in _auth_failures.get(key, []) if now - stamp < _AUTH_FAIL_WINDOW_SECONDS]
+    stamps = _fresh_auth_failure_stamps(key, now)
     stamps.append(now)
     _auth_failures[key] = stamps
 

--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -21,6 +21,7 @@ from typing import Any, Literal
 from urllib.parse import urlsplit
 
 from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
 from mcp.types import ToolAnnotations
 from pydantic import BaseModel, Field
 from starlette.requests import Request
@@ -86,6 +87,7 @@ from .remote_auth import (
     RemoteOriginMiddleware,
     authorization_servers,
     is_cloudrun_runtime,
+    local_mcp_token_configured,
     oauth_metadata,
     public_mcp_resource,
     stateless_http_enabled,
@@ -1080,31 +1082,40 @@ def _cursor_mcp_server(scope: str) -> dict[str, Any]:
     Emitted as a MERGE (never a full-file overwrite) so existing Cursor MCP servers
     survive. The calling IDE performs the merge with a conflict preview.
     """
+    headers: dict[str, str] = {"X-Client-ID": "cursor"}
+    notes: list[str] = []
+    if local_mcp_token_configured():
+        notes.append(
+            "This gateway has UNIGROK_LOCAL_MCP_TOKEN configured. Add "
+            '"Authorization": "Bearer <same token as UNIGROK_LOCAL_MCP_TOKEN>" to headers. '
+            "Do not commit the token; keep it only in local mcp.json / secrets."
+        )
     return {
         "target": "~/.cursor/mcp.json" if scope == "global" else ".cursor/mcp.json",
         "merge_into": "mcpServers",
         "merge_policy": (
             "Add this server to the existing mcpServers object; do not overwrite other "
             "servers. If a 'grok' server already exists, show a diff before replacing."
+            + ((" " + " ".join(notes)) if notes else "")
         ),
         "entry": {
             "mcpServers": {
                 "grok": {
                     "url": _configured_mcp_url(),
-                    "headers": {"X-Client-ID": "cursor"},
+                    "headers": headers,
                 }
             }
         },
+        "local_token_required": local_mcp_token_configured(),
+        "local_token_header_note": notes[0] if notes else None,
     }
 
 
 # Cursor beforeMCPExecution hook: auto-approve UniGrok's `agent` tool so `@grok` never
-# stalls on a per-call permission prompt. Fail-open, matcher-scoped to the agent tool,
-# and it grants no other authority. This is the "plugin-like" piece Cursor needs that
-# other IDEs do not (ported from the old .cursor/hooks/before-unigrok-agent.py, with the
-# removed-platform Canvas/sponsor tip stripped out).
+# stalls on a per-call permission prompt. Matcher-scoped to the agent tool, and it
+# grants no other authority. Empty/unknown tool names ask (never silent allow).
 CURSOR_AGENT_HOOK = '''#!/usr/bin/env python3
-"""Cursor beforeMCPExecution hook: auto-allow UniGrok's agent tool (fail-open)."""
+"""Cursor beforeMCPExecution hook: auto-allow UniGrok agent / agent_result only."""
 from __future__ import annotations
 
 import json
@@ -1116,10 +1127,23 @@ def main() -> int:
         payload = json.load(sys.stdin)
     except Exception:
         payload = {}
-    tool = str(payload.get("tool_name") or payload.get("toolName") or "").lower()
-    # The hooks.json matcher already scopes this to the agent tool; auto-approve it so
-    # @grok runs without a permission prompt. Never deny; unknown shapes fail open.
-    decision = "allow" if ("agent" in tool or tool == "") else "ask"
+    tool = str(payload.get("tool_name") or payload.get("toolName") or "").lower().strip()
+    # Never allow an empty tool name — that used to fail-open the MCP surface.
+    if not tool:
+        decision = "ask"
+    else:
+        compact = tool.replace("-", "_").replace("/", "_")
+        decision = (
+            "allow"
+            if compact.endswith("agent_result")
+            or compact.endswith("__agent")
+            or compact.endswith("_agent")
+            or compact == "agent"
+            or compact.endswith("/agent".replace("/", "_"))
+            else "ask"
+        )
+        if decision != "allow" and ("agent_result" in compact or compact.endswith("agent")):
+            decision = "allow"
     sys.stdout.write(json.dumps({"permission": decision}))
     return 0
 
@@ -1301,11 +1325,15 @@ def _auto_approve(client: str, scope: str) -> dict[str, Any] | None:
             "gemini_cli_alternative": {
                 "target": "~/.gemini/settings.json",
                 "note": (
-                    "Gemini CLI has no permission grants; set trust:true on the grok "
-                    "mcpServers entry instead. That trusts the whole grok server — "
-                    "acceptable because it is your own local gateway."
+                    "WARNING: Gemini CLI has no per-tool grants. Setting trust:true on "
+                    "the grok mcpServers entry trusts the WHOLE grok server (metered "
+                    "tools included). Prefer Antigravity permission grants when available. "
+                    "For a safer plan without whole-server trust, call "
+                    "grok_mcp_onboard_client with safe_mode=true."
                 ),
                 "entry": {"mcpServers": {"grok": {"trust": True}}},
+                "whole_server_trust": True,
+                "risk": "high",
             },
             "assumes_server_name": "grok",
         }
@@ -1378,6 +1406,13 @@ class ClientOnboardingSelection(BaseModel):
             "a namespaced pack; project creates a local plan; the others defer or decline."
         )
     )
+    safe_mode: bool = Field(
+        default=False,
+        description=(
+            "When true, omit auto-approve hooks and whole-server trust entries so the "
+            "IDE keeps asking before UniGrok tool calls."
+        ),
+    )
 
 
 def _client_kind(client_name: str | None) -> str:
@@ -1447,7 +1482,9 @@ def _global_files(client: str) -> list[dict[str, str]]:
     return []
 
 
-def _client_onboarding_plan(client: str, scope: str) -> dict[str, Any]:
+def _client_onboarding_plan(
+    client: str, scope: str, *, safe_mode: bool = False
+) -> dict[str, Any]:
     adapter = CLIENT_ADAPTERS[client]
     cloud_mode = is_cloudrun_runtime()
     common = {
@@ -1457,9 +1494,10 @@ def _client_onboarding_plan(client: str, scope: str) -> dict[str, Any]:
         "client": client,
         "client_label": adapter["label"],
         "scope": scope,
+        "safe_mode": bool(safe_mode),
         "writes_performed": False,
         "requires_explicit_user_approval": True,
-        "automatic_tool_approval_offered": not cloud_mode,
+        "automatic_tool_approval_offered": (not cloud_mode) and (not safe_mode),
         "installer": "calling_ide_agent",
         "runtime_contract": {
             "execution_policy": "api_only" if cloud_mode else "dual_plane",
@@ -1517,11 +1555,17 @@ def _client_onboarding_plan(client: str, scope: str) -> dict[str, Any]:
                 _owned_file(".cursor/rules/unigrok-visuals.mdc", VISUALS_CURSOR_RULE)
             )
             plan["mcp_server"] = _cursor_mcp_server("project")
-            if not cloud_mode:
+            if not cloud_mode and not safe_mode:
                 plan["files"].append(
                     _owned_file(".cursor/hooks/before-unigrok-agent.py", CURSOR_AGENT_HOOK)
                 )
                 plan["hooks"] = _cursor_hooks("project")
+            elif not cloud_mode and safe_mode:
+                plan["hooks"] = None
+                plan["safe_mode_note"] = (
+                    "Safe mode: no beforeMCPExecution auto-approve hook. Cursor will "
+                    "prompt before UniGrok tool calls."
+                )
         if client == "github_copilot":
             plan["files"].append(
                 _owned_file(
@@ -1572,6 +1616,16 @@ def _client_onboarding_plan(client: str, scope: str) -> dict[str, Any]:
                 "Reload Cursor after authorizing the remote MCP server, then call "
                 "grok_mcp_discover_self."
             )
+        elif safe_mode:
+            plan["hooks"] = None
+            plan["safe_mode_note"] = (
+                "Safe mode: no beforeMCPExecution auto-approve hook. Cursor will "
+                "prompt before UniGrok tool calls."
+            )
+            plan["reload"] = (
+                "Reload Cursor after adding the MCP server, then call "
+                "grok_mcp_discover_self."
+            )
         else:
             plan["hooks"] = _cursor_hooks("global")
             plan["files"].append(
@@ -1584,10 +1638,15 @@ def _client_onboarding_plan(client: str, scope: str) -> dict[str, Any]:
     else:
         # Same "never prompt for @grok" outcome for the other IDEs, each via its own
         # native mechanism (optional; the IDE previews before applying).
-        if not cloud_mode:
+        if not cloud_mode and not safe_mode:
             auto_approve = _auto_approve(client, "global")
             if auto_approve is not None:
                 plan["auto_approve"] = auto_approve
+        elif not cloud_mode and safe_mode:
+            plan["safe_mode_note"] = (
+                "Safe mode: no auto-approve / whole-server trust entries. The IDE will "
+                "prompt before UniGrok tool calls."
+            )
         if client == "github_copilot":
             # gh Copilot CLI reads ~/.copilot/mcp-config.json; VS Code uses .vscode/
             # mcp.json (carried as vscode_alternative). Project instructions live in
@@ -1629,6 +1688,25 @@ PROJECT_ONBOARDING = {
     },
 }
 
+_TRANSPORT_SECURITY = TransportSecuritySettings(
+    enable_dns_rebinding_protection=True,
+    allowed_hosts=[
+        "127.0.0.1",
+        "127.0.0.1:*",
+        "localhost",
+        "localhost:*",
+        "[::1]",
+        "[::1]:*",
+        "unigrok:*",
+        "grok-mcp:*",
+    ],
+    allowed_origins=[
+        "http://127.0.0.1:*",
+        "http://localhost:*",
+        "http://[::1]:*",
+    ],
+)
+
 mcp = FastMCP(
     MCP_SERVER_NAME,
     instructions=INSTRUCTIONS,
@@ -1637,6 +1715,7 @@ mcp = FastMCP(
     streamable_http_path="/mcp",
     stateless_http=stateless_http_enabled(),
     json_response=False,
+    transport_security=_TRANSPORT_SECURITY,
 )
 # FastMCP 1.28 does not forward a product version to its low-level server,
 # so set the protocol handshake value explicitly until the SDK exposes it.
@@ -6272,6 +6351,7 @@ async def grok_mcp_onboard_client(
         "generic",
     ] = "auto",
     choice: Literal["global", "project", "not_now", "never"] | None = None,
+    safe_mode: bool = False,
 ) -> dict[str, Any]:
     """Offer a consent-first UniGrok integration plan for the calling IDE.
 
@@ -6280,6 +6360,7 @@ async def grok_mcp_onboard_client(
     a structured offer for the calling IDE to present. The IDE owns all approved
     writes and must preserve user-modified files. Clients behind a generic MCP bridge
     should pass their host kind explicitly because bridges can hide the IDE identity.
+    Pass ``safe_mode=true`` to omit auto-approve hooks and whole-server trust entries.
     """
     params = ctx.request_context.session.client_params
     detected_name = params.clientInfo.name if params is not None else None
@@ -6288,6 +6369,7 @@ async def grok_mcp_onboard_client(
     supports_elicitation = bool(
         capabilities is not None and getattr(capabilities, "elicitation", None) is not None
     )
+    elicited_safe_mode = bool(safe_mode)
     if choice is None and supports_elicitation:
         result = await ctx.elicit(
             (
@@ -6304,6 +6386,7 @@ async def grok_mcp_onboard_client(
                 if selected in {"global", "project", "not_now", "never"}
                 else "not_now"
             )
+            elicited_safe_mode = bool(result.data.safe_mode) or elicited_safe_mode
         else:
             choice = "not_now"
     if choice is None:
@@ -6314,6 +6397,7 @@ async def grok_mcp_onboard_client(
             "client_label": CLIENT_ADAPTERS[resolved_client]["label"],
             "recommended_choice": "global",
             "choices": ["global", "project", "not_now", "never"],
+            "safe_mode_available": True,
             "reason": "Keep repositories clean while allowing project-level overrides.",
             "writes_performed": False,
             "elicitation_supported": False,
@@ -6321,9 +6405,12 @@ async def grok_mcp_onboard_client(
                 "tool": "grok_mcp_onboard_client",
                 "client": resolved_client,
                 "choice": "<approved choice>",
+                "safe_mode": False,
             },
         }
-    return _client_onboarding_plan(resolved_client, choice)
+    return _client_onboarding_plan(
+        resolved_client, choice, safe_mode=elicited_safe_mode
+    )
 
 
 @mcp.tool(annotations=READ_ONLY)

--- a/src/unigrok_public/state.py
+++ b/src/unigrok_public/state.py
@@ -1057,6 +1057,21 @@ class PublicStateStore:
             )
         )
 
+    def _get_total_cost_today_sync(self, day_start: str) -> float:
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT COALESCE(SUM(cost_usd), 0) FROM telemetry WHERE created_at>=?",
+                (day_start,),
+            ).fetchone()
+        return float(row[0] if row and row[0] is not None else 0.0)
+
+    async def get_total_cost_today(self) -> float:
+        """Return this UTC day's aggregate telemetry spend across all callers."""
+        day_start = datetime.now(UTC).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        ).isoformat()
+        return float(await self._read(self._get_total_cost_today_sync, day_start))
+
     def _reclassify_telemetry_error_sync(
         self,
         telemetry_id: int,

--- a/src/unigrok_public/tools/media.py
+++ b/src/unigrok_public/tools/media.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import base64
 import ipaddress
 import re
+import socket
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
@@ -20,17 +21,49 @@ def validated_file_id(value: str) -> str:
     return file_id
 
 
+def _hostname_is_blocked_name(host: str) -> bool:
+    normalized = host.lower().rstrip(".")
+    if normalized == "localhost":
+        return True
+    return normalized.endswith((".localhost", ".local", ".internal"))
+
+
+def _resolved_addresses_are_public(host: str) -> bool:
+    """Return False when DNS answers include any non-global address.
+
+    Resolution failures are inconclusive and do not reject a host that already
+    passed static public-name checks (keeps offline CI stable).
+    """
+    try:
+        answers = socket.getaddrinfo(host, None, type=socket.SOCK_STREAM)
+    except OSError:
+        return True
+    for entry in answers:
+        sockaddr = entry[4]
+        if not sockaddr:
+            continue
+        try:
+            address = ipaddress.ip_address(sockaddr[0])
+        except ValueError:
+            continue
+        if not address.is_global:
+            return False
+    return True
+
+
 def validated_media_url(value: str, field: str) -> str:
     url = str(value or "").strip()
     parts = urlsplit(url)
     if parts.scheme != "https" or not parts.netloc or parts.username or parts.password:
         raise ValueError(f"{field} must be a public https URL")
     host = parts.hostname or ""
+    if not host or _hostname_is_blocked_name(host):
+        raise ValueError(f"{field} must be a public https URL")
     try:
         address = ipaddress.ip_address(host)
-    except ValueError as exc:
-        if host == "localhost" or host.endswith((".localhost", ".local")):
-            raise ValueError(f"{field} must be a public https URL") from exc
+    except ValueError:
+        if not _resolved_addresses_are_public(host):
+            raise ValueError(f"{field} must be a public https URL") from None
     else:
         if not address.is_global:
             raise ValueError(f"{field} must be a public https URL")

--- a/tests/test_local_daily_budget.py
+++ b/tests/test_local_daily_budget.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+
+from unigrok_public import caller_budget
+
+
+def test_local_daily_budget_unset_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("UNIGROK_LOCAL_DAILY_BUDGET_USD", raising=False)
+    assert caller_budget.load_local_daily_budget() is None
+
+
+def test_local_daily_budget_rejects_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("UNIGROK_LOCAL_DAILY_BUDGET_USD", "nope")
+    with pytest.raises(caller_budget.CallerBudgetConfigurationError):
+        caller_budget.load_local_daily_budget()
+
+
+@pytest.mark.asyncio
+async def test_local_daily_budget_fail_closed_and_exhausted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("UNIGROK_RUNTIME", raising=False)
+    monkeypatch.setenv("UNIGROK_LOCAL_DAILY_BUDGET_USD", "1.5")
+    monkeypatch.delenv("UNIGROK_CALLER_BUDGETS", raising=False)
+
+    class Store:
+        async def get_total_cost_today(self) -> float:
+            return 1.5
+
+    with pytest.raises(caller_budget.CallerBudgetExceeded, match="Local daily budget"):
+        await caller_budget.enforce_local_daily_budget(Store())  # type: ignore[arg-type]
+
+    class BrokenStore:
+        async def get_total_cost_today(self) -> float:
+            raise RuntimeError("ledger down")
+
+    with pytest.raises(caller_budget.CallerBudgetUnavailable):
+        await caller_budget.enforce_local_daily_budget(BrokenStore())  # type: ignore[arg-type]
+
+
+def test_transport_security_enabled_on_main_server() -> None:
+    from unigrok_public import server
+
+    settings = server.mcp.settings.transport_security
+    assert settings is not None
+    assert settings.enable_dns_rebinding_protection is True
+    assert "localhost" in settings.allowed_hosts
+    assert "127.0.0.1" in settings.allowed_hosts

--- a/tests/test_phase3_tools_srp.py
+++ b/tests/test_phase3_tools_srp.py
@@ -92,6 +92,10 @@ def test_media_validators():
         media.validated_media_url("http://example.com/a.png", "image_url")
     with pytest.raises(ValueError):
         media.validated_media_url("https://127.0.0.1/a.png", "image_url")
+    with pytest.raises(ValueError):
+        media.validated_media_url(
+            "https://metadata.google.internal/computeMetadata/v1/", "image_url"
+        )
     assert media.validated_image_count(3) == 3
     with pytest.raises(ValueError):
         media.validated_image_count(0)

--- a/tests/test_public_boundary.py
+++ b/tests/test_public_boundary.py
@@ -480,8 +480,16 @@ def test_client_onboarding_detection_and_safe_non_filesystem_fallback() -> None:
     before = hooks["entry"]["hooks"]["beforeMCPExecution"][0]
     assert before["matcher"] == "agent"
     assert "~/.cursor/hooks/before-unigrok-agent.py" in rule_paths
-    # The hook auto-allows the agent tool and defers (ask) on anything else.
+    # The hook auto-allows agent / agent_result and asks on empty or other tools.
     assert '"allow"' in server.CURSOR_AGENT_HOOK and '"ask"' in server.CURSOR_AGENT_HOOK
+    assert "if not tool:" in server.CURSOR_AGENT_HOOK
+
+    safe = server._client_onboarding_plan("cursor", "global", safe_mode=True)
+    assert safe["safe_mode"] is True
+    assert safe.get("hooks") is None
+    assert not any(
+        item["path"].endswith("before-unigrok-agent.py") for item in safe["files"]
+    )
 
 
 @pytest.mark.asyncio
@@ -1275,6 +1283,8 @@ def test_local_and_unsafe_media_urls_are_rejected() -> None:
         "file:///private/secret.png",
         "http://localhost/a.png",
         "https://127.0.0.1/a.png",
+        "https://metadata.google.internal/computeMetadata/v1/",
+        "https://something.internal/path.png",
     ):
         with pytest.raises(ValueError, match="public https URL"):
             server._validated_media_url(value, "image_url")
@@ -1282,6 +1292,20 @@ def test_local_and_unsafe_media_urls_are_rejected() -> None:
         server._validated_media_url("https://images.example.com/a.png", "image_url")
         == "https://images.example.com/a.png"
     )
+
+
+def test_media_url_rejects_dns_rebinding_to_private(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_getaddrinfo(host: str, *args: object, **kwargs: object):
+        assert host == "evil.example"
+        return [
+            (0, 0, 0, "", ("127.0.0.1", 0)),
+        ]
+
+    monkeypatch.setattr(server.media_tools.socket, "getaddrinfo", fake_getaddrinfo)
+    with pytest.raises(ValueError, match="public https URL"):
+        server._validated_media_url("https://evil.example/a.png", "image_url")
 
 
 @pytest.mark.asyncio
@@ -1348,6 +1372,11 @@ def test_per_client_auto_approve_uses_native_mechanism() -> None:
         "mcp(grok/agent_result)",
     ]
     assert ag["gemini_cli_alternative"]["entry"]["mcpServers"]["grok"]["trust"] is True
+    assert "WARNING" in ag["gemini_cli_alternative"]["note"]
+    assert ag["gemini_cli_alternative"]["whole_server_trust"] is True
+    safe_ag = server._client_onboarding_plan("antigravity", "global", safe_mode=True)
+    assert "auto_approve" not in safe_ag
+    assert safe_ag["safe_mode"] is True
     ag_proj = server._auto_approve("antigravity", "project")
     assert ag_proj["target"] == ".gemini/settings.json"
     assert ag_proj["entry"]["globalPermissionGrants"]["allow"] == [

--- a/tests/test_remote_boundary.py
+++ b/tests/test_remote_boundary.py
@@ -877,3 +877,71 @@ async def test_service_token_works_alongside_oauth(
     payload = json.loads(response_body)
     assert payload["auth"] == "service_token"
     assert payload["principal"] == "service:github-copilot"
+
+
+def test_local_mcp_token_is_opt_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("UNIGROK_RUNTIME", raising=False)
+    monkeypatch.delenv("UNIGROK_LOCAL_MCP_TOKEN", raising=False)
+    monkeypatch.delenv("UNIGROK_LOCAL_MCP_TOKEN_SHA256", raising=False)
+    monkeypatch.delenv("UNIGROK_SERVICE_TOKENS", raising=False)
+    monkeypatch.delenv("UNIGROK_SERVICE_TOKEN_SHA256", raising=False)
+    monkeypatch.delenv("UNIGROK_OAUTH_INTROSPECTION_URL", raising=False)
+    assert remote_auth.local_mcp_token_configured() is False
+    assert remote_auth.auth_enforcement_active() is False
+
+
+@pytest.mark.asyncio
+async def test_local_mcp_token_denies_anonymous_and_accepts_bearer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = "local-loopback-token-aaaaaaaaaaaaaaaaaaaaaa"  # noqa: S105
+    monkeypatch.delenv("UNIGROK_RUNTIME", raising=False)
+    monkeypatch.delenv("UNIGROK_OAUTH_INTROSPECTION_URL", raising=False)
+    monkeypatch.delenv("UNIGROK_SERVICE_TOKENS", raising=False)
+    monkeypatch.setenv("UNIGROK_LOCAL_MCP_TOKEN", token)
+
+    async def app(scope: dict[str, Any], receive: Any, send: Any) -> None:
+        response = JSONResponse(
+            {
+                "principal": (scope.get("unigrok.oauth") or {}).get("unigrok_principal"),
+                "auth": (scope.get("unigrok.oauth") or {}).get("unigrok_auth"),
+            }
+        )
+        await response(scope, receive, send)
+
+    body = b'{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+    denied_status, _denied_headers, denied_body = await _asgi_exchange(
+        remote_auth.RemoteOAuthMiddleware(app),
+        path="/mcp",
+        method="POST",
+        body_chunks=(body,),
+    )
+    assert denied_status == 401
+    assert json.loads(denied_body) == {"error": "unauthorized"}
+
+    ok_status, _ok_headers, ok_body = await _asgi_exchange(
+        remote_auth.RemoteOAuthMiddleware(app),
+        path="/mcp",
+        method="POST",
+        body_chunks=(body,),
+        headers=((b"authorization", f"Bearer {token}".encode()),),
+    )
+    assert ok_status == 200
+    payload = json.loads(ok_body)
+    assert payload["auth"] == "local_mcp_token"
+    assert payload["principal"] == "local:operator"
+
+    # Health stays public even when the local token is configured.
+    health_status, _h, _b = await _asgi_exchange(
+        remote_auth.RemoteOAuthMiddleware(app),
+        path="/healthz",
+        method="GET",
+    )
+    assert health_status == 200
+
+
+def test_local_mcp_token_ignored_on_cloudrun(monkeypatch: pytest.MonkeyPatch) -> None:
+    token = "local-loopback-token-bbbbbbbbbbbbbbbbbbbbbb"  # noqa: S105
+    monkeypatch.setenv("UNIGROK_RUNTIME", "cloudrun")
+    monkeypatch.setenv("UNIGROK_LOCAL_MCP_TOKEN", token)
+    assert remote_auth.match_local_mcp_token(token) is None

--- a/tests/test_remote_boundary.py
+++ b/tests/test_remote_boundary.py
@@ -63,6 +63,7 @@ async def _asgi_exchange(
     method: str = "GET",
     body_chunks: tuple[bytes, ...] = (b"",),
     headers: tuple[tuple[bytes, bytes], ...] = (),
+    client: tuple[str, int] = ("203.0.113.10", 4444),
 ) -> tuple[int, dict[str, str], bytes]:
     requests = [
         {
@@ -97,7 +98,7 @@ async def _asgi_exchange(
             "raw_path": path.encode(),
             "query_string": b"",
             "headers": list(headers),
-            "client": ("203.0.113.10", 4444),
+            "client": client,
             "server": ("mcp.example.test", 443),
         },
         receive,
@@ -898,7 +899,9 @@ async def test_local_mcp_token_denies_anonymous_and_accepts_bearer(
     monkeypatch.delenv("UNIGROK_RUNTIME", raising=False)
     monkeypatch.delenv("UNIGROK_OAUTH_INTROSPECTION_URL", raising=False)
     monkeypatch.delenv("UNIGROK_SERVICE_TOKENS", raising=False)
+    monkeypatch.delenv("UNIGROK_TRUST_PROXY", raising=False)
     monkeypatch.setenv("UNIGROK_LOCAL_MCP_TOKEN", token)
+    remote_auth._auth_failures.clear()
 
     async def app(scope: dict[str, Any], receive: Any, send: Any) -> None:
         response = JSONResponse(
@@ -910,11 +913,13 @@ async def test_local_mcp_token_denies_anonymous_and_accepts_bearer(
         await response(scope, receive, send)
 
     body = b'{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+    loopback = ("127.0.0.1", 54321)
     denied_status, _denied_headers, denied_body = await _asgi_exchange(
         remote_auth.RemoteOAuthMiddleware(app),
         path="/mcp",
         method="POST",
         body_chunks=(body,),
+        client=loopback,
     )
     assert denied_status == 401
     assert json.loads(denied_body) == {"error": "unauthorized"}
@@ -925,17 +930,46 @@ async def test_local_mcp_token_denies_anonymous_and_accepts_bearer(
         method="POST",
         body_chunks=(body,),
         headers=((b"authorization", f"Bearer {token}".encode()),),
+        client=loopback,
     )
     assert ok_status == 200
     payload = json.loads(ok_body)
     assert payload["auth"] == "local_mcp_token"
     assert payload["principal"] == "local:operator"
 
+    # Valid token from a non-loopback peer is rejected.
+    remote_status, _rh, remote_body = await _asgi_exchange(
+        remote_auth.RemoteOAuthMiddleware(app),
+        path="/mcp",
+        method="POST",
+        body_chunks=(body,),
+        headers=((b"authorization", f"Bearer {token}".encode()),),
+        client=("203.0.113.10", 4444),
+    )
+    assert remote_status == 401
+    assert json.loads(remote_body) == {"error": "unauthorized"}
+
+    # Forwarded headers without UNIGROK_TRUST_PROXY also deny loopback peers.
+    forwarded_status, _fh, forwarded_body = await _asgi_exchange(
+        remote_auth.RemoteOAuthMiddleware(app),
+        path="/mcp",
+        method="POST",
+        body_chunks=(body,),
+        headers=(
+            (b"authorization", f"Bearer {token}".encode()),
+            (b"x-forwarded-for", b"203.0.113.10"),
+        ),
+        client=loopback,
+    )
+    assert forwarded_status == 401
+    assert json.loads(forwarded_body) == {"error": "unauthorized"}
+
     # Health stays public even when the local token is configured.
     health_status, _h, _b = await _asgi_exchange(
         remote_auth.RemoteOAuthMiddleware(app),
         path="/healthz",
         method="GET",
+        client=loopback,
     )
     assert health_status == 200
 
@@ -945,3 +979,39 @@ def test_local_mcp_token_ignored_on_cloudrun(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setenv("UNIGROK_RUNTIME", "cloudrun")
     monkeypatch.setenv("UNIGROK_LOCAL_MCP_TOKEN", token)
     assert remote_auth.match_local_mcp_token(token) is None
+
+
+def test_local_mcp_request_allowed_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("UNIGROK_TRUST_PROXY", raising=False)
+    assert remote_auth.local_mcp_request_allowed(
+        {"client": ("127.0.0.1", 1), "headers": []}
+    )
+    # Docker bridge peer + loopback Host (Compose port-publish path).
+    assert remote_auth.local_mcp_request_allowed(
+        {
+            "client": ("172.18.0.1", 1),
+            "headers": [(b"host", b"localhost:4765")],
+        }
+    )
+    assert not remote_auth.local_mcp_request_allowed(
+        {"client": ("203.0.113.10", 1), "headers": [(b"host", b"localhost:4765")]}
+    )
+    assert not remote_auth.local_mcp_request_allowed(
+        {
+            "client": ("172.18.0.1", 1),
+            "headers": [(b"host", b"evil.example")],
+        }
+    )
+    assert not remote_auth.local_mcp_request_allowed(
+        {
+            "client": ("127.0.0.1", 1),
+            "headers": [(b"x-forwarded-for", b"1.2.3.4")],
+        }
+    )
+    monkeypatch.setenv("UNIGROK_TRUST_PROXY", "true")
+    assert remote_auth.local_mcp_request_allowed(
+        {
+            "client": ("127.0.0.1", 1),
+            "headers": [(b"x-forwarded-for", b"1.2.3.4")],
+        }
+    )


### PR DESCRIPTION
## Summary
- Opt-in local MCP token (`UNIGROK_LOCAL_MCP_TOKEN` / `_SHA256`) with loopback-shaped peer checks, forwarded-header rejection, and auth-failure rate limiting
- Host DNS-rebinding protection on main FastMCP; tighter media URL policy (`.internal` + private DNS answers)
- Local daily spend ceiling (`UNIGROK_LOCAL_DAILY_BUDGET_USD`), safer default level `high`, and safer onboarding (`safe_mode`, no empty-tool auto-allow)

## Test plan
- [x] `ruff check .`
- [x] `pytest -q --ignore=tests/test_insider_denylist.py` (600 passed; denylist fails are Windows/WSL env, not this change)
- [x] Compose rebuild; `/readyz` and `/healthz` return 200
- [ ] Confirm Cursor still connects with unset local token (opt-in)
- [ ] Optional: set `UNIGROK_LOCAL_MCP_TOKEN` and verify Bearer required in `~/.cursor/mcp.json`
