### PR TITLE
feat(public): Ground pack, contributor auth, day-1 scope (no Forge/Sky)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,23 @@ Anyone can clone, run, and open a pull request. After you authenticate with GitH
 (locally or on the website), install the **GroundCommand pack** so your IDE can
 orchestrate multi-step UniGrok work the same way maintainers do.
 
+## What day-1 access includes (and does not)
+
+| You get after GitHub auth + Core + onboard | You do **not** get automatically |
+|--------------------------------------------|----------------------------------|
+| UniGrok Core on `localhost:4765` | Forge Docker / a second labor seat |
+| GroundCommand pack (`using-unigrok` + `mission-brief-harness`) | SkyCommand / Space Docker nodes |
+| Optional soft `affiliation` if you are an official collaborator | Private operator skills, CoC maps, or training pipelines |
+| Mission Briefs with host-as-orchestrator | Auto-install of anyone’s full `.agents/skills` tree |
+
+**Rule:** GroundCommand is the **safe valuable start**. Heavier, private, or multi-node
+capacity is granted **later** by a maintainer when (and only if) you run an approved
+**Sky-class node** under their map — not because you installed the public pack.
+
+Public skill cream still lands only through normal product review (PR + maintainer
+gate). Practice on Ground → densify findings → PR; do not expect Forge folders to
+mirror into your IDE.
+
 ## After GitHub auth → install GroundCommand
 
 Do this once per machine (or after a clean IDE profile).
@@ -94,6 +111,14 @@ not a secret vault. Service env for operators is documented in the README under
 Put a short **Mission Brief** in `agent`’s `task` (goal, options, constraints, done-when,
 return shape). Prefer densified returns: WHAT / WHY / DELTA / NEXT. Details live in
 skill `mission-brief-harness` and README “Multi-step agentic work (Ground pack)”.
+
+### F. Later: Sky-class node (maintainer grant only)
+
+If a maintainer invites you to operate a **Sky-class node** on your own machine, they
+will issue that access separately (Docker map, keys, and any optional labor seats such
+as Forge). That grant is **not** part of this pack, not part of website GitHub login
+alone, and not implied by `grok_mcp_onboard_client`. Until then, stay on Core +
+GroundCommand + normal git PRs.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,27 +1,27 @@
 # Contributing to UniGrok Public
 
 Anyone can clone, run, and open a pull request. After you authenticate with GitHub
-(locally or on the website), install the **GroundCommand pack** so your IDE can
+(locally or on the website), install the **public Ground pack** so your IDE can
 orchestrate multi-step UniGrok work the same way maintainers do.
 
 ## What day-1 access includes (and does not)
 
 | You get after GitHub auth + Core + onboard | You do **not** get automatically |
 |--------------------------------------------|----------------------------------|
-| UniGrok Core on `localhost:4765` | Forge Docker / a second labor seat |
-| GroundCommand pack (`using-unigrok` + `mission-brief-harness`) | SkyCommand / Space Docker nodes |
-| Optional soft `affiliation` if you are an official collaborator | Private operator skills, CoC maps, or training pipelines |
-| Mission Briefs with host-as-orchestrator | Auto-install of anyone’s full `.agents/skills` tree |
+| UniGrok Core on `localhost:4765` | A second labor Docker seat (e.g. forge-style) |
+| Public Ground pack (`using-unigrok` + `mission-brief-harness`) | Extra operator Docker nodes beyond Core |
+| Optional soft `affiliation` if you are an official collaborator | Private operator skills or training pipelines |
+| Mission Briefs with host-as-orchestrator | Auto-install of anyone’s full skill tree |
 
-**Rule:** GroundCommand is the **safe valuable start**. Heavier, private, or multi-node
-capacity is granted **later** by a maintainer when (and only if) you run an approved
-**Sky-class node** under their map — not because you installed the public pack.
+**Rule:** the public Ground pack is the **safe valuable start**. Heavier, private, or
+multi-node capacity is granted **later** by a maintainer when (and only if) you run an
+approved **extra node** under their map — not because you installed the public pack.
 
 Public skill cream still lands only through normal product review (PR + maintainer
-gate). Practice on Ground → densify findings → PR; do not expect Forge folders to
-mirror into your IDE.
+gate). Practice on Ground → densify findings → PR; do not expect private labor folders
+to mirror into your IDE.
 
-## After GitHub auth → install GroundCommand
+## After GitHub auth → install the public Ground pack
 
 Do this once per machine (or after a clean IDE profile).
 
@@ -57,10 +57,10 @@ curl --fail --silent http://localhost:4765/readyz
 Connect your IDE to `http://localhost:4765/mcp` (stable `X-Client-ID` per IDE).
 Optional local bearer: see README “Optional local bearer protection”.
 
-### C. Install the GroundCommand pack (skills)
+### C. Install the public Ground pack (skills)
 
-GroundCommand here means the **public Ground pack**: your IDE stays the orchestrator;
-UniGrok `agent` is leaf labor. The pack is two skills:
+The **public Ground pack** means: your IDE stays the orchestrator; UniGrok `agent` is
+leaf labor. The pack is two skills:
 
 | Skill | Role |
 |-------|------|
@@ -106,19 +106,19 @@ Look for `affiliation.is_official_contributor` (true/false/null). That is soft U
 not a secret vault. Service env for operators is documented in the README under
 “Official GitHub contributors”.
 
-### E. First multi-step task (GroundCommand in practice)
+### E. First multi-step task (Ground pack in practice)
 
 Put a short **Mission Brief** in `agent`’s `task` (goal, options, constraints, done-when,
 return shape). Prefer densified returns: WHAT / WHY / DELTA / NEXT. Details live in
 skill `mission-brief-harness` and README “Multi-step agentic work (Ground pack)”.
 
-### F. Later: Sky-class node (maintainer grant only)
+### F. Later: extra operator node (maintainer grant only)
 
-If a maintainer invites you to operate a **Sky-class node** on your own machine, they
-will issue that access separately (Docker map, keys, and any optional labor seats such
-as Forge). That grant is **not** part of this pack, not part of website GitHub login
-alone, and not implied by `grok_mcp_onboard_client`. Until then, stay on Core +
-GroundCommand + normal git PRs.
+If a maintainer invites you to operate an **extra node** on your own machine, they will
+issue that access separately (Docker map, keys, and any optional labor seats). That
+grant is **not** part of this pack, not part of website GitHub login alone, and not
+implied by `grok_mcp_onboard_client`. Until then, stay on Core + public Ground pack +
+normal git PRs.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,102 @@
 # Contributing to UniGrok Public
 
