### PR TITLE
docs: Windows DMR local plane ready signal and CLI volume auth

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,37 @@ Optional local bearer: see README “Optional local bearer protection”.
 Never put `XAI_API_KEY`, personal PATs, or Grok session tokens into IDE MCP JSON —
 credentials stay in the UniGrok service environment / CLI auth volume only.
 
+**Optional — local Docker Model Runner plane (zero-key text path):** day-1 does **not**
+require this. Core can chat on CLI/API while `planes.local.ready` is false. To arm the
+integrated local free path on Docker Desktop:
+
+```powershell
+docker desktop enable model-runner
+docker model pull ai/gemma3:4B-Q4_K_M
+docker model ls
+# models must appear here (partial downloads do not bind)
+docker compose up -d grok-mcp
+curl.exe -fsS http://127.0.0.1:4765/readyz
+```
+
+Inspect the `planes.local` object: you want `"ready": true`, `"data_ready": true`, and
+empty `rewrite.missing_min_roles`. Discovery IDs often look like
+`docker.io/ai/<name>:latest` (not only the short `ai/...` pull name). Min offline roles
+are `router` + `text_generator` (see [Local model routes](docs/offline-local-helper.md)).
+Local DMR models are **not** UltraHive persona voters — hive (`level: ultra`) still uses
+built-in personas on CLI/API.
+
+**Grok Build CLI inside Docker (subscription plane):** host CLI login is separate from
+the Core volume. Refresh with:
+
+```powershell
+docker compose --profile auth run --rm grok-cli-auth
+docker compose up -d --force-recreate grok-mcp
+curl.exe -fsS http://127.0.0.1:4765/readyz
+```
+
+Confirm `planes.cli.authenticated` is true when you intend SuperGrok-in-Core as the lead.
+
 ### C. Install the public Ground pack (skills)
 
 The **public Ground pack** means: your IDE stays the orchestrator; UniGrok `agent` is

--- a/docs/offline-local-helper.md
+++ b/docs/offline-local-helper.md
@@ -17,6 +17,17 @@ docker model pull ai/gemma3:4B-Q4_K_M
 docker model run --detach ai/gemma3:4B-Q4_K_M
 ```
 
+**Windows (PowerShell):** use the same sequence; confirm pulls finished before expecting
+a ready local plane:
+
+```powershell
+docker model status
+docker model ls
+# empty table = not ready (partial % downloads do not bind)
+docker compose up -d grok-mcp
+curl.exe -fsS http://127.0.0.1:4765/readyz
+```
+
 Then start UniGrok normally:
 
 ```bash
@@ -30,6 +41,13 @@ The container automatically probes Docker Model Runner through
 remote route is ready, the discovered Gemma model supplies the bounded router and text
 path. Requests without a funded local role, including cloud-only media and search, fail
 closed instead of escaping to a paid service or fabricating a result.
+
+**Ready signal:** under `planes.local` in `/readyz`, expect `"ready": true`,
+`"data_ready": true`, and `rewrite.missing_min_roles: []`. Discovered model ids are often
+prefixed (`docker.io/ai/...`). Family mapping + min roles `router` and `text_generator`
+must bind; discovery alone is not enough if roles are unfunded. Other DMR checkpoints
+(qwen, nemotron, …) can appear in `models` once pulled — they still do not replace
+UltraHive CLI/API persona voters.
 
 Set `UNIGROK_LOCAL_AUTO=off` to disable automatic probing. For another
 OpenAI-compatible loopback runtime, set `UNIGROK_LOCAL_RUNTIME_URL` to its base URL.


### PR DESCRIPTION
## Summary
- Document optional **Docker Model Runner local plane** for Windows contributors: `docker model ls` must show finished models, `curl.exe` `/readyz` checks for `planes.local.ready` / `data_ready` / empty `missing_min_roles`, and common `docker.io/ai/...` discovery ids.
- Clarify that **DMR models are not UltraHive persona voters** (hive stays CLI/API personas).
- Document **Docker `grok-cli-auth` volume refresh** so SuperGrok-in-Core is distinct from host CLI login.
- Extend `docs/offline-local-helper.md` with the same Windows ready-signal notes.

Cream-mined from a public Ground seat soak (`cfrat33`): cold-start local green, CLI auth, `level=max` + `level=ultra` Mission Brief dry-runs with plane receipts.

## Test plan
- [x] Docs-only change
- [x] Local seat: `local.ready=true` after DMR models + role arm; CLI authenticated
- [x] `level=max` and `level=ultra` agent dry-runs completed on Core
- [ ] Skim CONTRIBUTING section B + offline-local-helper for accuracy