### PR TITLE
fix: show uncommitted draft on continue envelopes

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -59,8 +59,11 @@ instance-local.
 ## Handling the response
 
 Every `agent` and metered-tool result is a **status envelope** — branch on `status`
-before reading `text`. On any non-`complete` result, `text` is a progress/status
-message, not the answer.
+before reading `text`. On `pending`, `error`, and `lost`, `text` is status or failure
+information. On `continue`, hosts that render only `text` may receive the uncommitted
+`proposed_text` draft first, followed by `[continue · not committed]` and the status
+note. That draft is never final: callers must still follow `continue_token`, `gaps`, and
+`committed: false`.
 
 | `status` | Meaning | What the caller must do |
 |----------|---------|-------------------------|

--- a/src/unigrok_public/autonomy.py
+++ b/src/unigrok_public/autonomy.py
@@ -208,6 +208,36 @@ def ledger_summary(events: list[dict[str, Any]], *, limit: int = 12) -> str:
     return "\n".join(lines)
 
 
+_CONTINUE_DRAFT_MARKER = "[continue · not committed]"
+
+
+def host_visible_continue_text(proposed_text: object, status_text: object) -> str:
+    cream = str(proposed_text or "").strip()
+    status = str(status_text or "").strip()
+    if not cream:
+        return status
+    footer = _CONTINUE_DRAFT_MARKER
+    if status:
+        footer = f"{footer}\n{status}"
+    return f"{cream}\n\n{footer}"
+
+
+def apply_continue_cream(
+    envelope: dict[str, object], proposed_text: object
+) -> dict[str, object]:
+    result = dict(envelope)
+    if str(result.get("status") or "").strip().casefold() != "continue":
+        return result
+    cream = str(proposed_text or "").strip()
+    if not cream:
+        return result
+    status_text = str(result.get("status_text") or result.get("text") or "").strip()
+    result["proposed_text"] = cream
+    result["status_text"] = status_text
+    result["text"] = host_visible_continue_text(cream, status_text)
+    return result
+
+
 def continue_envelope(
     *,
     job_id: str,

--- a/src/unigrok_public/mission/epoch.py
+++ b/src/unigrok_public/mission/epoch.py
@@ -6,7 +6,7 @@ import contextlib
 import math
 from typing import Any
 
-from unigrok_public.autonomy import continue_envelope
+from unigrok_public.autonomy import apply_continue_cream, continue_envelope
 
 from .artifacts import artifact_projection, sealed_content_hash
 from .evidence import default_agent_policy
@@ -653,7 +653,7 @@ async def seal_mission_epoch(
             text="Mission lease lost before verifying; re-invoke continue_token.",
             poll=False,
         )
-        sealed["proposed_text"] = projection
+        sealed = apply_continue_cream(sealed, projection)
         sealed["mission"] = {"status": fresh.get("status"), "lease_lost": True}
         return _apply_mission_billing(sealed, fresh_billing)
 
@@ -681,7 +681,7 @@ async def seal_mission_epoch(
             text="Mission lease lost while binding the envelope; re-invoke continue_token.",
             poll=False,
         )
-        sealed["proposed_text"] = projection
+        sealed = apply_continue_cream(sealed, projection)
         sealed["mission"] = {
             "status": current.get("status"),
             "lease_lost": True,
@@ -723,7 +723,7 @@ async def seal_mission_epoch(
             artifact_refs=[projection_digest],
             poll=False,
         )
-        sealed["proposed_text"] = projection
+        sealed = apply_continue_cream(sealed, projection)
         sealed["mission"] = {
             "protocol": "unigrok_mission_v2",
             "status": refreshed.get("status"),
@@ -793,7 +793,7 @@ async def seal_mission_epoch(
             text="Mission lease lost during verifying; re-invoke continue_token.",
             poll=False,
         )
-        sealed["proposed_text"] = projection
+        sealed = apply_continue_cream(sealed, projection)
         sealed["mission"] = {
             "status": pre_commit.get("status"),
             "lease_lost": True,
@@ -913,7 +913,7 @@ async def seal_mission_epoch(
                 ),
                 poll=False,
             )
-            sealed["proposed_text"] = projection
+            sealed = apply_continue_cream(sealed, projection)
             sealed["mission"] = {
                 "protocol": "unigrok_mission_v2",
                 "status": str(current.get("status") or ""),
@@ -1018,7 +1018,7 @@ async def seal_mission_epoch(
     ):
         if key in result:
             sealed[key] = result[key]
-    sealed["proposed_text"] = projection
+    sealed = apply_continue_cream(sealed, projection)
     sealed["mission"] = {
         "protocol": "unigrok_mission_v2",
         "status": str((cursor_row or {}).get("status") or MissionStatus.WAITING_EVENT.value),

--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -34,6 +34,7 @@ from .autonomy import (
     JOB_NEEDS_CONTINUATION,
     TERMINAL_JOB_STATUSES,
     acceptance_hash,
+    apply_continue_cream,
     artifact_hash,
     check_propose_done,
     continue_envelope,
@@ -3714,7 +3715,7 @@ async def _seal_autonomy_done(
     ):
         if key in result:
             sealed[key] = result[key]
-    sealed["proposed_text"] = answer
+    sealed = apply_continue_cream(sealed, answer)
     sealed["autonomy"]["check"] = check
     return sealed
 

--- a/src/unigrok_public/state.py
+++ b/src/unigrok_public/state.py
@@ -120,8 +120,18 @@ def _durable_agent_payload(payload: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(safe, dict):
         return {}
     mission = safe.get("mission")
-    if isinstance(mission, dict) and mission.get("protocol") == "unigrok_mission_v2":
-        for field in ("text", "proposed_text", "review"):
+    autonomy = safe.get("autonomy")
+    mission_payload = (
+        isinstance(mission, dict)
+        and mission.get("protocol") == "unigrok_mission_v2"
+    )
+    legacy_continue = (
+        safe.get("status") == "continue"
+        and isinstance(autonomy, dict)
+        and autonomy.get("protocol") == "unigrok_continue_v1"
+    )
+    if mission_payload or legacy_continue:
+        for field in ("text", "proposed_text", "status_text", "review"):
             if field in safe:
                 safe[field] = bounded_redacted_text(safe[field])
     return safe

--- a/tests/test_continue_cream.py
+++ b/tests/test_continue_cream.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import pytest
+
+from unigrok_public import autonomy, server, state
+from unigrok_public.state import PublicStateStore
+
+
+def test_continue_cream_is_host_visible_but_not_committed() -> None:
+    envelope = autonomy.continue_envelope(
+        job_id="job-cream",
+        continue_token="a" * 32,
+        ledger_cursor=4,
+        acceptance_hash_value="b" * 64,
+        gaps=["missing_checklist"],
+        text="Verifier rejected CommitDone.",
+        poll=False,
+    )
+    result = autonomy.apply_continue_cream(envelope, "Draft answer")
+
+    assert result["status"] == "continue"
+    assert result["autonomy"]["committed"] is False
+    assert result["proposed_text"] == "Draft answer"
+    assert result["status_text"] == "Verifier rejected CommitDone."
+    assert result["text"] == (
+        "Draft answer\n\n[continue · not committed]\n"
+        "Verifier rejected CommitDone."
+    )
+
+
+def test_continue_cream_does_not_relabel_terminal_payloads() -> None:
+    payload = {
+        "status": "error",
+        "text": "Terminal mission failure.",
+        "autonomy": {
+            "protocol": "unigrok_continue_v1",
+            "committed": False,
+        },
+    }
+
+    assert autonomy.apply_continue_cream(payload, "Rejected draft") == payload
+
+
+def test_empty_continue_cream_preserves_status_message() -> None:
+    envelope = autonomy.continue_envelope(
+        job_id="job-empty",
+        continue_token="c" * 32,
+        ledger_cursor=0,
+        acceptance_hash_value="d" * 64,
+        text="Continue later.",
+        poll=False,
+    )
+
+    assert autonomy.apply_continue_cream(envelope, "") == envelope
+    assert autonomy.host_visible_continue_text("", "Continue later.") == "Continue later."
+
+
+def test_legacy_continue_payload_is_redacted_and_bounded() -> None:
+    synthetic_marker = "xai-" + ("a" * 16)
+    large = synthetic_marker + ("x" * (state.DURABLE_TEXT_MAX_BYTES + 1024))
+    payload = {
+        "status": "continue",
+        "text": large,
+        "proposed_text": large,
+        "status_text": large,
+        "autonomy": {
+            "protocol": "unigrok_continue_v1",
+            "committed": False,
+        },
+    }
+
+    durable = state._durable_agent_payload(payload)
+
+    for field in ("text", "proposed_text", "status_text"):
+        value = durable[field]
+        assert synthetic_marker not in value
+        assert len(value.encode("utf-8")) <= state.DURABLE_TEXT_MAX_BYTES
+
+
+@pytest.mark.asyncio
+async def test_legacy_rejected_draft_is_cream_first_and_not_persisted(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    store = PublicStateStore(tmp_path / "cream-first.db")
+    monkeypatch.setattr(server, "STATE", store)
+    monkeypatch.setattr(server, "AUTONOMY_ENABLED", True)
+    monkeypatch.setattr(server, "MISSION_V2_ENABLED", False)
+
+    async def thin_turn(**_kwargs: object) -> dict:
+        return {
+            "text": "healthz",
+            "plane": "test",
+            "resolved_plane": "test",
+            "stop_reason": "EndTurn",
+            "workspace_attached": False,
+            "cost_usd": 0.0,
+            "orchestration": {},
+        }
+
+    monkeypatch.setattr(server, "_execute_team_turn", thin_turn)
+    result = await server.agent(
+        task="Return a checklist of deploy steps including healthz",
+        session="cream:first",
+    )
+
+    assert result["status"] == "continue"
+    assert result["autonomy"]["committed"] is False
+    assert result["proposed_text"] == "healthz"
+    assert result["text"].startswith(
+        "healthz\n\n[continue · not committed]\n"
+    )
+    assert "Acceptance checker rejected ProposeDone" in result["status_text"]
+    assert await store.load_messages("cream:first") == []

--- a/tests/test_continue_cream.py
+++ b/tests/test_continue_cream.py
@@ -28,6 +28,25 @@ def test_continue_cream_is_host_visible_but_not_committed() -> None:
     )
 
 
+def test_existing_status_text_remains_authoritative() -> None:
+    envelope = {
+        "status": "continue",
+        "text": "Fallback status.",
+        "status_text": "Canonical status.",
+        "autonomy": {
+            "protocol": "unigrok_continue_v1",
+            "committed": False,
+        },
+    }
+
+    result = autonomy.apply_continue_cream(envelope, "Draft answer")
+
+    assert result["status_text"] == "Canonical status."
+    assert result["text"] == (
+        "Draft answer\n\n[continue · not committed]\nCanonical status."
+    )
+
+
 def test_continue_cream_does_not_relabel_terminal_payloads() -> None:
     payload = {
         "status": "error",


### PR DESCRIPTION
## Status

Ready for protected review. The prior expanded branch was discarded because it mixed the original continue-envelope fix with unrelated routing, soft-continue, output-reordering, and polling behavior. The current branch is rebuilt from merged public `main` and contains only the focused envelope change.

## Focused behavior

When an autonomy result is genuinely `status=continue` and already has a non-empty draft:

- `proposed_text` remains the pure uncommitted draft
- primary `text` presents that draft first for hosts that render only `text`
- `[continue · not committed]` and the original status note follow the draft
- `status_text` preserves the canonical status note separately
- `status` remains `continue`, `committed` remains false, and session persistence remains CommitDone-gated

Terminal `complete` and `error` payloads are not rewritten. Legacy-autonomy continue payloads receive the same secret redaction and UTF-8 byte bound already applied to Mission V2 projections.

## Deliberately excluded

- pure-question agent short-circuiting
- soft-continue heuristics
- code/diff/artifact output reordering
- poll-contract changes
- empty CommitDone output rewriting

## Verification

Current head `ecee2db1378d833dbabfebf25b07c87e5837c3b9` passed normal CI run `30980811137`:

- Ruff
- insider denylist
- release and documentation contracts
- complete suite: **708 passed, 7 skipped, 1 existing deprecation warning**

Guarded publication run `30980575463` verified the identical product-code tree before the final test-only assertion was added:

- **41 focused continuation, mission, durable-state, and privacy tests**
- complete suite: **707 passed, 7 skipped**
- Docker image build
- installed-image continue-envelope and durable-redaction contract
- hardened live container and MCP initialization
- version `1.1.0` and exact **29-tool** catalog parity

The two prior Copilot findings are addressed and resolved: non-continue terminal payloads remain unchanged, and legacy continue drafts are bounded and redacted before durable storage.