+Anyone can clone, run, and open a pull request. After you authenticate with GitHub
+(locally or on the website), install the **GroundCommand pack** so your IDE can
+orchestrate multi-step UniGrok work the same way maintainers do.
+
+## After GitHub auth → install GroundCommand
+
+Do this once per machine (or after a clean IDE profile).
+
+### A. Authenticate with GitHub
+
+**Website (contributor control center)**
+
+1. Open [Contribute](https://grokmcp.org/contribute) (or your deployed site’s `/contribute`).
+2. Sign in with GitHub at [control.grokmcp.org](https://control.grokmcp.org).
+3. Access is rechecked against your GitHub role on this repository — no xAI keys on the site.
+
+**Local (git + GitHub CLI)**
+
+```bash
+# one-time (or when your token expires)
+gh auth login
+# confirm the login that will appear on PRs / collaborator checks
+gh api user --jq .login
+```
+
+Use that same GitHub login for branch names and collaborator invites. Do not put
+personal PATs into IDE MCP JSON.
+
+### B. Run UniGrok Core on this machine
+
+Follow the README “Get running in three minutes” path, then confirm readiness:
+
+```bash
+docker compose up -d grok-mcp
+curl --fail --silent http://localhost:4765/readyz
+```
+
+Connect your IDE to `http://localhost:4765/mcp` (stable `X-Client-ID` per IDE).
+Optional local bearer: see README “Optional local bearer protection”.
+
+### C. Install the GroundCommand pack (skills)
+
+GroundCommand here means the **public Ground pack**: your IDE stays the orchestrator;
+UniGrok `agent` is leaf labor. The pack is two skills:
+
+| Skill | Role |
+|-------|------|
+| `using-unigrok` | How to call `@grok` / `agent` safely |
+| `mission-brief-harness` | Mission Brief template, try ≤3 loop, offline free path |
+
+**From any connected IDE** (Claude Code, Cursor, Codex, Antigravity, Copilot, etc.):
+
+1. Ensure the UniGrok MCP server is connected.
+2. Call the tool **`grok_mcp_onboard_client`** (or accept the first-use offer).
+3. Choose **`global`** (recommended) so skills land in your IDE user scope — not every repo.
+4. Let the IDE preview files, approve the writes, then **reload** the session.
+5. Confirm skills exist: `using-unigrok` and `mission-brief-harness`.
+
+Example tool call when elicitation is not available:
+
+```text
+grok_mcp_onboard_client
+  client: auto   # or claude_code | cursor | codex | antigravity | github_copilot | generic
+  choice: global
+```
+
+**What “installed” looks like**
+
+- Claude Code: `~/.claude/skills/using-unigrok/` and `…/mission-brief-harness/`
+- Codex: `~/.codex/skills/using-unigrok/` (and companion)
+- Cursor / others: paths returned in the onboard plan — follow the IDE’s preview
+
+UniGrok never writes those files itself; the **calling IDE** installs after you approve.
+
+### D. Optional: confirm contributor affiliation
+
+If maintainers configured official-contributor detection on the service, after you are
+authenticated as a GitHub collaborator (or on the allowlist):
+
+```text
+grok_mcp_status
+# or
+grok_mcp_discover_self
+```
+
+Look for `affiliation.is_official_contributor` (true/false/null). That is soft UX only —
+not a secret vault. Service env for operators is documented in the README under
+“Official GitHub contributors”.
+
+### E. First multi-step task (GroundCommand in practice)
+
+Put a short **Mission Brief** in `agent`’s `task` (goal, options, constraints, done-when,
+return shape). Prefer densified returns: WHAT / WHY / DELTA / NEXT. Details live in
+skill `mission-brief-harness` and README “Multi-step agentic work (Ground pack)”.
+
+---
+
 ## Local checks
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ See [Local model routes](docs/offline-local-helper.md). Relay `resolved_plane` a
 receipts; disable web/X tools for true offline briefs; fail closed for cloud-only media.
 
 After onboarding, see skills `using-unigrok` and `mission-brief-harness` (installed by
-`grok_mcp_onboard_client` with consent).
+`grok_mcp_onboard_client` with consent). **Contributors:** after GitHub auth (website or
+local `gh auth login`), install that GroundCommand pack once — step-by-step in
+[CONTRIBUTING.md](CONTRIBUTING.md#after-github-auth--install-groundcommand).
 
 ### Official GitHub contributors (optional)
 
@@ -323,6 +325,7 @@ See [SECURITY.md](SECURITY.md) for the complete public runtime boundary.
 | See every tool and routing rule | [Technical reference](docs/reference.md) |
 | Use the integrated local route or named local helper | [Local model routes](docs/offline-local-helper.md) |
 | Drive `agent` from an IDE agent | [Technical reference](docs/reference.md#how-an-ide-agent-should-drive-agent) |
+| Auth with GitHub, then install GroundCommand | [Contributing](CONTRIBUTING.md#after-github-auth--install-groundcommand) |
 | Develop or acceptance-test UniGrok | [Development guide](docs/development.md) |
 | See what has limited soak and how to report a miss | [Known limits](docs/known-limits.md) |
 | See what changed between versions | [Changelog](CHANGELOG.md) |

--- a/README.md
+++ b/README.md
@@ -114,10 +114,11 @@ receipts; disable web/X tools for true offline briefs; fail closed for cloud-onl
 
 After onboarding, see skills `using-unigrok` and `mission-brief-harness` (installed by
 `grok_mcp_onboard_client` with consent). **Contributors:** after GitHub auth (website or
-local `gh auth login`), install that GroundCommand pack once — step-by-step in
-[CONTRIBUTING.md](CONTRIBUTING.md#after-github-auth--install-groundcommand). Day-1 is
-**Core + Ground pack only** (not Forge Docker, not Sky/Space nodes). Heavier capacity
-is a separate maintainer grant when someone runs an approved Sky-class node.
+local `gh auth login`), install that public Ground pack once — step-by-step in
+[CONTRIBUTING.md](CONTRIBUTING.md#after-github-auth--install-the-public-ground-pack).
+Day-1 is **Core + Ground pack only** (not a second labor Docker seat, not extra
+operator nodes). Heavier capacity is a separate maintainer grant when someone runs an
+approved extra node under their map.
 
 ### Official GitHub contributors (optional)
 
@@ -132,7 +133,7 @@ export UNIGROK_GITHUB_CONTRIBUTOR_ALLOWLIST='djtelicloud,curtisfratianne'
 
 # And/or live GitHub API checks (service token — never put a user PAT in IDE MCP JSON)
 export UNIGROK_GITHUB_TOKEN='ghp_…'   # or GITHUB_TOKEN
-export UNIGROK_GITHUB_CONTRIBUTOR_REPOS='djtelicloud/grok-mcp-server,djtelicloud/grok-mcp-intelligence'
+export UNIGROK_GITHUB_CONTRIBUTOR_REPOS='djtelicloud/grok-mcp-server,your-org/your-other-repo'
 export UNIGROK_GITHUB_CONTRIBUTOR_ORGS='your-org'
 
 # Local single-operator bind (optional)
@@ -327,7 +328,7 @@ See [SECURITY.md](SECURITY.md) for the complete public runtime boundary.
 | See every tool and routing rule | [Technical reference](docs/reference.md) |
 | Use the integrated local route or named local helper | [Local model routes](docs/offline-local-helper.md) |
 | Drive `agent` from an IDE agent | [Technical reference](docs/reference.md#how-an-ide-agent-should-drive-agent) |
-| Auth with GitHub, then install GroundCommand | [Contributing](CONTRIBUTING.md#after-github-auth--install-groundcommand) |
+| Auth with GitHub, then install the public Ground pack | [Contributing](CONTRIBUTING.md#after-github-auth--install-the-public-ground-pack) |
 | Develop or acceptance-test UniGrok | [Development guide](docs/development.md) |
 | See what has limited soak and how to report a miss | [Known limits](docs/known-limits.md) |
 | See what changed between versions | [Changelog](CHANGELOG.md) |

--- a/README.md
+++ b/README.md
@@ -99,6 +99,17 @@ curl --fail --silent http://localhost:4765/readyz
 
 You are ready when the response says `"status":"ready"`.
 
+### Multi-step agentic work (Ground pack)
+
+UniGrok’s `agent` tool is **leaf labor**. Your IDE or automation remains the **orchestrator**.
+
+For multi-step work, put a short **Mission Brief** in `task` (goal, options, constraints,
+done-when, return shape). Retry at most a few times with the same goal and an appended
+finding if a try fails. Prefer densified returns: WHAT / WHY / DELTA / NEXT.
+
+After onboarding, see skills `using-unigrok` and `mission-brief-harness` (installed by
+`grok_mcp_onboard_client` with consent).
+
 Optional local bearer protection is available for `/mcp` and `/v1`:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -115,7 +115,9 @@ receipts; disable web/X tools for true offline briefs; fail closed for cloud-onl
 After onboarding, see skills `using-unigrok` and `mission-brief-harness` (installed by
 `grok_mcp_onboard_client` with consent). **Contributors:** after GitHub auth (website or
 local `gh auth login`), install that GroundCommand pack once — step-by-step in
-[CONTRIBUTING.md](CONTRIBUTING.md#after-github-auth--install-groundcommand).
+[CONTRIBUTING.md](CONTRIBUTING.md#after-github-auth--install-groundcommand). Day-1 is
+**Core + Ground pack only** (not Forge Docker, not Sky/Space nodes). Heavier capacity
+is a separate maintainer grant when someone runs an approved Sky-class node.
 
 ### Official GitHub contributors (optional)
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,30 @@ receipts; disable web/X tools for true offline briefs; fail closed for cloud-onl
 After onboarding, see skills `using-unigrok` and `mission-brief-harness` (installed by
 `grok_mcp_onboard_client` with consent).
 
+### Official GitHub contributors (optional)
+
+UniGrok can detect whether the **authenticated** caller is one of your official GitHub
+contributors. This never trusts `X-Client-ID` alone.
+
+Service environment (examples):
+
+```bash
+# Fast path: explicit allowlist of GitHub logins
+export UNIGROK_GITHUB_CONTRIBUTOR_ALLOWLIST='djtelicloud,curtisfratianne'
+
+# And/or live GitHub API checks (service token — never put a user PAT in IDE MCP JSON)
+export UNIGROK_GITHUB_TOKEN='ghp_…'   # or GITHUB_TOKEN
+export UNIGROK_GITHUB_CONTRIBUTOR_REPOS='djtelicloud/grok-mcp-server,djtelicloud/grok-mcp-intelligence'
+export UNIGROK_GITHUB_CONTRIBUTOR_ORGS='your-org'
+
+# Local single-operator bind (optional)
+export UNIGROK_GITHUB_LOGIN='djtelicloud'
+```
+
+`grok_mcp_status` and `grok_mcp_discover_self` return an `affiliation` object:
+`is_official_contributor` (true/false/null), `source`, and whether a login was detected.
+Use this for soft UX (contributor tips, onboard tone) — not as a secret vault.
+
 Optional local bearer protection is available for `/mcp` and `/v1`:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ For multi-step work, put a short **Mission Brief** in `task` (goal, options, con
 done-when, return shape). Retry at most a few times with the same goal and an appended
 finding if a try fails. Prefer densified returns: WHAT / WHY / DELTA / NEXT.
 
+**Offline / free local path:** when subscription or API is unavailable, Core can still use a
+staged **local** model route (Docker Model Runner or loopback OpenAI-compatible runtime).
+See [Local model routes](docs/offline-local-helper.md). Relay `resolved_plane` and cost
+receipts; disable web/X tools for true offline briefs; fail closed for cloud-only media.
+
 After onboarding, see skills `using-unigrok` and `mission-brief-harness` (installed by
 `grok_mcp_onboard_client` with consent).
 

--- a/src/unigrok_public/github_affiliation.py
+++ b/src/unigrok_public/github_affiliation.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import os
 import re
 import time
+from contextvars import ContextVar
 from typing import Any
 
 import httpx
@@ -33,21 +34,19 @@ from .identity import get_active_principal, principal_kind
 
 _LOGIN_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$")
 _CACHE: dict[str, tuple[float, bool]] = {}
-_GITHUB_LOGIN_CLAIM: str | None = None  # set per-request by remote_auth / middleware
 
-# Context-style mutable for request-scoped GitHub login claim (set by auth layer).
-_REQUEST_GITHUB_LOGIN: str | None = None
+# Request-scoped GitHub login claim (set by auth middleware / remote_auth).
+_REQUEST_GITHUB_LOGIN: ContextVar[str | None] = ContextVar(
+    "unigrok_request_github_login", default=None
+)
 
 
 def set_request_github_login(login: str | None) -> None:
-    global _REQUEST_GITHUB_LOGIN
-    value = _normalize_login(login)
-    _REQUEST_GITHUB_LOGIN = value
+    _REQUEST_GITHUB_LOGIN.set(_normalize_login(login))
 
 
 def clear_request_github_login() -> None:
-    global _REQUEST_GITHUB_LOGIN
-    _REQUEST_GITHUB_LOGIN = None
+    _REQUEST_GITHUB_LOGIN.set(None)
 
 
 def _normalize_login(raw: Any) -> str | None:
@@ -120,8 +119,9 @@ def cache_ttl_seconds() -> int:
 
 def resolve_github_login(*, oauth_claims: dict[str, Any] | None = None) -> str | None:
     """Best-effort GitHub login for the current request (may be None)."""
-    if _REQUEST_GITHUB_LOGIN:
-        return _REQUEST_GITHUB_LOGIN
+    bound = _REQUEST_GITHUB_LOGIN.get()
+    if bound:
+        return bound
     if oauth_claims:
         for key in ("login", "preferred_username", "nickname", "name"):
             login = _normalize_login(oauth_claims.get(key))
@@ -250,6 +250,9 @@ async def affiliation_public_view(
     is_official, source = await is_official_contributor(
         login, oauth_claims=oauth_claims
     )
+    repos = configured_repos()
+    orgs = configured_orgs()
+    allow = configured_allowlist()
     return {
         "github_login_detected": bool(login),
         # Do not echo raw login to shared logs; optional short hash for self-debug
@@ -257,14 +260,16 @@ async def affiliation_public_view(
         "is_official_contributor": is_official,
         "source": source,
         "check_configured": bool(
-            configured_allowlist()
-            or configured_repos()
-            or configured_orgs()
+            allow
+            or repos
+            or orgs
             or service_github_token()
             or os.environ.get("UNIGROK_GITHUB_LOGIN", "").strip()
         ),
-        "repos": configured_repos(),
-        "orgs": configured_orgs(),
+        # Counts only — never echo private repo/org names to public status surfaces
+        "allowlist_entries": len(allow),
+        "repo_checks": len(repos),
+        "org_checks": len(orgs),
         "notes": (
             "X-Client-ID is never used for affiliation. "
             "Configure allowlist and/or GitHub API token + repos/orgs. "

--- a/src/unigrok_public/github_affiliation.py
+++ b/src/unigrok_public/github_affiliation.py
@@ -22,7 +22,6 @@ Optional request claim path: OAuth introspection may supply ``login`` /
 
 from __future__ import annotations
 
-import asyncio
 import os
 import re
 import time

--- a/src/unigrok_public/github_affiliation.py
+++ b/src/unigrok_public/github_affiliation.py
@@ -1,0 +1,278 @@
+"""Detect whether the active caller is an official GitHub contributor.
+
+Public-safe design:
+- Never trust ``X-Client-ID`` alone (telemetry label, not authentication).
+- Prefer server-side verification: allowlist and/or GitHub API with a **service** token.
+- Expose only a boolean affiliation view to the caller; do not leak the full roster.
+- Local single-operator installs can set an allowlist or optional login bind.
+
+Config (service environment):
+
+- ``UNIGROK_GITHUB_CONTRIBUTOR_ALLOWLIST`` — comma/space-separated GitHub logins
+- ``UNIGROK_GITHUB_CONTRIBUTOR_REPOS`` — ``owner/repo`` list to check collaborator status
+- ``UNIGROK_GITHUB_CONTRIBUTOR_ORGS`` — org logins; membership = official
+- ``UNIGROK_GITHUB_TOKEN`` / ``GITHUB_TOKEN`` — service token for API checks (never client-supplied)
+- ``UNIGROK_GITHUB_AFFILIATION_CACHE_SECONDS`` — cache TTL (default 300)
+- ``UNIGROK_GITHUB_LOGIN`` — optional **operator-configured** login for local:operator binds
+  (not a client spoof header)
+
+Optional request claim path: OAuth introspection may supply ``login`` /
+``preferred_username`` when the issuer is GitHub-shaped (wired by remote_auth).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+import time
+from typing import Any
+
+import httpx
+
+from .identity import get_active_principal, principal_kind
+
+_LOGIN_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$")
+_CACHE: dict[str, tuple[float, bool]] = {}
+_GITHUB_LOGIN_CLAIM: str | None = None  # set per-request by remote_auth / middleware
+
+# Context-style mutable for request-scoped GitHub login claim (set by auth layer).
+_REQUEST_GITHUB_LOGIN: str | None = None
+
+
+def set_request_github_login(login: str | None) -> None:
+    global _REQUEST_GITHUB_LOGIN
+    value = _normalize_login(login)
+    _REQUEST_GITHUB_LOGIN = value
+
+
+def clear_request_github_login() -> None:
+    global _REQUEST_GITHUB_LOGIN
+    _REQUEST_GITHUB_LOGIN = None
+
+
+def _normalize_login(raw: Any) -> str | None:
+    if not isinstance(raw, str):
+        return None
+    login = raw.strip().lstrip("@")
+    if not login or len(login) > 39:
+        return None
+    if not _LOGIN_RE.match(login):
+        return None
+    return login.lower()
+
+
+def _split_csv(name: str) -> list[str]:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return []
+    parts: list[str] = []
+    for chunk in raw.replace(";", ",").replace("\n", ",").split(","):
+        for bit in chunk.split():
+            bit = bit.strip()
+            if bit:
+                parts.append(bit)
+    return parts
+
+
+def configured_allowlist() -> set[str]:
+    out: set[str] = set()
+    for item in _split_csv("UNIGROK_GITHUB_CONTRIBUTOR_ALLOWLIST"):
+        login = _normalize_login(item)
+        if login:
+            out.add(login)
+    return out
+
+
+def configured_repos() -> list[str]:
+    repos: list[str] = []
+    for item in _split_csv("UNIGROK_GITHUB_CONTRIBUTOR_REPOS"):
+        if item.count("/") == 1:
+            owner, repo = item.split("/", 1)
+            if owner and repo and ".." not in owner and ".." not in repo:
+                repos.append(f"{owner}/{repo}")
+    return repos
+
+
+def configured_orgs() -> list[str]:
+    orgs: list[str] = []
+    for item in _split_csv("UNIGROK_GITHUB_CONTRIBUTOR_ORGS"):
+        login = _normalize_login(item)
+        if login:
+            orgs.append(login)
+    return orgs
+
+
+def service_github_token() -> str | None:
+    for key in ("UNIGROK_GITHUB_TOKEN", "GITHUB_TOKEN"):
+        value = os.environ.get(key, "").strip()
+        if value and len(value) <= 8_192:
+            return value
+    return None
+
+
+def cache_ttl_seconds() -> int:
+    try:
+        value = int(os.environ.get("UNIGROK_GITHUB_AFFILIATION_CACHE_SECONDS", "300"))
+    except (TypeError, ValueError):
+        value = 300
+    return max(30, min(value, 86_400))
+
+
+def resolve_github_login(*, oauth_claims: dict[str, Any] | None = None) -> str | None:
+    """Best-effort GitHub login for the current request (may be None)."""
+    if _REQUEST_GITHUB_LOGIN:
+        return _REQUEST_GITHUB_LOGIN
+    if oauth_claims:
+        for key in ("login", "preferred_username", "nickname", "name"):
+            login = _normalize_login(oauth_claims.get(key))
+            if login:
+                return login
+        # Some GitHub App tokens put login under nested user objects
+        user = oauth_claims.get("user")
+        if isinstance(user, dict):
+            login = _normalize_login(user.get("login"))
+            if login:
+                return login
+    # Local operator bind (service config only — not a client header)
+    principal = get_active_principal()
+    if principal in (None, "local:operator") or principal_kind() == "none":
+        return _normalize_login(os.environ.get("UNIGROK_GITHUB_LOGIN"))
+    return None
+
+
+def _cache_get(login: str) -> bool | None:
+    hit = _CACHE.get(login)
+    if not hit:
+        return None
+    expires, value = hit
+    if time.monotonic() >= expires:
+        _CACHE.pop(login, None)
+        return None
+    return value
+
+
+def _cache_set(login: str, value: bool) -> None:
+    _CACHE[login] = (time.monotonic() + float(cache_ttl_seconds()), value)
+
+
+async def _github_api_get(path: str, token: str) -> tuple[int, Any]:
+    url = f"https://api.github.com{path}"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "unigrok-public-affiliation/1",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=8.0) as client:
+            response = await client.get(url, headers=headers)
+    except (httpx.HTTPError, TypeError, ValueError):
+        return 0, None
+    try:
+        body = response.json() if response.content else None
+    except (TypeError, ValueError):
+        body = None
+    return response.status_code, body
+
+
+async def _api_is_official(login: str, token: str) -> bool | None:
+    """Return True/False if API decides, None if undetermined (network/config)."""
+    for org in configured_orgs():
+        status, _ = await _github_api_get(f"/orgs/{org}/members/{login}", token)
+        if status == 204:
+            return True
+        if status == 404:
+            continue
+        if status in (401, 403):
+            return None
+    for repo in configured_repos():
+        status, _ = await _github_api_get(
+            f"/repos/{repo}/collaborators/{login}", token
+        )
+        if status == 204:
+            return True
+        if status == 404:
+            continue
+        if status in (401, 403):
+            return None
+    # If we had orgs/repos configured and all 404 → not a collaborator
+    if configured_orgs() or configured_repos():
+        return False
+    return None
+
+
+async def is_official_contributor(
+    login: str | None = None,
+    *,
+    oauth_claims: dict[str, Any] | None = None,
+) -> tuple[bool | None, str]:
+    """Return (is_official, source).
+
+    is_official:
+      True  — verified official
+      False — verified not official (when roster sources exist)
+      None  — unknown (no login / no config / API unavailable)
+    """
+    resolved = login or resolve_github_login(oauth_claims=oauth_claims)
+    if not resolved:
+        return None, "no_github_login"
+
+    allow = configured_allowlist()
+    if resolved in allow:
+        return True, "allowlist"
+
+    cached = _cache_get(resolved)
+    if cached is not None:
+        return cached, "cache"
+
+    token = service_github_token()
+    if not token:
+        if allow:
+            # Allowlist configured but login not on it
+            return False, "allowlist_miss"
+        if not configured_repos() and not configured_orgs():
+            return None, "not_configured"
+        return None, "no_service_token"
+
+    decided = await _api_is_official(resolved, token)
+    if decided is None:
+        return None, "api_unavailable"
+    _cache_set(resolved, decided)
+    return decided, "github_api"
+
+
+async def affiliation_public_view(
+    *,
+    oauth_claims: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Safe dict for status/discover — no full roster, no tokens."""
+    login = resolve_github_login(oauth_claims=oauth_claims)
+    is_official, source = await is_official_contributor(
+        login, oauth_claims=oauth_claims
+    )
+    return {
+        "github_login_detected": bool(login),
+        # Do not echo raw login to shared logs; optional short hash for self-debug
+        "github_login_hint": (login[:2] + "***") if login and len(login) > 2 else None,
+        "is_official_contributor": is_official,
+        "source": source,
+        "check_configured": bool(
+            configured_allowlist()
+            or configured_repos()
+            or configured_orgs()
+            or service_github_token()
+            or os.environ.get("UNIGROK_GITHUB_LOGIN", "").strip()
+        ),
+        "repos": configured_repos(),
+        "orgs": configured_orgs(),
+        "notes": (
+            "X-Client-ID is never used for affiliation. "
+            "Configure allowlist and/or GitHub API token + repos/orgs. "
+            "Local operators may set UNIGROK_GITHUB_LOGIN + allowlist."
+        ),
+    }
+
+
+def clear_cache() -> None:
+    _CACHE.clear()

--- a/src/unigrok_public/remote_auth.py
+++ b/src/unigrok_public/remote_auth.py
@@ -443,12 +443,25 @@ async def _perform_oauth_introspection(
         return None
     if public_mcp_resource() not in audiences:
         return None
-    return {
+    claims: dict[str, Any] = {
         "active": True,
         "scope": scopes,
         "unigrok_principal": principal,
         "unigrok_auth": "oauth",
     }
+    # Optional GitHub-shaped fields for official-contributor affiliation (no trust of client headers).
+    for key in ("login", "preferred_username", "nickname"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            claims["github_login"] = value.strip().lstrip("@")
+            claims[key] = value.strip()
+            break
+    user = payload.get("user")
+    if "github_login" not in claims and isinstance(user, dict):
+        login = user.get("login")
+        if isinstance(login, str) and login.strip():
+            claims["github_login"] = login.strip().lstrip("@")
+    return claims
 
 
 async def introspect_oauth_token(token: str, required: str) -> dict[str, Any] | None:

--- a/src/unigrok_public/remote_auth.py
+++ b/src/unigrok_public/remote_auth.py
@@ -449,7 +449,8 @@ async def _perform_oauth_introspection(
         "unigrok_principal": principal,
         "unigrok_auth": "oauth",
     }
-    # Optional GitHub-shaped fields for official-contributor affiliation (no trust of client headers).
+    # Optional GitHub-shaped fields for official-contributor affiliation
+    # (never trust client headers alone for that claim).
     for key in ("login", "preferred_username", "nickname"):
         value = payload.get(key)
         if isinstance(value, str) and value.strip():

--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -1627,24 +1627,23 @@ def _client_onboarding_plan(
         "requires_explicit_user_approval": True,
         "automatic_tool_approval_offered": not cloud_mode and not safe_mode,
         "installer": "calling_ide_agent",
-        # Day-1 public Ground pack only — no Forge/Sky auto-install (CONTRIBUTING.md).
+        # Day-1 public Ground pack only — no extra labor/operator nodes (CONTRIBUTING.md).
         "pack": {
-            "name": "groundcommand_public",
+            "name": "ground_pack_public",
             "includes": [
                 "using-unigrok",
                 "mission-brief-harness",
                 "unigrok-visuals (host adapter when applicable)",
             ],
             "does_not_include": [
-                "forge_docker",
-                "skycommand_node",
-                "spacecommand_node",
+                "secondary_labor_docker",
+                "extra_operator_nodes",
                 "private_operator_skills",
-                "full_agents_skills_tree",
+                "full_skill_tree_mirror",
             ],
             "heavier_capacity": (
                 "Separate maintainer grant only if the contributor runs an approved "
-                "Sky-class node — not implied by this onboard pack or GitHub login alone."
+                "extra node — not implied by this onboard pack or GitHub login alone."
             ),
             "docs": "CONTRIBUTING.md#what-day-1-access-includes-and-does-not",
         },

--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -860,7 +860,9 @@ GLOBAL_SKILL = """---
 name: using-unigrok
 description: >-
   Use when the user says @grok, asks for a Grok second opinion, wants web or X research,
-  or requests Grok image, video, vision, file, or remote-code capabilities.
+  or requests Grok image, video, vision, file, or remote-code capabilities. Also use for
+  multi-step agentic work: structure the agent task as a short Mission Brief (see
+  mission-brief-harness).
 ---
 
 # Using UniGrok
@@ -880,6 +882,79 @@ models, billing planes, capabilities, or safety boundaries matter.
 - Send project material only as deliberately selected, bounded `workspace_context`.
 - UniGrok has no direct project filesystem, shell, Git, credential, or external-MCP access.
 - Never place provider credentials in project files or chat.
+
+## Multi-step agentic work (Ground-style harness)
+
+The **host** (you / your IDE agent / human) is the **orchestrator**. UniGrok is **leaf labor**.
+For anything beyond a one-shot answer, put a structured **Mission Brief** in `task` and keep
+orchestration on the host. Prefer densified returns: WHAT / WHY / DELTA / NEXT.
+
+See skill `mission-brief-harness` for the full template and try ≤3 heal-forward loop.
+"""
+
+MISSION_BRIEF_HARNESS_SKILL = """---
+name: mission-brief-harness
+description: >-
+  Structure multi-step UniGrok agent work as Mission Briefs. Host orchestrates;
+  UniGrok is leaf labor. Use for agentic tasks, retries, and densified returns.
+---
+
+# Mission Brief harness (public Ground pack)
+
+Workspace-neutral product pattern. The host stays the orchestrator; UniGrok `agent` is leaf labor.
+
+## Roles
+
+| Role | Who |
+|------|-----|
+| Orchestrator | Host IDE / human / local agent |
+| Leaf labor | UniGrok `agent` |
+| Judge (optional) | Host second pass or human |
+
+## Brief template (put this in `task`)
+
+```markdown
+# Mission Brief · <title>
+
+## L0 Goal
+One sentence.
+
+## L1 Options
+Rank ≥2 approaches (virtual-first).
+
+## L2 Constraints
+DO NOT · time · tools to avoid.
+
+## L3 Context
+Only bounded quotes or paths the labor needs (no credentials).
+
+## L4 Done when
+Acceptance check + what to return.
+
+## L5 Decision
+EXECUTE | HOLD
+
+## Return form
+WHAT / WHY / DELTA / NEXT · optional confidence 1–100
+```
+
+## Host loop
+
+```text
+BRIEF → try (≤3) → observe result → judge
+  pass → densify return
+  fail → heal-forward (keep original goal, append finding)
+```
+
+## Clean install
+
+1. Connect UniGrok MCP.
+2. Install skills via consent (`grok_mcp_onboard_client` / host skill pack).
+3. Host remains orchestrator; put Mission Briefs in `task`.
+
+## Not included
+
+Private multi-seat OS doctrine, training pipelines, contest scoreboards, or credential values.
 """
 
 ANTIGRAVITY_WORKFLOW = """# Ask Grok
@@ -1443,6 +1518,22 @@ def _visuals_skill_files(client: str, skill_dir: str) -> list[dict[str, str]]:
     ]
 
 
+def _ground_pack_skill_files(skills_root: str) -> list[dict[str, str]]:
+    """Public Ground pack: using-unigrok + mission-brief-harness under a skills root.
+
+    skills_root examples:
+      ~/.claude/skills
+      ~/.codex/skills
+      ~/.gemini/config/plugins/unigrok/skills
+      .agents/skills
+    """
+    root = skills_root.rstrip("/")
+    return [
+        _owned_file(f"{root}/using-unigrok/SKILL.md", GLOBAL_SKILL),
+        _owned_file(f"{root}/mission-brief-harness/SKILL.md", MISSION_BRIEF_HARNESS_SKILL),
+    ]
+
+
 def _global_files(client: str) -> list[dict[str, str]]:
     if client == "antigravity":
         manifest = json.dumps(
@@ -1457,7 +1548,7 @@ def _global_files(client: str) -> list[dict[str, str]]:
         root = "~/.gemini/config/plugins/unigrok"
         return [
             _owned_file(f"{root}/plugin.json", manifest),
-            _owned_file(f"{root}/skills/using-unigrok/SKILL.md", GLOBAL_SKILL),
+            *_ground_pack_skill_files(f"{root}/skills"),
             _owned_file(
                 "~/.gemini/config/global_workflows/ask-grok.md",
                 ANTIGRAVITY_WORKFLOW,
@@ -1466,12 +1557,12 @@ def _global_files(client: str) -> list[dict[str, str]]:
         ]
     if client == "codex":
         return [
-            _owned_file("~/.codex/skills/using-unigrok/SKILL.md", GLOBAL_SKILL),
+            *_ground_pack_skill_files("~/.codex/skills"),
             *_visuals_skill_files("codex", "~/.codex/skills/unigrok-visuals"),
         ]
     if client == "claude_code":
         return [
-            _owned_file("~/.claude/skills/using-unigrok/SKILL.md", GLOBAL_SKILL),
+            *_ground_pack_skill_files("~/.claude/skills"),
             *_visuals_skill_files("claude_code", "~/.claude/skills/unigrok-visuals"),
         ]
     return []
@@ -1530,7 +1621,7 @@ def _client_onboarding_plan(
             "project_root_files_avoided": False,
             "precedence": "project customizations override the global baseline",
             "files": [
-                _owned_file(".agents/skills/using-unigrok/SKILL.md", GLOBAL_SKILL),
+                *_ground_pack_skill_files(".agents/skills"),
                 *_visuals_skill_files(client, ".agents/skills/unigrok-visuals"),
             ],
             "optional_paths": [

--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -80,6 +80,7 @@ from .harness import (
     should_auto_deepen,
     workspace_courier,
 )
+from . import github_affiliation
 from .identity import (
     get_active_principal,
     principal_label,
@@ -6604,7 +6605,9 @@ async def chat(
 @mcp.tool(annotations=READ_ONLY)
 async def grok_mcp_discover_self(refresh_models: bool = False) -> dict[str, Any]:
     """Return the gateway's authoritative live public tools, planes, and model catalogs."""
-    return _live_self_description(await _catalogs(refresh=refresh_models))
+    body = _live_self_description(await _catalogs(refresh=refresh_models))
+    body["affiliation"] = await github_affiliation.affiliation_public_view()
+    return body
 
 
 @mcp.tool(annotations=READ_ONLY)
@@ -6685,13 +6688,14 @@ async def grok_mcp_onboard_client(
 @mcp.tool(annotations=READ_ONLY)
 async def grok_mcp_status(refresh: bool = False) -> dict[str, Any]:
     """Report non-secret credential-plane readiness and the exact public boundary."""
-    catalogs, state_ready, telemetry = await asyncio.gather(
+    catalogs, state_ready, telemetry, affiliation = await asyncio.gather(
         _catalogs(refresh=refresh),
         STATE.health(),
         STATE.telemetry_summary(limit=1000, caller=_tenant_caller()),
+        github_affiliation.affiliation_public_view(),
     )
     description = _live_self_description(catalogs)
-    return system_tools.status_body(
+    body = system_tools.status_body(
         service=MCP_SERVER_NAME,
         version=__version__,
         layer=UNIGROK_LAYER or "public",
@@ -6704,6 +6708,8 @@ async def grok_mcp_status(refresh: bool = False) -> dict[str, Any]:
         metered_api_enabled=METERED_API_ENABLED,
         cloudrun=is_cloudrun_runtime(),
     )
+    body["affiliation"] = affiliation
+    return body
 
 
 @mcp.tool(annotations=READ_ONLY)
@@ -7493,6 +7499,13 @@ class CallerIdentityMiddleware:
                 caller = principal_label(principal)
                 if caller:
                     caller_token = _CALLER_ID_CONTEXT.set(caller)
+                # OAuth claims may carry a GitHub login for affiliation (never X-Client-ID).
+                if isinstance(claims, dict):
+                    github_affiliation.set_request_github_login(
+                        claims.get("github_login")
+                        or claims.get("login")
+                        or claims.get("preferred_username")
+                    )
             else:
                 headers = {
                     key.decode("latin-1").lower(): value.decode("latin-1")
@@ -7502,9 +7515,12 @@ class CallerIdentityMiddleware:
                 if raw:
                     caller = re.sub(r"[^a-z0-9._:-]+", "-", raw)[:80]
                     caller_token = _CALLER_ID_CONTEXT.set(caller)
+                # Never treat X-Client-ID as GitHub affiliation.
+                github_affiliation.clear_request_github_login()
         try:
             await self.app(scope, receive, send)
         finally:
+            github_affiliation.clear_request_github_login()
             if caller_token is not None:
                 _CALLER_ID_CONTEXT.reset(caller_token)
             if principal_token is not None:

--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -27,7 +27,7 @@ from pydantic import BaseModel, Field
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, PlainTextResponse
 
-from . import __version__, local_plane_loader, xai_api
+from . import __version__, github_affiliation, local_plane_loader, xai_api
 from .autonomy import (
     JOB_COMPLETE,
     JOB_ERROR,
@@ -80,7 +80,6 @@ from .harness import (
     should_auto_deepen,
     workspace_courier,
 )
-from . import github_affiliation
 from .identity import (
     get_active_principal,
     principal_label,
@@ -901,7 +900,8 @@ loopback OpenAI-compatible runtime) is staged — see `docs/offline-local-helper
 - Relay `resolved_plane` and `cost_usd` (local is `0`) to the user.
 - Prefer `disable_tools: ["web","x_search"]` for true offline briefs.
 - Cloud-only work (media/search without a funded plane) must **fail closed**, not invent.
-- Optional named local helper `gemmagrok-local` is separate from `@grok` — never auto-escape to paid.
+- Optional named local helper `gemmagrok-local` is separate from `@grok` —
+  never auto-escape to paid.
 """
 
 MISSION_BRIEF_HARNESS_SKILL = """---
@@ -922,7 +922,7 @@ Workspace-neutral product pattern. The host stays the orchestrator; UniGrok `age
 |------|-----|
 | Orchestrator | Host IDE / human / local agent |
 | Leaf labor | UniGrok `agent` (CLI / API / **local** free path when staged) |
-| Free local helper (optional) | `gemmagrok-local` MCP — one pinned local model; never remote escape |
+| Free local helper (optional) | `gemmagrok-local` MCP — one pinned local model; no remote escape |
 | Judge (optional) | Host second pass, human, or short local prior if the host installs one |
 
 ## Brief template (put this in `task`)

--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -1627,6 +1627,27 @@ def _client_onboarding_plan(
         "requires_explicit_user_approval": True,
         "automatic_tool_approval_offered": not cloud_mode and not safe_mode,
         "installer": "calling_ide_agent",
+        # Day-1 public Ground pack only — no Forge/Sky auto-install (CONTRIBUTING.md).
+        "pack": {
+            "name": "groundcommand_public",
+            "includes": [
+                "using-unigrok",
+                "mission-brief-harness",
+                "unigrok-visuals (host adapter when applicable)",
+            ],
+            "does_not_include": [
+                "forge_docker",
+                "skycommand_node",
+                "spacecommand_node",
+                "private_operator_skills",
+                "full_agents_skills_tree",
+            ],
+            "heavier_capacity": (
+                "Separate maintainer grant only if the contributor runs an approved "
+                "Sky-class node — not implied by this onboard pack or GitHub login alone."
+            ),
+            "docs": "CONTRIBUTING.md#what-day-1-access-includes-and-does-not",
+        },
         "runtime_contract": {
             "execution_policy": "api_only" if cloud_mode else "dual_plane",
             "inference_billing": "metered" if cloud_mode else "conditional",

--- a/src/unigrok_public/server.py
+++ b/src/unigrok_public/server.py
@@ -889,14 +889,26 @@ The **host** (you / your IDE agent / human) is the **orchestrator**. UniGrok is 
 For anything beyond a one-shot answer, put a structured **Mission Brief** in `task` and keep
 orchestration on the host. Prefer densified returns: WHAT / WHY / DELTA / NEXT.
 
-See skill `mission-brief-harness` for the full template and try ≤3 heal-forward loop.
+See skill `mission-brief-harness` for the full template, try ≤3 heal-forward loop, and
+**offline / free local failover** (no paid plane, no private forge).
+
+## Free path when net or subscription is down
+
+UniGrok Core can still answer on a **local plane** when Docker Model Runner (or another
+loopback OpenAI-compatible runtime) is staged — see `docs/offline-local-helper.md`.
+
+- Relay `resolved_plane` and `cost_usd` (local is `0`) to the user.
+- Prefer `disable_tools: ["web","x_search"]` for true offline briefs.
+- Cloud-only work (media/search without a funded plane) must **fail closed**, not invent.
+- Optional named local helper `gemmagrok-local` is separate from `@grok` — never auto-escape to paid.
 """
 
 MISSION_BRIEF_HARNESS_SKILL = """---
 name: mission-brief-harness
 description: >-
   Structure multi-step UniGrok agent work as Mission Briefs. Host orchestrates;
-  UniGrok is leaf labor. Use for agentic tasks, retries, and densified returns.
+  UniGrok is leaf labor. Covers offline/local free-path failover when net or paid
+  planes are unavailable. Use for agentic tasks, retries, densified returns.
 ---
 
 # Mission Brief harness (public Ground pack)
@@ -908,8 +920,9 @@ Workspace-neutral product pattern. The host stays the orchestrator; UniGrok `age
 | Role | Who |
 |------|-----|
 | Orchestrator | Host IDE / human / local agent |
-| Leaf labor | UniGrok `agent` |
-| Judge (optional) | Host second pass or human |
+| Leaf labor | UniGrok `agent` (CLI / API / **local** free path when staged) |
+| Free local helper (optional) | `gemmagrok-local` MCP — one pinned local model; never remote escape |
+| Judge (optional) | Host second pass, human, or short local prior if the host installs one |
 
 ## Brief template (put this in `task`)
 
@@ -920,41 +933,69 @@ Workspace-neutral product pattern. The host stays the orchestrator; UniGrok `age
 One sentence.
 
 ## L1 Options
-Rank ≥2 approaches (virtual-first).
+Rank ≥2 approaches (virtual-first). Prefer free/local when offline.
 
 ## L2 Constraints
 DO NOT · time · tools to avoid.
+Offline tip: disable_tools web and x_search; do not request cloud-only media.
 
 ## L3 Context
 Only bounded quotes or paths the labor needs (no credentials).
 
 ## L4 Done when
-Acceptance check + what to return.
+Acceptance check + what to return. Receipt must name plane (cli|api|local).
 
 ## L5 Decision
 EXECUTE | HOLD
 
 ## Return form
-WHAT / WHY / DELTA / NEXT · optional confidence 1–100
+WHAT / WHY / DELTA / NEXT · optional confidence 1–100 · resolved_plane if known
 ```
 
 ## Host loop
 
 ```text
-BRIEF → try (≤3) → observe result → judge
+BRIEF → try (≤3) → observe result (plane + cost) → judge
   pass → densify return
   fail → heal-forward (keep original goal, append finding)
+  offline → stage local runtime first (docs/offline-local-helper.md), then retry brief
 ```
+
+## Free path / no-internet / no-paid-plane (product fact)
+
+1. **Integrated zero-key local route** on the normal `@grok` service (`4765`): when remote
+   planes are not ready, Core may use Docker Model Runner / loopback local models if
+   `UNIGROK_LOCAL_AUTO` is on (default) and a runtime is reachable.
+2. Results use `billing_class: local_runtime` and `cost_usd: 0` when local.
+3. **Fail closed** for work that needs web/media without a funded plane — never fabricate.
+4. Optional **gemmagrok-local** (`compose --profile offline`) is a **named** local chat helper,
+   not a secret second UniGrok and not an automatic paid fallback.
+5. Host may run additional short local judges (e.g. operator-owned prior seats) **outside**
+   this product; they are not required for clean install.
+
+Operator doc: `docs/offline-local-helper.md`.
 
 ## Clean install
 
 1. Connect UniGrok MCP.
 2. Install skills via consent (`grok_mcp_onboard_client` / host skill pack).
 3. Host remains orchestrator; put Mission Briefs in `task`.
+4. For offline: enable Model Runner, pull the pinned local model, start UniGrok, then brief.
+
+## Edge cases (orchestrator must handle)
+
+| Situation | Host action |
+|-----------|-------------|
+| Local runtime missing offline | HOLD · stage model · retry brief |
+| Paid-only tool requested offline | HOLD · shrink L4 to text-only or fail closed |
+| `continue` / pending | Reattach with `continue_token` / poll `agent_result` — do not duplicate |
+| Hive/ultra depth offline | May be unavailable; fall back to direct brief + local plane |
+| Receipt plane unexpected | Surface to user; do not claim free if metered |
 
 ## Not included
 
-Private multi-seat OS doctrine, training pipelines, contest scoreboards, or credential values.
+Private multi-seat OS doctrine, training pipelines, contest scoreboards, credential values,
+or a mandatory private judge port map.
 """
 
 ANTIGRAVITY_WORKFLOW = """# Ask Grok

--- a/tests/test_github_affiliation.py
+++ b/tests/test_github_affiliation.py
@@ -35,6 +35,10 @@ async def test_allowlist_marks_official(monkeypatch: pytest.MonkeyPatch) -> None
     assert view["source"] == "allowlist"
     # roster not leaked as plaintext login
     assert view.get("github_login_hint") == "cu***"
+    # no raw repo/org names on public surface
+    assert "repos" not in view
+    assert "orgs" not in view
+    assert view["allowlist_entries"] == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_github_affiliation.py
+++ b/tests/test_github_affiliation.py
@@ -1,0 +1,80 @@
+"""Official GitHub contributor affiliation (public-safe)."""
+
+from __future__ import annotations
+
+import pytest
+
+from unigrok_public import github_affiliation as ga
+
+
+@pytest.fixture(autouse=True)
+def _clear_affiliation_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    ga.clear_cache()
+    ga.clear_request_github_login()
+    for key in (
+        "UNIGROK_GITHUB_CONTRIBUTOR_ALLOWLIST",
+        "UNIGROK_GITHUB_CONTRIBUTOR_REPOS",
+        "UNIGROK_GITHUB_CONTRIBUTOR_ORGS",
+        "UNIGROK_GITHUB_TOKEN",
+        "GITHUB_TOKEN",
+        "UNIGROK_GITHUB_LOGIN",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.mark.asyncio
+async def test_allowlist_marks_official(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("UNIGROK_GITHUB_CONTRIBUTOR_ALLOWLIST", "CurtisFratianne, djtelicloud")
+    ga.set_request_github_login("curtisfratianne")
+    is_official, source = await ga.is_official_contributor()
+    assert is_official is True
+    assert source == "allowlist"
+    view = await ga.affiliation_public_view()
+    assert view["is_official_contributor"] is True
+    assert view["github_login_detected"] is True
+    assert view["source"] == "allowlist"
+    # roster not leaked as plaintext login
+    assert view.get("github_login_hint") == "cu***"
+
+
+@pytest.mark.asyncio
+async def test_allowlist_miss_is_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("UNIGROK_GITHUB_CONTRIBUTOR_ALLOWLIST", "djtelicloud")
+    ga.set_request_github_login("random-user")
+    is_official, source = await ga.is_official_contributor()
+    assert is_official is False
+    assert source == "allowlist_miss"
+
+
+@pytest.mark.asyncio
+async def test_no_login_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("UNIGROK_GITHUB_CONTRIBUTOR_ALLOWLIST", "djtelicloud")
+    is_official, source = await ga.is_official_contributor()
+    assert is_official is None
+    assert source == "no_github_login"
+
+
+@pytest.mark.asyncio
+async def test_x_client_id_never_used_for_affiliation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("UNIGROK_GITHUB_CONTRIBUTOR_ALLOWLIST", "cursor")
+    # Simulate telemetry label only — no request github login set
+    is_official, source = await ga.is_official_contributor()
+    assert is_official is None
+    assert source == "no_github_login"
+
+
+@pytest.mark.asyncio
+async def test_local_operator_login_bind(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("UNIGROK_GITHUB_LOGIN", "djtelicloud")
+    monkeypatch.setenv("UNIGROK_GITHUB_CONTRIBUTOR_ALLOWLIST", "djtelicloud")
+    is_official, source = await ga.is_official_contributor()
+    assert is_official is True
+    assert source == "allowlist"
+
+
+def test_normalize_login_rejects_spoof() -> None:
+    assert ga._normalize_login("../../../etc") is None
+    assert ga._normalize_login("good-user") == "good-user"
+    assert ga._normalize_login("@Good-User") == "good-user"

--- a/tests/test_onboarding_safe_mode.py
+++ b/tests/test_onboarding_safe_mode.py
@@ -57,6 +57,24 @@ def test_default_onboarding_behavior_remains_compatible() -> None:
     assert "auto_approve" in antigravity
 
 
+def test_onboarding_pack_is_ground_only_not_forge_or_sky() -> None:
+    """Day-1 public pack must not imply Forge Docker or Sky/Space nodes."""
+    plan = server._client_onboarding_plan("claude_code", "global")
+    pack = plan["pack"]
+    assert pack["name"] == "groundcommand_public"
+    assert "using-unigrok" in pack["includes"]
+    assert "mission-brief-harness" in pack["includes"]
+    for denied in (
+        "forge_docker",
+        "skycommand_node",
+        "spacecommand_node",
+        "private_operator_skills",
+        "full_agents_skills_tree",
+    ):
+        assert denied in pack["does_not_include"]
+    assert "Sky-class" in pack["heavier_capacity"]
+
+
 def test_cursor_hook_never_allows_empty_or_ambiguous_tool_names() -> None:
     assert _hook_decision({}) == "ask"
     assert _hook_decision({"tool_name": ""}) == "ask"

--- a/tests/test_onboarding_safe_mode.py
+++ b/tests/test_onboarding_safe_mode.py
@@ -57,22 +57,21 @@ def test_default_onboarding_behavior_remains_compatible() -> None:
     assert "auto_approve" in antigravity
 
 
-def test_onboarding_pack_is_ground_only_not_forge_or_sky() -> None:
-    """Day-1 public pack must not imply Forge Docker or Sky/Space nodes."""
+def test_onboarding_pack_is_ground_only_not_extra_nodes() -> None:
+    """Day-1 public pack must not imply secondary labor or extra operator nodes."""
     plan = server._client_onboarding_plan("claude_code", "global")
     pack = plan["pack"]
-    assert pack["name"] == "groundcommand_public"
+    assert pack["name"] == "ground_pack_public"
     assert "using-unigrok" in pack["includes"]
     assert "mission-brief-harness" in pack["includes"]
     for denied in (
-        "forge_docker",
-        "skycommand_node",
-        "spacecommand_node",
+        "secondary_labor_docker",
+        "extra_operator_nodes",
         "private_operator_skills",
-        "full_agents_skills_tree",
+        "full_skill_tree_mirror",
     ):
         assert denied in pack["does_not_include"]
-    assert "Sky-class" in pack["heavier_capacity"]
+    assert "extra node" in pack["heavier_capacity"]
 
 
 def test_cursor_hook_never_allows_empty_or_ambiguous_tool_names() -> None:

--- a/tests/test_public_boundary.py
+++ b/tests/test_public_boundary.py
@@ -445,9 +445,20 @@ def test_client_onboarding_is_namespaced_and_never_writes() -> None:
     paths = [item["path"] for item in plan["files"]]
     assert "~/.gemini/config/plugins/unigrok/plugin.json" in paths
     assert "~/.gemini/config/plugins/unigrok/skills/using-unigrok/SKILL.md" in paths
+    assert (
+        "~/.gemini/config/plugins/unigrok/skills/mission-brief-harness/SKILL.md"
+        in paths
+    )
     assert "~/.gemini/config/global_workflows/ask-grok.md" in paths
     assert not any(path.startswith(".agents/") for path in paths)
     assert all(len(item["sha256"]) == 64 for item in plan["files"])
+    mission = next(
+        item
+        for item in plan["files"]
+        if item["path"].endswith("mission-brief-harness/SKILL.md")
+    )
+    assert "Mission Brief" in mission["content"]
+    assert "leaf labor" in mission["content"]
 
 
 def test_client_onboarding_detection_and_safe_non_filesystem_fallback() -> None:

--- a/tests/test_public_boundary.py
+++ b/tests/test_public_boundary.py
@@ -459,6 +459,9 @@ def test_client_onboarding_is_namespaced_and_never_writes() -> None:
     )
     assert "Mission Brief" in mission["content"]
     assert "leaf labor" in mission["content"]
+    assert "local" in mission["content"].lower()
+    assert "offline" in mission["content"].lower() or "free path" in mission["content"].lower()
+    assert "gemmagrok-local" in mission["content"] or "Model Runner" in mission["content"]
 
 
 def test_client_onboarding_detection_and_safe_non_filesystem_fallback() -> None:


### PR DESCRIPTION
## Summary
- Public **GroundCommand pack**: Mission Brief harness + `using-unigrok` multi-step, free-path offline cream.
- Official GitHub contributor soft affiliation (`affiliation` on status/discover; never trust X-Client-ID alone).
- **CONTRIBUTING**: after GitHub auth (website or local), install Ground pack; day-1 scope table — **Core + pack only**, not Forge Docker / Sky / Space.
- Onboard plan exposes `pack.includes` / `pack.does_not_include` so IDEs tell the truth.
- Heavier capacity = separate maintainer **Sky-class node** grant.

## Test plan
- [x] `scripts/check_docs.py`
- [x] `tests/test_onboarding_safe_mode.py` (incl. pack boundary)
- [ ] CI green on PR
- [ ] After merge: update live `/contribute` site if still separate repo

Private tier law (T0–T4) is intelligence-only, not in this tree.