### PR TITLE
[Completed] inspect media capacity delta from budget head

### DIFF
--- a/src/unigrok_public/tools/media.py
+++ b/src/unigrok_public/tools/media.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import contextlib
 import ipaddress
 import re
 import socket
@@ -138,15 +139,12 @@ async def _validate_resolved_target(
     target: _MediaTarget,
     field: str,
     resolver: MediaResolver,
-    timeout_seconds: float,
 ) -> None:
     if target.literal_address is not None:
         return
     try:
-        answers = await asyncio.wait_for(
-            resolver(target.host, target.port), timeout=timeout_seconds
-        )
-    except (OSError, TimeoutError, UnicodeError) as exc:
+        answers = await resolver(target.host, target.port)
+    except (OSError, UnicodeError) as exc:
         raise ValueError(f"{field} must be a public https URL") from exc
     if not answers:
         raise ValueError(f"{field} must be a public https URL")
@@ -156,6 +154,45 @@ async def _validate_resolved_target(
         raise ValueError(f"{field} must be a public https URL") from exc
     if any(not _is_public_address(address) for address in addresses):
         raise ValueError(f"{field} must be a public https URL")
+
+
+def _consume_media_dns_task(task: asyncio.Task[None]) -> None:
+    if task.cancelled():
+        return
+    with contextlib.suppress(Exception):
+        task.exception()
+
+
+async def _validate_target_with_slot(
+    target: _MediaTarget,
+    field: str,
+    resolver: MediaResolver,
+    limiter: asyncio.Semaphore,
+    timeout_seconds: float,
+) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout_seconds
+    try:
+        await asyncio.wait_for(limiter.acquire(), timeout=timeout_seconds)
+    except TimeoutError as exc:
+        raise ValueError(f"{field} must be a public https URL") from exc
+    remaining = deadline - loop.time()
+    if remaining <= 0:
+        limiter.release()
+        raise ValueError(f"{field} must be a public https URL")
+
+    async def resolve_and_release() -> None:
+        try:
+            await _validate_resolved_target(target, field, resolver)
+        finally:
+            limiter.release()
+
+    worker = asyncio.create_task(resolve_and_release())
+    worker.add_done_callback(_consume_media_dns_task)
+    try:
+        await asyncio.wait_for(asyncio.shield(worker), timeout=remaining)
+    except TimeoutError as exc:
+        raise ValueError(f"{field} must be a public https URL") from exc
 
 
 async def validated_public_media_urls(
@@ -181,10 +218,9 @@ async def validated_public_media_urls(
         limiter = _media_dns_limiter()
 
         async def validate(target: _MediaTarget) -> None:
-            async with limiter:
-                await _validate_resolved_target(
-                    target, field, active_resolver, timeout_seconds
-                )
+            await _validate_target_with_slot(
+                target, field, active_resolver, limiter, timeout_seconds
+            )
 
         async def validate_all() -> None:
             tasks = [

--- a/tests/test_media_url_boundary.py
+++ b/tests/test_media_url_boundary.py
@@ -125,9 +125,10 @@ async def test_media_dns_concurrency_is_bounded_across_requests() -> None:
 
 
 @pytest.mark.asyncio
-async def test_media_dns_failure_cancels_sibling_resolutions() -> None:
+async def test_media_dns_failure_preserves_active_sibling_slot() -> None:
     slow_started = asyncio.Event()
-    slow_cancelled = asyncio.Event()
+    slow_release = asyncio.Event()
+    slow_finished = asyncio.Event()
 
     async def resolver(host: str, _port: int) -> Sequence[str]:
         if host == "private.example.com":
@@ -135,11 +136,10 @@ async def test_media_dns_failure_cancels_sibling_resolutions() -> None:
             return ["127.0.0.1"]
         slow_started.set()
         try:
-            await asyncio.sleep(10)
-        except asyncio.CancelledError:
-            slow_cancelled.set()
-            raise
-        return ["93.184.216.34"]
+            await slow_release.wait()
+            return ["93.184.216.34"]
+        finally:
+            slow_finished.set()
 
     with pytest.raises(ValueError, match="public https URL"):
         await media.validated_public_media_urls(
@@ -151,7 +151,70 @@ async def test_media_dns_failure_cancels_sibling_resolutions() -> None:
             10,
             resolver=resolver,
         )
-    assert slow_cancelled.is_set()
+    assert not slow_finished.is_set()
+    slow_release.set()
+    await asyncio.wait_for(slow_finished.wait(), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_media_dns_timeout_retains_slots_until_resolver_work_finishes() -> None:
+    release = asyncio.Event()
+    all_started = asyncio.Event()
+    active = 0
+    started = 0
+
+    async def stalled(_host: str, _port: int) -> Sequence[str]:
+        nonlocal active, started
+        active += 1
+        started += 1
+        if started == media.MEDIA_DNS_CONCURRENCY:
+            all_started.set()
+        try:
+            await release.wait()
+            return ["93.184.216.34"]
+        finally:
+            active -= 1
+
+    requests = [
+        asyncio.create_task(
+            media.validated_public_media_url(
+                f"https://stalled-{index}.example.com/a.png",
+                "image_url",
+                resolver=stalled,
+                timeout_seconds=0.02,
+                total_timeout_seconds=0.1,
+            )
+        )
+        for index in range(media.MEDIA_DNS_CONCURRENCY)
+    ]
+    await asyncio.wait_for(all_started.wait(), timeout=1)
+    results = await asyncio.gather(*requests, return_exceptions=True)
+    assert all(isinstance(result, ValueError) for result in results)
+    assert active == media.MEDIA_DNS_CONCURRENCY
+
+    fifth_called = False
+
+    async def fifth(_host: str, _port: int) -> Sequence[str]:
+        nonlocal fifth_called
+        fifth_called = True
+        return ["93.184.216.34"]
+
+    with pytest.raises(ValueError, match="public https URL"):
+        await media.validated_public_media_url(
+            "https://fifth.example.com/a.png",
+            "image_url",
+            resolver=fifth,
+            timeout_seconds=0.02,
+            total_timeout_seconds=0.1,
+        )
+    assert fifth_called is False
+
+    release.set()
+    for _ in range(100):
+        if active == 0:
+            break
+        await asyncio.sleep(0.01)
+    assert active == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Temporary read-only comparison from the verified budget head to the current media-capacity staging tree. This PR will not be merged and exists only to extract the exact independently authored media source/test delta before clean publication.